### PR TITLE
docs(cohere): add absolute recipe links and remove dead blog reference

### DIFF
--- a/docs/model-coverage/vlm/coherelabs/north-micro-vision.mdx
+++ b/docs/model-coverage/vlm/coherelabs/north-micro-vision.mdx
@@ -34,10 +34,10 @@ slug: model-coverage/vision-language-models/coherelabs/north-micro-vision
 
 | Recipe | Description |
 |---|---|
-| `north_micro_vision_rdr.yaml` | 18-step LoRA SFT on the built-in RDR dataset; smallest end-to-end check |
-| `north_micro_vision_shopify_full.yaml` | Full-epoch LoRA SFT on Shopify product-catalogue with FSDP2 and DP2 |
-| `north_micro_vision_shopify_lora.yaml` | 2,000-sample bounded variant for pipeline smoke tests |
-| `north_micro_vision_shopify_resume.yaml` | Resumes from a saved checkpoint to validate the restore path |
+| [`north_micro_vision_rdr.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/vlm_finetune/cohere_micro_vision/north_micro_vision_rdr.yaml) | 18-step LoRA SFT on the built-in RDR dataset; smallest end-to-end check |
+| [`north_micro_vision_shopify_full.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/vlm_finetune/cohere_micro_vision/north_micro_vision_shopify_full.yaml) | Full-epoch LoRA SFT on Shopify product-catalogue with FSDP2 and DP2 |
+| [`north_micro_vision_shopify_lora.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/vlm_finetune/cohere_micro_vision/north_micro_vision_shopify_lora.yaml) | 2,000-sample bounded variant for pipeline smoke tests |
+| [`north_micro_vision_shopify_resume.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/vlm_finetune/cohere_micro_vision/north_micro_vision_shopify_resume.yaml) | Resumes from a saved checkpoint to validate the restore path |
 
 ## Run the Recipe
 
@@ -55,5 +55,4 @@ Both datasets feed the generic `default_collate_fn`, since `CohereCompassProcess
 ## References
 
 - [North Micro Vision model card](https://huggingface.co/CohereLabs/North-Micro-Vision-Instruct)
-- [Introducing North Micro Vision](https://huggingface.co/blog/CohereLabs/introducing-north-micro-vision)
 - [Shopify product-catalogue dataset](https://huggingface.co/datasets/Shopify/product-catalogue)


### PR DESCRIPTION
## Summary

- Add GitHub absolute URLs to the four North Micro Vision recipe YAMLs in the Example Recipe table in `docs/model-coverage/vlm/coherelabs/north-micro-vision.mdx`
- Remove the broken `[Introducing North Micro Vision](https://huggingface.co/blog/CohereLabs/introducing-north-micro-vision)` reference that 404s

## Test plan

- [ ] Verify all four recipe links resolve on GitHub
- [ ] Confirm the References section no longer contains the dead blog link
- [ ] Run `fern check` if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)