### PR TITLE
feat(loss): return per-depth MTP losses

### DIFF
--- a/nemo_automodel/components/loss/mtp.py
+++ b/nemo_automodel/components/loss/mtp.py
@@ -29,21 +29,36 @@ from nemo_automodel.components.loss.utils import (
 from nemo_automodel.components.models.common.mtp import get_mtp_loss_scaling_factor, roll_tensor
 
 
+@dataclass(frozen=True)
+class MTPLossOutput:
+    """Aggregate MTP loss and its per-depth components.
+
+    Attributes:
+        loss: Scalar loss tensor after applying ``scaling_factor / num_depths``.
+        per_depth_losses: Scalar loss tensor for each MTP depth before applying
+            ``scaling_factor / num_depths``. The tensors retain their autograd graphs.
+    """
+
+    loss: torch.Tensor
+    per_depth_losses: list[torch.Tensor]
+
+
 def calculate_mtp_loss(
-    loss_fn,
+    loss_fn: nn.Module,
     *,
     mtp_per_depth_h: list[torch.Tensor] | None = None,
     mtp_per_depth_logits: list[torch.Tensor] | None = None,
     labels: torch.Tensor,
     model: nn.Module,
     scaling_factor: float = 0.1,
-    num_label_tokens: Optional[int] = None,
+    num_label_tokens: int | None = None,
     ignore_index: int = -100,
-    cu_seqlens: Optional[torch.Tensor] = None,
-    seq_idx: Optional[torch.Tensor] = None,
-    lm_weight: Optional[torch.Tensor] = None,
+    cu_seqlens: torch.Tensor | None = None,
+    seq_idx: torch.Tensor | None = None,
+    lm_weight: torch.Tensor | None = None,
     grad_reduce_group: dist.ProcessGroup | None = None,
-) -> torch.Tensor:
+    return_per_depth: bool = False,
+) -> torch.Tensor | MTPLossOutput:
     """Compute the DeepSeek-V3 Multi-Token Prediction auxiliary loss.
 
     Each depth's CE is dispatched through :func:`calculate_loss` with the
@@ -53,14 +68,19 @@ def calculate_mtp_loss(
     Args:
         loss_fn: Configured per-token loss class (same instance the main
             path uses).
-        mtp_per_depth_h: Per-depth hidden states from the model's MTP head,
-            one ``[B, S, H]`` tensor per depth.
-        labels: Original (unshifted) labels.
+        mtp_per_depth_h: Per-depth hidden-state tensors of shape
+            ``[batch, sequence, hidden]``, or ``[1, tokens, hidden]`` for a
+            flattened THD-packed stream.
+        mtp_per_depth_logits: Per-depth logit tensors of shape
+            ``[batch, sequence, vocab]``, or ``[1, tokens, vocab]`` for a
+            flattened THD-packed stream.
+        labels: Original unshifted label tensor of shape ``[batch, sequence]``
+            or ``[tokens]`` for a flattened THD-packed stream.
         model: The wrapped model; used to fetch the shared LM head when the
             loss class needs materialized logits (non-FusedLinearCE path).
         scaling_factor: Coefficient applied to the summed per-depth CE.
-        num_label_tokens: Total non-ignore label tokens (forwarded to the
-            base loss for sum-reduction normalization).
+        num_label_tokens: Total non-ignore label-token count used for
+            sum-reduction normalization.
         ignore_index: Label value masked out of the CE loss for the trailing
             ``k+1`` rolled positions at depth ``k``.
         cu_seqlens: Optional cumulative sequence lengths ``[num_seqs+1]``
@@ -71,14 +91,19 @@ def calculate_mtp_loss(
             Equality classes are what matter; absolute values can be any
             ints. Takes precedence over ``cu_seqlens``. Used to mask label
             rolls whose source position lies in a different sub-sequence.
-        lm_weight: Optional caller-materialized LM-head weight. Supplying this
-            lets the main loss and all MTP depths share one DTensor
+        lm_weight: Optional LM-head weight tensor of shape ``[vocab, hidden]``.
+            Supplying it lets the main loss and all MTP depths share one DTensor
             ``full_tensor()`` gather on the FusedLinearCrossEntropy path.
         grad_reduce_group: Group that contributes independent loss shards when
             the shared LM-head weight is a DTensor.
+        return_per_depth: Return the aggregate loss together with the unscaled
+            loss for each MTP depth. Defaults to ``False`` to preserve the
+            scalar return expected by existing callers.
 
     Returns:
-        Scalar MTP loss with autograd graph.
+        Scalar MTP loss tensor. When ``return_per_depth=True``, returns an
+        :class:`MTPLossOutput` containing the scalar aggregate and scalar
+        per-depth losses. All returned tensors retain their autograd graphs.
     """
     if (mtp_per_depth_h is None) == (mtp_per_depth_logits is None):
         raise ValueError("Provide exactly one of mtp_per_depth_h or mtp_per_depth_logits")
