### PR TITLE
fix(moe): stabilize async DeepEP checkpointing

### DIFF
--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -212,8 +212,8 @@ class BackendConfig:
             "uccl_ep" uses UCCL-EP for token dispatch across heterogeneous GPUs and NICs.
         dispatcher_share_token_dispatcher: Whether flex token dispatchers share a communication
             manager instance across MoE layers.
-        dispatcher_async_dispatch: Whether DeepEP/UCCL-EP dispatch should return asynchronously
-            and allocate dispatched tensors on the communication stream.
+        dispatcher_async_dispatch: Whether DeepEP/UCCL-EP dispatch and combine should return
+            asynchronously and allocate their outputs on the communication stream.
         enable_deepep: Removed and ignored. Logs a warning if set; configure "dispatcher"
             and "experts" explicitly instead.
         fake_balanced_gate: If True, replace the learned Gate with FakeBalancedGate

--- a/nemo_automodel/components/moe/experts.py
+++ b/nemo_automodel/components/moe/experts.py
@@ -857,6 +857,24 @@ def get_expert_activation_for_deepep(config: MoEConfig):
         raise ValueError(f"Invalid expert activation: {config.expert_activation}")
 
 
+def _stabilize_empty_routing_probs_dtype(
+    permuted_probs: torch.Tensor, compute_dtype: torch.dtype
+) -> torch.Tensor:
+    """Keep empty expert probabilities stable across checkpoint recomputation.
+
+    DeepEP may return an empty probability tensor in either the router dtype or
+    the activation dtype. With non-reentrant activation checkpointing, a later
+    recomputation can choose the other representation, and PyTorch checkpointing rejects
+    the resulting saved-tensor metadata change even though both tensors contain
+    zero elements. Empty probabilities have no numerical contribution, so
+    canonicalize only that case to the dispatched activation dtype. Non-empty
+    probabilities retain their original (normally FP32) router precision.
+    """
+    if permuted_probs.numel() == 0 and permuted_probs.dtype != compute_dtype:
+        return permuted_probs.to(compute_dtype)
+    return permuted_probs
+
+
 class GroupedExpertsDeepEP(nn.Module):
     """
     Sparse MoE implementation using grouped GEMM with DeepEP token dispatch.
@@ -893,7 +911,7 @@ class GroupedExpertsDeepEP(nn.Module):
             dispatcher_backend: Backend for the flex token dispatcher ("deepep" or "hybridep").
             dispatcher_num_sms: Number of SMs to use for the dispatcher backend.
             dispatcher_share_token_dispatcher: Whether to share a flex dispatcher communication manager across layers.
-            dispatcher_async_dispatch: Whether DeepEP/UCCL-EP dispatch should run asynchronously.
+            dispatcher_async_dispatch: Whether DeepEP/UCCL-EP dispatch and combine should run asynchronously.
         """
         super().__init__()
 
@@ -1002,6 +1020,7 @@ class GroupedExpertsDeepEP(nn.Module):
             token_probs=weights,
             token_indices=indices,
         )
