### PR TITLE
feat(expansion): grow a pretrained model by expanding selected linear layers

### DIFF
--- a/examples/llm_finetune/llama3_2/llama3_2_1b_expansion.yaml
+++ b/examples/llm_finetune/llama3_2/llama3_2_1b_expansion.yaml
@@ -1,0 +1,126 @@
+# Growing Llama-3.2-1B-Instruct by expanding two of its decoder layers.
+#
+# Expansion adds a second, trainable weight to the projections of the named layers while
+# the pretrained weights stay frozen. At step 0 the expanded model reproduces its parent
+# exactly -- the projections that write into the residual stream start at zero -- so this
+# continues pretraining rather than restarting it. Only the expansion weights reach the
+# optimizer, which is why the learning rate here is far above a full-finetune one.
+#
+# Works with tensor, data and pipeline parallelism. Not supported with `peft:`, which
+# patches the same linear layers. Under pipeline parallelism, `expansion.layers` must name
+# at least one layer in every stage's range -- a stage is a contiguous slice of the decoder
+# stack, and one holding no expanded layer would have nothing to train.
+#
+#   uv run automodel finetune llm -c examples/llm_finetune/llama3_2/llama3_2_1b_expansion.yaml
+#
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: meta-llama/Llama-3.2-1B-Instruct
+  # This is the storage dtype of the resident parameters and of Adam's EMA buffers -- not
+  # the compute dtype, which FSDP2's mp_policy owns (see `distributed:` below). float32 is
+  # the master-weights pattern from docs/guides/mixed-precision-training.mdx. Do not set
+  # this to float16: Adam's eps (1e-8) is below fp16's smallest subnormal and flushes to
+  # zero, exp_avg_sq underflows with it, and the update becomes 0/0 -> NaN.
+  torch_dtype: float32
+  attn_implementation: sdpa
+  trust_remote_code: false
+
+expansion:
+  _target_: nemo_automodel.components.expansion.ExpansionConfig
+  enabled: true
+  # Zero-based decoder-layer indices to expand. Omit to expand every layer; every layer
+  # left out still carries both hidden-state streams, at no extra compute.
+  layers: [8, 12]   # with pp_size=2 over 16 layers, use e.g. [4, 12] so both stages train
+  # lambda in h = h_a + lambda * (h_b - h_a), applied just before the final norm.
+  merge_weight: 0.5
+
+distributed:
+  _target_: nemo_automodel.components.distributed.fsdp2.FSDP2Manager
+  # Compute dtype. Left unset, FSDP2 defaults to bf16 compute with fp32 gradient
+  # reduction, which is right for Ampere and newer. Pre-Ampere cards (V100, sm70) have
+  # fp16 tensor cores but no bf16 ones, so bf16 there is emulated; uncomment this to run
+  # the compute in fp16 while the master weights above stay fp32. Measured on 4xV100 with
+  # this config: 2.7x faster, with the loss curve and grad norms unchanged to within
+  # rounding. No loss scaling is involved -- gradients are reduced in fp32 and the
+  # optimizer state never leaves fp32, so there is nothing here for fp16 to underflow.
+  # mp_policy:
+  #   _target_: torch.distributed.fsdp.MixedPrecisionPolicy
+  #   param_dtype: float16
+  #   reduce_dtype: float32
+  #   output_dtype: float16
+  #   cast_forward_inputs: true
+  dp_size: 4
+  tp_size: 1
+  pp_size: 1
+  cp_size: 1
+  ep_size: null
+  sequence_parallel: false
+
+step_scheduler:
+  global_batch_size: 8
+  local_batch_size: 1
+  max_steps: 50
+  num_epochs: 1
+  val_every_steps: 25
+  ckpt_every_steps: 50
+
+optimizer:
+  _target_: torch.optim.Adam
+  lr: 1.0e-04
+  weight_decay: 0.01
+  betas: [0.9, 0.999]
+  eps: 1.0e-08
+
+lr_scheduler:
+  lr_decay_style: cosine
+  lr_warmup_steps: 5
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+packed_sequence:
+  packed_sequence_size: 0
+
+checkpoint:
+  enabled: true
+  model_save_format: safetensors
+  checkpoint_dir: ./checkpoints/llama3_2_1b_expansion
+  save_consolidated: false
+
+# Local OpenAI-format chat rows. The safety subset is the smallest one in the release
+# (~15 MB, 3570 rows), which keeps a smoke run's startup short; point this at any other
+# subset for a real run. Validation reuses the same file, so its loss is a sanity signal
+# rather than a held-out measurement.
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.chat_dataset.ChatDataset
+  path_or_dataset_id: /data/datasets/Nemotron-Cascade-2-SFT-Data/safety/safety.jsonl
+  split: train
+  seq_length: 1024
+  truncation: true
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.chat_dataset.ChatDataset
+  path_or_dataset_id: /data/datasets/Nemotron-Cascade-2-SFT-Data/safety/safety.jsonl
+  split: train
+  seq_length: 1024
+  truncation: true
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater

--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -416,6 +416,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
         kwargs = dict(kwargs)  # Defensive copy so retries get clean state
         has_packed_sequence = kwargs.pop("has_packed_sequence", False)
         freeze_config = kwargs.pop("freeze_config", None)
+        expansion_config = kwargs.pop("expansion_config", None)
         cache_dir = kwargs.pop("cache_dir", hf_constants.HF_HUB_CACHE)
 
         def _retry(**override):
@@ -426,6 +427,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
                 **kwargs,
                 "has_packed_sequence": has_packed_sequence,
                 "freeze_config": freeze_config,
+                "expansion_config": expansion_config,
                 "cache_dir": cache_dir,
             }
             return cls._build_model(
@@ -634,6 +636,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
             load_base_model=load_base_model,
             cache_dir=cache_dir,
             freeze_config=freeze_config,
+            expansion_config=expansion_config,
             weights_already_loaded=weights_already_loaded,
             inject_te_attention=inject_te_attention,
         )