@@ -97,6 +122,7 @@ def calculate_mtp_loss(
     D = len(mtp_outputs)
     cur_labels = labels
     total = mtp_outputs[0].new_zeros(())
+    per_depth_losses = []
 
     # Materialize the (possibly DTensor-sharded) LM head ONCE for all depths
     # under FusedLinearCrossEntropy. calculate_loss would otherwise re-gather it
@@ -183,9 +209,13 @@ def calculate_mtp_loss(
                 model=model,
                 num_label_tokens=num_label_tokens,
             )
+        per_depth_losses.append(depth_loss)
         total = total + depth_loss
 
-    return total * (scaling_factor / D)
+    total = total * (scaling_factor / D)
+    if return_per_depth:
+        return MTPLossOutput(loss=total, per_depth_losses=per_depth_losses)
+    return total
 
 
 class PipelineCausalLMLoss(nn.Module):

--- a/nemo_automodel/components/loss/mtp.py
+++ b/nemo_automodel/components/loss/mtp.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Literal, Optional, overload
 
 import torch
 import torch.distributed as dist
@@ -41,6 +41,63 @@ class MTPLossOutput:
 
     loss: torch.Tensor
     per_depth_losses: list[torch.Tensor]
+
+
+@overload
+def calculate_mtp_loss(
+    loss_fn: nn.Module,
+    *,
+    mtp_per_depth_h: list[torch.Tensor] | None = None,
+    mtp_per_depth_logits: list[torch.Tensor] | None = None,
+    labels: torch.Tensor,
+    model: nn.Module,
+    scaling_factor: float = 0.1,
+    num_label_tokens: int | None = None,
+    ignore_index: int = -100,
+    cu_seqlens: torch.Tensor | None = None,
+    seq_idx: torch.Tensor | None = None,
+    lm_weight: torch.Tensor | None = None,
+    grad_reduce_group: dist.ProcessGroup | None = None,
+    return_per_depth: Literal[False] = False,
+) -> torch.Tensor: ...
+
+
+@overload
+def calculate_mtp_loss(
+    loss_fn: nn.Module,
+    *,
+    mtp_per_depth_h: list[torch.Tensor] | None = None,
+    mtp_per_depth_logits: list[torch.Tensor] | None = None,
+    labels: torch.Tensor,
+    model: nn.Module,
+    scaling_factor: float = 0.1,
+    num_label_tokens: int | None = None,
+    ignore_index: int = -100,
+    cu_seqlens: torch.Tensor | None = None,
+    seq_idx: torch.Tensor | None = None,
+    lm_weight: torch.Tensor | None = None,
+    grad_reduce_group: dist.ProcessGroup | None = None,
+    return_per_depth: Literal[True],
+) -> MTPLossOutput: ...
+
+
+@overload
+def calculate_mtp_loss(
+    loss_fn: nn.Module,
+    *,
+    mtp_per_depth_h: list[torch.Tensor] | None = None,
+    mtp_per_depth_logits: list[torch.Tensor] | None = None,
+    labels: torch.Tensor,
+    model: nn.Module,
+    scaling_factor: float = 0.1,
+    num_label_tokens: int | None = None,
+    ignore_index: int = -100,
+    cu_seqlens: torch.Tensor | None = None,
+    seq_idx: torch.Tensor | None = None,
+    lm_weight: torch.Tensor | None = None,
+    grad_reduce_group: dist.ProcessGroup | None = None,
+    return_per_depth: bool,
+) -> torch.Tensor | MTPLossOutput: ...
 
 
 def calculate_mtp_loss(
@@ -105,10 +162,14 @@ def calculate_mtp_loss(
         :class:`MTPLossOutput` containing the scalar aggregate and scalar
         per-depth losses. All returned tensors retain their autograd graphs.
     """
-    if (mtp_per_depth_h is None) == (mtp_per_depth_logits is None):
+    if mtp_per_depth_logits is not None:
+        if mtp_per_depth_h is not None:
+            raise ValueError("Provide exactly one of mtp_per_depth_h or mtp_per_depth_logits")
+        mtp_outputs = mtp_per_depth_logits
+    elif mtp_per_depth_h is not None:
+        mtp_outputs = mtp_per_depth_h
+    else:
         raise ValueError("Provide exactly one of mtp_per_depth_h or mtp_per_depth_logits")
-
-    mtp_outputs = mtp_per_depth_logits if mtp_per_depth_logits is not None else mtp_per_depth_h
 
     # Reconcile per-depth output and label dims for the THD-packed non-PP path:
     # the model unsqueezes outputs from ``[T, *]`` back to ``[1, T, *]`` (model.py

--- a/tests/unit_tests/loss/test_mtp_lm_head_gather.py
+++ b/tests/unit_tests/loss/test_mtp_lm_head_gather.py
@@ -142,6 +142,42 @@ def test_mtp_loss_matches_reference(ref_cce):
     torch.testing.assert_close(got, expected, rtol=1e-5, atol=1e-6)
 
 
+def test_mtp_loss_optionally_returns_unscaled_per_depth_losses(ref_cce):
+    torch.manual_seed(7)
+    m = _TinyModel()
+    hs, labels = _inputs(requires_grad=True)
+    output = calculate_mtp_loss(
+        FusedLinearCrossEntropy(reduction="sum"),
+        mtp_per_depth_h=hs,
+        labels=labels,
+        model=m,
+        scaling_factor=SF,
+        num_label_tokens=NLT,
+        ignore_index=IGN,
+        return_per_depth=True,
+    )
+    assert isinstance(output, _mtp.MTPLossOutput)
+
+    expected_per_depth = []
+    cur_labels = labels
+    for depth, hidden_states in enumerate(hs, start=1):
+        cur_labels = roll_tensor(cur_labels, shifts=-1, dim=-1)
+        masked = cur_labels.clone()
+        masked[..., -depth:] = IGN
+        logits = hidden_states.float() @ m.lm_head.weight.float().t()
+        expected_per_depth.append(
+            F.cross_entropy(logits.reshape(-1, V), masked.reshape(-1), ignore_index=IGN, reduction="sum") / NLT
+        )
+
+    assert len(output.per_depth_losses) == D
+    for actual, expected in zip(output.per_depth_losses, expected_per_depth):
+        torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(output.loss, sum(expected_per_depth) * (SF / D), rtol=1e-5, atol=1e-6)
+
+    output.loss.backward()
+    assert all(loss.grad_fn is not None for loss in output.per_depth_losses)
+
+
 def test_lm_head_gathered_once(ref_cce):
     torch.manual_seed(1)
     m = _TinyModel()


### PR DESCRIPTION
# What does this PR do ?

Extends `calculate_mtp_loss` with an opt-in typed result containing the aggregate MTP loss and the already-computed loss for each prediction depth.

This lets training integrations report per-depth MTP metrics without duplicating Automodel's label shifting, packed-sequence boundary masking, LM-head projection, or fused cross-entropy dispatch. Existing callers remain unchanged because the default return value is still the aggregate scalar tensor.

# Changelog

- Add the frozen `MTPLossOutput` result type with aggregate and per-depth scalar losses.
- Add the backward-compatible `return_per_depth=False` option to `calculate_mtp_loss`.
- Add literal overloads so static type checkers preserve the scalar return type for existing callers.
- Preserve each returned loss tensor's autograd graph and the existing aggregate normalization.
- Add a CPU numerical test against independently computed per-depth cross-entropy values.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Validation

- `uvx --from 'ruff~=0.9.0' ruff format --check nemo_automodel/components/loss/mtp.py tests/unit_tests/loss/test_mtp_lm_head_gather.py`
- `uvx --from 'ruff~=0.9.0' ruff check nemo_automodel/components/loss/mtp.py tests/unit_tests/loss/test_mtp_lm_head_gather.py`
- `uv run --active ty check nemo_automodel/components/loss/mtp.py`
- `pytest -q tests/unit_tests/loss/test_mtp_cross_boundary.py tests/unit_tests/loss/test_mtp_lm_head_gather.py` — 17 passed, 1 skipped (threaded distributed backend unavailable)

# Additional Information

This API is intended to remove the duplicated MTP loss implementation currently proposed in NVIDIA-NeMo/Speech#16050.
