### PR TITLE
fix(pp): keep accumulated grads across stage re-initialization

### DIFF
--- a/nemo_automodel/components/distributed/pipelining/functional.py
+++ b/nemo_automodel/components/distributed/pipelining/functional.py
@@ -442,6 +442,50 @@ def _use_static_pipeline_stage_metadata(schedule: _PipelineSchedule, stages: lis
     logger.info("Using static pipeline metadata with preinitialized neighbor P2P communicators")
 
 
+def _preserve_grads_across_stage_reinit(stages: list[PipelineStage]) -> None:
+    """Keep accumulated gradients alive when stage infrastructure is rebuilt.
+
+    ``_initialize_pp_stages`` ends by calling ``_post_metadata_inference_cleanup``
+    on every stage, which sets ``param.grad = None`` on FSDP modules. Upstream that
+    is safe: it assumes initialization happens once, before any real backward, and
+    only clears the throwaway gradients left behind by dynamic metadata inference.
+
+    ``reset_pp_stage_shapes`` breaks that assumption. It re-initializes the stages
+    whenever the sequence length changes, which for VLM batches is most steps -- and
+    with gradient accumulation that lands *between* micro-batches, so the cleanup
+    discards everything accumulated so far and only the final micro-batch's
+    gradients reach the optimizer.
+
+    With static metadata no inference forward/backward runs, so there are no stale
+    gradients to clear and the whole wipe is collateral damage. Restore the
+    gradients in that case, and leave dynamic mode alone, where the cleanup is doing
+    real work.
+
+    Args:
+        stages: The local pipeline stages to protect.
+    """
+    try:
+        from torch.distributed.pipelining._utils import InferenceMode
+    except ImportError:
+        return
+
+    for stage in stages:
+        cleanup = getattr(stage, "_post_metadata_inference_cleanup", None)
+        if cleanup is None:
+            continue
+
+        def _cleanup_preserving_grads(self, *, _cleanup=cleanup) -> None:
+            if getattr(self, "_inference_mode", None) is not InferenceMode.STATIC:
+                _cleanup()
+                return
+            saved = [(param, param.grad) for param in self.submod.parameters() if param.grad is not None]
+            _cleanup()
+            for param, grad in saved:
+                param.grad = grad
+
+        stage._post_metadata_inference_cleanup = types.MethodType(_cleanup_preserving_grads, stage)
+
+
 def reset_pp_stage_shapes(
     schedule: _PipelineSchedule,
     stages: list[PipelineStage],
@@ -932,6 +976,7 @@ def pipeline_model(
     )
     if seq_len is not None:
         _use_static_pipeline_stage_metadata(pp_schedule, stages)
+    _preserve_grads_across_stage_reinit(stages)
 
     # Patch FSDP backward for MoE models, or when per-microbatch grad reduce-scatter
     # is requested (mapped from surface-level defer_fsdp_grad_sync=False for memory

--- a/tests/unit_tests/distributed/pipelining/test_functional.py
+++ b/tests/unit_tests/distributed/pipelining/test_functional.py
@@ -26,6 +26,7 @@ from torch.distributed.pipelining.schedules import (
 from nemo_automodel.components.distributed.pipelining.functional import (
     _get_hidden_and_vocab_size,
     _precompute_stage_shapes,
+    _preserve_grads_across_stage_reinit,
     _set_stage_metas,
     _use_static_pipeline_stage_metadata,
     _warmup_pipeline_stage_neighbors,
@@ -1648,3 +1649,69 @@ class TestWrapStageForwardToEmitTensor:
         _wrap_stage_forward_to_emit_tensor(m)
         params = list(inspect.signature(m.forward).parameters)
         assert params == ["input_ids", "position_ids", "attention_mask"]
+
+
+class TestPreserveGradsAcrossStageReinit:
+    """Stage re-initialization must not discard accumulated gradients.
+
+    ``_initialize_pp_stages`` always ends by calling
+    ``_post_metadata_inference_cleanup``, which nulls parameter gradients.
+    ``reset_pp_stage_shapes`` re-initializes on every sequence-length change, so
+    under gradient accumulation that cleanup lands between micro-batches and drops
+    everything accumulated so far.
+    """
+
+    def _make_stage(self, inference_mode):
+        """Build a stage stand-in whose cleanup nulls its submodule's gradients.
+
+        Args:
+            inference_mode: Value to expose as the stage's ``_inference_mode``.
+
+        Returns:
+            Tuple of (stage, param) where ``param`` is a tensor of shape [2] whose
+            ``.grad`` is also shape [2].
+        """
+        submod = torch.nn.Linear(2, 1, bias=False)
+        param = submod.weight
+        param.grad = torch.ones_like(param)
+
+        stage = types.SimpleNamespace(submod=submod, _inference_mode=inference_mode)
+
+        def _cleanup():
+            for p in submod.parameters():
+                p.grad = None
+
+        stage._post_metadata_inference_cleanup = _cleanup
+        return stage, param
+
+    def test_static_mode_keeps_accumulated_grads(self, monkeypatch):
+        """With static metadata no inference ran, so gradients must survive."""
+        from torch.distributed.pipelining._utils import InferenceMode
+
+        stage, param = self._make_stage(InferenceMode.STATIC)
+        expected = param.grad.clone()
+
+        _preserve_grads_across_stage_reinit([stage])
+        stage._post_metadata_inference_cleanup()
+
+        assert param.grad is not None, "accumulated gradients were discarded on stage re-init"
+        torch.testing.assert_close(param.grad, expected)
+
+    def test_dynamic_mode_still_clears_stale_grads(self):
+        """Dynamic inference runs a throwaway backward, so its grads must be cleared."""
+        from torch.distributed.pipelining._utils import InferenceMode
+
+        stage, param = self._make_stage(InferenceMode.DYNAMIC)
+
+        _preserve_grads_across_stage_reinit([stage])
+        stage._post_metadata_inference_cleanup()
+
+        assert param.grad is None
+
+    def test_stage_without_cleanup_hook_is_skipped(self):
+        """Older PyTorch stages have no cleanup hook and must not raise."""
+        stage = types.SimpleNamespace(submod=torch.nn.Linear(2, 1))
+
+        _preserve_grads_across_stage_reinit([stage])
+
+        assert not hasattr(stage, "_post_metadata_inference_cleanup")


### PR DESCRIPTION
# What does this PR do ?

Fixes pipeline parallelism throwing away gradients when gradient accumulation is on. Only the **last** micro-batch was actually training the model.

# The bug

PyTorch's `_initialize_pp_stages` finishes by calling `_post_metadata_inference_cleanup`, which does `param.grad = None`. That's fine upstream — it assumes stages are initialized once, before any real backward, so the only gradients around are throwaway ones from metadata inference.

We break that assumption. `reset_pp_stage_shapes` re-initializes the stages every time the sequence length changes, which for VLM batches is nearly every step. With gradient accumulation that lands *between* micro-batches, so everything accumulated so far gets wiped.

Loss looked fine (it's summed separately), so only the gradient norm gave it away.

# The fix

Keep the gradients when the stage is using static metadata — no inference forward/backward ran, so there is nothing stale to clear. Dynamic mode is untouched.

# Numbers

## What was compared

The same Gemma4 proxy trained twice, differing **only** in the pipeline split:

| | baseline | pipeline run |
|---|---|---|
| ranks | 1 | 2 |
| `pp_size` | 1 | 2 |
| `dp_size` | 1 | 1 |
| weights, seed, dataset, `local_batch_size` | identical | identical |

`dp_size` is 1 on both sides, so the dataloader hands both runs the same batches in the same order. Any difference in the numbers is down to the pipeline split, not to different data.

The metric is `grad_norm` straight out of `training.jsonl`: the pre-clip global L2 norm over all parameters, all-reduced across the pipeline mesh. If pipeline parallelism is correct, it should match the single-rank run.

`num_label_tokens` is shown as a sanity check — it is identical across every run, which is what proves they really did train on the same batches.

## Two micro-batches per step (`global_batch_size` 4, `local_batch_size` 2)

| step | num_label_tokens | baseline | before fix | after fix |
|---|---|---|---|---|
| 0 | 836 | 75.38 | 38.88 (**1.94x off**) | 70.49 (1.07x) |
| 1 | 717 | 73.92 | 37.13 (**1.99x off**) | 76.73 (0.96x) |
| 2 | 1123 | 70.53 | 58.57 (**1.20x off**) | 72.35 (0.97x) |

## Three micro-batches per step (`global_batch_size` 6, `local_batch_size` 2)

| step | num_label_tokens | baseline | before fix | after fix |
|---|---|---|---|---|
| 0 | 1266 | 60.75 | 36.37 (**1.67x off**) | 59.66 (1.02x) |
| 1 | 1410 | 59.79 | 44.47 (**1.34x off**) | 59.81 (1.00x) |
| 2 | 1985 | 60.94 | 59.07 (1.03x) | 61.88 (0.98x) |

## Reading it

After the fix everything lands within ~7% of the baseline. That residual is structural rather than noise: `FSDP2Manager` skips parallelization entirely at `world_size=1`, so the baseline runs unwrapped while the pipeline run goes through FSDP2's default bf16 mixed-precision policy. The two are not bit-comparable by construction.

The baseline column is bit-identical before and after the fix, as it should be — the change only touches the pipeline path.

## Sanity check on the proxy

20 steps at `pp_size=2` with accumulation, on the **randomly-initialized proxy** (not real weights), lr raised to 5e-4 so movement is visible over so few steps: loss descends from the random-init plateau of `ln(262144) = 12.48` down to 2.60, gradient norm 70.5 -> 2.26, all finite.

This only shows that gradients flow and the optimizer moves the model on the pipeline path. It is not a convergence result -- a real Gemma4 31B run starts near 1-3, not 12.5.

## Real Gemma4 31B run

The proxy numbers above are a controlled measurement, but the proxy is randomly initialized. So the same comparison on the **real recipe and real weights**: `examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp2.yaml`, `google/gemma-4-31B-it`, MedPix-VQA, TP=4 x PP=2 on 8xH100, 10 steps. `global_batch_size` 4 / `local_batch_size` 2, so two micro-batches per step. Both runs use identical data (`num_label_tokens` matches step for step).

| step | num_label_tokens | loss (no fix) | loss (fix) | grad norm (no fix) | grad norm (fix) |
|---|---|---|---|---|---|
| 0 | 470 | 3.4308 | 3.4308 | 56.40 | 236.57 |
| 1 | 514 | 3.5103 | 3.5151 | 86.70 | 108.25 |
| 2 | 900 | 2.3719 | 2.3280 | 12.07 | 34.80 |
| 3 | 150 | 2.3358 | 2.2535 | 39.27 | 53.45 |
| 4 | 278 | 2.9615 | 2.8371 | 21.94 | 50.31 |
| 5 | 181 | 1.8534 | 1.7478 | 175.62 | 33.13 |
| 6 | 136 | 1.9373 | 1.8616 | 30.50 | 36.62 |
| 7 | 598 | 2.7757 | 2.5736 | 38.22 | 35.01 |
| 8 | 112 | 1.9013 | 1.7728 | 36.29 | 50.08 |
| 9 | 500 | 2.3505 | 2.1775 | 209.94 | 31.62 |

**Step 0 is the clean measurement.** Both runs start from the same weights and see the same batch, so the only difference is the bug: the optimizer sees a gradient **4.2x smaller** than it should (56.40 vs 236.57). From step 1 on the two runs have different weights, so later rows mix the bug with the divergence it already caused.

Wandb curves: [https://wandb.ai/Nemo-automodel/gemma4-31b-pp-grad-accum/workspace?nw=nwuserathittenaman](https://wandb.ai/Nemo-automodel/gemma4-31b-pp-grad-accum/workspace?nw=nwuserathittenaman)

**The effect on training.** The fixed run reaches a lower loss at 8 of the 9 remaining steps; mean loss over steps 1-9 is 2.344 with the fix versus 2.444 without, and final loss 2.18 versus 2.35. Gradient norm is also far more erratic without the fix (12 to 210) than with it (32 to 237) — throwing away half the batch makes each update noisier.

# Who was affected

Any PP recipe with `global_batch_size > local_batch_size` and variable sequence lengths — the VLM ones, e.g. `gemma4_31b_tp4_pp2/pp4` and `mistral3p5_128b`.

# Changelog

- Preserve parameter gradients across pipeline stage re-initialization in static-metadata mode
- 3 CPU unit tests: gradients survive in static mode, are still cleared in dynamic mode, and older stages without the hook are skipped

# Verified

- `tests/unit_tests/distributed/pipelining`: 236 passed
- `tests/unit_tests/distributed` + `tests/unit_tests/datasets`: 2432 passed
- 2×H100, container `26.08.rc5` (torch 2.13)

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?



