### PR TITLE
fix(vlm): truncate only the token axis in gemma4 collate

### DIFF
--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -2115,6 +2115,54 @@ def gemma4_inject_thinking_prefix(
     return _inject_thinking_prefix_tokens(batch, tokenizer)
 
 
+# Batch entries whose axis 1 is the text-token axis. Everything else in a VLM
+# batch is indexed by patch/frame and must not be sliced to a token count.
+_TOKEN_AXIS_KEYS: tuple[str, ...] = (
+    "input_ids",
+    "attention_mask",
+    "labels",
+    "token_type_ids",
+    "mm_token_type_ids",
+)
+
+
+def _truncate_token_axis(batch: Dict[str, torch.Tensor], max_length: int) -> None:
+    """Truncate the text-token axis of a batch in place.
+
+    Only the tensors listed in ``_TOKEN_AXIS_KEYS`` are indexed on axis 1 by text
+    token. Media tensors such as ``pixel_values`` of shape
+    ``[batch, patches, patch_dim]`` and ``image_position_ids`` of shape
+    ``[batch, patches, 2]`` are indexed by *patch*, so slicing them to a token
+    count silently decouples the image features from the placeholder tokens that
+    address them. Truncating by an allowlist keeps new media keys safe by default;
+    the previous denylist only spared ``pixel_values`` and clipped
+    ``image_position_ids`` alongside the text.
+
+    Args:
+        batch: Collated batch. Token-aligned entries have shape
+            ``[batch, sequence]``; media entries keep their own axis 1 and are
+            left untouched.
+        max_length: Maximum number of text tokens to keep.
+
+    Raises:
+        ValueError: If truncating would drop multimodal placeholder tokens, which
+            would leave more image features than positions to scatter them into.
+    """
+    media_marker = batch.get("mm_token_type_ids")
+    if isinstance(media_marker, torch.Tensor) and media_marker.dim() >= 2 and media_marker.size(1) > max_length:
+        if bool((media_marker[:, max_length:] != 0).any()):
+            raise ValueError(
+                f"max_length={max_length} cuts into multimodal tokens, which would leave image features "
+                "with no placeholder tokens to scatter into. Raise max_length above the prompt's image "
+                "token span, or drop the corresponding images before collation."
+            )
+
+    for key in _TOKEN_AXIS_KEYS:
+        value = batch.get(key)
+        if isinstance(value, torch.Tensor) and value.dim() >= 2 and value.size(1) > max_length:
+            batch[key] = value[:, :max_length]
+
+
 def gemma4_prefix_collate_fn(
     examples: Sequence[Dict[str, Any]],
     processor,
@@ -2132,10 +2180,7 @@ def gemma4_prefix_collate_fn(
     def _inject(batch, proc):
         batch = gemma4_inject_thinking_prefix(batch, proc)
         if max_length is not None and batch["input_ids"].size(1) > max_length:
-            for key in list(batch.keys()):
-                v = batch[key]
-                if isinstance(v, torch.Tensor) and v.dim() >= 2 and v.size(1) > max_length and key != "pixel_values":
-                    batch[key] = v[:, :max_length]
+            _truncate_token_axis(batch, max_length)
         return batch
 
     return default_collate_fn(examples, processor, max_length, _post_tokenize_hook=_inject)

--- a/tests/unit_tests/datasets/vlm/test_collate_token_axis_truncation.py
+++ b/tests/unit_tests/datasets/vlm/test_collate_token_axis_truncation.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Token-axis truncation must leave patch-indexed media tensors alone."""
+
+import pytest
+import torch
+
+from nemo_automodel.components.datasets.vlm.collate_fns import _truncate_token_axis
+
+
+def _batch(seq: int, patches: int, media_span: slice | None = None) -> dict[str, torch.Tensor]:
+    """Build a VLM batch with text- and patch-indexed entries.
+
+    Args:
+        seq: Text sequence length; token-aligned tensors get shape [1, seq].
+        patches: Number of image patches; ``pixel_values`` is [1, patches, 8] and
+            ``image_position_ids`` is [1, patches, 2].
+        media_span: Positions along the token axis marked as multimodal in
+            ``mm_token_type_ids``; ``None`` marks no multimodal tokens.
+
+    Returns:
+        Batch dict mixing token-aligned and patch-aligned tensors.
+    """
+    mm = torch.zeros(1, seq, dtype=torch.long)
+    if media_span is not None:
+        mm[:, media_span] = 1
+    return {
+        "input_ids": torch.arange(seq).unsqueeze(0),
+        "attention_mask": torch.ones(1, seq, dtype=torch.long),
+        "labels": torch.arange(seq).unsqueeze(0),
+        "mm_token_type_ids": mm,
+        "pixel_values": torch.randn(1, patches, 8),
+        "image_position_ids": torch.zeros(1, patches, 2, dtype=torch.long),
+    }
+
+
+def test_media_tensors_keep_their_patch_axis():
+    """pixel_values and image_position_ids must stay full length."""
+    batch = _batch(seq=100, patches=64, media_span=slice(0, 10))
+
+    _truncate_token_axis(batch, max_length=50)
+
+    assert batch["input_ids"].shape == (1, 50)
+    assert batch["labels"].shape == (1, 50)
+    assert batch["mm_token_type_ids"].shape == (1, 50)
+    # Previously image_position_ids was clipped to 50 while pixel_values kept 64,
+    # so the vision tower failed on hidden_states + position_embeddings.
+    assert batch["pixel_values"].shape == (1, 64, 8)
+    assert batch["image_position_ids"].shape == (1, 64, 2)
+
+
+def test_truncating_into_image_tokens_raises():
+    """Dropping placeholder tokens would orphan the image features."""
+    batch = _batch(seq=100, patches=64, media_span=slice(60, 90))
+
+    with pytest.raises(ValueError, match="cuts into multimodal tokens"):
+        _truncate_token_axis(batch, max_length=50)
+
+
+def test_no_truncation_when_already_short():
+    """A batch shorter than max_length is left untouched."""
+    batch = _batch(seq=32, patches=64, media_span=slice(0, 4))
+
+    _truncate_token_axis(batch, max_length=50)
+
+    assert batch["input_ids"].shape == (1, 32)
+    assert batch["pixel_values"].shape == (1, 64, 8)


### PR DESCRIPTION
# What does this PR do ?

Fixes `max_length` truncation in the Gemma4 collate function corrupting image batches.

# The bug

The truncation sliced every 2-D tensor in the batch on axis 1, with one exception for `pixel_values`:

```python
if isinstance(v, torch.Tensor) and v.dim() >= 2 and v.size(1) > max_length and key != "pixel_values":
    batch[key] = v[:, :max_length]
```

`image_position_ids` is indexed by **patch**, not by token, and it isn't in that exception. So the positions got clipped to `max_length` while `pixel_values` kept all its patches, and the vision tower then died on `hidden_states + position_embeddings`:

```
RuntimeError: The size of tensor a (2520) must match the size of tensor b (512) at non-singleton dimension 1
```

# The fix

Truncate by an **allowlist** of token-aligned keys (`input_ids`, `attention_mask`, `labels`, `token_type_ids`, `mm_token_type_ids`) instead of a denylist, so any media key added later is safe by default.

Also refuse to truncate into image placeholder tokens. Cutting them leaves image features with no positions to scatter into, so a clear error is better than a silently broken batch.

# Impact

Latent — no shipped recipe passes `max_length` to this collate function. Found while building a Gemma4 proxy for the parallelism tests.

# Changelog

- `_truncate_token_axis` truncates only token-aligned tensors; media tensors keep their patch axis
- Raises a clear `ValueError` when `max_length` would cut multimodal tokens
- 3 CPU unit tests

# Verified

`tests/unit_tests/datasets/vlm`: 365 passed

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?