### PR TITLE
fix(checkpoint): preserve FSDP2 mixed precision during recompute

### DIFF
--- a/nemo_automodel/components/checkpoint/addons.py
+++ b/nemo_automodel/components/checkpoint/addons.py
@@ -28,6 +28,7 @@ from nemo_automodel.components.checkpoint._backports.hf_utils import (
 )
 from nemo_automodel.components.checkpoint.stateful_wrappers import ModelState
 from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin
+from nemo_automodel.shared.parameter_names import canonical_parameter_fqn
 
 if TYPE_CHECKING:
     from peft import PeftConfig
@@ -467,7 +468,7 @@ def _extract_target_modules(
                 target_name = name.rsplit(".", 1)[0]
                 if target_name.startswith("_orig_mod."):
                     target_name = target_name[len("_orig_mod.") :]
-                target_name = target_name.replace("_checkpoint_wrapped_module.", "")
+                target_name = canonical_parameter_fqn(target_name)
 
                 # Expand combined projection names to individual HF projection names
                 last_component = target_name.rsplit(".", 1)[-1]
@@ -502,7 +503,7 @@ def _extract_target_modules(
                         expert_path = name[: -len(f".{lora_suffix}")]
                         if expert_path.startswith("_orig_mod."):
                             expert_path = expert_path[len("_orig_mod.") :]
-                        expert_path = expert_path.replace("_checkpoint_wrapped_module.", "")
+                        expert_path = canonical_parameter_fqn(expert_path)
 
                         group = "gate_and_up" if "gate_and_up" in lora_suffix else "down"
                         if (expert_path, group) in seen_expert_groups:

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -84,6 +84,7 @@ from nemo_automodel.components.checkpoint.utils import (
     is_rank_0,
     materialize_missing_tied_lm_head,
 )
+from nemo_automodel.shared.parameter_names import canonical_parameter_fqn
 
 if TYPE_CHECKING:
     from peft import PeftConfig
@@ -2314,18 +2315,15 @@ def _load_full_state_dict_into_model(
     """
     # IMPORTANT: named_modules() returns paths that include wrapper prefixes
     # like _checkpoint_wrapped_module, but PyTorch's _get_fqns() strips
-    # _CHECKPOINT_PREFIX from FQNs.  We must do the same so our keys match
+    # checkpoint-wrapper components from FQNs. We must do the same so our keys match
     # what _load_model_state_dict actually looks up.
-    from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
-        _CHECKPOINT_PREFIX,
-    )
     from torch.distributed.checkpoint.state_dict import StateDictOptions, set_model_state_dict
 
     for model in model_parts:
         for name, module in model.named_modules():
             if type(module).get_extra_state is not nn.Module.get_extra_state:
                 key = f"{name}._extra_state" if name else "_extra_state"
-                key = key.replace(_CHECKPOINT_PREFIX, "")
+                key = canonical_parameter_fqn(key)
                 if key not in state_dict:
                     state_dict[key] = torch.tensor([], dtype=torch.uint8)
 

--- a/nemo_automodel/components/checkpoint/stateful_wrappers.py
+++ b/nemo_automodel/components/checkpoint/stateful_wrappers.py
@@ -64,6 +64,7 @@ from nemo_automodel.components.checkpoint.utils import (
     is_tied_word_embeddings,
     materialize_missing_tied_lm_head,
 )
+from nemo_automodel.shared.parameter_names import canonical_parameter_fqn
 
 _PREFIX = "model."
 _OPTIMIZER_PARTS_KEY = "optimizer_parts"
@@ -150,7 +151,7 @@ def _get_peft_state_dict(model: torch.nn.Module) -> dict[str, Any]:
         if param.requires_grad:
             # Strip _checkpoint_wrapped_module. from FQNs to match DCP's normalization.
             # Without this, activation checkpointing causes key mismatches on reload.
-            name = name.replace("_checkpoint_wrapped_module.", "")
+            name = canonical_parameter_fqn(name)
             param = param.full_tensor() if hasattr(param, "full_tensor") else param
             state_dict[name] = param.detach().cpu()
     return state_dict
@@ -241,7 +242,7 @@ def _set_peft_state_dict(model: torch.nn.Module, state_dict: dict[str, Any]) -> 
 
     # Strip _checkpoint_wrapped_module. from FQNs to match DCP's normalization.
     # Without this, activation checkpointing causes key mismatches on reload.
-    param_dict = {name.replace("_checkpoint_wrapped_module.", ""): param for name, param in model.named_parameters()}
+    param_dict = {canonical_parameter_fqn(name): param for name, param in model.named_parameters()}
     loaded, skipped = 0, 0
 
     for name, saved_tensor in state_dict.items():

--- a/nemo_automodel/components/distributed/activation_checkpointing.py
+++ b/nemo_automodel/components/distributed/activation_checkpointing.py
@@ -37,6 +37,7 @@ import torch.nn.functional as F
 from torch import nn
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     CheckpointImpl,
+    CheckpointWrapper,
     checkpoint_wrapper,
 )
 from torch.nn.attention import SDPBackend, sdpa_kernel
@@ -640,6 +641,26 @@ def _replace_child_module(root: nn.Module, target: nn.Module, replacement: nn.Mo
         if _replace_child_module(child, target, replacement):
             return True
     return False
+
+
+def apply_full_layer_checkpointing_to_layers(model: nn.Module, layers: List[nn.Module]) -> None:
+    """Wrap transformer layers with non-reentrant activation checkpointing."""
+    context_fn = functools.partial(
+        transformer_engine_attention_backend_snapshot_context_fn,
+        sdpa_backend_snapshot_context_fn,
+    )
+    for index, layer in enumerate(layers):
+        if isinstance(layer, CheckpointWrapper):
+            continue
+        wrapped_layer = checkpoint_wrapper(
+            layer,
+            checkpoint_impl=CheckpointImpl.NO_REENTRANT,
+            context_fn=context_fn,
+            preserve_rng_state=True,
+        )
+        if not _replace_child_module(model, layer, wrapped_layer):
+            raise RuntimeError(f"Could not replace layer {index} with an activation checkpoint wrapper.")
+        layers[index] = wrapped_layer
 
 
 def detect_kv_sharing_and_maybe_disable_cache(model: nn.Module) -> bool:

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -63,6 +63,7 @@ except (ImportError, ModuleNotFoundError):
 
 from nemo_automodel.components.distributed.activation_checkpointing import (
     SELECTIVE_AC_WRAPPER_FLAG,
+    apply_full_layer_checkpointing_to_layers,
     apply_selective_checkpointing_to_layers,
     apply_submodule_checkpointing,
     detect_kv_sharing_and_maybe_disable_cache,
@@ -410,10 +411,10 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
                     layer_groups,
                     ac_scopes,
                     enable_compile=enable_compile,
-                ):
-                    # Reentrant HF checkpointing reruns FSDP2 forward hooks during backward and can retrigger
-                    # explicit forward-prefetch chains, issuing duplicate parameter all-gathers.
-                    model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
+                ) and not _has_kv_sharing:
+                    # Work around a PyTorch FSDP2 bug that skips mixed-precision input casts during
+                    # checkpoint recomputation. Remove when the minimum PyTorch version is 2.13.
+                    apply_full_layer_checkpointing_to_layers(model, ac_layers)
                 else:
                     apply_submodule_checkpointing(ac_layers, _has_kv_sharing)
 

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -406,12 +406,15 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
                         if m is not None:
                             setattr(layer, attr, checkpoint_wrapper(m, checkpoint_impl=CheckpointImpl.NO_REENTRANT))
             else:
-                if _should_use_hf_native_gradient_checkpointing(
-                    model,
-                    layer_groups,
-                    ac_scopes,
-                    enable_compile=enable_compile,
-                ) and not _has_kv_sharing:
+                if (
+                    _should_use_hf_native_gradient_checkpointing(
+                        model,
+                        layer_groups,
+                        ac_scopes,
+                        enable_compile=enable_compile,
+                    )
+                    and not _has_kv_sharing
+                ):
                     # Work around a PyTorch FSDP2 bug that skips mixed-precision input casts during
                     # checkpoint recomputation. Remove when the minimum PyTorch version is 2.13.
                     apply_full_layer_checkpointing_to_layers(model, ac_layers)

--- a/nemo_automodel/components/models/bagel/hf_backbone_loader.py
+++ b/nemo_automodel/components/models/bagel/hf_backbone_loader.py
@@ -25,6 +25,8 @@ from typing import TYPE_CHECKING, Any, Dict
 
 import torch
 
+from nemo_automodel.shared.parameter_names import canonical_parameter_fqn
+
 if TYPE_CHECKING:
     from nemo_automodel.components.models.bagel.configuration import BagelBackendConfig
 
@@ -46,9 +48,8 @@ def _load_siglip_vision_config(vit_path: str):
 
 def _normalize_wrapped_param_name(name: str) -> str:
     """Remove wrapper path fragments that are not part of logical parameter FQNs."""
-    for fragment in ("._checkpoint_wrapped_module", "._fsdp_wrapped_module"):
-        name = name.replace(fragment, "")
-    for fragment in ("_checkpoint_wrapped_module.", "_fsdp_wrapped_module."):
+    name = canonical_parameter_fqn(name)
+    for fragment in ("._fsdp_wrapped_module", "_fsdp_wrapped_module."):
         name = name.replace(fragment, "")
     return name
 

--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -24,6 +24,7 @@ from torch.distributed.fsdp import FSDPModule
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from nemo_automodel.shared.import_utils import safe_import_from
+from nemo_automodel.shared.parameter_names import canonical_parameter_fqn
 from nemo_automodel.shared.utils import dtype_from_str
 
 logger = logging.getLogger(__name__)
@@ -779,7 +780,7 @@ def _restore_fp32_tensor_snapshots(
         # module. Try the literal FQN first for buffers registered on the wrapped
         # leaf, then strip the wrapper alias as a fallback for forwarded names.
         candidate_names = [name]
-        stripped_name = name.replace("._checkpoint_wrapped_module", "")
+        stripped_name = canonical_parameter_fqn(name)
         if stripped_name != name:
             candidate_names.append(stripped_name)
 

--- a/nemo_automodel/components/optim/optimizer.py
+++ b/nemo_automodel/components/optim/optimizer.py
@@ -54,6 +54,7 @@ from torch.distributed.tensor import DTensor
 from nemo_automodel.components.optim.dion import build_dion_optimizer, is_dion_optimizer
 from nemo_automodel.components.optim.precision_warnings import warn_if_torch_adam_with_bf16_params
 from nemo_automodel.components.optim.scheduler import OptimizerParamScheduler
+from nemo_automodel.shared.parameter_names import canonical_parameter_fqn
 from nemo_automodel.shared.utils import dtype_from_str
 
 if TYPE_CHECKING:
@@ -141,7 +142,8 @@ def _build_param_groups(
     compiled = [re.compile(override.pattern) for override in overrides]
     default_params: list[torch.nn.Parameter] = []
     matched_params: list[list[torch.nn.Parameter]] = [[] for _ in overrides]
-    for name, param in named_params:
+    for raw_name, param in named_params:
+        name = canonical_parameter_fqn(raw_name)
         for idx, regex in enumerate(compiled):
             if regex.search(name):
                 matched_params[idx].append(param)

--- a/nemo_automodel/shared/parameter_names.py
+++ b/nemo_automodel/shared/parameter_names.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for stable logical parameter names."""
+
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import _CHECKPOINT_PREFIX
+
+
+def canonical_parameter_fqn(name: str) -> str:
+    """Remove activation-checkpoint wrapper components from a parameter FQN.
+
+    PyTorch exposes ``CheckpointWrapper`` as a registered child module through
+    ``named_parameters()``, but strips the same component from state-dict keys.
+    Canonicalizing name-sensitive consumers keeps their logical names aligned
+    with the stable state-dict contract.
+
+    Args:
+        name: Module-qualified parameter name.
+
+    Returns:
+        The logical parameter name without checkpoint-wrapper components.
+    """
+    return name.replace(_CHECKPOINT_PREFIX, "")

--- a/nemo_automodel/shared/tied_weights.py
+++ b/nemo_automodel/shared/tied_weights.py
@@ -17,6 +17,8 @@ from enum import Enum
 import torch
 import torch.nn as nn
 
+from nemo_automodel.shared.parameter_names import canonical_parameter_fqn
+
 
 class TieSupport(Enum):
     """Which ``tie_word_embeddings`` settings a model class supports.
@@ -84,7 +86,7 @@ def is_tied_word_embeddings(model: nn.Module) -> bool:
 
 def _normalize_param_name(name: str) -> str:
     """Strip wrapper-specific prefixes from a parameter name."""
-    return name.replace("_orig_mod.", "")
+    return canonical_parameter_fqn(name).replace("_orig_mod.", "")
 
 
 def get_lm_head_weight_and_name(model: nn.Module) -> tuple[torch.Tensor | None, str | None]:

--- a/tests/functional_tests/hf_transformer/test_fsdp2_hf_checkpoint_prefetch.py
+++ b/tests/functional_tests/hf_transformer/test_fsdp2_hf_checkpoint_prefetch.py
@@ -32,6 +32,7 @@ from torch.utils.checkpoint import checkpoint
 from transformers.modeling_layers import GradientCheckpointingLayer
 
 from nemo_automodel.components.distributed.parallelizer import DefaultParallelizationStrategy
+from nemo_automodel.shared.parameter_names import canonical_parameter_fqn
 
 _WORLD_SIZE = 2
 _NUM_LAYERS = 4
@@ -45,6 +46,7 @@ class _HFCheckpointLayer(GradientCheckpointingLayer):
         super().__init__()
         self.up = nn.Linear(_HIDDEN_SIZE, 2 * _HIDDEN_SIZE)
         self.down = nn.Linear(2 * _HIDDEN_SIZE, _HIDDEN_SIZE)
+        self.observed_dtypes: list[torch.dtype] = []
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """Apply a residual MLP.
@@ -55,6 +57,7 @@ class _HFCheckpointLayer(GradientCheckpointingLayer):
         Returns:
             Tensor of shape [batch, sequence, hidden].
         """
+        self.observed_dtypes.append(hidden_states.dtype)
         return hidden_states + self.down(torch.nn.functional.silu(self.up(hidden_states)))
 
 
@@ -144,7 +147,7 @@ def _worker(rank: int, port: int) -> None:
     try:
         torch.manual_seed(1234)
         model = _TinyHFModel().cuda(rank)
-        reference = copy.deepcopy(model)
+        reference = copy.deepcopy(model).to(torch.bfloat16)
         mesh = init_device_mesh(
             "cuda",
             (1, _WORLD_SIZE, 1),
@@ -166,7 +169,7 @@ def _worker(rank: int, port: int) -> None:
             model=model,
             device_mesh=mesh,
             mp_policy=MixedPrecisionPolicy(
-                param_dtype=torch.float32,
+                param_dtype=torch.bfloat16,
                 reduce_dtype=torch.float32,
                 output_dtype=torch.float32,
             ),
@@ -177,26 +180,42 @@ def _worker(rank: int, port: int) -> None:
             reshard_after_forward=True,
         )
 
+        assert all(parameter.dtype == torch.float32 for parameter in model.parameters())
+        assert set(model.state_dict()) == set(reference.state_dict())
         for layer in model.model.layers:
-            assert layer._gradient_checkpointing_func.keywords["use_reentrant"] is False
+            assert hasattr(layer, "_checkpoint_wrapped_module")
+            assert not hasattr(layer._checkpoint_wrapped_module, "_gradient_checkpointing_func")
 
         torch.manual_seed(5678)
         inputs = torch.randn(2, 4, _HIDDEN_SIZE, device=rank)
 
         phase["name"] = "forward"
-        output = model(inputs)
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            output = model(inputs)
         phase["name"] = "backward"
         output.sum().backward()
         phase["name"] = "done"
 
-        reference_output = reference(inputs)
+        assert all(
+            layer._checkpoint_wrapped_module.observed_dtypes == [torch.bfloat16, torch.bfloat16]
+            for layer in model.model.layers
+        )
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            reference_output = reference(inputs.to(torch.bfloat16)).float()
         reference_output.sum().backward()
 
         assert all_gather_counts == {"forward": _NUM_LAYERS + 1, "backward": _NUM_LAYERS}
-        torch.testing.assert_close(output, reference_output)
+        torch.testing.assert_close(output, reference_output, rtol=1e-2, atol=1e-2)
         reference_parameters = dict(reference.named_parameters())
         for name, parameter in model.named_parameters():
-            torch.testing.assert_close(_full_gradient(parameter), reference_parameters[name].grad)
+            reference_name = canonical_parameter_fqn(name)
+            torch.testing.assert_close(
+                _full_gradient(parameter),
+                reference_parameters[reference_name].grad,
+                rtol=1e-2,
+                atol=1e-2,
+                check_dtype=False,
+            )
     finally:
         FSDPParamGroup.unshard = original_unshard
         dist.destroy_process_group()

--- a/tests/unit_tests/distributed/test_parallelizer.py
+++ b/tests/unit_tests/distributed/test_parallelizer.py
@@ -1966,10 +1966,10 @@ class TestActivationCheckpointingKVSharing:
             rejects non-Module values when replacing a registered child module.
             """
 
-            def __init__(self, inner, context_fn=None):
+            def __init__(self, inner, **kwargs):
                 super().__init__()
                 self._inner = inner
-                self._context_fn = context_fn
+                self.kwargs = kwargs
 
             @property
             def _checkpoint_wrapped_module(self):
@@ -1982,7 +1982,7 @@ class TestActivationCheckpointingKVSharing:
 
         monkeypatch.setattr(
             "nemo_automodel.components.distributed.parallelizer.checkpoint_wrapper",
-            lambda module, **kwargs: _Wrapped(module),
+            lambda module, **kwargs: _Wrapped(module, **kwargs),
         )
         monkeypatch.setattr(
             "nemo_automodel.components.distributed.activation_checkpointing.checkpoint_wrapper",
@@ -2427,7 +2427,7 @@ class TestActivationCheckpointingKVSharing:
             assert not hasattr(layer, "mlp")
 
     # ------------------------------------------------------------------ #
-    # HF native gradient-checkpointing path
+    # HF-native gradient-checkpointing candidates
     # ------------------------------------------------------------------ #
 
     @staticmethod
@@ -2451,25 +2451,28 @@ class TestActivationCheckpointingKVSharing:
         model.gradient_checkpointing_enable = MagicMock()  # type: ignore[attr-defined]
         return model
 
-    def test_hf_native_grad_ckpt_preserves_use_cache_with_kv_sharing(self, monkeypatch):
-        """Even when the HF native path is taken, use_cache stays True for KV-shared models."""
+    def test_hf_native_candidate_with_kv_sharing_uses_submodule_checkpointing(self, monkeypatch):
+        """KV-shared models preserve their cache and use submodule checkpointing."""
         model = self._setup_hf_native_model(monkeypatch, num_kv_shared_layers=20)
         self._run_parallelize(model)
 
         assert model.config.use_cache is True
-        model.gradient_checkpointing_enable.assert_called_once_with(
-            gradient_checkpointing_kwargs={"use_reentrant": False}
-        )
+        model.gradient_checkpointing_enable.assert_not_called()
+        assert all(not isinstance(layer, self._Wrapped) for layer in model.model.layers)
+        assert all(isinstance(layer.mlp, self._Wrapped) for layer in model.model.layers)
 
-    def test_hf_native_grad_ckpt_disables_use_cache_and_uses_non_reentrant(self, monkeypatch):
-        """HF native checkpointing disables cache and avoids reentrant FSDP2 forward hooks."""
+    def test_hf_native_candidate_uses_non_reentrant_full_layer_checkpointing(self, monkeypatch):
+        """HF-native candidates use full-layer checkpoint wrappers instead of the HF API."""
+        from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import CheckpointImpl
+
         model = self._setup_hf_native_model(monkeypatch, num_kv_shared_layers=0)
         self._run_parallelize(model)
 
         assert model.config.use_cache is False
-        model.gradient_checkpointing_enable.assert_called_once_with(
-            gradient_checkpointing_kwargs={"use_reentrant": False}
-        )
+        model.gradient_checkpointing_enable.assert_not_called()
+        assert all(isinstance(layer, self._Wrapped) for layer in model.model.layers)
+        assert all(layer.kwargs["checkpoint_impl"] is CheckpointImpl.NO_REENTRANT for layer in model.model.layers)
+        assert all(layer.kwargs["preserve_rng_state"] is True for layer in model.model.layers)
 
     def test_hf_native_grad_ckpt_skips_frozen_layers(self, monkeypatch):
         """Frozen layers force scoped submodule wrapping instead of whole-model HF native GC."""

--- a/tests/unit_tests/optim/test_optim_config.py
+++ b/tests/unit_tests/optim/test_optim_config.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 import torch.nn as nn
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
 
 from nemo_automodel.components.optim.optimizer import (
     AdamConfig,
@@ -485,6 +486,19 @@ class TestParamGroupOverrides:
         assert groups["default"]["lr"] == pytest.approx(1e-3)
         # default group is placed first so base-LR detection reads the unscaled lr.
         assert opt.param_groups[0]["lr"] == pytest.approx(1e-3)
+
+    def test_group_pattern_matches_canonical_name_through_checkpoint_wrapper(self):
+        model = _RouterModel()
+        router_weight = model.router.weight
+        model.router = checkpoint_wrapper(model.router)
+
+        opt = AdamWConfig(
+            lr=1e-3,
+            param_group_overrides=[ParamGroupOverride(r"^router\.weight$", lr_mult=0.1)],
+        ).build(model)[0]
+
+        override_group = next(group for group in opt.param_groups if group.get("lr_mult") == 0.1)
+        assert override_group["params"] == [router_weight]
 
     def test_non_matching_pattern_dropped(self, caplog):
         with caplog.at_level("WARNING"):

--- a/tests/unit_tests/shared/test_parameter_names.py
+++ b/tests/unit_tests/shared/test_parameter_names.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from torch import nn
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
+
+from nemo_automodel.shared.parameter_names import canonical_parameter_fqn
+
+
+def test_canonical_parameter_fqns_match_checkpoint_wrapper_state_dict_keys():
+    model = nn.Sequential(checkpoint_wrapper(nn.Linear(4, 2)))
+
+    canonical_names = {canonical_parameter_fqn(name) for name, _ in model.named_parameters()}
+
+    assert canonical_names == set(model.state_dict()) == {"0.weight", "0.bias"}
+
+
+def test_canonical_parameter_fqn_preserves_unwrapped_name():
+    name = "model.layers.0.mlp.up_proj.weight"
+    assert canonical_parameter_fqn(name) == name
+
+
+def test_canonical_parameter_fqn_strips_nested_checkpoint_wrappers():
+    assert (
+        canonical_parameter_fqn(
+            "_checkpoint_wrapped_module.layers.0._checkpoint_wrapped_module.self_attn.q_proj.weight"
+        )
+        == "layers.0.self_attn.q_proj.weight"
+    )


### PR DESCRIPTION
Fixes https://github.com/NVIDIA-NeMo/Automodel/issues/3504

# What does this PR do ?

Fix full-layer activation checkpointing for Hugging Face transformer layers trained with FSDP2 mixed precision.

With PyTorch 2.11/2.12, the Hugging Face non-reentrant checkpointing path can skip the FSDP2 mixed-precision input cast during backward recomputation. The original forward and recomputation then produce different dtypes, which can raise `CheckpointError` metadata mismatches or matrix-multiplication dtype errors.

The fix wraps eligible transformer layers with `CheckpointWrapper(NO_REENTRANT)` before FSDP2 sharding. This keeps recomputation on the FSDP2 module boundary, preserves RNG and attention-backend state, and retains submodule checkpointing for KV-sharing models.

PyTorch 2.13.0 fixes the underlying FSDP2 behavior: the `PRE_BACKWARD` recomputation path now applies both [`_cast_forward_inputs()` and `_cast_output_dtype()`](https://github.com/pytorch/pytorch/blob/v2.13.0/torch/distributed/fsdp/_fully_shard/_fsdp_state.py#L293-L328). Once Automodel's minimum supported PyTorch version is 2.13.0, this workaround can be removed and the Hugging Face native non-reentrant checkpointing path can be restored.

# Changelog

- Use full-layer non-reentrant checkpoint wrappers for eligible Hugging Face models.
- Preserve RNG and attention-backend state across recomputation.
- Keep the existing KV-sharing submodule-checkpointing path.
- Add focused CPU unit coverage for both routing decisions.

# Validation

- `pytest tests/unit_tests/distributed/test_parallelizer.py -q -k hf_native`: 4 passed.
- `pytest tests/unit_tests/distributed/test_parallelizer.py::TestActivationCheckpointingKVSharing -q`: 27 passed.
- NeMo-RL Qwen3 32B -> 1.7B FSDP2 distillation smoke: 10/10 steps and 4/4 metric checks passed.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added focused tests.
- [x] Documentation is not required for this internal compatibility workaround.

# Additional Information

The `r0.6.0` label requests automatic cherry-pick to the release branch after this PR merges into `main`.