--- a/nemo_automodel/_transformers/infrastructure.py
+++ b/nemo_automodel/_transformers/infrastructure.py
@@ -61,6 +61,13 @@ from nemo_automodel.components.distributed.megatron_fsdp import (
 from nemo_automodel.components.distributed.mesh import MeshContext
 from nemo_automodel.components.distributed.pipelining.autopipeline import AutoPipeline
 from nemo_automodel.components.distributed.pipelining.config import PipelineConfig
+from nemo_automodel.components.expansion import (
+    ExpansionConfig,
+    apply_expansion,
+    expanded_linears,
+    freeze_non_expansion_parameters,
+    initialize_expansion,
+)
 from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
 from nemo_automodel.components.models.common.utils import cast_frozen_modules_to_compute_dtype
 from nemo_automodel.components.quantization.fp8 import apply_fp8_to_model
@@ -483,6 +490,7 @@ def apply_model_infrastructure(
     pretrained_model_name_or_path="",
     weights_already_loaded=False,
     inject_te_attention: bool = False,
+    expansion_config: ExpansionConfig | None = None,
     **_kwargs,
 ):
     """Apply sharding, PEFT, quantization, and checkpoint loading to a model.
@@ -504,6 +512,10 @@ def apply_model_infrastructure(
         mesh: MeshContext with parallelism sizes (tp_size, cp_size, etc.) and mesh
             references. Default: None (treated as single-GPU defaults).
         peft_config: PEFT/LoRA configuration dict. Default: None
+        expansion_config: Dual-stream model expansion configuration. Default: None.
+            Expansion weights are allocated alongside PEFT, before sharding, and given
+            their values after the checkpoint load -- see
+            ``nemo_automodel.components.expansion.apply_expansion``.
         quantization_config: Quantization configuration. Default: None
         fp8_config: FP8 configuration. Default: None
         qat_quantizer: QAT quantizer instance. Default: None
@@ -556,6 +568,18 @@ def apply_model_infrastructure(
                 getattr(model, "config", None), "quantization_config"
             )
 
+    # Model expansion rejects PEFT, checked before anything is applied so the run fails on
+    # its configuration rather than partway through building the model. Pipeline
+    # parallelism needs no rejection: the two streams travel between layers concatenated
+    # on the hidden axis, so a stage boundary sends one ordinary tensor.
+    expanding = expansion_config is not None and expansion_config.enabled
+    if expanding:
+        if peft_config is not None:
+            raise NotImplementedError(
+                "Model expansion and PEFT cannot be combined: both patch the same linear "
+                "layers in place, and the combination is untested. Choose one."
+            )
+
     # Apply PEFT and lower precision if configured
     # When on meta device, wrap in init_empty_weights() so new LoRA modules are also on meta device
     # This allows copy operations between meta tensors to succeed (they're no-ops)
@@ -564,6 +588,14 @@ def apply_model_infrastructure(
         model = _apply_peft_and_lower_precision(
             model, mesh.tp_size, autopipeline, peft_config, quantization_config, fp8_config, qat_quantizer
         )
+
+        # Model expansion: allocate the second weight of every expanded projection here, in
+        # the same slot as PEFT and for the same reason -- sharding has to see the new
+        # parameters so the tensor-parallel plan and FSDP distribute them. Unlike a LoRA
+        # adapter, an expansion weight is a copy of the pretrained weight beside it, so it
+        # can only be given a value once the checkpoint has loaded, further down.
+        if expanding:
+            apply_expansion(model, expansion_config, initialize=False)
 
     # Inject TE attention into HF models when requested.
     # Done after PEFT (so projection shapes are final) and before sharding
@@ -602,6 +634,8 @@ def apply_model_infrastructure(
                 cache_dir,
                 pretrained_model_name_or_path,
                 load_base_model=load_base_model,
+                allow_checkpoint_key_subset=expanding,
+                model_is_pipeline_stage=autopipeline is not None,
             )
         else:
             # Non-meta models already have weights from from_pretrained.
@@ -715,12 +749,54 @@ def apply_model_infrastructure(
                 cache_dir,
                 pretrained_model_name_or_path,
                 load_base_model=load_base_model,
+                allow_checkpoint_key_subset=expanding,
+                model_is_pipeline_stage=autopipeline is not None,
             )
 
     _verify_safe_moe_tp_weights_loaded(
         model,
         checkpoint_loaded=bool(checkpoint_already_loaded or weights_already_loaded or should_load_checkpoint),
     )
+
+    # Model expansion: the pretrained weights are in, so the expansion weights allocated
+    # above can now be copied from them. Sharding in between is fine -- both weights are
+    # distributed the same way, so the copy is local to each rank. Freezing here rather
+    # than earlier keeps stream A out of the autograd graph for the whole run.
+    if expanding:
+        # Under pipeline parallelism the model is a list of stages and the expanded layers
+        # sit on whichever stages own them, so a stage can legitimately hold none. Both
+        # helpers refuse an unexpanded module -- correct for a whole model, wrong for a
+        # stage -- so they are applied per stage and the totals are checked globally.
+        parts = model.parts if hasattr(model, "parts") else [model]
+        trainable = frozen = 0
+        for part in parts:
+            if next(iter(expanded_linears(part)), None) is None:
+                part.requires_grad_(False)
+                frozen += sum(param.numel() for param in part.parameters())
+                continue
+            initialize_expansion(part)
+            part_trainable, part_frozen = freeze_non_expansion_parameters(part)
+            trainable += part_trainable
+            frozen += part_frozen
+        if not trainable and autopipeline is not None:
+            raise RuntimeError(
+                "model expansion is enabled but this pipeline rank holds no expanded layer, so "
+                "it has nothing to train and the optimizer would be built with no parameters. "
+                "Pipeline parallelism splits the decoder stack into contiguous stages, so "
+                "expansion.layers has to name at least one layer in each stage's range -- "
+                f"expanding only layers that land on one stage leaves the others idle. This "
+                f"rank owns {len(parts)} stage(s)."
+            )
+        if not trainable:
+            raise RuntimeError(
+                "model expansion is enabled but no expanded layer survived; "
+                "check that expansion.layers names layers this model has"
+            )
+        logger.info(
+            "Model expansion: %d trainable expansion parameters, %d frozen pretrained parameters",
+            trainable,
+            frozen,
+        )
 
     # Freeze parameters after checkpoint loading and parallelization
     # This catches params created during parallelization (e.g., GroupedExpertsTE in init_token_dispatcher)

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -783,6 +783,7 @@ class Checkpointer:
         use_checkpoint_id: bool = True,
         key_mapping: Optional[dict[str, str]] = None,
         allow_checkpoint_key_subset: bool = False,
+        model_is_pipeline_stage: bool = False,
     ) -> None:
         """
         Load model weights from `model_path`.
@@ -799,6 +800,9 @@ class Checkpointer:
             is_init_step: If True, treat load as initialization from a base checkpoint.
             use_checkpoint_id: Pass `checkpoint_id` to DCP if True; disable when using direct HF paths.
             key_mapping: Optional key remapping when reading from HF checkpoints.
+            model_is_pipeline_stage: If True, `model` holds one pipeline stage's layers, so
+                    checkpoint keys belonging to other stages are expected rather than a sign
+                    of a wrong architecture. Only consulted with allow_checkpoint_key_subset.
             allow_checkpoint_key_subset: If True, keep the model's current initialization for
                 parameters that are absent from the checkpoint instead of requiring an exact key match.
         """
@@ -1005,8 +1009,18 @@ class Checkpointer:
             # loaded into an LLM model would drop the vision tower), so refuse rather than
             # silently export a partial model. lm_head is never a false positive here: it is
             # only popped from state_dict when it is also absent from the checkpoint.
-            unmatched_checkpoint_keys = sorted(
-                key for key in checkpoint_metadata_keys if key not in state_dict and not key.endswith("_extra_state")
+            # A pipeline stage owns only its own layers, so the checkpoint legitimately
+            # carries keys it does not have. That is the one case where the subset must
+            # hold in neither direction, and the caller has to say so: nothing here can
+            # tell a stage apart from a model built with the wrong architecture.
+            unmatched_checkpoint_keys = (
+                []
+                if model_is_pipeline_stage
+                else sorted(
+                    key
+                    for key in checkpoint_metadata_keys
+                    if key not in state_dict and not key.endswith("_extra_state")
+                )
             )
             if unmatched_checkpoint_keys:
                 raise RuntimeError(
@@ -1216,6 +1230,8 @@ class Checkpointer:
         root_dir: str,
         model_name: str | None,
         load_base_model: bool = True,
+        allow_checkpoint_key_subset: bool = False,
+        model_is_pipeline_stage: bool = False,
     ) -> None:
         """
         Load a model from the base Hugging Face checkpoint in parallel.
@@ -1226,6 +1242,12 @@ class Checkpointer:
             root_dir: Root directory of the model cache or snapshots
             model_name: Name of the model or an absolute path to a snapshot
             load_base_model: If True, restore from HF base checkpoint
+            allow_checkpoint_key_subset: Keep the model's current initialization for
+                parameters the checkpoint does not carry, instead of failing. Needed when
+                the model has parameters the pretrained checkpoint predates, such as the
+                weights added by model expansion. See :meth:`load_model`.
+            model_is_pipeline_stage: Whether `model` is one stage of a pipeline, which
+                makes the checkpoint's other-stage keys expected. See :meth:`load_model`.
         """
         model_type = getattr(getattr(model, "config", None), "model_type", None)
 
@@ -1245,6 +1267,8 @@ class Checkpointer:
                 else _get_hf_safetensors_reference_path(root_dir, model_name),
                 is_init_step=True,
                 key_mapping=key_mapping,
+                allow_checkpoint_key_subset=allow_checkpoint_key_subset,
+                model_is_pipeline_stage=model_is_pipeline_stage,
             )
 
         _reinit_non_persistent_buffers(model, device, model_type=model_type)

--- a/nemo_automodel/components/expansion/__init__.py
+++ b/nemo_automodel/components/expansion/__init__.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dual-stream model expansion.
+
+Grows a pretrained model by giving selected linear layers a second, trainable weight while
+the pretrained weights stay frozen. The expanded model reproduces its parent exactly until
+the new weights learn, which makes it a continuation of pretraining rather than a restart.
+
+See :mod:`nemo_automodel.components.expansion.dual_stream` for how the second hidden-state
+stream is carried, and :mod:`nemo_automodel.components.expansion.expanded_linear` for the
+lateral connection between the streams.
+"""
+
+from nemo_automodel.components.expansion.apply import (
+    ExpansionConfig,
+    apply_expansion,
+    expanded_linears,
+    expansion_parameters,
+    freeze_non_expansion_parameters,
+    initialize_expansion,
+    is_expansion_parameter,
+)
+from nemo_automodel.components.expansion.expanded_linear import (
+    ExpandedLinear,
+    LateralBus,
+    LateralBusMode,
+    patch_linear_for_expansion,
+)
+
+__all__ = [
+    "ExpandedLinear",
+    "ExpansionConfig",
+    "LateralBus",
+    "LateralBusMode",
+    "apply_expansion",
+    "expanded_linears",
+    "expansion_parameters",
+    "freeze_non_expansion_parameters",
+    "initialize_expansion",
+    "is_expansion_parameter",
+    "patch_linear_for_expansion",
+]

--- a/nemo_automodel/components/expansion/apply.py
+++ b/nemo_automodel/components/expansion/apply.py
@@ -1,0 +1,388 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Applying model expansion to a causal-LM and freezing everything else."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Iterable
+
+import torch.nn as nn
+
+from nemo_automodel.components.expansion.dual_stream import (
+    patch_layer_for_expansion,
+    patch_model_for_pipeline,
+    patch_norm_for_merge,
+)
+from nemo_automodel.components.expansion.expanded_linear import (
+    ExpandedLinear,
+    patch_linear_for_expansion,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ExpansionConfig", "apply_expansion", "freeze_non_expansion_parameters", "initialize_expansion"]
+
+#: Projections that write into the residual stream. Starting these at zero is what makes
+#: the expanded model reproduce its parent exactly before the first optimizer step.
+DEFAULT_ZERO_INIT_MODULES = ("o_proj", "down_proj")
+
+#: Projections expanded by default; the leaf names shared by the llama-style families.
+DEFAULT_TARGET_MODULES = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+)
+
+
+@dataclass
+class ExpansionConfig:
+    """Configuration for dual-stream model expansion.
+
+    Attributes:
+        enabled: Whether to expand at all.
+        layers: Zero-based decoder-layer indices to expand. ``None`` expands every layer.
+            Layers left out still carry both streams, in ``skip`` mode, which is exact and
+            costs no extra compute.
+        target_modules: Leaf module names to expand within an expanded layer.
+        zero_init_modules: Subset of ``target_modules`` whose expansion weight starts at
+            zero rather than as a copy of the pretrained weight.
+        merge_weight: ``lambda`` in ``h = h_a + lambda * (h_b - h_a)``, applied just before
+            the decoder stack's final norm.
+    """
+
+    enabled: bool = False
+    layers: list[int] | None = None
+    target_modules: list[str] = field(default_factory=lambda: list(DEFAULT_TARGET_MODULES))
+    zero_init_modules: list[str] = field(default_factory=lambda: list(DEFAULT_ZERO_INIT_MODULES))
+    merge_weight: float = 0.5
+
+    def __post_init__(self) -> None:
+        """Validate the field combination.
+
+        Raises:
+            ValueError: If ``merge_weight`` is outside ``[0, 1]`` or ``zero_init_modules``
+                names something absent from ``target_modules``.
+        """
+        if not 0.0 <= self.merge_weight <= 1.0:
+            raise ValueError(f"merge_weight must be in [0, 1], got {self.merge_weight}")
+        unknown = set(self.zero_init_modules) - set(self.target_modules)
+        if unknown:
+            raise ValueError(
+                f"zero_init_modules contains {sorted(unknown)}, which are not in "
+                f"target_modules {sorted(self.target_modules)}"
+            )
+
+
+def _decoder_layers(model: nn.Module) -> nn.ModuleList:
+    """Locate the decoder-layer list of a causal-LM.
+
+    Args:
+        model: A causal-LM whose decoder exposes ``.layers``, the convention both stock
+            Hugging Face models and this repository's own implementations follow.
+
+    Returns:
+        The ``nn.ModuleList`` of decoder layers.
+
+    Raises:
+        AttributeError: If the model does not follow that convention, which means it needs
+            explicit support rather than a silently wrong expansion.
+    """
+    for attr in ("model", "language_model", "transformer"):
+        inner = getattr(model, attr, None)
+        if inner is not None and getattr(inner, "layers", None) is not None:
+            return inner.layers
+    raise AttributeError(
+        f"{type(model).__name__} does not expose a decoder layer list at "
+        "`.model.layers` / `.language_model.layers` / `.transformer.layers`; model "
+        "expansion needs explicit support for this architecture."
+    )
+
+
+def _hidden_size(model: nn.Module) -> int:
+    """Read the width of one hidden-state stream from the model config.
+
+    The two streams travel between decoder layers concatenated on the hidden axis, and a
+    layer tells that carrier from the embedding output by its width, so the number has to
+    be known at patch time.
+
+    Args:
+        model: The causal-LM being expanded.
+
+    Returns:
+        The model's hidden size.
+
+    Raises:
+        AttributeError: If the config does not report one, which means this architecture
+            needs explicit support rather than a guess.
+    """
+    config = getattr(model, "config", None)
+    for holder in (config, getattr(config, "text_config", None)):
+        hidden_size = getattr(holder, "hidden_size", None)
+        if isinstance(hidden_size, int):
+            return hidden_size
+    # Models built without a Hugging Face config still have a final norm, and a decoder
+    # stack's final norm normalizes over exactly one stream's width.
+    weight = getattr(_final_norm(model), "weight", None)
+    if weight is not None and weight.dim() >= 1:
+        return weight.shape[-1]
+    raise AttributeError(
+        f"{type(model).__name__} reports no `config.hidden_size` and its final norm has no "
+        "weight to read a width from; model expansion needs the hidden size to recognize "
+        "the two-stream carrier passed between decoder layers."
+    )
+
+
+def _final_norm(model: nn.Module) -> nn.Module:
+    """Locate the norm applied after the decoder stack.
+
+    Args:
+        model: A causal-LM.
+
+    Returns:
+        The final norm module.
+
+    Raises:
+        AttributeError: If it cannot be found, since the stream pair has to be merged
+            somewhere before the LM head.
+    """
+    for attr in ("model", "language_model", "transformer"):
+        inner = getattr(model, attr, None)
+        if inner is None:
+            continue
+        for norm_attr in ("norm", "final_layernorm", "ln_f"):
+            norm = getattr(inner, norm_attr, None)
+            if norm is not None:
+                return norm
+    raise AttributeError(
+        f"{type(model).__name__} does not expose a final norm; model expansion needs one "
+        "to merge the two hidden-state streams before the LM head."
+    )
+
+
+def _unreachable_grouped_weights(layer: nn.Module) -> list[str]:
+    """Find weights in a decoder layer that expansion cannot reach.
+
+    Expansion patches ``nn.Linear`` modules. A mixture-of-experts block in this repository
+    does not use them: every expert's projection lives in one stacked parameter of shape
+    ``[experts, in, out]``, so :func:`apply_expansion` walks straight past it and expands
+    only the attention projections beside it. The resulting model is half-expanded and
+    nothing about it says so.
+
+    Args:
+        layer: A decoder layer being expanded.
+
+    Returns:
+        Names of stacked (3-D or higher) floating-point parameters, which is what a grouped
+        expert stack looks like. Empty for a dense layer.
+    """
+    return [
+        name
+        for name, param in layer.named_parameters()
+        if param.dim() >= 3 and param.is_floating_point() and not is_expansion_parameter(name)
+    ]
+
+
+def apply_expansion(model: nn.Module, config: ExpansionConfig, initialize: bool = True) -> nn.Module:
+    """Expand a causal-LM in place.
+
+    Every decoder layer is patched to carry two hidden-state streams; the layers named by
+    ``config.layers`` additionally get expansion weights on their target projections. The
+    final norm is patched to merge the streams before it normalizes.
+
+    Every module is patched in place rather than wrapped, so module paths and state-dict
+    keys are unchanged. Tensor-parallel plans match on paths and ``to_hf`` / ``from_hf``
+    match on keys; both would break if a wrapper inserted a level. Because the expansion
+    weights are ordinary parameters on ordinarily-named modules, checkpointing needs no
+    special handling: they are saved and restored with everything else.
+
+    Allocating an expansion weight has to happen **before the model is parallelized**,
+    because the tensor-parallel plan and ``fully_shard`` are what distribute it. Giving it
+    a value has to happen **after the pretrained weights are loaded**, because it copies
+    them. On a single process both moments are the same one and the default
+    ``initialize=True`` covers it; a parallel run materializes its weights only after
+    sharding, so it passes ``initialize=False`` here and calls
+    :func:`initialize_expansion` once the checkpoint is in.
+
+    A checkpoint written before expansion has no expansion keys, so loading one into an
+    already-expanded model needs ``Checkpointer.load_model(...,
+    allow_checkpoint_key_subset=True)``, which keeps the values set here.
+
+    Under pipeline parallelism ``config.layers`` has to name at least one layer in every
+    stage's range. A stage owns a contiguous slice of the decoder stack, and one holding no
+    expanded layer has nothing to train, which leaves its optimizer with no parameters.
+
+    Args:
+        model: The pretrained causal-LM to expand. Modified in place.
+        config: Which layers and projections to expand, and how to merge.
+        initialize: Also give the expansion weights their values. See above.
+
+    Returns:
+        The same model, expanded.
+
+    Raises:
+        ValueError: If ``config.layers`` names an index outside the decoder stack.
+        RuntimeError: If ``initialize`` is set and the weights are not ready for it. See
+            :meth:`ExpandedLinear.initialize_expansion`.
+    """
+    if not config.enabled:
+        return model
+
+    layers = _decoder_layers(model)
+    selected = set(range(len(layers)) if config.layers is None else config.layers)
+    invalid = sorted(i for i in selected if not 0 <= i < len(layers))
+    if invalid:
+        raise ValueError(f"expansion layers {invalid} are outside the decoder stack of {len(layers)} layers")
+
+    hidden_size = _hidden_size(model)
+    targets = set(config.target_modules)
+    zero_init = set(config.zero_init_modules)
+    n_expanded = 0
+    for index, layer in enumerate(layers):
+        if index in selected:
+            for parent in layer.modules():
+                for child_name, child in parent.named_children():
+                    if child_name in targets and isinstance(child, nn.Linear):
+                        patch_linear_for_expansion(child, zero_init=child_name in zero_init, initialize=initialize)
+                        n_expanded += 1
+        patch_layer_for_expansion(layer, "expand" if index in selected else "skip", hidden_size)
+    patch_norm_for_merge(_final_norm(model), config.merge_weight, hidden_size)
+    # Pipeline parallelism precomputes inter-stage shapes from the config rather than
+    # inferring them, so the doubled carrier width has to be declared.
+    vocab_size = getattr(getattr(model, "config", None), "vocab_size", None)
+    if isinstance(vocab_size, int):
+        patch_model_for_pipeline(model, hidden_size, vocab_size)
+
+    unreachable = {index: _unreachable_grouped_weights(layers[index]) for index in sorted(selected)}
+    unreachable = {index: names for index, names in unreachable.items() if names}
+    if unreachable:
+        index, names = next(iter(unreachable.items()))
+        raise NotImplementedError(
+            f"Layer {index} holds stacked expert weights that expansion cannot reach "
+            f"(for example {names[0]!r}, shape {dict(layers[index].named_parameters())[names[0]].shape}). "
+            "Expansion patches nn.Linear modules, and a mixture-of-experts block keeps every "
+            "expert's projection in one stacked parameter instead. Expanding this layer would "
+            "silently grow its attention and leave its experts untouched. Layers affected: "
+            f"{sorted(unreachable)}."
+        )
+
+    logger.info(
+        "Model expansion: %d/%d layers expanded, %d expansion weights added, merge_weight=%s",
+        len(selected),
+        len(layers),
+        n_expanded,
+        config.merge_weight,
+    )
+    return model
+
+
+def initialize_expansion(model: nn.Module) -> int:
+    """Give every expansion weight in an expanded model its value.
+
+    The counterpart to ``apply_expansion(..., initialize=False)``, for the case where the
+    pretrained weights arrive after the model has been built and sharded. Idempotent: it
+    recomputes each weight from the pretrained one, so calling it twice is harmless, and
+    calling it after training has started would discard what was learned.
+
+    Args:
+        model: A model expanded with ``initialize=False``. Modified in place.
+
+    Returns:
+        The number of expansion weights initialized.
+
+    Raises:
+        ValueError: If the model has no expansion weights, which means ``apply_expansion``
+            was never called and the initialization would silently do nothing.
+        RuntimeError: If the weights are not ready. See
+            :meth:`ExpandedLinear.initialize_expansion`.
+    """
+    linears = [module for _, module in expanded_linears(model)]
+    if not linears:
+        raise ValueError("initialize_expansion found no expanded linears; was apply_expansion called first?")
+    for linear in linears:
+        linear.initialize_expansion()
+    logger.info("Model expansion: initialized %d expansion weights", len(linears))
+    return len(linears)
+
+
+def is_expansion_parameter(name: str) -> bool:
+    """Whether a parameter name belongs to an expansion weight.
+
+    Args:
+        name: A dotted parameter name as produced by ``named_parameters()``.
+
+    Returns:
+        True for expansion weights, False for pretrained ones.
+    """
+    return ".expansion." in name
+
+
+def freeze_non_expansion_parameters(model: nn.Module) -> tuple[int, int]:
+    """Freeze every parameter except the expansion weights.
+
+    Freezing the rest is what keeps stream A out of the autograd graph entirely, so no
+    activations are stored for it and backward only runs over the expanded layers.
+
+    Args:
+        model: The expanded model. Modified in place.
+
+    Returns:
+        ``(trainable, frozen)`` parameter counts, in elements.
+    """
+    trainable = frozen = 0
+    for name, param in model.named_parameters():
+        param.requires_grad = is_expansion_parameter(name)
+        if param.requires_grad:
+            trainable += param.numel()
+        else:
+            frozen += param.numel()
+    if not trainable:
+        raise ValueError(
+            "freeze_non_expansion_parameters left no trainable parameters; was apply_expansion called first?"
+        )
+    return trainable, frozen
+
+
+def expansion_parameters(model: nn.Module) -> Iterable[tuple[str, nn.Parameter]]:
+    """Iterate the expansion weights of an expanded model.
+
+    Args:
+        model: An expanded model.
+
+    Yields:
+        ``(name, parameter)`` for each expansion weight.
+    """
+    for name, param in model.named_parameters():
+        if is_expansion_parameter(name):
+            yield name, param
+
+
+def expanded_linears(model: nn.Module) -> Iterable[tuple[str, ExpandedLinear]]:
+    """Iterate the expanded linear layers of an expanded model.
+
+    Args:
+        model: An expanded model.
+
+    Yields:
+        ``(name, module)`` for each :class:`ExpandedLinear`.
+    """
+    for name, module in model.named_modules():
+        if isinstance(module, ExpandedLinear):
+            yield name, module

--- a/nemo_automodel/components/expansion/dual_stream.py
+++ b/nemo_automodel/components/expansion/dual_stream.py
@@ -1,0 +1,326 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Carrying two hidden-state streams through a decoder stack.
+
+The expansion needs a second hidden state alongside the pretrained one. It is carried as
+an ``(h_a, h_b)`` tuple passed from one decoder layer to the next, rather than by stacking
+the streams on the batch axis. Stacking was ruled out by sequence packing and MoE: both
+flatten the batch axis into a token stream, and MoE additionally permutes it per routing
+decision, which destroys the token-to-token correspondence the lateral term needs.
+
+With a tuple, each stream is handed to the *unmodified* decoder layer with the
+*unmodified* ``attention_mask`` and ``position_ids``, so packing, ``cu_seqlens``, context
+parallelism and MoE dispatch keep working exactly as they do without expansion.
+
+Two per-layer modes:
+
+``expand``
+    The layer owns expansion weights. Its forward runs twice, once per stream. The A pass
+    records each expanded linear's output; the B pass consumes it as the lateral term.
+    For a MoE layer this is also what makes routing alignable: with
+    ``RouterReplay`` replaying the A pass's expert selection, both passes dispatch tokens
+    in the same order, so the lateral applies elementwise.
+
+``skip``
+    The layer owns no expansion weight, which is exactly the case ``W_b == 0``.
+    Substituting zero into ``y_b = W_b x_b + y_a`` makes every stream-B intermediate --
+    its norms, attention and MLP results -- multiply by zero and vanish, leaving only
+    stream A's residual contributions::
+
+        h_b' = h_b + (h_a' - h_a) = h_a' + (h_b - h_a)
+
+    So the layer runs *once*, on stream A, and forwards its residual delta to stream B.
+    This is exact, not an approximation, and costs one layer instead of two.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+__all__ = ["ExpansionMode", "patch_layer_for_expansion", "patch_model_for_pipeline", "patch_norm_for_merge"]
+
+ExpansionMode = str  # "expand" | "skip"
+
+# Dynamically created subclasses, keyed so a decoder-layer class is only subclassed once.
+_PATCHED_CLASSES: dict[tuple[str, type], type] = {}
+
+
+def _split_streams(hidden_states: torch.Tensor, hidden_size: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return the ``(h_a, h_b)`` pair, seeding stream B on the first patched layer.
+
+    Args:
+        hidden_states: Either ``[batch, seq, hidden]`` -- the first patched layer in the
+            stack receives the embedding output -- or ``[batch, seq, 2 * hidden]``, the
+            carrier a previous patched layer produced. The width is what distinguishes
+            them, which is why this needs to be told the model's hidden size.
+        hidden_size: The model's hidden size, i.e. the width of a single stream.
+
+    Returns:
+        ``(h_a, h_b)``, each ``[batch, seq, hidden]``. Seeding stream B from stream A is
+        why the two are identical at initialization, and hence why the merge collapses to
+        the pretrained result whatever the merge weight.
+    """
+    if hidden_states.shape[-1] == 2 * hidden_size:
+        h_a, h_b = hidden_states.chunk(2, dim=-1)
+        return h_a, h_b
+    return hidden_states, hidden_states
+
+
+def _join_streams(h_a: torch.Tensor, h_b: torch.Tensor) -> torch.Tensor:
+    """Pack a stream pair back into the single tensor passed between layers.
+
+    Args:
+        h_a: Stream A, ``[batch, seq, hidden]``.
+        h_b: Stream B, same shape.
+
+    Returns:
+        ``[batch, seq, 2 * hidden]``, contiguous, owning its storage.
+    """
+    return torch.cat((h_a, h_b), dim=-1)
+
+
+def _stream_b_kwargs(hidden_states: torch.Tensor, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Cache arguments for the stream-B pass of an expanded layer.
+
+    Stream A owns the layer's KV cache and uses it normally. Stream B cannot share it: its
+    hidden states differ once the expansion weights learn, so its keys and values differ,
+    and appending both to one cache makes attention run against a mix of the two. Serving
+    stream B without a cache is exact whenever the pass sees the whole sequence, which
+    covers training and prefill; it is only decoding, where the layer is handed one token
+    and the history lives in the cache, that stream B genuinely needs a cache of its own.
+
+    Args:
+        hidden_states: Stream B's input, of shape ``[batch, sequence, hidden]``. Only its
+            sequence length is read, to tell a whole-sequence pass from a decode step.
+        kwargs: Keyword arguments destined for the decoder layer's ``forward``.
+
+    Returns:
+        A copy with the cache arguments neutralized, so stream B recomputes rather than
+        reading or writing stream A's cache.
+
+    Raises:
+        NotImplementedError: When the layer is decoding, which stream B cannot serve
+            without a second cache. Refusing beats returning plausible wrong tokens.
+    """
+    cache = kwargs.get("past_key_values")
+    cached_length = cache.get_seq_length() if cache is not None else 0
+    if cached_length > hidden_states.shape[1]:
+        raise NotImplementedError(
+            "model expansion does not support generation with a KV cache: stream B would "
+            f"need a cache of its own, and this layer was handed {hidden_states.shape[1]} "
+            f"token(s) against {cached_length} cached. Generate with use_cache=False -- "
+            "correct, and quadratic in the generated length."
+        )
+    stripped = dict(kwargs)
+    stripped["past_key_values"] = None
+    stripped["use_cache"] = False
+    return stripped
+
+
+def _dual_stream_forward(self, hidden_states: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
+    """Decoder-layer forward carrying two hidden-state streams.
+
+    Args:
+        hidden_states: ``[batch, seq, hidden]`` on the first patched layer, otherwise the
+            ``(h_a, h_b)`` pair from the previous one.
+        *args: Forwarded to the pretrained layer unchanged.
+        **kwargs: Forwarded to the pretrained layer with cache arguments stripped.
+
+    Returns:
+        ``(h_a, h_b)``, each ``[batch, seq, hidden]``.
+    """
+    from nemo_automodel.components.expansion.expanded_linear import LateralBus, LateralBusMode
+    from nemo_automodel.components.expansion.routing import aligned_routing, switch_to_replay
+
+    h_a, h_b = _split_streams(hidden_states, self._expansion_hidden_size)
+    # Not ``super(type(self), self)``: ``fully_shard`` also patches ``__class__``, and that
+    # form would re-enter this function through the new subclass and recurse. Bind the
+    # class captured at patch time so the target is fixed however many layers wrap us.
+    pretrained_forward = partial(self._expansion_base_cls.forward, self)
+
+    if self._expansion_mode == "skip":
+        # One pass, on stream A, with the layer's arguments untouched -- including its KV
+        # cache, which stream A owns and uses exactly as it would without expansion.
+        h_a_out = pretrained_forward(h_a, *args, **kwargs)
+        # Accumulated in fp32 so that h_b == h_a at initialization reproduces h_a_out
+        # bit-exactly, and so the difference of two same-magnitude residual streams does
+        # not lose precision once they diverge.
+        h_b_out = (h_a_out.float() + (h_b.float() - h_a.float())).to(h_a_out.dtype)
+        return _join_streams(h_a_out, h_b_out)
+
+    # A MoE layer routes from the hidden state, so the two streams pick different experts
+    # as soon as they diverge and the lateral term stops lining up. Pin stream B to stream
+    # A's expert selection for the duration of the pair.
+    b_kwargs = _stream_b_kwargs(h_b, kwargs)
+    previous = LateralBus.set_mode(LateralBusMode.RECORD)
+    try:
+        with aligned_routing(self._expansion_router_replays):
+            h_a_out = pretrained_forward(h_a, *args, **kwargs)
+            LateralBus.set_mode(LateralBusMode.APPLY)
+            switch_to_replay(self._expansion_router_replays)
+            h_b_out = pretrained_forward(h_b, *args, **b_kwargs)
+    finally:
+        LateralBus.set_mode(previous)
+    return _join_streams(h_a_out, h_b_out)
+
+
+def _merge_then_norm(self, hidden_states: Any) -> torch.Tensor:
+    """Collapse the stream pair, then apply the pretrained norm.
+
+    Merging before the final norm rather than after is deliberate. Merging afterwards
+    would average two already-normalized vectors, whose mean has a smaller norm than
+    either: the logit scale would be capped at the pretrained level and would shrink
+    monotonically as stream B diverges from stream A.
+
+    Args:
+        hidden_states: ``(h_a, h_b)`` from the last patched layer, or a plain
+            ``[batch, seq, hidden]`` tensor when expansion is inactive.
+
+    Returns:
+        ``[batch, seq, hidden]``.
+    """
+    if hidden_states.shape[-1] == 2 * self._merge_hidden_size:
+        h_a, h_b = hidden_states.chunk(2, dim=-1)
+        # lerp(a, b, w) == a + w * (b - a); in fp32 so that h_b == h_a reproduces h_a.
+        hidden_states = torch.lerp(h_a.float(), h_b.float(), self._merge_weight).to(h_a.dtype)
+    return self._merge_base_cls.forward(self, hidden_states)
+
+
+def _patch_class(module: nn.Module, kind: str, forward: Any, base_attr: str) -> nn.Module:
+    """Replace ``module.__class__`` with a cached subclass overriding ``forward``."""
+    return _patch_class_with(module, kind, {"forward": forward, base_attr: type(module)})
+
+
+def _patch_class_with(module: nn.Module, kind: str, namespace: dict[str, Any]) -> nn.Module:
+    """Replace ``module.__class__`` with a cached subclass carrying ``namespace``."""
+    cls = type(module)
+    key = (kind, cls)
+    patched = _PATCHED_CLASSES.get(key)
+    if patched is None:
+        patched = type(f"{kind}{cls.__name__}", (cls,), namespace)
+        _PATCHED_CLASSES[key] = patched
+    module.__class__ = patched
+    return module
+
+
+def _pipeline_stage_metas(
+    self, *, is_first: bool, microbatch_size: int, seq_len: int, dtype: torch.dtype
+) -> tuple[tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]]:
+    """Declare this pipeline stage's inter-stage tensor shapes.
+
+    The pipeline precomputes stage metadata from ``config.hidden_size`` rather than
+    inferring it, so it expects one stream's width where expansion sends two. This hook
+    is the extension point it offers for exactly that: a model that moves something other
+    than a plain hidden state between stages says so itself.
+
+    Args:
+        is_first: Whether this stage owns the embedding, and so takes token ids.
+        microbatch_size: Rows per microbatch.
+        seq_len: Sequence length.
+        dtype: Dtype of the tensors crossing stage boundaries.
+
+    Returns:
+        ``(inputs_meta, outputs_meta)``, each a tuple of meta-device tensors. A stage takes
+        ``[microbatch, seq]`` token ids when first and ``[microbatch, seq, 2 * hidden]``
+        otherwise; it emits ``[microbatch, seq, vocab]`` when it owns the LM head -- the
+        streams are merged before it -- and ``[microbatch, seq, 2 * hidden]`` otherwise.
+    """
+    hidden_size = self._expansion_stage_hidden_size
+    carrier = torch.empty(microbatch_size, seq_len, 2 * hidden_size, device="meta", dtype=dtype)
+    if is_first:
+        inputs_meta = (torch.empty(microbatch_size, seq_len, device="meta", dtype=torch.long),)
+    else:
+        inputs_meta = (carrier,)
+
+    lm_head = getattr(self, "lm_head", None)
+    if lm_head is not None:
+        outputs_meta = (
+            torch.empty(microbatch_size, seq_len, self._expansion_stage_vocab_size, device="meta", dtype=dtype),
+        )
+    else:
+        outputs_meta = (carrier,)
+    return inputs_meta, outputs_meta
+
+
+def patch_model_for_pipeline(model: nn.Module, hidden_size: int, vocab_size: int) -> nn.Module:
+    """Teach the pipeline that this model moves two streams between stages, in place.
+
+    Args:
+        model: The causal-LM being expanded.
+        hidden_size: Width of a single stream.
+        vocab_size: Width of the LM head's output, for the final stage.
+
+    Returns:
+        The same object, now answering ``get_pipeline_stage_metas``.
+    """
+    _patch_class_with(model, "PipelineMetas", {"get_pipeline_stage_metas": _pipeline_stage_metas})
+    model._expansion_stage_hidden_size = hidden_size
+    model._expansion_stage_vocab_size = vocab_size
+    return model
+
+
+def patch_layer_for_expansion(layer: nn.Module, mode: ExpansionMode, hidden_size: int) -> nn.Module:
+    """Give a decoder layer a second hidden-state stream, in place.
+
+    Args:
+        layer: The decoder layer to patch. Modified in place so its module path is
+            preserved; wrapping would insert a path segment and stop tensor-parallel plan
+            patterns, which match segment-wise, from resolving.
+        mode: ``"expand"`` if this layer owns expansion weights, ``"skip"`` otherwise.
+        hidden_size: Width of a single stream, used to tell an incoming carrier from the
+            embedding output.
+
+    Returns:
+        The same object, now carrying two streams.
+    """
+    from nemo_automodel.components.expansion.routing import (
+        find_router_replays,
+        requires_routing_replay,
+    )
+
+    if mode == "expand":
+        problem = requires_routing_replay(layer)
+        if problem is not None:
+            raise ValueError(f"cannot expand this layer: {problem}")
+    _patch_class(layer, "DualStream", _dual_stream_forward, "_expansion_base_cls")
+    layer._expansion_mode = mode
+    layer._expansion_hidden_size = hidden_size
+    # Resolved once at patch time; the registry is ordered by construction and says
+    # nothing about which handle belongs to this layer.
+    layer._expansion_router_replays = find_router_replays(layer) if mode == "expand" else []
+    return layer
+
+
+def patch_norm_for_merge(norm: nn.Module, merge_weight: float, hidden_size: int) -> nn.Module:
+    """Make the final norm merge the stream pair before normalizing, in place.
+
+    Args:
+        norm: The decoder stack's final norm.
+        merge_weight: ``lambda`` in ``h = h_a + lambda * (h_b - h_a)``. ``1.0`` keeps only
+            the expanded stream, ``0.5`` averages the two. The value does not affect the
+            model at initialization, where the streams are identical.
+        hidden_size: Width of a single stream, used to recognize the carrier.
+
+    Returns:
+        The same object, now merging before it normalizes.
+    """
+    _patch_class(norm, "Merging", _merge_then_norm, "_merge_base_cls")
+    norm._merge_weight = merge_weight
+    norm._merge_hidden_size = hidden_size
+    return norm

--- a/nemo_automodel/components/expansion/expanded_linear.py
+++ b/nemo_automodel/components/expansion/expanded_linear.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The linear layer that carries a dual-stream expansion weight.
+
+Model expansion grows an already-pretrained model by giving selected linear layers a
+second weight. The pretrained weight stays frozen and only the new one trains, so the
+expanded model starts as an exact copy of its parent and departs from it only as the new
+weights learn.
+
+Within an expanded decoder layer two hidden-state streams are computed. Stream A is the
+pretrained computation, untouched. Stream B is the expanded one, and at every expanded
+linear it receives stream A's output as a lateral term::
+
+    y_a = W_a @ x_a                 (frozen)
+    y_b = W_b @ x_b + y_a           (trainable)
+
+Adding the lateral on the *output* side is the only formulation that type-checks for the
+non-square projections (fused QKV, gate/up), so it is used for all of them.
+
+The two streams are computed by running the enclosing decoder layer twice -- see
+``dual_stream.py`` -- so this module never sees both at once. It instead records ``y_a``
+on the A pass and consumes it on the B pass, driven by :class:`LateralBus`. That mirrors
+how ``nemo_automodel.components.moe.router_replay.RouterReplay`` records a routing
+decision on one pass and replays it on the next.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+__all__ = ["LateralBusMode", "LateralBus", "ExpandedLinear", "patch_linear_for_expansion"]
+
+
+class LateralBusMode(Enum):
+    """Which stream the enclosing decoder layer is currently running."""
+
+    RECORD = "record"  # stream A: compute with the frozen weight and stash the result
+    APPLY = "apply"  # stream B: add the stashed result to the expansion weight's output
+
+
+class LateralBus:
+    """Process-global switch naming the stream currently being computed.
+
+    A module-level switch rather than an argument because the signal has to reach every
+    expanded linear nested anywhere inside a decoder layer whose ``forward`` this code
+    does not own.
+    """
+
+    mode: LateralBusMode | None = None
+
+    @classmethod
+    def set_mode(cls, mode: LateralBusMode | None) -> LateralBusMode | None:
+        """Set the active mode and return the previous one, for save/restore."""
+        previous = cls.mode
+        cls.mode = mode
+        return previous
+
+
+class ExpandedLinear(nn.Linear):
+    """An ``nn.Linear`` carrying a second, trainable weight of the same shape.
+
+    Subclassing ``nn.Linear`` in place rather than wrapping it is load-bearing, not a
+    style choice:
+
+    * tensor-parallel plans match on module *paths* (``model.layers.*.self_attn.q_proj``)
+      and match segment-wise, so an inserted wrapper level stops the pattern matching;
+    * ``to_hf`` / ``from_hf`` match on state-dict keys, so moving the pretrained weight to
+      ``q_proj.base.weight`` breaks checkpoint conversion;
+    * modules built under a meta device have no allocated weight to copy out of.
+
+    ``nemo_automodel.components._peft.lora.patch_linear_module`` patches in place for the
+    same reasons.
+
+    Allocating the expansion weight and giving it a value are separate steps, because the
+    two happen at different points in a training run. Allocation has to precede sharding,
+    since the tensor-parallel plan and ``fully_shard`` are what distribute the new weight;
+    initialization has to follow the checkpoint load, since it reads the pretrained weight
+    it is copying. On a single process those two moments coincide and
+    :func:`patch_linear_for_expansion` does both at once, which is why ``initialize``
+    defaults to true.
+
+    Attributes:
+        expansion: The trainable weight, same shape as ``self.weight``, no bias. The bias
+            reaches stream B through the lateral term, which is what keeps a zero
+            expansion weight exactly equivalent to an unexpanded layer.
+        zero_init: Whether :meth:`initialize_expansion` starts this weight at zero rather
+            than as a copy of the pretrained one. Recorded at allocation because the
+            decision is made there and acted on later.
+    """
+
+    expansion: nn.Linear
+    zero_init: bool
+
+    def allocate_expansion(self, zero_init: bool) -> None:
+        """Give an already-constructed linear its expansion weight, with no value yet.
+
+        Safe on a meta-device model: nothing is read from the pretrained weight here.
+
+        Args:
+            zero_init: Start the expansion weight at zero instead of copying the
+                pretrained weight. Used for the projections that write into the residual
+                stream (``o_proj``, ``down_proj``); it is what makes the expanded model
+                reproduce its parent exactly before any optimizer step. Applied by
+                :meth:`initialize_expansion`.
+        """
+        self.expansion = nn.Linear(self.in_features, self.out_features, bias=False)
+        self.expansion.to(device=self.weight.device, dtype=self.weight.dtype)
+        self.zero_init = zero_init
+        self._lateral: torch.Tensor | None = None
+
+    def initialize_expansion(self) -> None:
+        """Set the expansion weight from the pretrained one.
+
+        Call after the pretrained weights are materialized and loaded. Sharding in between
+        is fine: once both weights are distributed the copy is a local operation on each
+        rank's shard.
+
+        Raises:
+            RuntimeError: If the pretrained weight is still on the meta device, or if only
+                one of the two weights is distributed, which means expansion was applied
+                somewhere in the middle of sharding.
+        """
+        # DTensor is detected by class name so this module stays importable without
+        # torch.distributed, the same test `checkpointing.py` uses.
+        if self.weight.device.type == "meta":
+            raise RuntimeError(
+                "Cannot initialize an expansion weight from a pretrained weight that is "
+                "still on the meta device: the copy would be a silent no-op and the "
+                "expansion weight would later be filled with arbitrary memory. Nothing "
+                "downstream would notice, because the zero-initialized output projections "
+                "discard stream B until training starts. Initialize expansion after the "
+                "pretrained weights are materialized and loaded."
+            )
+        if (type(self.weight).__name__ == "DTensor") != (type(self.expansion.weight).__name__ == "DTensor"):
+            raise RuntimeError(
+                "Cannot initialize an expansion weight when it and the pretrained weight "
+                "disagree about being distributed: the pretrained weight is "
+                f"{'already distributed' if type(self.weight).__name__ == 'DTensor' else 'local'} "
+                f"and the expansion weight is "
+                f"{'distributed' if type(self.expansion.weight).__name__ == 'DTensor' else 'local'}. "
+                "Allocate the expansion weight before the model is parallelized so that "
+                "both are distributed together."
+            )
+        with torch.no_grad():
+            if self.zero_init:
+                self.expansion.weight.zero_()
+            else:
+                self.expansion.weight.copy_(self.weight)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Apply the pretrained weight, the expansion weight, or both.
+
+        Args:
+            input: ``[*, in_features]``. The leading dimensions are whatever the enclosing
+                model uses -- ``[batch, seq, in_features]`` for a padded batch, or a
+                flattened ``[tokens, in_features]`` inside a MoE expert. This layer is
+                elementwise over those leading dimensions and does not interpret them.
+
+        Returns:
+            ``[*, out_features]``, with the same leading dimensions as ``input``.
+        """
+        if LateralBus.mode is LateralBusMode.RECORD:
+            output = F.linear(input, self.weight, self.bias)
+            self._lateral = output
+            return output
+        if LateralBus.mode is LateralBusMode.APPLY:
+            if self._lateral is None:
+                raise RuntimeError(
+                    f"{type(self).__name__} ran a stream-B pass with no recorded stream-A "
+                    "output. The two passes must alternate; check that nothing reset the "
+                    "lateral bus between them."
+                )
+            lateral, self._lateral = self._lateral, None
+            return self.expansion(input) + lateral
+        return F.linear(input, self.weight, self.bias)
+
+
+def patch_linear_for_expansion(linear: nn.Linear, zero_init: bool, initialize: bool = True) -> ExpandedLinear:
+    """Give an existing ``nn.Linear`` an expansion weight, in place.
+
+    Args:
+        linear: The pretrained linear to expand. Modified in place; its identity, module
+            path and ``weight`` are preserved.
+        zero_init: See :meth:`ExpandedLinear.allocate_expansion`.
+        initialize: Also give the expansion weight its value. Pass ``False`` when the
+            pretrained weights are not loaded yet, then call
+            :meth:`ExpandedLinear.initialize_expansion` once they are.
+
+    Returns:
+        The same object, now an :class:`ExpandedLinear`.
+    """
+    linear.__class__ = ExpandedLinear
+    linear.allocate_expansion(zero_init)
+    if initialize:
+        linear.initialize_expansion()
+    return linear

--- a/nemo_automodel/components/expansion/parallel_styles.py
+++ b/nemo_automodel/components/expansion/parallel_styles.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tensor-parallel styles that also distribute an expansion weight.
+
+A stock ``ColwiseParallel`` / ``RowwiseParallel`` distributes the parameters it knows
+about, which does not include the expansion weight an :class:`ExpandedLinear` carries.
+Left undistributed it would stay replicated on every rank while its base weight is
+sharded, and the two would not compose.
+
+This mirrors ``nemo_automodel.components.distributed.parallel_styles``' LoRA-aware styles
+and their ``translate_to_lora`` entry point, with one simplification: the expansion weight
+has the *same shape* as the base weight, so it takes the same placement. LoRA's low-rank
+factors have different shapes and need their own handling.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import DTensor, Placement, Replicate, Shard, distribute_tensor
+from torch.distributed.tensor.parallel import ColwiseParallel, RowwiseParallel
+
+__all__ = ["ColwiseParallelExpanded", "RowwiseParallelExpanded", "translate_to_expanded"]
+
+
+def _distribute(module: nn.Module, name: str, mesh: DeviceMesh, placement: Placement) -> None:
+    """Replace one parameter with its distributed counterpart, if it has one."""
+    param = getattr(module, name, None)
+    if param is None or isinstance(param, DTensor):
+        return
+    setattr(
+        module,
+        name,
+        nn.Parameter(distribute_tensor(param.data, mesh, [placement]), requires_grad=param.requires_grad),
+    )
+
+
+def _partition(module: nn.Module, mesh: DeviceMesh, weight_placement: Placement, bias_placement: Placement) -> None:
+    """Distribute a linear's weight, bias and expansion weight."""
+    # ``distribute_module`` invokes the partition function for every submodule, so the
+    # expansion gets its own call after the parent already handled it. Returning early on
+    # an already-distributed weight avoids re-distributing it, which would clash.
+    if isinstance(getattr(module, "weight", None), DTensor):
+        return
+    _distribute(module, "weight", mesh, weight_placement)
+    _distribute(module, "bias", mesh, bias_placement)
+    expansion = getattr(module, "expansion", None)
+    if expansion is not None:
+        _distribute(expansion, "weight", mesh, weight_placement)
+
+
+class ColwiseParallelExpanded(ColwiseParallel):
+    """``ColwiseParallel`` that also distributes an :class:`ExpandedLinear`'s expansion weight."""
+
+    def _partition_linear_fn(self, name: str, module: nn.Module, device_mesh: DeviceMesh) -> None:
+        """Shard weight, bias and expansion weight on the output dimension.
+
+        Args:
+            name: Module name, unused; kept for the base-class signature.
+            module: The linear being partitioned.
+            device_mesh: Mesh to distribute over.
+        """
+        _partition(module, device_mesh, Shard(0), Shard(0))
+
+
+class RowwiseParallelExpanded(RowwiseParallel):
+    """``RowwiseParallel`` that also distributes an :class:`ExpandedLinear`'s expansion weight."""
+
+    def _partition_linear_fn(self, name: str, module: nn.Module, device_mesh: DeviceMesh) -> None:
+        """Shard weight and expansion weight on the input dimension; replicate the bias.
+
+        Args:
+            name: Module name, unused; kept for the base-class signature.
+            module: The linear being partitioned.
+            device_mesh: Mesh to distribute over.
+        """
+        _partition(module, device_mesh, Shard(1), Replicate())
+
+
+def translate_to_expanded(plan: Union[ColwiseParallel, RowwiseParallel]) -> Union[ColwiseParallel, RowwiseParallel]:
+    """Mutate a tensor-parallel style in place to its expansion-aware equivalent.
+
+    Args:
+        plan: A parallel style from a model's TP plan. Styles with no expansion-aware
+            equivalent are returned unchanged.
+
+    Returns:
+        The same object, retyped where an equivalent exists.
+    """
+    CLS_MAP = {
+        ColwiseParallel: ColwiseParallelExpanded,
+        RowwiseParallel: RowwiseParallelExpanded,
+    }
+    plan.__class__ = CLS_MAP.get(type(plan), plan.__class__)
+    return plan

--- a/nemo_automodel/components/expansion/routing.py
+++ b/nemo_automodel/components/expansion/routing.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Keeping the two streams' MoE routing aligned.
+
+The lateral term ``y_b = W_b x_b + y_a`` is per token, and an expanded linear inside a MoE
+expert only ever sees the tokens routed to that expert. If the two streams route
+differently, the expert receives a different number of tokens on each pass and the
+recorded ``y_a`` cannot be added to ``y_b`` at all -- it fails loudly on a shape mismatch
+rather than corrupting silently, but it fails.
+
+The streams do route differently as soon as they diverge, because the router reads the
+hidden state and the whole point of the expansion is that stream B's hidden state moves.
+
+``RouterReplay`` already solves this, for a different reason: it exists so that on-policy
+RL can replay the rollout's expert selection during the training forward. The same
+mechanism pins stream B to stream A's selection, which makes the dispatch order identical
+and the lateral applicable elementwise. Only the discrete selection is replayed -- each
+stream still computes its own routing weights from its own hidden state -- so stream B is
+not forced to be stream A, only to visit the same experts.
+
+Coexistence with RL is the reason this is written as save/restore rather than as ownership.
+When an outer ``RouterReplay.replay(...)`` is already active, both streams are pinned to
+the rollout's selection, which satisfies RL and the expansion at once, so this code stays
+out of the way.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+import torch.nn as nn
+
+from nemo_automodel.shared.import_utils import safe_import
+
+HAVE_ROUTER_REPLAY, _router_replay = safe_import("nemo_automodel.components.moe.router_replay")
+
+__all__ = ["aligned_routing", "find_router_replays", "requires_routing_replay", "switch_to_replay"]
+
+
+def find_router_replays(layer: nn.Module) -> list:
+    """Collect the ``RouterReplay`` handles owned by a decoder layer's gates.
+
+    Looked up by traversal rather than by index into ``RouterReplay``'s process-global
+    registry: the registry is ordered by construction, which says nothing about which
+    handle belongs to the layer being expanded.
+
+    Args:
+        layer: A decoder layer, possibly containing one or more  MoE gates.
+
+    Returns:
+        The layer's ``RouterReplay`` handles, empty if it has no MoE gate or if routing
+        replay was not enabled when the model was built.
+    """
+    if not HAVE_ROUTER_REPLAY:
+        return []
+    handles = []
+    for module in layer.modules():
+        handle = getattr(module, "router_replay", None)
+        if handle is not None:
+            handles.append(handle)
+    return handles
+
+
+@contextmanager
+def aligned_routing(handles: list) -> Iterator[None]:
+    """Make the enclosed stream-B pass reuse the stream-A pass's expert selection.
+
+    Enter this around the pair of passes. On entry the handles are put in record mode so
+    the A pass captures its selection; :func:`switch_to_replay` promotes them to replay
+    before the B pass; on exit the previous mode is restored.
+
+    Args:
+        handles: The layer's ``RouterReplay`` handles, from :func:`find_router_replays`.
+
+    Yields:
+        None.
+    """
+    previous = [handle.mode for handle in handles]
+    externally_driven = _externally_driven(handles)
+    if not externally_driven:
+        for handle in handles:
+            handle.mode = _router_replay.RouterReplayMode.RECORD
+    try:
+        yield
+    finally:
+        for handle, mode in zip(handles, previous):
+            handle.mode = mode
+
+
+def switch_to_replay(handles: list) -> None:
+    """Promote recorded selections to replay targets, between the two passes.
+
+    Args:
+        handles: The layer's ``RouterReplay`` handles.
+    """
+    if _externally_driven(handles):
+        # An outer RL replay already pins both streams to the rollout's selection, which
+        # is exactly the alignment needed here. Overwriting its target would break it.
+        return
+    for handle in handles:
+        handle.set_target(handle.recorded_indices)
+        handle.mode = _router_replay.RouterReplayMode.REPLAY
+
+
+def _externally_driven(handles: list) -> bool:
+    """Whether an outer caller (RL routing replay) already owns these handles."""
+    if not HAVE_ROUTER_REPLAY:
+        return False
+    return any(handle.mode is _router_replay.RouterReplayMode.REPLAY for handle in handles)
+
+
+def requires_routing_replay(layer: nn.Module) -> Optional[str]:
+    """Explain why a layer cannot be expanded, if it cannot.
+
+    Args:
+        layer: A decoder layer about to be expanded.
+
+    Returns:
+        A message naming the problem, or ``None`` if the layer can be expanded. A MoE layer
+        built without routing replay cannot: its two passes would route independently and
+        the lateral term would not line up.
+    """
+    has_gate = any(hasattr(module, "router_replay") for module in layer.modules())
+    if not has_gate:
+        return None
+    if find_router_replays(layer):
+        return None
+    return (
+        "this layer has a MoE gate but no RouterReplay handle, so the two expansion "
+        "streams would route independently and their lateral connection would not line "
+        "up. Build the model with enable_routing_replay=True to expand a MoE layer."
+    )

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -911,6 +911,21 @@ def _extract_model_signature(cfg: dict) -> dict:
     peft_cfg = cfg.get("peft", None)
     sig["_has_peft"] = peft_cfg is not None and isinstance(peft_cfg, dict)
 
+    # Model expansion adds parameters the base architecture does not have, and which
+    # layers and projections it expands decides exactly which ones. Two runs that differ
+    # there have different model *and* optimizer state dicts, so neither checkpoint loads
+    # into the other -- the model signature above cannot see the difference, because the
+    # expanded model is built from the same architecture config.
+    expansion_cfg = cfg.get("expansion", None)
+    if not isinstance(expansion_cfg, dict):
+        expansion_cfg = {}
+    sig["_has_expansion"] = bool(expansion_cfg.get("enabled", False))
+    # Only the fields that decide which parameters exist. `merge_weight` and
+    # `zero_init_modules` change numerics or initial values, not the parameter set, so
+    # tuning them on resume stays compatible.
+    sig["_expansion_layers"] = expansion_cfg.get("layers", None) if sig["_has_expansion"] else None
+    sig["_expansion_target_modules"] = expansion_cfg.get("target_modules", None) if sig["_has_expansion"] else None
+
     return sig
 
 

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -176,6 +176,7 @@ def build_model(
     cfg_model,
     cfg_peft,
     seed,
+    cfg_expansion=None,
     has_packed_sequence=False,
     cfg_fp8=None,
     cfg_compile=None,
@@ -191,6 +192,8 @@ def build_model(
     Args:
         cfg_model: Configuration for model instantiation.
         cfg_peft: Configuration for PEFT.
+        cfg_expansion: Instantiated ``ExpansionConfig`` for dual-stream model expansion,
+            or ``None``.
         seed: Random seed.
         has_packed_sequence: Whether using packed sequences.
         cfg_fp8: Configuration for FP8.
@@ -208,6 +211,7 @@ def build_model(
         kwargs = {
             "has_packed_sequence": has_packed_sequence,
             "peft_config": cfg_peft,
+            "expansion_config": cfg_expansion,
             "sdpa_method": sdpa_method,
         }
         if distributed_setup is not None:
@@ -286,6 +290,7 @@ def build_model(
                 qat_quantizer=qat_quantizer,
                 loss_fn=loss_fn,
                 peft_config=kwargs.get("peft_config"),
+                expansion_config=kwargs.get("expansion_config"),
                 fp8_config=kwargs.get("fp8_config"),
                 compile_config=kwargs.get("compile_config"),
                 quantization_config=kwargs.get("quantization_config"),
@@ -586,6 +591,10 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         if self.cfg.get("peft", None) is not None:
             self.peft_config = self.cfg.peft.instantiate()
 
+        self.expansion_config = None
+        if self.cfg.get("expansion", None) is not None:
+            self.expansion_config = self.cfg.expansion.instantiate()
+
         # Checkpoint config (model-derived fields are filled in by RecipeConfig)
         checkpoint_config = self.cfg.checkpoint
 
@@ -621,6 +630,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             distributed_setup=self.distributed_setup,
             cfg_qat=self.cfg.get("qat", None),
             sdpa_method=self.cfg.get("sdpa_method", None),
+            cfg_expansion=self.expansion_config,
         )
         self.embedding_row_repair_report = None
         embedding_row_repair = self.cfg.embedding_row_repair

--- a/tests/functional_tests/expansion/run_expansion_generation.py
+++ b/tests/functional_tests/expansion/run_expansion_generation.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generation from an expanded model, on a real checkpoint and a real GPU.
+
+Three properties, in the order they matter.
+
+Decoding from a KV cache must be refused. An expanded layer runs twice, and stream B's
+keys and values differ from stream A's once the expansion weights learn, so one cache
+cannot serve both. Before this was caught, ``generate()`` -- whose ``use_cache`` defaults
+to true -- returned well-formed tokens computed against the wrong history, with no error.
+
+Decoding without a cache must be correct, not merely non-crashing. It is checked against a
+decode loop written out by hand, one full forward per step, because that is the reference
+the recommendation in the refusal message implicitly promises.
+
+At initialization the expanded model must generate exactly what its parent generates.
+
+Every check perturbs the expansion weights first, except the last one, which is about the
+unperturbed state. At their initial values the expanded model *is* its parent, so any
+generation check passes no matter how broken stream B is.
+
+Usage:
+    python tests/functional_tests/expansion/run_expansion_generation.py \\
+        --model /path/to/Llama-3.2-1B-Instruct
+
+Single GPU; generation here is not distributed.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+# Importable from a source checkout with the package uninstalled, the way the pytest
+# conftest puts the repo root on the path.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from nemo_automodel.components.expansion import (  # noqa: E402
+    ExpansionConfig,
+    apply_expansion,
+    expansion_parameters,
+)
+
+PROMPT = "The capital of France is"
+STEPS = 12
+
+
+def build(model_path: str, layers: list[int] | None, perturb: float, dtype: torch.dtype) -> torch.nn.Module:
+    """Load the pretrained model, optionally expand it and move its expansion weights.
+
+    Args:
+        model_path: Local path or hub id of the pretrained causal LM.
+        layers: Decoder-layer indices to expand, or ``None`` to leave it unexpanded.
+        perturb: Standard deviation of noise added to every expansion weight. Non-zero
+            makes stream B observable; at zero the output projections discard it.
+        dtype: Parameter dtype.
+
+    Returns:
+        The model, in eval mode on the current CUDA device.
+    """
+    torch.manual_seed(0)
+    model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=dtype).cuda().eval()
+    if layers is not None:
+        apply_expansion(model, ExpansionConfig(enabled=True, layers=layers))
+    if perturb:
+        generator = torch.Generator(device="cuda").manual_seed(3)
+        with torch.no_grad():
+            for _, param in expansion_parameters(model):
+                param.add_(torch.randn(param.shape, generator=generator, device="cuda") * perturb)
+    return model
+
+
+def greedy_without_cache(model: torch.nn.Module, input_ids: torch.Tensor, steps: int) -> torch.Tensor:
+    """Decode greedily with a full forward per step and no cache anywhere.
+
+    Args:
+        model: A causal LM.
+        input_ids: Token ids of shape ``[batch, sequence]``.
+        steps: How many tokens to append.
+
+    Returns:
+        Token ids of shape ``[batch, sequence + steps]``.
+    """
+    for _ in range(steps):
+        with torch.no_grad():
+            logits = model(input_ids=input_ids, use_cache=False).logits
+        input_ids = torch.cat([input_ids, logits[:, -1:].argmax(-1)], dim=1)
+    return input_ids
+
+
+def main() -> None:
+    """Run the three generation checks and print a decoded sample."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="local path or hub id of the pretrained model")
+    parser.add_argument("--layers", type=int, nargs="+", default=[8, 12])
+    parser.add_argument("--dtype", default="float32", choices=["float32", "bfloat16", "float16"])
+    args = parser.parse_args()
+
+    dtype = getattr(torch, args.dtype)
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    input_ids = tokenizer(PROMPT, return_tensors="pt").input_ids.cuda()
+
+    print(f"model={args.model} layers={args.layers} dtype={args.dtype}")
+    print(f"prompt: {PROMPT!r}\n")
+
+    expanded = build(args.model, args.layers, perturb=0.02, dtype=dtype)
+
+    print("[1] decoding from a KV cache is refused")
+    try:
+        with torch.no_grad():
+            expanded.generate(input_ids, max_new_tokens=STEPS, do_sample=False, use_cache=True)
+    except NotImplementedError as error:
+        print(f"  refused, as it must be: {str(error)[:110]}...")
+    else:
+        raise AssertionError("cached generation was not refused; it returns tokens computed on the wrong history")
+
+    print("\n[2] decoding without a cache matches a hand-rolled reference")
+    reference = greedy_without_cache(expanded, input_ids, STEPS)
+    with torch.no_grad():
+        generated = expanded.generate(input_ids, max_new_tokens=STEPS, do_sample=False, use_cache=False)
+    assert torch.equal(generated, reference), (
+        f"generate() and the reference disagree:\n  {generated.tolist()}\n  {reference.tolist()}"
+    )
+    print(f"  match; expanded model says: {tokenizer.decode(generated[0], skip_special_tokens=True)!r}")
+
+    print("\n[3] at initialization the expanded model generates exactly like its parent")
+    with torch.no_grad():
+        parent_out = build(args.model, None, 0.0, dtype).generate(
+            input_ids, max_new_tokens=STEPS, do_sample=False, use_cache=False
+        )
+        fresh_out = build(args.model, args.layers, 0.0, dtype).generate(
+            input_ids, max_new_tokens=STEPS, do_sample=False, use_cache=False
+        )
+    assert torch.equal(fresh_out, parent_out), "an unperturbed expanded model diverged from its parent"
+    print(f"  match; parent says: {tokenizer.decode(parent_out[0], skip_special_tokens=True)!r}")
+
+    print("\n[generation] OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional_tests/expansion/run_expansion_parallel.py
+++ b/tests/functional_tests/expansion/run_expansion_parallel.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Standalone multi-GPU checks for model expansion under tensor and data parallelism.
+
+Three checks, run separately because they fail differently.
+
+Tensor parallelism reaches the expansion weight only if the plan knows to distribute it;
+``translate_to_expanded`` is what closes that. The TP check also runs the stock styles and
+asserts they do *not* work, so the positive check cannot pass vacuously.
+
+FSDP2 reduce-scatters gradients across the data-parallel axis, so the check that matters is
+whether the expansion weights receive the gradient of the *global* batch rather than of one
+rank's shard. Every unit here also holds a mix of frozen and trainable parameters, the usual
+source of missing gradient hooks, and ``fully_shard`` patches ``__class__`` the same way the
+expansion does -- which is what turned an earlier ``super(type(self), self)`` into infinite
+recursion.
+
+The ``deferred`` check covers the ordering a real training run is forced into:
+allocate the expansion weights before sharding, give them values after the checkpoint
+load. Function preservation has to hold there too.
+
+The gradient check perturbs the expansion weights first. Left at their initial values the
+output projections are zero, most expansion gradients are zero with them, and a comparison
+of zeros passes no matter what the collectives did.
+
+Any world size from 2 up works; the model is sized from it (see :func:`model_config`).
+
+Usage:
+    torchrun --nproc_per_node=2 tests/functional_tests/expansion/run_expansion_parallel.py
+
+    # Optional: more ranks, or one mechanism only
+    torchrun --nproc_per_node=4 tests/functional_tests/expansion/run_expansion_parallel.py \\
+        --mode tp
+
+This is also the implementation behind ``test_expansion_parallel.py``, which spawns the
+same checks under pytest. It stays runnable on its own because the training containers do
+not all carry pytest.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+from torch.distributed.fsdp import fully_shard
+from torch.distributed.tensor import DTensor, init_device_mesh
+from torch.distributed.tensor.parallel import ColwiseParallel, RowwiseParallel, parallelize_module
+from transformers import LlamaConfig
+from transformers.models.llama.modeling_llama import LlamaForCausalLM
+
+# Importable from a source checkout with the package uninstalled, the way the pytest
+# conftest puts the repo root on the path. Without this, running the script directly out
+# of a clone fails with a bare ModuleNotFoundError.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from nemo_automodel.components.expansion import (  # noqa: E402
+    ExpansionConfig,
+    apply_expansion,
+    expansion_parameters,
+    freeze_non_expansion_parameters,
+    initialize_expansion,
+    is_expansion_parameter,
+)
+from nemo_automodel.components.expansion.parallel_styles import translate_to_expanded  # noqa: E402
+
+VOCAB, HEAD_DIM, LAYERS, SEQ = 64, 8, 4, 8
+LOCAL_BATCH = 2
+#: World size the pytest wrapper spawns. CI caps functional tests at 2 GPUs; the checks
+#: themselves run at any world size >= 2.
+WORLD_SIZE = 2
+EXPANDED_LAYERS = [1, 2]
+
+#: Leaf projections of one decoder layer and the style each takes. The defaults compose:
+#: colwise hands the next module a locally-sharded tensor, rowwise declares its input
+#: sharded on the feature dimension and returns a replicated one.
+TP_STYLES = {
+    "self_attn.q_proj": ColwiseParallel,
+    "self_attn.k_proj": ColwiseParallel,
+    "self_attn.v_proj": ColwiseParallel,
+    "self_attn.o_proj": RowwiseParallel,
+    "mlp.gate_proj": ColwiseParallel,
+    "mlp.up_proj": ColwiseParallel,
+    "mlp.down_proj": RowwiseParallel,
+}
+
+
+def model_config(world_size: int) -> LlamaConfig:
+    """A tiny Llama sized so tensor parallelism divides it evenly.
+
+    The head counts scale with the world size because tensor parallelism shards the
+    attention projections by head. Fixed counts would silently cap the runnable world
+    size: two KV heads over four ranks gives each rank half a head, and attention's
+    ``view(batch, seq, -1, head_dim)`` then fails inside transformers, several frames away
+    from anything to do with expansion.
+
+    Args:
+        world_size: Number of ranks the model will be sharded over.
+
+    Returns:
+        A config with ``world_size`` KV heads and twice as many attention heads.
+    """
+    attention_heads = 2 * world_size
+    hidden = attention_heads * HEAD_DIM
+    return LlamaConfig(
+        vocab_size=VOCAB,
+        hidden_size=hidden,
+        intermediate_size=2 * hidden,
+        num_hidden_layers=LAYERS,
+        num_attention_heads=attention_heads,
+        num_key_value_heads=world_size,
+        max_position_embeddings=SEQ * 2,
+        attention_dropout=0.0,
+    )
+
+
+def build(
+    world_size: int, layers: list[int] | None = None, perturb: float = 0.0, initialize: bool = True
+) -> LlamaForCausalLM:
+    """A tiny Llama on the current CUDA device, optionally expanded and perturbed.
+
+    Args:
+        world_size: Number of ranks, which sets the head counts. See :func:`model_config`.
+        layers: Decoder-layer indices to expand, or ``None`` to leave the model unexpanded.
+        perturb: Standard deviation of noise added to every expansion weight. Non-zero
+            makes stream B observable; at zero the output projections discard it.
+        initialize: Give the expansion weights their values now. ``False`` allocates them
+            only, leaving :func:`initialize_expansion` to run after sharding.
+
+    Returns:
+        The model, in eval mode, identical on every rank.
+    """
+    torch.manual_seed(0)
+    model = LlamaForCausalLM(model_config(world_size)).cuda().eval()
+    if layers is not None:
+        apply_expansion(model, ExpansionConfig(enabled=True, layers=layers), initialize=initialize)
+    if perturb:
+        generator = torch.Generator(device="cuda").manual_seed(3)
+        with torch.no_grad():
+            for _, param in expansion_parameters(model):
+                param.add_(torch.randn(param.shape, generator=generator, device="cuda") * perturb)
+    return model
+
+
+def global_input_ids(world_size: int) -> torch.Tensor:
+    """Returns: ``[world_size * LOCAL_BATCH, SEQ]`` token ids, identical on every rank."""
+    torch.manual_seed(1)
+    return torch.randint(0, VOCAB, (world_size * LOCAL_BATCH, SEQ), device="cuda")
+
+
+def full(tensor: torch.Tensor) -> torch.Tensor:
+    """Materialize a possibly-distributed tensor. Collective when the input is a DTensor."""
+    return tensor.full_tensor() if isinstance(tensor, DTensor) else tensor
+
+
+def logits(model: LlamaForCausalLM, input_ids: torch.Tensor) -> torch.Tensor:
+    with torch.no_grad():
+        return full(model(input_ids=input_ids, use_cache=False).logits)
+
+
+def parallelize(model: LlamaForCausalLM, mesh, expansion_aware: bool) -> LlamaForCausalLM:
+    """Apply a per-layer TP plan, optionally translated to its expansion-aware equivalent."""
+    plan = {}
+    for index in range(LAYERS):
+        for suffix, style in TP_STYLES.items():
+            instance = style()
+            plan[f"model.layers.{index}.{suffix}"] = translate_to_expanded(instance) if expansion_aware else instance
+    parallelize_module(model, mesh, plan)
+    return model
+
+
+def shard(model: LlamaForCausalLM, mesh) -> LlamaForCausalLM:
+    """Shard every decoder layer and the root, the grouping the recipes use."""
+    for layer in model.model.layers:
+        fully_shard(layer, mesh=mesh)
+    return fully_shard(model, mesh=mesh)
+
+
+def grads_of(model: LlamaForCausalLM) -> dict[str, torch.Tensor]:
+    return {name: param.grad for name, param in model.named_parameters() if param.grad is not None}
+
+
+def reference_grads(input_ids: torch.Tensor, world_size: int) -> dict[str, torch.Tensor]:
+    """Gradients of the same loss over the whole batch, computed without any parallelism."""
+    model = build(world_size, layers=EXPANDED_LAYERS, perturb=0.05)
+    freeze_non_expansion_parameters(model)
+    model.train()
+    model(input_ids=input_ids, use_cache=False).logits.square().mean().backward()
+    return grads_of(model)
+
+
+def check_tensor_parallel(mesh, rank: int, world_size: int) -> None:
+    """Function preservation and expansion-weight distribution under a TP plan."""
+    input_ids = global_input_ids(world_size)
+
+    # 1. Sharding does not perturb the model at initialization. Bit-exactness is the
+    # assertion because the two paths are algebraically identical while the output
+    # projections are zero; a near miss would mean TP changed the arithmetic.
+    parent = logits(parallelize(build(world_size), mesh, expansion_aware=False), input_ids)
+    expanded = logits(parallelize(build(world_size, layers=EXPANDED_LAYERS), mesh, expansion_aware=True), input_ids)
+    assert torch.equal(expanded, parent), f"max abs diff {(expanded - parent).abs().max().item():.3e}"
+
+    # 2. The expansion weight takes its base weight's placement. This is where expansion is
+    # simpler than LoRA: same shape as the base, so the same placement, with no need for
+    # the per-factor handling ColwiseParallelLora needs.
+    model = parallelize(build(world_size, layers=EXPANDED_LAYERS), mesh, expansion_aware=True)
+    params = dict(model.named_parameters())
+    expansion = dict(expansion_parameters(model))
+    assert expansion
+    for name, param in expansion.items():
+        base = params[name.replace(".expansion.weight", ".weight")]
+        assert isinstance(param, DTensor), f"{name} was left replicated"
+        assert param.placements == base.placements, f"{name}: {param.placements} vs base {base.placements}"
+        assert param.to_local().numel() < param.numel(), f"{name} is a DTensor but not sharded"
+
+    # 3. Negative control: the stock styles do not handle an expanded linear, so the
+    # assertions above are load-bearing rather than true of any plan at all. Torch's own
+    # partition function iterates `named_parameters()` recursively and then calls
+    # `register_parameter` with what it finds, so the nested `expansion.weight` makes it
+    # raise outright. The exception type is not pinned -- a future torch might instead
+    # leave the weight replicated, which is equally a failure and equally caught here.
+    try:
+        stock = parallelize(build(world_size, layers=EXPANDED_LAYERS), mesh, expansion_aware=False)
+    except Exception as error:
+        if rank == 0:
+            print(f"  stock TP plan rejected the expanded linear, as expected: {type(error).__name__}")
+    else:
+        assert any(not isinstance(param, DTensor) for _, param in expansion_parameters(stock)), (
+            "the stock TP plan handled the expansion weight; the expansion-aware styles are untested"
+        )
+
+
+def check_fsdp(mesh, rank: int, world_size: int) -> None:
+    """Function preservation, weight sharding and data-parallel gradient correctness."""
+    input_ids = global_input_ids(world_size)
+    local_input_ids = input_ids.chunk(world_size)[rank]
+
+    # 1. Sharding does not perturb the model at initialization.
+    parent = logits(shard(build(world_size), mesh), local_input_ids)
+    expanded = logits(shard(build(world_size, layers=EXPANDED_LAYERS), mesh), local_input_ids)
+    assert torch.equal(expanded, parent), f"max abs diff {(expanded - parent).abs().max().item():.3e}"
+
+    # 2. fully_shard treats the expansion weight like any other parameter. Frozen before
+    # sharding, the order a recipe uses, so each unit holds a mix of frozen and trainable
+    # parameters.
+    model = build(world_size, layers=EXPANDED_LAYERS, perturb=0.05)
+    freeze_non_expansion_parameters(model)
+    model = shard(model, mesh)
+    expansion = dict(expansion_parameters(model))
+    assert expansion
+    for name, param in expansion.items():
+        assert isinstance(param, DTensor), f"{name} was left replicated"
+        assert param.to_local().numel() < param.numel(), f"{name} is a DTensor but not sharded"
+
+    # 3. The gradient each rank ends up with is the gradient of the *global* batch, not of
+    # its own shard. Each rank runs a different slice of the batch and its local mean loss;
+    # FSDP2 averages the gradients, which is the gradient of the global mean only when the
+    # reduction actually happens.
+    model.train()
+    model(input_ids=local_input_ids, use_cache=False).logits.square().mean().backward()
+
+    grads = grads_of(model)
+    assert grads, "no parameter received a gradient"
+    assert all(is_expansion_parameter(name) for name in grads), "a frozen weight received a gradient"
+
+    reference = reference_grads(input_ids, world_size)
+    assert set(grads) == set(reference), sorted(set(grads) ^ set(reference))
+    for name, grad in grads.items():
+        assert grad.abs().sum() > 0, f"{name} received a zero gradient; the comparison would be vacuous"
+        torch.testing.assert_close(full(grad), reference[name], rtol=1e-4, atol=1e-6, msg=name)
+
+
+def check_deferred_initialization(mesh, rank: int, world_size: int) -> None:
+    """Allocate the expansion weights before sharding, give them values after.
+
+    This is the order a parallel run is forced into: its weights are materialized only
+    once the model is already sharded, so the copy from the pretrained weight has to
+    happen against distributed tensors. Function preservation has to survive that, or
+    whether the expanded model equals its parent would depend on the launch topology.
+    """
+    input_ids = global_input_ids(world_size)
+    parent = logits(parallelize(build(world_size), mesh, expansion_aware=False), input_ids)
+
+    model = parallelize(build(world_size, layers=EXPANDED_LAYERS, initialize=False), mesh, expansion_aware=True)
+    expansion = dict(expansion_parameters(model))
+    assert expansion
+    assert all(isinstance(param, DTensor) for param in expansion.values()), "allocation did not survive sharding"
+
+    assert initialize_expansion(model) == len(expansion)
+    assert torch.equal(logits(model, input_ids), parent)
+
+
+#: Mesh dimension name per mode. The name is cosmetic -- every mesh here is 1-D over all
+#: ranks -- but it keeps the intent readable in a mesh repr.
+CHECKS = {
+    "tp": ("tp", check_tensor_parallel),
+    "fsdp": ("dp", check_fsdp),
+    "deferred": ("tp", check_deferred_initialization),
+}
+
+
+def run_check(mode: str, rank: int, world_size: int) -> None:
+    """Build the mesh for ``mode`` and run its checks. Assumes an initialized process group."""
+    mesh_dim, check = CHECKS[mode]
+    mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=(mesh_dim,))
+    check(mesh, rank, world_size)
+    dist.barrier()
+    if rank == 0:
+        print(f"[{mode}] OK", flush=True)
+
+
+def spawn_worker(rank: int, world_size: int, init_file: str, mode: str) -> None:
+    """One rank, rendezvous by file. Used by the pytest wrapper; must stay top-level."""
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", init_method=f"file://{init_file}", rank=rank, world_size=world_size)
+    try:
+        run_check(mode, rank, world_size)
+    finally:
+        dist.destroy_process_group()
+
+
+def main() -> None:
+    """Entry point under ``torchrun``, which supplies the rank environment."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=[*CHECKS, "both"], default="both")
+    args = parser.parse_args()
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    if world_size < 2:
+        raise SystemExit(
+            f"these checks need at least 2 ranks to shard anything, got {world_size}; "
+            "launch with torchrun --nproc_per_node=2 or more"
+        )
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", rank)))
+    dist.init_process_group("nccl")
+    try:
+        for mode in CHECKS if args.mode == "both" else [args.mode]:
+            run_check(mode, rank, world_size)
+    finally:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional_tests/expansion/test_expansion_parallel.py
+++ b/tests/functional_tests/expansion/test_expansion_parallel.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""2-GPU functional tests for model expansion under tensor and data parallelism.
+
+The checks live in ``run_expansion_parallel.py`` next to this file, which also runs under
+``torchrun`` on its own -- the training containers do not all carry pytest. This module
+spawns the same checks so they are collected with the rest of the suite; keeping one
+implementation means the two entry points cannot drift.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from run_expansion_parallel import CHECKS, WORLD_SIZE, spawn_worker  # noqa: E402
+
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(torch.cuda.device_count() < WORLD_SIZE, reason=f"requires {WORLD_SIZE} GPUs"),
+]
+
+
+@pytest.mark.parametrize("mode", list(CHECKS))
+def test_expansion_under_parallelism(mode, tmp_path):
+    """Function preservation, weight distribution and gradient correctness on 2 ranks."""
+    mp.spawn(spawn_worker, args=(WORLD_SIZE, str(tmp_path / "dist_init"), mode), nprocs=WORLD_SIZE, join=True)

--- a/tests/unit_tests/_transformers/test_infrastructure.py
+++ b/tests/unit_tests/_transformers/test_infrastructure.py
@@ -608,14 +608,28 @@ class TestLoadBeforeShardPath:
 
         mock_ckpt.initialize_model_weights.assert_called_once_with(model, torch.device("cpu"), peft_init_method=None)
         mock_ckpt.load_base_model.assert_called_once_with(
-            model, torch.device("cpu"), "/tmp/cache", "test/model", load_base_model=True
+            model,
+            torch.device("cpu"),
+            "/tmp/cache",
+            "test/model",
+            load_base_model=True,
+            allow_checkpoint_key_subset=False,
+            model_is_pipeline_stage=False,
         )
 
         init_idx = mock_ckpt.method_calls.index(
             call.initialize_model_weights(model, torch.device("cpu"), peft_init_method=None)
         )
         load_idx = mock_ckpt.method_calls.index(
-            call.load_base_model(model, torch.device("cpu"), "/tmp/cache", "test/model", load_base_model=True)
+            call.load_base_model(
+                model,
+                torch.device("cpu"),
+                "/tmp/cache",
+                "test/model",
+                load_base_model=True,
+                allow_checkpoint_key_subset=False,
+                model_is_pipeline_stage=False,
+            )
         )
         assert init_idx < load_idx
 

--- a/tests/unit_tests/expansion/test_expansion.py
+++ b/tests/unit_tests/expansion/test_expansion.py
@@ -1,0 +1,309 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for dual-stream model expansion.
+
+The property the whole design rests on is that an expanded model reproduces its parent
+*bit-exactly* until the expansion weights learn. Several tests below deliberately assert
+bit-exactness rather than a tolerance: an expanded layer that merely comes close is a bug,
+because zero-initialized output projections make the two paths algebraically identical.
+
+Two traps are worth knowing when adding tests here.
+
+* **Zero-init hides stream-B bugs.** At initialization the output projections discard
+  whatever stream B computed, so a function-preservation check cannot see an error inside
+  stream B. ``test_no_state_leaks_between_passes`` perturbs the expansion weights first,
+  which is what makes such errors observable.
+* **Streams stay identical until an expanded layer diverges them.** Expanding only layer 1
+  leaves layer 1's input identical on both streams, because layer 0 runs in skip mode. Any
+  test that needs genuinely diverged streams has to expand an *upstream* layer too.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+from transformers import LlamaConfig
+from transformers.models.llama.modeling_llama import LlamaForCausalLM
+
+from nemo_automodel.components.expansion import (
+    ExpandedLinear,
+    ExpansionConfig,
+    apply_expansion,
+    expansion_parameters,
+    freeze_non_expansion_parameters,
+    is_expansion_parameter,
+)
+
+VOCAB, HIDDEN, LAYERS, SEQ, BATCH = 64, 32, 4, 8, 2
+
+
+def _build(layers=None, merge_weight=0.5, dtype=torch.float32):
+    """A tiny Llama, optionally expanded. Deterministic across calls."""
+    torch.manual_seed(0)
+    config = LlamaConfig(
+        vocab_size=VOCAB,
+        hidden_size=HIDDEN,
+        intermediate_size=2 * HIDDEN,
+        num_hidden_layers=LAYERS,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=SEQ * 2,
+        attention_dropout=0.0,
+    )
+    model = LlamaForCausalLM(config).to(dtype).eval()
+    if layers is not None:
+        apply_expansion(model, ExpansionConfig(enabled=True, layers=layers, merge_weight=merge_weight))
+    return model
+
+
+@pytest.fixture
+def input_ids():
+    torch.manual_seed(1)
+    return torch.randint(0, VOCAB, (BATCH, SEQ))
+
+
+def _logits(model, input_ids):
+    with torch.no_grad():
+        return model(input_ids=input_ids, use_cache=False).logits
+
+
+@pytest.mark.parametrize("merge_weight", [0.0, 0.5, 1.0])
+def test_expanded_model_reproduces_parent_bit_exactly(input_ids, merge_weight):
+    """The expanded model is its parent until the expansion weights learn.
+
+    Holds for any merge weight because the two streams are seeded identically and the
+    output projections start at zero, so the merge has nothing to interpolate between.
+    """
+    parent = _logits(_build(), input_ids)
+    expanded = _logits(_build(layers=[1, 2], merge_weight=merge_weight), input_ids)
+    assert torch.equal(expanded, parent)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_function_preservation_holds_in_reduced_precision(input_ids, dtype):
+    """Precision does not weaken the guarantee, so bf16 and fp16 runs start from the parent.
+
+    The output projections start at exactly zero, and zero is representable in every float
+    format, so stream B contributes nothing no matter how coarse the mantissa. The two
+    places that could still drift -- the skip-mode delta and the final merge -- accumulate
+    in fp32 before casting back, which is why this is bit-exact rather than merely close.
+    """
+    parent = _logits(_build(dtype=dtype), input_ids)
+    expanded = _logits(_build(layers=[1, 2], dtype=dtype), input_ids)
+    assert torch.equal(expanded, parent)
+
+
+def test_skip_mode_equals_a_zero_expansion_weight(input_ids):
+    """A non-expanded layer computes exactly what an expanded layer with ``W_b == 0`` does.
+
+    This is the claim that lets unexpanded layers run once instead of twice. Comparing a
+    fully expanded model whose expansion weights are zeroed against a partially expanded
+    one exercises both code paths on the same weights.
+    """
+    fully_expanded = _build(layers=list(range(LAYERS)))
+    partially_expanded = _build(layers=[1])
+    for model in (fully_expanded, partially_expanded):
+        with torch.no_grad():
+            for _, param in expansion_parameters(model):
+                param.zero_()
+
+    assert torch.equal(_logits(fully_expanded, input_ids), _logits(partially_expanded, input_ids))
+
+
+def test_only_expansion_weights_are_trainable(input_ids):
+    """Freezing the pretrained weights keeps stream A out of the autograd graph."""
+    model = _build(layers=[1, 2])
+    trainable, frozen = freeze_non_expansion_parameters(model)
+    assert trainable > 0 and frozen > 0
+
+    model.train()
+    model(input_ids=input_ids, use_cache=False).logits.square().mean().backward()
+    with_grad = [name for name, param in model.named_parameters() if param.grad is not None]
+    assert with_grad
+    assert all(is_expansion_parameter(name) for name in with_grad)
+
+
+def test_only_output_projections_have_gradient_at_step_zero(input_ids):
+    """Zero-initialized output projections gate their layer's input-side linears.
+
+    At initialization the gradient of ``q_proj``'s expansion weight flows through
+    ``o_proj``'s, which is zero, so it is zero too. Input-side weights start learning only
+    once the output-side ones move. A regression here means the zero-init policy changed.
+    """
+    model = _build(layers=[1, 2])
+    freeze_non_expansion_parameters(model)
+    model.train()
+    model(input_ids=input_ids, use_cache=False).logits.square().mean().backward()
+
+    nonzero = [
+        name for name, param in model.named_parameters() if param.grad is not None and param.grad.abs().sum() > 0
+    ]
+    assert len(nonzero) == 2 * len(ExpansionConfig().zero_init_modules)
+    assert all("o_proj" in name or "down_proj" in name for name in nonzero)
+
+
+def test_module_paths_and_state_dict_keys_are_preserved(input_ids):
+    """Patching in place keeps tensor-parallel plans and ``to_hf``/``from_hf`` working.
+
+    TP plans match module paths segment-wise and checkpoint conversion matches state-dict
+    keys, so a wrapper that inserted a level would silently break both.
+    """
+    parent, expanded = _build(), _build(layers=[1, 2])
+
+    parent_paths = {name for name, _ in parent.named_modules()}
+    expanded_paths = {name for name, _ in expanded.named_modules()}
+    assert not parent_paths - expanded_paths
+    assert not {name for name in expanded_paths - parent_paths if not name.endswith("expansion")}
+
+    parent_keys, expanded_keys = set(parent.state_dict()), set(expanded.state_dict())
+    assert not parent_keys - expanded_keys
+    assert not {key for key in expanded_keys - parent_keys if not is_expansion_parameter(key)}
+
+
+def test_no_state_leaks_between_passes(input_ids):
+    """Running the layer twice must not let the passes share mutable state.
+
+    The KV cache was the first instance: the A pass appended its keys and the B pass
+    appended its own, so attention ran against twice the keys. Zero-init hid it from every
+    function-preservation check, so the expansion weights are perturbed first here.
+    """
+    model = _build(layers=[1, 2])
+    with torch.no_grad():
+        for _, param in expansion_parameters(model):
+            param.normal_(0.0, 0.05)
+
+    assert torch.equal(_logits(model, input_ids), _logits(model, input_ids))
+
+
+def _greedy_without_cache(model, input_ids, steps):
+    """Decode greedily with a full forward per step and no cache anywhere.
+
+    Args:
+        model: A causal LM.
+        input_ids: Token ids of shape ``[batch, sequence]``.
+        steps: How many tokens to append.
+
+    Returns:
+        Token ids of shape ``[batch, sequence + steps]``.
+    """
+    for _ in range(steps):
+        with torch.no_grad():
+            logits = model(input_ids=input_ids, use_cache=False).logits
+        input_ids = torch.cat([input_ids, logits[:, -1:].argmax(-1)], dim=1)
+    return input_ids
+
+
+def test_cached_generation_is_refused(input_ids):
+    """Decoding from a cache must fail loudly rather than return plausible wrong tokens.
+
+    Stream B's keys and values differ from stream A's once the expansion weights learn, so
+    one cache cannot serve both. Nothing about the output looks wrong when it is: the
+    tokens are well-formed, just computed against the wrong history.
+    """
+    model = _build(layers=[1, 2])
+    with torch.no_grad():
+        for _, param in expansion_parameters(model):
+            param.normal_(0.0, 0.05)
+
+    with pytest.raises(NotImplementedError, match="use_cache=False"):
+        with torch.no_grad():
+            model.generate(input_ids, max_new_tokens=4, do_sample=False, use_cache=True)
+
+
+def test_uncached_generation_is_correct(input_ids):
+    """The path the refusal recommends has to actually produce the right tokens.
+
+    Compared against a decode loop written out by hand, so this checks the recommendation
+    rather than merely that ``generate`` returns something. The expansion weights are
+    perturbed first: at their initial values any generation check passes, because the
+    expanded model is its parent.
+    """
+    model = _build(layers=[1, 2])
+    with torch.no_grad():
+        for _, param in expansion_parameters(model):
+            param.normal_(0.0, 0.05)
+
+    expected = _greedy_without_cache(model, input_ids, steps=4)
+    with torch.no_grad():
+        generated = model.generate(input_ids, max_new_tokens=4, do_sample=False, use_cache=False)
+    assert torch.equal(generated, expected)
+
+
+def test_expanded_model_generates_exactly_like_its_parent(input_ids):
+    """Function preservation, observed through the decoding loop rather than the logits."""
+    with torch.no_grad():
+        parent = _build().generate(input_ids, max_new_tokens=4, do_sample=False, use_cache=False)
+        expanded = _build(layers=[1, 2]).generate(input_ids, max_new_tokens=4, do_sample=False, use_cache=False)
+    assert torch.equal(expanded, parent)
+
+
+def test_expanded_linear_replaces_the_module_in_place():
+    """The expanded linear must remain an ``nn.Linear`` holding the pretrained weight."""
+    model = _build(layers=[0])
+    q_proj = model.model.layers[0].self_attn.q_proj
+    assert isinstance(q_proj, ExpandedLinear)
+    assert isinstance(q_proj, nn.Linear)
+    assert q_proj.expansion.weight.shape == q_proj.weight.shape
+
+
+def test_zero_init_applies_only_to_output_projections():
+    """Copy-initialized input-side weights, zero-initialized output-side ones."""
+    model = _build(layers=[0])
+    for name, param in expansion_parameters(model):
+        is_output_projection = "o_proj" in name or "down_proj" in name
+        assert bool(param.abs().sum() == 0) is is_output_projection, name
+
+
+def test_disabled_config_is_a_no_op(input_ids):
+    """``enabled=False`` must leave the model untouched."""
+    model = _build()
+    before = _logits(model, input_ids)
+    apply_expansion(model, ExpansionConfig(enabled=False))
+    assert not list(expansion_parameters(model))
+    assert torch.equal(_logits(model, input_ids), before)
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({"merge_weight": 1.5}, "merge_weight"),
+        ({"zero_init_modules": ["not_a_projection"]}, "zero_init_modules"),
+    ],
+)
+def test_config_rejects_invalid_combinations(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        ExpansionConfig(enabled=True, **kwargs)
+
+
+def test_out_of_range_layer_is_rejected():
+    with pytest.raises(ValueError, match="outside the decoder stack"):
+        apply_expansion(_build(), ExpansionConfig(enabled=True, layers=[LAYERS]))
+
+
+def test_unsupported_architecture_is_rejected():
+    """A model without a decoder layer list needs explicit support, not a silent no-op."""
+
+    class Shapeless(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(HIDDEN, HIDDEN)
+
+    with pytest.raises(AttributeError, match="decoder layer list"):
+        apply_expansion(Shapeless(), ExpansionConfig(enabled=True))
+
+
+def test_freeze_without_expansion_is_rejected():
+    """Freezing a model that was never expanded would leave nothing to train."""
+    with pytest.raises(ValueError, match="apply_expansion"):
+        freeze_non_expansion_parameters(_build())

--- a/tests/unit_tests/expansion/test_expansion_checkpoint.py
+++ b/tests/unit_tests/expansion/test_expansion_checkpoint.py
@@ -1,0 +1,310 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Checkpointing an expanded model, and the ordering that makes it work.
+
+Expansion adds ordinary parameters on ordinarily-named modules, so the checkpoint path
+needs no special handling and a saved expanded model reloads bit-exactly. What does need
+pinning down is *when* each half of expansion may run. Allocating the expansion weight has
+to precede sharding, because the tensor-parallel plan is what distributes it; giving it a
+value has to follow the checkpoint load, because it copies the pretrained weight. A single
+process does both at once, and a parallel run cannot -- it materializes its weights only
+after sharding -- which is why the two are separable.
+
+The meta-device case is the one worth a guard rather than a comment. Left unchecked it
+succeeds silently -- the copy is a no-op on meta, the weights are later filled with
+arbitrary memory, and every function-preservation check still passes because the
+zero-initialized output projections discard stream B until training starts.
+
+Tests run single-process with ``torch.distributed`` reported as uninitialized, which is
+the pattern ``tests/unit_tests/checkpoint`` uses for a CPU round trip.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.distributed as dist
+from safetensors.torch import load_file
+from torch.distributed.checkpoint.api import CheckpointException
+from torch.distributed.tensor import Shard, distribute_tensor, init_device_mesh
+from transformers import LlamaConfig
+from transformers.models.llama.modeling_llama import LlamaForCausalLM
+
+from nemo_automodel.components.checkpoint.checkpointing import Checkpointer
+from nemo_automodel.components.checkpoint.config import CheckpointingConfig
+from nemo_automodel.components.expansion import (
+    ExpansionConfig,
+    apply_expansion,
+    expansion_parameters,
+    initialize_expansion,
+)
+
+VOCAB, HIDDEN, LAYERS, SEQ, BATCH = 64, 32, 4, 8, 2
+EXPANDED_LAYERS = [1, 2]
+
+
+def _config() -> LlamaConfig:
+    return LlamaConfig(
+        vocab_size=VOCAB,
+        hidden_size=HIDDEN,
+        intermediate_size=2 * HIDDEN,
+        num_hidden_layers=LAYERS,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=SEQ * 2,
+        attention_dropout=0.0,
+    )
+
+
+def _build(expand: bool = True, perturb: float = 0.0) -> LlamaForCausalLM:
+    """A tiny Llama, optionally expanded and perturbed away from its initial values."""
+    torch.manual_seed(0)
+    model = LlamaForCausalLM(_config()).eval()
+    if expand:
+        apply_expansion(model, ExpansionConfig(enabled=True, layers=EXPANDED_LAYERS))
+    if perturb:
+        generator = torch.Generator().manual_seed(3)
+        with torch.no_grad():
+            for _, param in expansion_parameters(model):
+                param.add_(torch.randn(param.shape, generator=generator) * perturb)
+    return model
+
+
+def _checkpointer(directory: Path, model_save_format: str = "safetensors") -> Checkpointer:
+    config = CheckpointingConfig(
+        checkpoint_dir=str(directory),
+        model_save_format=model_save_format,
+        model_cache_dir=str(directory / "cache"),
+        model_repo_id="test/model",
+        save_consolidated=False,
+    )
+    with patch("torch.distributed.is_initialized", return_value=False):
+        return Checkpointer(config, dp_rank=0, tp_rank=0, pp_rank=0)
+
+
+def _logits(model: LlamaForCausalLM, input_ids: torch.Tensor) -> torch.Tensor:
+    with torch.no_grad():
+        return model(input_ids=input_ids, use_cache=False).logits
+
+
+@pytest.fixture
+def input_ids() -> torch.Tensor:
+    return torch.randint(0, VOCAB, (BATCH, SEQ), generator=torch.Generator().manual_seed(1))
+
+
+@pytest.fixture
+def single_rank_mesh():
+    """A one-rank CPU mesh, torn down so the group does not leak into later tests."""
+    dist.init_process_group("gloo", init_method=f"file://{tempfile.mktemp()}", rank=0, world_size=1)
+    try:
+        yield init_device_mesh("cpu", (1,), mesh_dim_names=("tp",))
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("model_save_format", ["safetensors", "torch_save"])
+def test_expanded_checkpoint_round_trips(tmp_path, input_ids, model_save_format):
+    """Save then load reproduces the model exactly, expansion weights included.
+
+    The weights are perturbed first: at their initial values the expansion weights are a
+    copy of the pretrained weight or zero, both of which a broken load could reproduce by
+    accident.
+    """
+    model = _build(perturb=0.05)
+    expected_logits = _logits(model, input_ids)
+    expected_weights = {name: param.detach().clone() for name, param in expansion_parameters(model)}
+
+    checkpointer = _checkpointer(tmp_path, model_save_format)
+    checkpointer.save_model(model, str(tmp_path / "step_1"))
+
+    restored = _build(perturb=0.0)
+    checkpointer.load_model(restored, str(tmp_path / "step_1" / "model"))
+
+    assert expected_weights
+    for name, param in expansion_parameters(restored):
+        assert torch.equal(param, expected_weights[name]), name
+    assert torch.equal(_logits(restored, input_ids), expected_logits)
+
+
+def test_expansion_weights_reach_the_checkpoint_under_their_own_keys(tmp_path):
+    """The on-disk keys are the module paths, so no adapter has to know about expansion."""
+    model = _build(perturb=0.05)
+    checkpointer = _checkpointer(tmp_path)
+    checkpointer.save_model(model, str(tmp_path / "step_1"))
+
+    shard = next(p for p in (tmp_path / "step_1" / "model").iterdir() if p.suffix == ".safetensors")
+    saved_keys = set(load_file(str(shard)))
+    expected_keys = {name for name, _ in expansion_parameters(model)}
+    assert expected_keys
+    assert expected_keys <= saved_keys
+
+
+def test_base_checkpoint_loads_into_an_expanded_model(tmp_path):
+    """A pre-expansion checkpoint has no expansion keys; the subset load keeps ours.
+
+    This is the resume-from-parent case. ``allow_checkpoint_key_subset`` is what makes it
+    work, and the expansion weights must come through untouched rather than zeroed.
+    """
+    checkpointer = _checkpointer(tmp_path)
+    checkpointer.save_model(_build(expand=False), str(tmp_path / "base"))
+
+    expanded = _build(perturb=0.05)
+    expected_weights = {name: param.detach().clone() for name, param in expansion_parameters(expanded)}
+    pretrained_weight = expanded.model.layers[0].self_attn.q_proj.weight.detach().clone()
+    with torch.no_grad():
+        expanded.model.layers[0].self_attn.q_proj.weight.zero_()
+
+    checkpointer.load_model(expanded, str(tmp_path / "base" / "model"), allow_checkpoint_key_subset=True)
+
+    assert torch.equal(expanded.model.layers[0].self_attn.q_proj.weight, pretrained_weight)
+    for name, param in expansion_parameters(expanded):
+        assert torch.equal(param, expected_weights[name]), name
+
+
+def test_base_checkpoint_without_the_subset_flag_is_refused(tmp_path):
+    """Without the flag the missing expansion keys are an error, not a silent skip.
+
+    ``CheckpointException`` derives from ``BaseException``, so a ``pytest.raises(Exception)``
+    here would let the failure through and the test would report the wrong thing.
+    """
+    checkpointer = _checkpointer(tmp_path)
+    checkpointer.save_model(_build(expand=False), str(tmp_path / "base"))
+
+    with pytest.raises(CheckpointException, match=r"expansion\.weight"):
+        checkpointer.load_model(_build(), str(tmp_path / "base" / "model"))
+
+
+def test_expanding_a_meta_device_model_is_refused():
+    """Copying a meta weight is a no-op, and zero-init would hide the resulting garbage."""
+    with torch.device("meta"):
+        model = LlamaForCausalLM(_config())
+
+    with pytest.raises(RuntimeError, match="meta device"):
+        apply_expansion(model, ExpansionConfig(enabled=True, layers=EXPANDED_LAYERS))
+
+
+def test_deferred_initialization_matches_the_eager_path(input_ids):
+    """Splitting allocation from initialization must not change the result.
+
+    Deferring is what lets a parallel run expand a model whose weights arrive later, so
+    the two paths have to agree exactly or function preservation depends on the launch
+    topology.
+    """
+    eager = _build()
+
+    deferred = _build(expand=False)
+    apply_expansion(deferred, ExpansionConfig(enabled=True, layers=EXPANDED_LAYERS), initialize=False)
+    assert initialize_expansion(deferred) == len(list(expansion_parameters(deferred)))
+
+    eager_weights = dict(expansion_parameters(eager))
+    for name, param in expansion_parameters(deferred):
+        assert torch.equal(param, eager_weights[name]), name
+    assert torch.equal(_logits(deferred, input_ids), _logits(eager, input_ids))
+
+
+def test_allocation_on_a_meta_device_model_is_allowed():
+    """Allocation reads nothing from the pretrained weight, so meta is fine.
+
+    This is the ordering a parallel run needs: allocate before sharding, when the weights
+    are still meta, and initialize after the checkpoint load.
+    """
+    with torch.device("meta"):
+        model = LlamaForCausalLM(_config())
+
+    apply_expansion(model, ExpansionConfig(enabled=True, layers=EXPANDED_LAYERS), initialize=False)
+    assert list(expansion_parameters(model))
+
+    with pytest.raises(RuntimeError, match="meta device"):
+        initialize_expansion(model)
+
+
+def test_initialization_works_once_both_weights_are_sharded(single_rank_mesh):
+    """The case the split exists for: initialize after the model has been parallelized.
+
+    Sharding distributes the expansion weight alongside its base weight, so by the time
+    the checkpoint has loaded the copy is a local operation on each rank's shard. Both
+    weights are distributed here the way ``ColwiseParallelExpanded`` would.
+    """
+    model = _build(expand=False)
+    apply_expansion(model, ExpansionConfig(enabled=True, layers=EXPANDED_LAYERS), initialize=False)
+
+    for index in EXPANDED_LAYERS:
+        linear = model.model.layers[index].self_attn.q_proj
+        for owner in (linear, linear.expansion):
+            owner.weight = torch.nn.Parameter(distribute_tensor(owner.weight.data, single_rank_mesh, [Shard(0)]))
+
+    initialize_expansion(model)
+
+    linear = model.model.layers[EXPANDED_LAYERS[0]].self_attn.q_proj
+    assert torch.equal(linear.expansion.weight.full_tensor(), linear.weight.full_tensor())
+
+
+def test_initializing_a_half_sharded_linear_is_refused(single_rank_mesh):
+    """Expanding in the middle of sharding leaves the two weights incompatible."""
+    model = _build(expand=False)
+    apply_expansion(model, ExpansionConfig(enabled=True, layers=EXPANDED_LAYERS), initialize=False)
+
+    linear = model.model.layers[EXPANDED_LAYERS[0]].self_attn.q_proj
+    linear.weight = torch.nn.Parameter(distribute_tensor(linear.weight.data, single_rank_mesh, [Shard(0)]))
+
+    with pytest.raises(RuntimeError, match="disagree about being distributed"):
+        initialize_expansion(model)
+
+
+def test_initializing_an_unexpanded_model_is_rejected():
+    """Initializing a model that was never expanded would silently do nothing."""
+    with pytest.raises(ValueError, match="apply_expansion"):
+        initialize_expansion(_build(expand=False))
+
+
+def test_expanding_an_already_sharded_model_is_refused(single_rank_mesh):
+    """Sharding runs after expansion, because it is what distributes the expansion weight."""
+    model = _build(expand=False)
+    linear = model.model.layers[EXPANDED_LAYERS[0]].self_attn.q_proj
+    linear.weight = torch.nn.Parameter(distribute_tensor(linear.weight.data, single_rank_mesh, [Shard(0)]))
+
+    with pytest.raises(RuntimeError, match="already distributed"):
+        apply_expansion(model, ExpansionConfig(enabled=True, layers=EXPANDED_LAYERS))
+
+
+def test_a_pipeline_stage_tolerates_the_other_stages_checkpoint_keys(tmp_path):
+    """A stage owns only its layers, so the checkpoint carries keys it does not have.
+
+    ``allow_checkpoint_key_subset`` normally also asserts the reverse direction -- every
+    checkpoint key must exist in the model -- to catch a model built from the wrong
+    architecture. A pipeline stage violates that by construction, and nothing inside the
+    load can tell the two apart, so the caller declares it.
+    """
+    checkpointer = _checkpointer(tmp_path)
+    checkpointer.save_model(_build(expand=False), str(tmp_path / "base"))
+
+    stage = _build(perturb=0.05)
+    # Keep the second half of the stack, the way pipeline splitting leaves a later stage.
+    stage.model.layers = torch.nn.ModuleList(list(stage.model.layers)[LAYERS // 2 :])
+    expected_weights = {name: param.detach().clone() for name, param in expansion_parameters(stage)}
+
+    with pytest.raises(RuntimeError, match="absent from the built model"):
+        checkpointer.load_model(stage, str(tmp_path / "base" / "model"), allow_checkpoint_key_subset=True)
+
+    checkpointer.load_model(
+        stage,
+        str(tmp_path / "base" / "model"),
+        allow_checkpoint_key_subset=True,
+        model_is_pipeline_stage=True,
+    )
+    for name, param in expansion_parameters(stage):
+        assert torch.equal(param, expected_weights[name]), name

--- a/tests/unit_tests/expansion/test_expansion_moe.py
+++ b/tests/unit_tests/expansion/test_expansion_moe.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for expanding a MoE decoder layer.
+
+The lateral term ``y_b = W_b x_b + y_a`` is per token, and an expanded linear inside an
+expert only sees the tokens routed to that expert. Once the streams diverge they route
+differently, the expert receives a different token count on each pass, and the recorded
+``y_a`` cannot be added. ``RouterReplay`` fixes this by pinning stream B to stream A's
+expert selection.
+
+The MoE block here is a stand-in that mirrors ``Gate``'s call pattern
+(``replay_selection`` then ``scores.gather``); it uses the real ``RouterReplay``. A test
+against ``nemo_automodel.components.moe.layers`` would be a functional test -- it pulls in
+kernels this CPU-only tier cannot run.
+
+The divergence trap is the thing to remember when editing these: expanding only layer 1
+leaves layer 1's input identical on both streams, because layer 0 runs in skip mode. Tests
+that need genuinely different routing per stream must expand an upstream layer too.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from nemo_automodel.components.expansion import (
+    ExpansionConfig,
+    apply_expansion,
+    expansion_parameters,
+)
+from nemo_automodel.components.moe.router_replay import RouterReplay, replay_selection
+
+DIM, N_EXPERTS, TOPK, LAYERS, BATCH, SEQ = 16, 4, 2, 3, 2, 8
+
+
+class _Expert(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.gate_proj = nn.Linear(DIM, DIM, bias=False)
+        self.down_proj = nn.Linear(DIM, DIM, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Args: x ``[tokens, DIM]``. Returns: ``[tokens, DIM]``."""
+        return self.down_proj(F.silu(self.gate_proj(x)))
+
+
+class _MoEBlock(nn.Module):
+    """Gate plus experts, dispatching in the flattened token layout AutoModel's MoE uses."""
+
+    def __init__(self, enable_routing_replay: bool) -> None:
+        super().__init__()
+        self.router = nn.Linear(DIM, N_EXPERTS, bias=False)
+        self.experts = nn.ModuleList(_Expert() for _ in range(N_EXPERTS))
+        self.router_replay = RouterReplay() if enable_routing_replay else None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Args: x ``[batch, seq, DIM]``. Returns: ``[batch, seq, DIM]``."""
+        flat = x.reshape(-1, DIM)
+        scores = self.router(flat).softmax(-1)
+        _, indices = scores.topk(TOPK, dim=-1)
+        indices = replay_selection(self.router_replay, indices)
+        weights = scores.gather(1, indices)
+
+        out = torch.zeros_like(flat)
+        for expert_id, expert in enumerate(self.experts):
+            hit = indices == expert_id
+            token_mask = hit.any(-1)
+            if not token_mask.any():
+                continue
+            weight = (weights * hit).sum(-1)[token_mask].unsqueeze(-1)
+            out[token_mask] += expert(flat[token_mask]) * weight
+        return out.view_as(x)
+
+
+class _MoEDecoderLayer(nn.Module):
+    def __init__(self, enable_routing_replay: bool) -> None:
+        super().__init__()
+        self.mlp = _MoEBlock(enable_routing_replay)
+
+    def forward(self, hidden_states: torch.Tensor, **kwargs) -> torch.Tensor:
+        """Args: hidden_states ``[batch, seq, DIM]``. Returns: ``[batch, seq, DIM]``."""
+        return hidden_states + self.mlp(hidden_states)
+
+
+class _Decoder(nn.Module):
+    def __init__(self, enable_routing_replay: bool) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList(_MoEDecoderLayer(enable_routing_replay) for _ in range(LAYERS))
+        self.norm = nn.LayerNorm(DIM)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Args: hidden_states ``[batch, seq, DIM]``. Returns: ``[batch, seq, DIM]``."""
+        for layer in self.layers:
+            hidden_states = layer(hidden_states)
+        return self.norm(hidden_states)
+
+
+class _TinyMoECausalLM(nn.Module):
+    """Minimal model exposing the ``.model.layers`` / ``.model.norm`` shape expansion needs."""
+
+    def __init__(self, enable_routing_replay: bool = True) -> None:
+        super().__init__()
+        self.model = _Decoder(enable_routing_replay)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Args: hidden_states ``[batch, seq, DIM]``. Returns: ``[batch, seq, DIM]``."""
+        return self.model(hidden_states)
+
+
+def _build(layers, enable_routing_replay=True, diverge=0.0):
+    RouterReplay.clear_registry()
+    torch.manual_seed(0)
+    model = _TinyMoECausalLM(enable_routing_replay).eval()
+    if layers is not None:
+        apply_expansion(
+            model,
+            ExpansionConfig(
+                enabled=True,
+                layers=layers,
+                target_modules=["gate_proj", "down_proj"],
+                zero_init_modules=["down_proj"],
+            ),
+        )
+    if diverge:
+        with torch.no_grad():
+            for _, param in expansion_parameters(model):
+                param.add_(torch.randn_like(param) * diverge)
+    return model
+
+
+@pytest.fixture
+def hidden_states():
+    torch.manual_seed(1)
+    return torch.randn(BATCH, SEQ, DIM)
+
+
+def test_expanded_moe_reproduces_parent_bit_exactly(hidden_states):
+    """At initialization the streams are identical, so routing aligns trivially."""
+    parent = _build(None)
+    with torch.no_grad():
+        expected = parent(hidden_states)
+    expanded = _build([1])
+    with torch.no_grad():
+        assert torch.equal(expanded(hidden_states), expected)
+
+
+def test_diverged_streams_keep_their_routing_aligned(hidden_states):
+    """Layer 0 is expanded too, so layer 1 genuinely sees a different hidden state per stream.
+
+    Without routing replay this raises a shape mismatch, because an expert receives a
+    different number of tokens on each pass.
+    """
+    model = _build([0, 1], diverge=0.5)
+    with torch.no_grad():
+        model(hidden_states)
+
+
+def test_moe_without_routing_replay_is_refused():
+    """Refusing beats a shape error thrown from somewhere inside the expert dispatch."""
+    with pytest.raises(ValueError, match="RouterReplay"):
+        _build([0, 1], enable_routing_replay=False)
+
+
+def test_outer_routing_replay_is_not_clobbered(hidden_states):
+    """Expansion must compose with the RL routing replay it borrows the mechanism from.
+
+    While an outer ``RouterReplay.replay(...)`` is active both streams are already pinned
+    to the rollout's selection, which is exactly the alignment the lateral term needs, so
+    the expansion leaves the handles alone and restores whatever mode it found.
+    """
+    model = _build([0, 1], diverge=0.5)
+    handles = RouterReplay.instances()
+    rollout_selection = torch.zeros(BATCH * SEQ, TOPK, dtype=torch.long)
+    rollout_selection[:, 1] = 1
+
+    with RouterReplay.replay([rollout_selection] * len(handles)):
+        modes_before = [handle.mode for handle in handles]
+        with torch.no_grad():
+            model(hidden_states)
+        assert [handle.mode for handle in handles] == modes_before
+        assert all(torch.equal(handle.target_indices, rollout_selection) for handle in handles)
+
+    assert all(handle.mode is None for handle in handles)
+
+
+class _GroupedExperts(nn.Module):
+    """Experts as one stacked parameter, the layout this repository's MoE blocks use.
+
+    ``nemo_automodel.components.moe.experts.GroupedExperts`` keeps every expert's
+    projection in a single ``[experts, in, out]`` parameter rather than in per-expert
+    ``nn.Linear`` modules, so there is nothing for expansion to patch.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.gate_and_up_projs = nn.Parameter(torch.empty(N_EXPERTS, DIM, DIM))
+        self.down_projs = nn.Parameter(torch.empty(N_EXPERTS, DIM, DIM))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Args: x ``[tokens, DIM]``. Returns: ``[tokens, DIM]``."""
+        return x
+
+
+class _GroupedMoEDecoderLayer(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.self_attn = nn.Linear(DIM, DIM, bias=False)
+        self.mlp = _GroupedExperts()
+
+    def forward(self, hidden_states: torch.Tensor, **kwargs) -> torch.Tensor:
+        """Args: hidden_states ``[batch, seq, DIM]``. Returns: ``[batch, seq, DIM]``."""
+        return hidden_states + self.self_attn(hidden_states)
+
+
+class _GroupedMoECausalLM(nn.Module):
+    """Minimal model whose experts live in stacked parameters."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.model = nn.Module()
+        self.model.layers = nn.ModuleList(_GroupedMoEDecoderLayer() for _ in range(LAYERS))
+        self.model.norm = nn.LayerNorm(DIM)
+
+
+def test_stacked_expert_weights_are_refused_rather_than_skipped():
+    """Half-expanding a MoE layer must fail, not pass quietly.
+
+    Expansion patches ``nn.Linear``. Applied to a block whose experts are one stacked
+    parameter, it reaches the attention projection beside them and nothing else, and the
+    resulting model looks expanded while its experts are untouched.
+    """
+    with pytest.raises(NotImplementedError, match="stacked expert weights"):
+        apply_expansion(
+            _GroupedMoECausalLM(),
+            # zero_init_modules must stay a subset of target_modules; the stand-in has no
+            # residual-stream projection to zero, so it names none.
+            ExpansionConfig(enabled=True, layers=[1], target_modules=["self_attn"], zero_init_modules=[]),
+        )
+
+
+def test_dense_layers_are_unaffected_by_the_stacked_weight_check():
+    """The check must not fire on a model that has no stacked parameters at all."""
+    model = _build([1])
+    assert list(expansion_parameters(model))

--- a/tests/unit_tests/expansion/test_expansion_packing.py
+++ b/tests/unit_tests/expansion/test_expansion_packing.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Expansion under sequence packing.
+
+Packing concatenates several sequences into one row and relies on ``position_ids`` -- which
+restart at zero per sequence -- to keep attention from crossing the boundaries. Transformers
+derives the flash-attention ``cu_seq_lens`` from those ids and passes them to the layer as
+keyword arguments.
+
+That is the whole interaction surface with expansion, and the design's answer to it is to
+carry the two streams as a tuple rather than stacked on the batch axis, so each stream is
+handed the layer's *unmodified* arguments. Batch stacking would have broken here: packing
+flattens the batch axis into a token stream, so a stacked second stream would be read as
+more tokens of the same pack.
+
+These tests therefore check two things: that the two passes really do receive identical
+packing metadata, and that function preservation survives a packed layout.
+
+The real flash-attention varlen kernel is not exercised here -- it needs Ampere or newer and
+is an optional dependency. What is exercised is the part this repository owns: which
+arguments reach each stream.
+"""
+
+import pytest
+import torch
+from transformers import LlamaConfig
+from transformers.models.llama.modeling_llama import LlamaForCausalLM
+
+from nemo_automodel.components.expansion import (
+    ExpansionConfig,
+    apply_expansion,
+    expansion_parameters,
+)
+
+VOCAB, HIDDEN, LAYERS, SEQ = 64, 32, 4, 12
+EXPANDED_LAYERS = [1, 2]
+#: Three sequences of 4 tokens packed into one row of 12.
+PACKED_POSITION_IDS = torch.tensor([[0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]])
+
+
+def _build(layers: list[int] | None = None, perturb: float = 0.0) -> LlamaForCausalLM:
+    """A tiny Llama, optionally expanded and perturbed."""
+    torch.manual_seed(0)
+    config = LlamaConfig(
+        vocab_size=VOCAB,
+        hidden_size=HIDDEN,
+        intermediate_size=2 * HIDDEN,
+        num_hidden_layers=LAYERS,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=SEQ * 2,
+        attention_dropout=0.0,
+    )
+    model = LlamaForCausalLM(config).eval()
+    if layers is not None:
+        apply_expansion(model, ExpansionConfig(enabled=True, layers=layers))
+    if perturb:
+        generator = torch.Generator().manual_seed(3)
+        with torch.no_grad():
+            for _, param in expansion_parameters(model):
+                param.add_(torch.randn(param.shape, generator=generator) * perturb)
+    return model
+
+
+@pytest.fixture
+def packed_batch() -> dict:
+    """A single row holding three packed sequences, with per-sequence position ids."""
+    torch.manual_seed(1)
+    return {
+        "input_ids": torch.randint(0, VOCAB, (1, SEQ)),
+        "position_ids": PACKED_POSITION_IDS,
+        "use_cache": False,
+    }
+
+
+def _logits(model: LlamaForCausalLM, batch: dict) -> torch.Tensor:
+    with torch.no_grad():
+        return model(**batch).logits
+
+
+def test_function_preservation_holds_under_a_packed_layout(packed_batch):
+    """A packed batch must not disturb the guarantee the unpacked one gives."""
+    assert torch.equal(_logits(_build(layers=EXPANDED_LAYERS), packed_batch), _logits(_build(), packed_batch))
+
+
+def test_both_streams_receive_identical_packing_metadata(packed_batch):
+    """Stream B has to see the same sequence boundaries stream A saw.
+
+    If the two passes disagreed about where sequences begin, stream B's attention would
+    cross a boundary stream A respected, and the lateral term would be added to tokens that
+    attended to different context. Zero-initialized output projections would hide it, so
+    the expansion weights are perturbed and the arguments are inspected directly.
+    """
+    model = _build(layers=EXPANDED_LAYERS, perturb=0.05)
+    layer = model.model.layers[EXPANDED_LAYERS[0]]
+    calls = []
+
+    attention = layer.self_attn
+    original = type(attention).forward
+
+    def spy(self, hidden_states, *args, **kwargs):
+        """Args: hidden_states ``[batch, sequence, hidden]``. Returns: what the real forward returns."""
+        # Patching the class catches every layer's attention, so record only the one under
+        # test; the other layers run in skip mode and would drown the two calls that matter.
+        if self is attention:
+            calls.append(
+                {
+                    "position_embeddings": kwargs.get("position_embeddings"),
+                    "attention_mask": kwargs.get("attention_mask"),
+                    "position_ids": kwargs.get("position_ids"),
+                    "shape": tuple(hidden_states.shape),
+                }
+            )
+        return original(self, hidden_states, *args, **kwargs)
+
+    type(attention).forward = spy
+    try:
+        _logits(model, packed_batch)
+    finally:
+        type(attention).forward = original
+
+    assert len(calls) == 2, f"an expanded layer must run once per stream, saw {len(calls)} calls"
+    stream_a, stream_b = calls
+    assert stream_a["shape"] == stream_b["shape"]
+    for key in ("attention_mask", "position_ids"):
+        a, b = stream_a[key], stream_b[key]
+        assert (a is None and b is None) or torch.equal(a, b), f"{key} differed between the streams"
+    for a, b in zip(stream_a["position_embeddings"] or (), stream_b["position_embeddings"] or ()):
+        assert torch.equal(a, b), "rotary embeddings differed between the streams"
+
+
+def test_packing_metadata_reaches_the_layer_unchanged(packed_batch):
+    """The carrier must not rewrite the ids packing depends on."""
+    model = _build(layers=EXPANDED_LAYERS, perturb=0.05)
+    layer = model.model.layers[EXPANDED_LAYERS[0]]
+    seen = []
+
+    original = type(layer.self_attn).forward
+
+    def spy(self, hidden_states, *args, **kwargs):
+        """Args: hidden_states ``[batch, sequence, hidden]``. Returns: what the real forward returns."""
+        seen.append(kwargs.get("position_ids"))  # every layer, expanded or not
+        return original(self, hidden_states, *args, **kwargs)
+
+    type(layer.self_attn).forward = spy
+    try:
+        _logits(model, packed_batch)
+    finally:
+        type(layer.self_attn).forward = original
+
+    assert seen, "the attention module was never called"
+    for position_ids in seen:
+        if position_ids is not None:
+            assert torch.equal(position_ids, PACKED_POSITION_IDS)

--- a/tests/unit_tests/expansion/test_expansion_recipe.py
+++ b/tests/unit_tests/expansion/test_expansion_recipe.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Model expansion as the recipe applies it, through ``apply_model_infrastructure``.
+
+The recipe hands an ``ExpansionConfig`` down the same route ``freeze_config`` takes, and
+``apply_model_infrastructure`` splits the work in two: it allocates the expansion weights
+beside PEFT, before sharding, and gives them their values after the checkpoint load. That
+split is invisible from outside -- what a caller can observe is that the model comes back
+expanded, frozen everywhere but the expansion weights, and still numerically its parent.
+
+PEFT is refused outright, because it patches the same linears expansion does. The refusal
+is checked before anything is applied, so a bad configuration fails on the configuration
+rather than partway through the build. Pipeline parallelism needs no refusal: the two
+streams travel between layers concatenated on the hidden axis, so a stage boundary carries
+one ordinary tensor.
+"""
+
+import pytest
+import torch
+from transformers import LlamaConfig
+from transformers.models.llama.modeling_llama import LlamaForCausalLM
+
+from nemo_automodel._transformers.infrastructure import apply_model_infrastructure
+from nemo_automodel.components.distributed.mesh import MeshContext
+from nemo_automodel.components.expansion import (
+    ExpansionConfig,
+    expansion_parameters,
+    is_expansion_parameter,
+)
+
+VOCAB, HIDDEN, LAYERS, SEQ, BATCH = 64, 32, 4, 8, 2
+EXPANDED_LAYERS = [1, 2]
+
+
+def _build() -> LlamaForCausalLM:
+    """A tiny Llama on CPU, deterministic across calls."""
+    torch.manual_seed(0)
+    config = LlamaConfig(
+        vocab_size=VOCAB,
+        hidden_size=HIDDEN,
+        intermediate_size=2 * HIDDEN,
+        num_hidden_layers=LAYERS,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=SEQ * 2,
+        attention_dropout=0.0,
+    )
+    return LlamaForCausalLM(config).eval()
+
+
+def _apply(model: LlamaForCausalLM, expansion_config: ExpansionConfig | None, **kwargs) -> LlamaForCausalLM:
+    """Run the infrastructure step the recipe runs, single-process and without a checkpoint."""
+    return apply_model_infrastructure(
+        model=model,
+        is_meta_device=False,
+        device=torch.device("cpu"),
+        mesh=MeshContext(),
+        expansion_config=expansion_config,
+        load_base_model=False,
+        **kwargs,
+    )
+
+
+def _logits(model: LlamaForCausalLM, input_ids: torch.Tensor) -> torch.Tensor:
+    with torch.no_grad():
+        return model(input_ids=input_ids, use_cache=False).logits
+
+
+@pytest.fixture
+def input_ids() -> torch.Tensor:
+    return torch.randint(0, VOCAB, (BATCH, SEQ), generator=torch.Generator().manual_seed(1))
+
+
+def test_recipe_path_expands_freezes_and_preserves_the_parent(input_ids):
+    """One call has to leave the model expanded, frozen, initialized and unchanged.
+
+    Bit-exactness is the assertion that catches a half-finished initialization: expansion
+    weights left at whatever the allocation produced would still give the parent's logits
+    only if the output projections really are zero, and the trainable-parameter check
+    catches the freezing half.
+    """
+    expected = _logits(_build(), input_ids)
+    model = _apply(_build(), ExpansionConfig(enabled=True, layers=EXPANDED_LAYERS))
+
+    expansion = dict(expansion_parameters(model))
+    assert expansion, "the recipe path produced no expansion weights"
+
+    trainable = [name for name, param in model.named_parameters() if param.requires_grad]
+    assert trainable and all(is_expansion_parameter(name) for name in trainable)
+    assert len(trainable) == len(expansion)
+
+    zeroed = [name for name, param in expansion.items() if param.abs().sum() == 0]
+    assert len(zeroed) == len(EXPANDED_LAYERS) * len(ExpansionConfig().zero_init_modules)
+
+    assert torch.equal(_logits(model, input_ids), expected)
+
+
+def test_disabled_expansion_config_is_a_no_op(input_ids):
+    """``enabled: false`` in the YAML must not touch the model."""
+    expected = _logits(_build(), input_ids)
+    model = _apply(_build(), ExpansionConfig(enabled=False))
+
+    assert not list(expansion_parameters(model))
+    assert torch.equal(_logits(model, input_ids), expected)
+
+
+def test_no_expansion_config_is_a_no_op(input_ids):
+    """Configs without an ``expansion:`` block go through the pre-existing path."""
+    expected = _logits(_build(), input_ids)
+    model = _apply(_build(), None)
+
+    assert not list(expansion_parameters(model))
+    assert torch.equal(_logits(model, input_ids), expected)
+
+
+def test_combining_with_peft_is_refused():
+    """Refused before anything is applied.
+
+    The sentinel object here carries none of the attributes a real PEFT config does, so a
+    refusal raised too late would surface as an ``AttributeError`` from inside PEFT rather
+    than as the ``NotImplementedError`` under test.
+    """
+    with pytest.raises(NotImplementedError, match="PEFT"):
+        _apply(_build(), ExpansionConfig(enabled=True, layers=EXPANDED_LAYERS), peft_config=object())
+
+
+def test_expanded_model_declares_its_inter_stage_shapes():
+    """Pipeline parallelism precomputes stage shapes; expansion has to correct them.
+
+    ``functional._precompute_stage_shapes`` sizes the inter-stage tensor from
+    ``config.hidden_size`` instead of inferring it, so without this hook stage 0 emits the
+    doubled carrier into a slot declared one stream wide and the schedule raises
+    ``PipeliningShapeError`` at the first step.
+    """
+    model = _apply(_build(), ExpansionConfig(enabled=True, layers=EXPANDED_LAYERS))
+    hook = getattr(model, "get_pipeline_stage_metas", None)
+    assert callable(hook), "the pipeline shape hook was not attached"
+
+    inputs, outputs = hook(is_first=True, microbatch_size=2, seq_len=SEQ, dtype=torch.float32)
+    assert inputs[0].shape == (2, SEQ)
+    assert outputs[0].shape == (2, SEQ, VOCAB), "a stage owning the LM head emits logits"
+
+    model.lm_head = None  # what pipeline splitting leaves on a non-final stage
+    inputs, outputs = hook(is_first=False, microbatch_size=2, seq_len=SEQ, dtype=torch.float32)
+    assert inputs[0].shape == (2, SEQ, 2 * HIDDEN), "a later stage receives the two-stream carrier"
+    assert outputs[0].shape == (2, SEQ, 2 * HIDDEN), "a non-final stage emits it too"
+
+
+def test_an_unexpanded_model_declares_nothing():
+    """The hook must not appear on models that are not expanded."""
+    assert getattr(_apply(_build(), None), "get_pipeline_stage_metas", None) is None

--- a/tests/unit_tests/expansion/test_expansion_resume_guard.py
+++ b/tests/unit_tests/expansion/test_expansion_resume_guard.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Auto-resume must not pick up a checkpoint from a differently-expanded run.
+
+With no explicit ``restore_from``, a recipe resumes from the latest checkpoint it finds in
+``checkpoint_dir``, and a signature check is what stops it from loading one that belongs to
+a different run. Expansion is invisible to the architecture half of that signature -- an
+expanded model is built from the same ``model:`` block as its parent -- so the signature
+has to carry the expansion configuration too.
+
+Which layers and projections are expanded decides which parameters exist, so it decides
+both the model and the optimizer state dict. ``merge_weight`` and ``zero_init_modules`` do
+not: they change numerics and initial values, so changing them on resume stays compatible.
+
+Without this, running the parent for comparison in a directory holding an expanded run's
+checkpoints fails deep inside the optimizer load with ``Missing key in checkpoint
+state_dict: optim.state.model.embed_tokens.weight.step``.
+"""
+
+import pytest
+
+from nemo_automodel.recipes.base_recipe import _extract_model_signature, _signatures_match
+
+BASE_MODEL = {
+    "model": {
+        "pretrained_model_name_or_path": "meta-llama/Llama-3.2-1B-Instruct",
+        "hidden_size": 2048,
+        "num_hidden_layers": 16,
+    }
+}
+
+
+def _signature(expansion: dict | None) -> dict:
+    config = dict(BASE_MODEL)
+    if expansion is not None:
+        config["expansion"] = expansion
+    return _extract_model_signature(config)
+
+
+EXPANDED = {"enabled": True, "layers": [8, 12], "merge_weight": 0.5}
+
+
+@pytest.mark.parametrize(
+    "other, compatible",
+    [
+        (EXPANDED, True),
+        ({"enabled": True, "layers": [8, 12], "merge_weight": 0.9}, True),
+        ({"enabled": True, "layers": [8, 12], "zero_init_modules": ["o_proj"]}, True),
+        ({"enabled": True, "layers": [4, 5], "merge_weight": 0.5}, False),
+        ({"enabled": True, "layers": [8, 12], "target_modules": ["q_proj"]}, False),
+        ({"enabled": False}, False),
+        (None, False),
+    ],
+    ids=[
+        "identical",
+        "merge_weight_differs",
+        "zero_init_differs",
+        "layers_differ",
+        "target_modules_differ",
+        "expansion_disabled",
+        "no_expansion_block",
+    ],
+)
+def test_expansion_identity_decides_checkpoint_compatibility(other, compatible):
+    """Only the fields that change which parameters exist may break compatibility."""
+    assert _signatures_match(_signature(EXPANDED), _signature(other)) is compatible
+
+
+def test_two_unexpanded_runs_stay_compatible():
+    """The guard must not start rejecting checkpoints that predate expansion."""
+    assert _signatures_match(_signature(None), _signature({"enabled": False}))


### PR DESCRIPTION
## What

Grows an already-pretrained model by giving selected linear layers a second, trainable
weight while the pretrained ones stay frozen. The expanded model reproduces its parent
**bit-exactly** until the new weights learn, so this continues pretraining rather than
restarting it.

An expanded decoder layer runs twice, once per hidden-state stream. At every expanded
linear, stream A's output is added to stream B's as a lateral term (`y_b = W_b x_b + y_a`).
Projections that write into the residual stream start at zero, which is what makes step 0
exact. Layers left unexpanded run **once** and forward their residual delta — exact, not an
approximation, and no extra compute.

```yaml
expansion:
  _target_: nemo_automodel.components.expansion.ExpansionConfig
  enabled: true
  layers: [8, 12]
  merge_weight: 0.5
```

## Design decisions worth reviewing

**Patched in place, never wrapped.** Tensor-parallel plans match on module paths and
checkpoint conversion matches on state-dict keys; a wrapper would insert a path segment and
break both. As a result checkpointing needs no special handling at all — the expansion
weights are ordinary parameters on ordinarily-named modules.

**The streams travel concatenated on the hidden axis**, not stacked on the batch axis.
Sequence packing and MoE flatten and permute the batch axis, which a stacked stream cannot
survive. Concatenating leaves batch and sequence intact, which is also what lets a pipeline
stage boundary carry the pair as one ordinary tensor — no changes to shared pipeline code.

**Allocation and initialization are separable**, because they happen at different times:
allocation must precede sharding (the parallel plans distribute the new weight), while
initialization must follow the checkpoint load (it copies the pretrained weight). A single
process does both at once; a parallel run cannot.

## Refused rather than silently wrong

- **Decoding from a KV cache.** Stream B's keys differ from stream A's, so one cache cannot
  serve both. Before this was caught, `generate()` — whose `use_cache` defaults to true —
  returned well-formed tokens computed against the wrong history. `use_cache=False` is
  exact and is checked against a hand-rolled decode loop.
- **Stacked mixture-of-experts weights.** They are one parameter per expert group rather
  than `nn.Linear`, so expansion would reach the attention beside them and nothing else,
  producing a half-expanded model that says nothing about it.
- **PEFT.** Both patch the same linear layers in place.

Auto-resume now also treats a differing `expansion:` block as an incompatible checkpoint;
the parameter set differs, so neither run's optimizer state loads into the other.

## Verification

On 4×V100 with Llama-3.2-1B, and CPU unit tests throughout:

| Check | Result |
|---|---|
| Step-0 loss, expanded vs parent | identical |
| Training, 50 steps | 2.85 → 2.09, only the 121.6M expansion weights training |
| Checkpoint save / resume | loss continues, expansion weights restored |
| TP / FSDP2 / deferred-init, 4 ranks | bit-exact function preservation |
| FSDP2 gradients | match a single-process gradient over the global batch |
| Pipeline parallelism, pp=2 | tracks a non-pipelined run to 1e-4 |
| fp16 compute (fp32 master weights) | 2.7× faster, loss curve unchanged |
| Generation | cached decoding refused; uncached matches reference |

Every check perturbs the expansion weights first. At their initial values the expanded model
*is* its parent, so any check passes however broken stream B is — which is why several of
these failures stayed hidden until the perturbation was added.

## Limitations

- Sequence packing requires flash-attention (Ampere or newer), so the varlen kernel path is
  untested here; what this repository owns — that both streams receive identical packing
  metadata — is covered by unit tests.
- Under pipeline parallelism, `expansion.layers` must name at least one layer in every
  stage's range, since a stage with no expanded layer has nothing to train. Raised early
  with an explanatory message.
- Expert parallelism is out of scope until stacked expert weights are supported.

## Test plan

- `pytest tests/unit_tests/expansion` — 58 tests, CPU only
- `torchrun --nproc_per_node=2 tests/functional_tests/expansion/run_expansion_parallel.py`
  (also runnable via `pytest tests/functional_tests/expansion`)
- `python tests/functional_tests/expansion/run_expansion_generation.py --model <path>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)