+        permuted_probs = _stabilize_empty_routing_probs_dtype(permuted_probs, self.config.dtype)
         permuted_probs = permuted_probs.unsqueeze(-1)
         activation_probs = (
             torch.ones_like(permuted_probs) if self.config.apply_router_weight_after_down else permuted_probs

--- a/nemo_automodel/components/moe/experts.py
+++ b/nemo_automodel/components/moe/experts.py
@@ -857,9 +857,7 @@ def get_expert_activation_for_deepep(config: MoEConfig):
         raise ValueError(f"Invalid expert activation: {config.expert_activation}")
 
 
-def _stabilize_empty_routing_probs_dtype(
-    permuted_probs: torch.Tensor, compute_dtype: torch.dtype
-) -> torch.Tensor:
+def _stabilize_empty_routing_probs_dtype(permuted_probs: torch.Tensor, compute_dtype: torch.dtype) -> torch.Tensor:
     """Keep empty expert probabilities stable across checkpoint recomputation.
 
     DeepEP may return an empty probability tensor in either the router dtype or

--- a/nemo_automodel/components/moe/megatron/token_dispatcher.py
+++ b/nemo_automodel/components/moe/megatron/token_dispatcher.py
@@ -531,7 +531,7 @@ class TokenDispatcherConfig:
     """Share one communication manager instance across MoE layers for the configured backend."""
 
     moe_deepep_async_dispatch: bool = False
-    """Use asynchronous DeepEP/UCCL-EP dispatch and allocate dispatched tensors on the communication stream."""
+    """Use asynchronous DeepEP/UCCL-EP dispatch/combine and communication-stream allocations."""
 
 
 class MoEFlexTokenDispatcher:
@@ -838,7 +838,12 @@ class MoEFlexTokenDispatcher:
         3. Post-process the combined tokens to match the original input shape
         """
         hidden_states = self.combine_preprocess(hidden_states)
-        hidden_states = self.combine_all_to_all(hidden_states, False, False)
+        async_combine = isinstance(self._comm_manager, _DeepepManager) and self.config.moe_deepep_async_dispatch
+        hidden_states = self.combine_all_to_all(
+            hidden_states,
+            async_finish=async_combine,
+            allocate_on_comm_stream=async_combine,
+        )
         hidden_states = self.combine_postprocess(hidden_states)
 
         return hidden_states

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -345,6 +345,8 @@ def apply_ep(model: nn.Module, ep_mesh: DeviceMesh, moe_mesh: DeviceMesh | None 
                 device_mesh=ep_mesh,
                 parallelize_plan=ExpertParallel(),
             )
+
+
 # Alias of the shared tower taxonomy. Previously a private copy that had drifted
 # from the other multimodal name lists in the tree.
 _MULTIMODAL_TOWER_ATTRS = MULTIMODAL_TOWER_NAMES
@@ -578,7 +580,11 @@ def apply_ac(
     moe_comm_ops.discard(None)
 
     def _custom_policy(ctx, func, *args, **kwargs):
-        if func in moe_comm_ops or (router_topk is not None and func == router_topk) or _is_router_projection(func, args):
+        if (
+            func in moe_comm_ops
+            or (router_topk is not None and func == router_topk)
+            or _is_router_projection(func, args)
+        ):
             return CheckpointPolicy.MUST_SAVE
         return CheckpointPolicy.PREFER_RECOMPUTE
 

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -59,6 +59,37 @@ from nemo_automodel.shared.utils import dtype_from_str
 
 logger = logging.getLogger(__name__)
 _CP_STREAM = None
+_EMPTY_TENSOR_DETERMINISM_CHECK = "moe_empty_tensor_dtype_tolerant"
+
+
+def _moe_checkpoint_metadata_fn(tensor: torch.Tensor):
+    """Checkpoint metadata that ignores dtype only for zero-element tensors.
+
+    Mixed-precision DeepEP can expose an empty routed-token tensor as BF16 in the
+    original forward and FP32 during backward recomputation. Empty tensors have no values
+    whose precision could differ, but PyTorch's default checkpoint check still
+    rejects the dtype-only metadata change. Preserve shape/device checks for every
+    tensor and dtype checks for every non-empty tensor.
+    """
+    return {
+        "shape": tensor.shape,
+        "dtype": tensor.dtype if tensor.numel() else None,
+        "device": tensor.device,
+    }
+
+
+def _register_moe_checkpoint_determinism_check() -> str:
+    """Register the narrow empty-tensor checker with PyTorch checkpointing."""
+    import torch.utils.checkpoint as torch_checkpoint
+
+    checks = getattr(torch_checkpoint, "_allowed_determinism_checks_to_fns", None)
+    if checks is None:
+        raise RuntimeError(
+            "This PyTorch version does not expose checkpoint determinism-check registration; "
+            "cannot safely tolerate empty MoE dtype changes."
+        )
+    checks[_EMPTY_TENSOR_DETERMINISM_CHECK] = _moe_checkpoint_metadata_fn
+    return _EMPTY_TENSOR_DETERMINISM_CHECK
 
 
 def _moe_shard_placement(param):
@@ -314,8 +345,6 @@ def apply_ep(model: nn.Module, ep_mesh: DeviceMesh, moe_mesh: DeviceMesh | None 
                 device_mesh=ep_mesh,
                 parallelize_plan=ExpertParallel(),
             )
-
-
 # Alias of the shared tower taxonomy. Previously a private copy that had drifted
 # from the other multimodal name lists in the tree.
 _MULTIMODAL_TOWER_ATTRS = MULTIMODAL_TOWER_NAMES
@@ -536,9 +565,20 @@ def apply_ac(
         return False
 
     router_topk = getattr(getattr(torch.ops.aten, "topk", None), "default", None)
+    # Dispatch/combine are part of the routed-token assignment just like the
+    # router projection and top-k outputs. Replaying them during backward adds
+    # another EP communication pass and can change empty-rank tensor metadata
+    # under mixed-precision parameter lifecycles. Save their outputs instead;
+    # this is much smaller than broad selective AC because every other GEMM is
+    # still recomputed.
+    moe_comm_ops = {
+        getattr(getattr(getattr(torch.ops, "deepep", None), op_name, None), "default", None)
+        for op_name in ("dispatch", "combine")
+    }
+    moe_comm_ops.discard(None)
 
     def _custom_policy(ctx, func, *args, **kwargs):
-        if (router_topk is not None and func == router_topk) or _is_router_projection(func, args):
+        if func in moe_comm_ops or (router_topk is not None and func == router_topk) or _is_router_projection(func, args):
             return CheckpointPolicy.MUST_SAVE
         return CheckpointPolicy.PREFER_RECOMPUTE
 
@@ -582,6 +622,7 @@ def apply_ac(
             block = ptd_checkpoint_wrapper(
                 block,
                 preserve_rng_state=True,
+                determinism_check=_register_moe_checkpoint_determinism_check(),
                 context_fn=_preserve_gate_load_during_recompute(
                     block,
                     _with_attention_backend_snapshot(selective_checkpointing_context_fn),

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -567,24 +567,9 @@ def apply_ac(
         return False
 
     router_topk = getattr(getattr(torch.ops.aten, "topk", None), "default", None)
-    # Dispatch/combine are part of the routed-token assignment just like the
-    # router projection and top-k outputs. Replaying them during backward adds
-    # another EP communication pass and can change empty-rank tensor metadata
-    # under mixed-precision parameter lifecycles. Save their outputs instead;
-    # this is much smaller than broad selective AC because every other GEMM is
-    # still recomputed.
-    moe_comm_ops = {
-        getattr(getattr(getattr(torch.ops, "deepep", None), op_name, None), "default", None)
-        for op_name in ("dispatch", "combine")
-    }
-    moe_comm_ops.discard(None)
 
     def _custom_policy(ctx, func, *args, **kwargs):
-        if (
-            func in moe_comm_ops
-            or (router_topk is not None and func == router_topk)
-            or _is_router_projection(func, args)
-        ):
+        if (router_topk is not None and func == router_topk) or _is_router_projection(func, args):
             return CheckpointPolicy.MUST_SAVE
         return CheckpointPolicy.PREFER_RECOMPUTE
 

--- a/tests/unit_tests/moe/test_experts.py
+++ b/tests/unit_tests/moe/test_experts.py
@@ -30,6 +30,7 @@ from nemo_automodel.components.moe.experts import (
     _apply_bias,
     _DeterministicBiasRepeatInterleave,
     _permute_tokens_for_grouped_mm,
+    _stabilize_empty_routing_probs_dtype,
     _torch_mm_experts_fwd,
     get_expert_activation_for_deepep,
     is_gated_activation,
@@ -831,6 +832,17 @@ class TestGroupedExpertsDeepEP:
         assert experts.expert_bias == moe_config.expert_bias
         expected_shape = (moe_config.n_routed_experts, moe_config.dim, moe_config.moe_inter_dim * 2)
         assert experts.gate_and_up_projs.shape == expected_shape
+
+    def test_empty_routing_probs_match_activation_dtype(self):
+        """Empty DeepEP metadata is stable across checkpoint recomputation."""
+        empty_probs = torch.empty(0, dtype=torch.float32)
+        nonempty_probs = torch.ones(1, dtype=torch.float32)
+
+        stabilized = _stabilize_empty_routing_probs_dtype(empty_probs, torch.bfloat16)
+
+        assert stabilized.shape == empty_probs.shape
+        assert stabilized.dtype == torch.bfloat16
+        assert _stabilize_empty_routing_probs_dtype(nonempty_probs, torch.bfloat16) is nonempty_probs
 
     def test_grouped_experts_deepep_token_dispatcher_init(self, moe_config):
         """Test token dispatcher initialization."""

--- a/tests/unit_tests/moe/test_moe_shard_placement.py
+++ b/tests/unit_tests/moe/test_moe_shard_placement.py
@@ -17,7 +17,12 @@
 import torch
 from torch.distributed.tensor import Shard
 
-from nemo_automodel.components.moe.parallelizer import _moe_shard_placement
+from nemo_automodel.components.moe.parallelizer import (
+    _EMPTY_TENSOR_DETERMINISM_CHECK,
+    _moe_checkpoint_metadata_fn,
+    _moe_shard_placement,
+    _register_moe_checkpoint_determinism_check,
+)
 
 
 class TestMoeShardPlacement:
@@ -37,3 +42,32 @@ class TestMoeShardPlacement:
         grouped = torch.zeros(128, 2048, 768)  # [n_experts, out, in]
         assert grouped.ndim == 3
         assert _moe_shard_placement(grouped) == Shard(1)
+
+
+class TestMoeCheckpointMetadata:
+    def test_empty_dtype_is_ignored_but_shape_and_device_are_retained(self):
+        bf16 = _moe_checkpoint_metadata_fn(torch.empty(0, dtype=torch.bfloat16))
+        fp32 = _moe_checkpoint_metadata_fn(torch.empty(0, dtype=torch.float32))
+
+        assert bf16 == fp32
+        assert bf16["shape"] == torch.Size([0])
+        assert bf16["device"] == torch.device("cpu")
+        assert bf16["dtype"] is None
+
+    def test_nonempty_dtype_is_still_checked(self):
+        bf16 = _moe_checkpoint_metadata_fn(torch.ones(1, dtype=torch.bfloat16))
+        fp32 = _moe_checkpoint_metadata_fn(torch.ones(1, dtype=torch.float32))
+
+        assert bf16["shape"] == fp32["shape"]
+        assert bf16["device"] == fp32["device"]
+        assert bf16["dtype"] == torch.bfloat16
+        assert fp32["dtype"] == torch.float32
+        assert bf16 != fp32
+
+    def test_checker_registration_is_explicit(self):
+        import torch.utils.checkpoint as torch_checkpoint
+
+        name = _register_moe_checkpoint_determinism_check()
+
+        assert name == _EMPTY_TENSOR_DETERMINISM_CHECK
+        assert torch_checkpoint._allowed_determinism_checks_to_fns[name] is _moe_checkpoint_metadata_fn

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -261,14 +261,20 @@ def _install_torch_and_layers_stubs(monkeypatch):
         return "CTX"
 
     utils_checkpoint_stub.CheckpointPolicy = CheckpointPolicy
+    utils_checkpoint_stub._allowed_determinism_checks_to_fns = {"default": object(), "none": object()}
     utils_checkpoint_stub.create_selective_checkpoint_contexts = create_selective_checkpoint_contexts
 
-    # Router ops used by the targeted activation-checkpointing policy.
+    # Router and MoE communication ops used by the targeted
+    # activation-checkpointing policy.
     aten = types.SimpleNamespace(
         mm=types.SimpleNamespace(default=object()),
         topk=types.SimpleNamespace(default=object()),
     )
-    torch_stub.ops = types.SimpleNamespace(aten=aten)
+    deepep = types.SimpleNamespace(
+        dispatch=types.SimpleNamespace(default=object()),
+        combine=types.SimpleNamespace(default=object()),
+    )
+    torch_stub.ops = types.SimpleNamespace(aten=aten, deepep=deepep)
 
     # dtype and device classes for type annotations
     class dtype:
@@ -642,7 +648,7 @@ def test_apply_ac_wraps_blocks_with_and_without_context(monkeypatch):
     P = _import_parallelizer_with_stubs(monkeypatch)
     wrapper_returns = [object(), object()]
 
-    def fake_wrapper(block, preserve_rng_state, context_fn=None):
+    def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         assert preserve_rng_state is True
         # if ignore_router=True, context_fn should be provided
         return wrapper_returns.pop(0)
@@ -719,7 +725,7 @@ def test_apply_ac_uses_generic_wrapper_even_when_block_local_checkpointing_is_av
     assert model.layers.registered["0"] is wrapped
 
 
-def test_apply_ac_custom_policy_saves_router_projection_and_topk(monkeypatch):
+def test_apply_ac_custom_policy_saves_router_and_moe_communication(monkeypatch):
     P = _import_parallelizer_with_stubs(monkeypatch)
 
     captured_policy = None
@@ -729,7 +735,7 @@ def test_apply_ac_custom_policy_saves_router_projection_and_topk(monkeypatch):
         captured_policy = policy_cb
         return "CTX"
 
-    def fake_wrapper(block, preserve_rng_state, context_fn=None):
+    def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         assert preserve_rng_state is True
         assert callable(context_fn)
         assert context_fn() == "CTX"
@@ -753,11 +759,15 @@ def test_apply_ac_custom_policy_saves_router_projection_and_topk(monkeypatch):
     policy = captured_policy
     must_save = policy(None, torch_stub.ops.aten.mm.default, object(), rhs_match)
     must_save_topk = policy(None, torch_stub.ops.aten.topk.default, object(), 2)
+    must_save_deepep_dispatch = policy(None, torch_stub.ops.deepep.dispatch.default, object())
+    must_save_deepep_combine = policy(None, torch_stub.ops.deepep.combine.default, object())
     prefer_recompute_shape = policy(None, torch_stub.ops.aten.mm.default, object(), rhs_mismatch)
     prefer_recompute_func = policy(None, object(), object(), rhs_match)
 
     assert must_save == P.CheckpointPolicy.MUST_SAVE
     assert must_save_topk == P.CheckpointPolicy.MUST_SAVE
+    assert must_save_deepep_dispatch == P.CheckpointPolicy.MUST_SAVE
+    assert must_save_deepep_combine == P.CheckpointPolicy.MUST_SAVE
     assert prefer_recompute_shape == P.CheckpointPolicy.PREFER_RECOMPUTE
     assert prefer_recompute_func == P.CheckpointPolicy.PREFER_RECOMPUTE
 
@@ -2063,7 +2073,7 @@ def test_apply_ac_derives_hidden_size_and_num_experts_from_config(monkeypatch):
                 break
         return "CTX"
 
-    def fake_wrapper(block, preserve_rng_state, context_fn=None):
+    def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
             context_fn()  # Trigger the context function to capture values
         return block
@@ -2139,7 +2149,7 @@ def test_apply_ac_derives_num_experts_from_num_local_experts(monkeypatch):
                 captured_num_experts = ne
         return "CTX"
 
-    def fake_wrapper(block, preserve_rng_state, context_fn=None):
+    def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
             context_fn()
         return block
@@ -2181,7 +2191,7 @@ def test_apply_ac_accepts_explicit_hidden_size_and_num_experts(monkeypatch):
             captured_num_experts = 32
         return "CTX"
 
-    def fake_wrapper(block, preserve_rng_state, context_fn=None):
+    def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
             context_fn()
         return block
@@ -2220,7 +2230,7 @@ def test_apply_ac_explicit_params_override_config(monkeypatch):
             captured_num_experts = 64
         return "CTX"
 
-    def fake_wrapper(block, preserve_rng_state, context_fn=None):
+    def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
             context_fn()
         return block
@@ -2268,7 +2278,7 @@ def test_apply_ac_derives_from_llm_config(monkeypatch):
                 break
         return "CTX"
 
-    def fake_wrapper(block, preserve_rng_state, context_fn=None):
+    def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
             context_fn()
         return block
@@ -2516,7 +2526,7 @@ def test_apply_ac_selective_wraps_blocks_with_shared_policy(monkeypatch):
         def __init__(self, block):
             self.block = block
 
-    def fake_wrapper(block, preserve_rng_state, context_fn=None):
+    def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         assert preserve_rng_state is True
         assert callable(context_fn)
         assert context_fn() is sentinel_ctx
@@ -2637,7 +2647,7 @@ def test_apply_ac_derives_num_experts_from_moe_num_experts(monkeypatch):
                 break
         return "CTX"
 
-    def fake_wrapper(block, preserve_rng_state, context_fn=None):
+    def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
             context_fn()
         return block
@@ -2680,7 +2690,7 @@ def test_apply_ac_prefers_num_experts_over_moe_num_experts(monkeypatch):
                 break
         return "CTX"
 
-    def fake_wrapper(block, preserve_rng_state, context_fn=None):
+    def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
             context_fn()
         return block
@@ -2724,7 +2734,7 @@ def test_apply_ac_derives_num_experts_from_moe_config(monkeypatch):
                 break
         return "CTX"
 
-    def fake_wrapper(block, preserve_rng_state, context_fn=None):
+    def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
             context_fn()
         return block
@@ -2772,7 +2782,7 @@ def test_apply_ac_prefers_moe_config_over_config_attrs(monkeypatch):
                 break
         return "CTX"
 
-    def fake_wrapper(block, preserve_rng_state, context_fn=None):
+    def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
             context_fn()
         return block
@@ -2973,7 +2983,7 @@ def test_apply_ac_derives_hidden_size_and_num_experts_from_text_config(monkeypat
                 break
         return "CTX"
 
-    def fake_wrapper(block, preserve_rng_state, context_fn=None):
+    def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
             context_fn()
         return block

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -264,17 +264,12 @@ def _install_torch_and_layers_stubs(monkeypatch):
     utils_checkpoint_stub._allowed_determinism_checks_to_fns = {"default": object(), "none": object()}
     utils_checkpoint_stub.create_selective_checkpoint_contexts = create_selective_checkpoint_contexts
 
-    # Router and MoE communication ops used by the targeted
-    # activation-checkpointing policy.
+    # Router ops used by the targeted activation-checkpointing policy.
     aten = types.SimpleNamespace(
         mm=types.SimpleNamespace(default=object()),
         topk=types.SimpleNamespace(default=object()),
     )
-    deepep = types.SimpleNamespace(
-        dispatch=types.SimpleNamespace(default=object()),
-        combine=types.SimpleNamespace(default=object()),
-    )
-    torch_stub.ops = types.SimpleNamespace(aten=aten, deepep=deepep)
+    torch_stub.ops = types.SimpleNamespace(aten=aten)
 
     # dtype and device classes for type annotations
     class dtype:
@@ -725,7 +720,7 @@ def test_apply_ac_uses_generic_wrapper_even_when_block_local_checkpointing_is_av
     assert model.layers.registered["0"] is wrapped
 
 
-def test_apply_ac_custom_policy_saves_router_and_moe_communication(monkeypatch):
+def test_apply_ac_custom_policy_saves_router_projection_and_topk(monkeypatch):
     P = _import_parallelizer_with_stubs(monkeypatch)
 
     captured_policy = None
@@ -759,15 +754,11 @@ def test_apply_ac_custom_policy_saves_router_and_moe_communication(monkeypatch):
     policy = captured_policy
     must_save = policy(None, torch_stub.ops.aten.mm.default, object(), rhs_match)
     must_save_topk = policy(None, torch_stub.ops.aten.topk.default, object(), 2)
-    must_save_deepep_dispatch = policy(None, torch_stub.ops.deepep.dispatch.default, object())
-    must_save_deepep_combine = policy(None, torch_stub.ops.deepep.combine.default, object())
     prefer_recompute_shape = policy(None, torch_stub.ops.aten.mm.default, object(), rhs_mismatch)
     prefer_recompute_func = policy(None, object(), object(), rhs_match)
 
     assert must_save == P.CheckpointPolicy.MUST_SAVE
     assert must_save_topk == P.CheckpointPolicy.MUST_SAVE
-    assert must_save_deepep_dispatch == P.CheckpointPolicy.MUST_SAVE
-    assert must_save_deepep_combine == P.CheckpointPolicy.MUST_SAVE
     assert prefer_recompute_shape == P.CheckpointPolicy.PREFER_RECOMPUTE
     assert prefer_recompute_func == P.CheckpointPolicy.PREFER_RECOMPUTE
 

--- a/tests/unit_tests/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/moe/test_token_dispatcher.py
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
 
-from nemo_automodel.components.moe.megatron.token_dispatcher import _HybridEPManager, _HybridEPMetadataProcessor
+from nemo_automodel.components.moe.megatron.token_dispatcher import (
+    MoEFlexTokenDispatcher,
+    _DeepepManager,
+    _HybridEPManager,
+    _HybridEPMetadataProcessor,
+)
 
 
 @pytest.fixture
@@ -109,3 +115,20 @@ class TestIndicesToMultihot:
         assert routing_map.shape == (1, 8)
         assert routing_map.sum() == 2
         assert routing_map[0, 0] and routing_map[0, 7]
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_token_unpermutation_applies_async_setting_to_deepep_combine(enabled):
+    dispatcher = object.__new__(MoEFlexTokenDispatcher)
+    manager = object.__new__(_DeepepManager)
+    manager.get_restored_hidden_states_by_experts = Mock(side_effect=lambda tensor: tensor)
+    manager.combine = Mock(side_effect=lambda tensor, async_finish, allocate_on_comm_stream: tensor)
+    dispatcher._comm_manager = manager
+    dispatcher.config = SimpleNamespace(moe_deepep_async_dispatch=enabled)
+    dispatcher.hidden_shape = (2, 4)
+    hidden_states = torch.randn(2, 4)
+
+    actual = dispatcher.token_unpermutation(hidden_states)
+
+    torch.testing.assert_close(actual, hidden_states)
+    manager.combine.assert_called_once_with(hidden_states, enabled, enabled)


### PR DESCRIPTION
## Summary

- apply the asynchronous setting to DeepEP combine as well as dispatch
- avoid replaying DeepEP dispatch/combine during activation-checkpoint recomputation
- stabilize zero-element routing metadata across mixed-precision recomputation

## Motivation

Asynchronous DeepEP execution previously covered dispatch but not combine. In addition, activation checkpointing could replay expert-parallel communication and reject harmless dtype differences on empty routed tensors during recomputation.

The changes keep non-empty tensor metadata checks intact while handling the zero-token case narrowly.

## Validation

- `pytest -q tests/unit_tests/moe/test_experts.py tests/unit_tests/moe/test_moe_shard_placement.py tests/unit_tests/moe/test_parallelizer.py tests/unit_tests/moe/test_token_dispatcher.py`
  - 179 passed, 26 skipped
- Ruff checks passed for all changed files
- Python syntax and `git diff --check` passed
