### PR TITLE
fix(checkpoint): restore single-GPU custom-model DCP loading

### DIFF
--- a/examples/llm_finetune/nemotron/nemotron_nano_v3_5_lightning_singlegpu_lora.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_nano_v3_5_lightning_singlegpu_lora.yaml
@@ -114,6 +114,7 @@ ci:
   recipe_owner: huiyingl
   time: "00:30:00"
   cluster_tag: gb10
+  nodes: 1
   nproc_per_node: 1
   env_vars:
     OMP_NUM_THREADS: 8

--- a/examples/llm_finetune/nemotron/nemotron_nano_v3_5_lightning_singlegpu_lora.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_nano_v3_5_lightning_singlegpu_lora.yaml
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Single-GPU BF16 LoRA SFT for NVIDIA Nemotron 3.5 Lightning 30B-A3B.
+#
+# This recipe keeps every parallelism axis at one. Activation checkpointing and
+# memory-efficient LoRA reduce training-time activation memory, while DCP loads
+# split HF experts directly through views into the final grouped parameters.
+#
+# Run on exactly one GPU:
+#   CUDA_VISIBLE_DEVICES=0 OMP_NUM_THREADS=8 MKL_NUM_THREADS=8 automodel \
+#     examples/llm_finetune/nemotron/nemotron_nano_v3_5_lightning_singlegpu_lora.yaml \
+#     --nproc-per-node 1
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 8
+  local_batch_size: 1
+  ckpt_every_steps: 1000
+  val_every_steps: 1000
+  max_steps: 20
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 5
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+  # Reuse the checkpoint's single physical MTP layer for two prediction steps.
+  num_nextn_predict_layers: 2
+  mtp_use_repeated_layer: true
+  mtp_loss_scaling_factor: 0.1
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: te
+    linear: torch
+    rms_norm: torch_fp32
+    experts: torch_mm
+    dispatcher: torch
+
+compile:
+  enabled: false
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/nemotron_nano_v3_5_lightning_singlegpu_lora/
+  model_save_format: safetensors
+  save_consolidated: final
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  exclude_modules: ["*.out_proj"]  # Mamba out_proj takes its weight directly, so LoRA cannot wrap it.
+  dim: 8
+  alpha: 32
+  use_triton: true
+  use_memory_efficient_lora: true
+
+distributed:
+  strategy: fsdp2
+  dp_size: 1
+  tp_size: 1
+  cp_size: 1
+  ep_size: 1
+  sequence_parallel: false
+  activation_checkpointing: true
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: train
+
+packed_sequence:
+  packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.95]
+  eps: 1.0e-8
+  lr: 1.0e-4
+  weight_decay: 0.1
+
+lr_scheduler:
+  lr_decay_style: cosine
+  lr_warmup_steps: 2
+  min_lr: 1.0e-5
+
+ci:
+  recipe_owner: huiyingl
+  time: "00:30:00"
+  nproc_per_node: 1
+  env_vars:
+    OMP_NUM_THREADS: 8
+    MKL_NUM_THREADS: 8

--- a/examples/llm_finetune/nemotron/nemotron_nano_v3_5_lightning_singlegpu_lora.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_nano_v3_5_lightning_singlegpu_lora.yaml
@@ -113,6 +113,7 @@ lr_scheduler:
 ci:
   recipe_owner: huiyingl
   time: "00:30:00"
+  cluster_tag: gb10
   nproc_per_node: 1
   env_vars:
     OMP_NUM_THREADS: 8

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -163,22 +163,6 @@ def load_torch_ckpt(
         raise RuntimeError(_format_restricted_load_error(f)) from err
 
 
-# NOTE [nemotron-singlegpu-lora]: the branches tagged with this marker below exist to make
-# single-GPU LoRA SFT of merged-expert Nemotron-H MoE (30B-class) fit on one 80GB GPU.  The
-# default DCP / set_model_state_dict load path transiently materializes a second on-device
-# copy of the (merged) expert weights, which OOMs when the whole model lives on one device.
-# The affected sites are:
-#   * Checkpointer.load                -- route single-device custom safetensors through the
-#                                         frugal full-state path instead of DCP
-#   * _load_full_state_dict_into_model -- normalize stray real (CPU) buffers onto the param
-#                                         device, and use plain load_state_dict when the model
-#                                         is not DTensor-sharded
-# Exercised by: examples/llm_finetune/nemotron/nemotron_nano_v3_singlegpu_lora.yaml
-# These are point fixes bolted onto an already-overloaded load path; a future checkpoint
-# refactor should consolidate the single-device vs. sharded loading logic into one place.
-# `grep -n nemotron-singlegpu-lora` finds every affected site.
-
-
 def _unwrap_ddp_model(model: nn.Module) -> nn.Module:
     """Return the module that owns model metadata hidden by DDP."""
     if isinstance(model, DistributedDataParallel):
@@ -844,27 +828,13 @@ class Checkpointer:
         # the broadcast_from_rank0 hang where rank 0's synchronous CPU→GPU copies
         # fall behind other ranks' async allocations.
         is_safetensors = _is_safetensors_checkpoint(model_path)
-        # [nemotron-singlegpu-lora] (see module note at top of file)
-        # Custom models (e.g. NemotronH) normally take the DCP path below, which converts the
-        # model's state dict to_hf to build load destinations.  For merged-expert MoE models that
-        # transiently materializes a second copy of the expert weights on-device, which OOMs when
-        # the whole model lives on one GPU.  On a single device there is no DTensor sharding, so the
-        # frugal full-state path (load to CPU, from_hf-merge on CPU, copy into the model) is correct
-        # and keeps device memory at ~model size — letting 30B-class MoE LoRA SFT fit on one 80GB GPU.
-        # World size inline (not via components.distributed) so the checkpoint component stays
-        # independent per the import-linter contract.
-        if torch.distributed.is_initialized():
-            world_size = torch.distributed.get_world_size()
-        else:
-            world_size = int(os.environ.get("WORLD_SIZE", "1"))
-        single_device_custom_safetensors = is_safetensors and _is_custom_model(model_state.model[0]) and world_size == 1
+        is_custom_model = _is_custom_model(model_state.model[0])
         if (
             is_init_step
             and len(model_state.model) == 1
             and (
                 _is_bin_checkpoint(model_path)
-                or (is_safetensors and not _is_custom_model(model_state.model[0]))
-                or single_device_custom_safetensors
+                or (is_safetensors and not is_custom_model)
             )
         ):
             t0 = time.monotonic()
@@ -2327,7 +2297,6 @@ def _load_full_state_dict_into_model(
                 if key not in state_dict:
                     state_dict[key] = torch.tensor([], dtype=torch.uint8)
 
-    # [nemotron-singlegpu-lora] (see module note at top of file)
     # set_model_state_dict(full_state_dict=True) requires every parameter/buffer of a
     # part to live on a single device.  Custom models (e.g. NemotronH/Mamba) can leave a
     # concrete CPU buffer behind after meta materialization (initialize_model_weights only
@@ -2356,7 +2325,6 @@ def _load_full_state_dict_into_model(
     except ImportError:  # pragma: no cover - older torch
         from torch.distributed._tensor import DTensor
 
-    # [nemotron-singlegpu-lora] (see module note at top of file)
     for part in model_parts:
         if any(isinstance(p, DTensor) for p in part.parameters()):
             # Sharded model (FSDP/TP): set_model_state_dict slices each rank's local

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -832,10 +832,7 @@ class Checkpointer:
         if (
             is_init_step
             and len(model_state.model) == 1
-            and (
-                _is_bin_checkpoint(model_path)
-                or (is_safetensors and not is_custom_model)
-            )
+            and (_is_bin_checkpoint(model_path) or (is_safetensors and not is_custom_model))
         ):
             t0 = time.monotonic()
             state_dict_from_disk = _load_hf_checkpoint_preserving_dtype(model_path)

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -1424,14 +1424,7 @@ def test_training_checkpoint_resume_ignores_base_fp8_metadata(tmp_path):
 
 
 class TestLoadModelCustomModelGuard:
-    """Verify custom-model load routing: sharded uses DCP, single-device uses the fast path.
-
-    Under multi-rank (sharded) loading, custom models use the standard DCP path so each
-    rank slices its local DTensor shard. On a single device (world_size == 1) there is no
-    sharding, so a custom safetensors model takes the frugal full-state fast path instead
-    (which still applies the state_dict_adapter from_hf conversion on CPU). See
-    NOTE [nemotron-singlegpu-lora] in checkpointing.py.
-    """
+    """Verify custom safetensors models use DCP on both single and multiple devices."""
 
     def _make_checkpointer(self):
         """Create a minimally configured Checkpointer for testing."""
@@ -1494,11 +1487,7 @@ class TestLoadModelCustomModelGuard:
     @patch("nemo_automodel.components.checkpoint.checkpointing._load_hf_checkpoint_preserving_dtype")
     @patch("nemo_automodel.components.checkpoint.checkpointing._load_full_state_dict_into_model")
     def test_custom_model_skips_fast_path_uses_dcp(self, mock_load_full, mock_load_hf, mock_is_st):
-        """Under sharded (multi-rank) loading, a custom model uses the standard DCP path.
-
-        DCP lets each rank slice its local DTensor shard. The single-device exception is
-        covered by test_single_device_custom_model_uses_fast_path.
-        """
+        """Under sharded loading, a custom model uses DCP to load its local shard."""
         checkpointer = self._make_checkpointer()
 
         # Create a model class in the custom namespace
@@ -1543,15 +1532,10 @@ class TestLoadModelCustomModelGuard:
     @patch("nemo_automodel.components.checkpoint.checkpointing._is_safetensors_checkpoint", return_value=True)
     @patch("nemo_automodel.components.checkpoint.checkpointing._load_hf_checkpoint_preserving_dtype")
     @patch("nemo_automodel.components.checkpoint.checkpointing._load_full_state_dict_into_model")
-    def test_single_device_custom_model_uses_fast_path(self, mock_load_full, mock_load_hf, mock_is_st):
-        """On a single device (world_size == 1) a custom safetensors model uses the fast path.
-
-        The fast path applies the state_dict_adapter from_hf conversion on CPU (via
-        _maybe_adapt_state_dict_from_hf) and copies into the model, keeping device memory at
-        ~model size. DCP would transiently materialize a second on-device copy of the merged
-        expert weights and OOM a 30B-class MoE on one 80GB GPU.
-        See NOTE [nemotron-singlegpu-lora] in checkpointing.py.
-        """
+    def test_single_device_custom_model_uses_dcp(
+        self, mock_load_full, mock_load_hf, mock_is_st
+    ):
+        """A single-device custom model uses DCP instead of a full host state dict."""
         checkpointer = self._make_checkpointer()
 
         CustomModel = type("CustomModel", (torch.nn.Module,), {})
@@ -1559,21 +1543,33 @@ class TestLoadModelCustomModelGuard:
         model = CustomModel()
         model.layer = torch.nn.Linear(4, 4)
         assert _is_custom_model(model) is True
-
-        mock_load_hf.return_value = {"layer.weight": torch.randn(4, 4), "layer.bias": torch.randn(4)}
+        mock_state_dict = {"layer.weight": torch.randn(4, 4), "layer.bias": torch.randn(4)}
 
         with (
             patch("os.path.exists", return_value=True),
-            # Single-device (non-sharded) load.
             patch("torch.distributed.is_initialized", return_value=False),
             patch.dict("os.environ", {"WORLD_SIZE": "1"}),
-            patch.object(checkpointer, "_do_load") as mock_dcp_load,
+            patch("nemo_automodel.components.checkpoint.checkpointing.ModelState") as MockModelState,
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_to_hf",
+                side_effect=lambda m, sd, **kw: sd,
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_from_hf",
+                side_effect=lambda m, sd, **kw: sd,
+            ),
+            patch.object(checkpointer, "_do_load", return_value=mock_state_dict) as mock_dcp_load,
+            patch.object(checkpointer, "_get_storage_reader", return_value=None),
         ):
+            mock_model_state = MockModelState.return_value
+            mock_model_state.model = [model]
+            mock_model_state.state_dict.return_value = mock_state_dict
+
             checkpointer.load_model(model, model_path="/fake/path", is_init_step=True)
 
-        # Single-device custom model takes the frugal fast path, not DCP.
-        mock_load_full.assert_called_once()
-        mock_dcp_load.assert_not_called()
+        mock_load_full.assert_not_called()
+        mock_load_hf.assert_not_called()
+        mock_dcp_load.assert_called_once()
 
 
 class TestLoadModelCheckpointKeySubset:

--- a/tests/unit_tests/recipes/llm/test_nemotron_v3_5_lightning_singlegpu_lora_config.py
+++ b/tests/unit_tests/recipes/llm/test_nemotron_v3_5_lightning_singlegpu_lora_config.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration contract for the single-GPU Nemotron 3.5 Lightning LoRA example."""
+
+from pathlib import Path
+
+import yaml
+
+from nemo_automodel.components._peft.lora import PeftConfig
+from nemo_automodel.components.config.loader import load_yaml_config
+from nemo_automodel.components.models.common import BackendConfig
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONFIG_PATH = (
+    REPO_ROOT
+    / "examples"
+    / "llm_finetune"
+    / "nemotron"
+    / "nemotron_nano_v3_5_lightning_singlegpu_lora.yaml"
+)
+
+
+def test_nemotron_v3_5_lightning_lora_is_strictly_single_gpu() -> None:
+    """The example must retain its BF16 LoRA, MTP, memory, and topology contract."""
+    raw_config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+    config = load_yaml_config(CONFIG_PATH)
+
+    backend = config.model.backend.instantiate()
+    peft = config.peft.instantiate()
+
+    assert isinstance(backend, BackendConfig)
+    assert backend.attn == "te"
+    assert backend.linear == "torch"
+    assert backend.rms_norm == "torch_fp32"
+    assert backend.experts == "torch_mm"
+    assert backend.dispatcher == "torch"
+
+    assert isinstance(peft, PeftConfig)
+    assert peft.dim == 8
+    assert peft.alpha == 32
+    assert peft.use_memory_efficient_lora is True
+
+    assert config.model.pretrained_model_name_or_path == (
+        "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"
+    )
+    assert config.model.num_nextn_predict_layers == 2
+    assert config.model.mtp_use_repeated_layer is True
+    assert config.model.mtp_loss_scaling_factor == 0.1
+    assert "quantization" not in raw_config
+
+    assert config.step_scheduler.local_batch_size == 1
+    assert config.distributed.strategy == "fsdp2"
+    assert config.distributed.dp_size == 1
+    assert config.distributed.tp_size == 1
+    assert config.distributed.cp_size == 1
+    assert config.distributed.ep_size == 1
+    assert config.distributed.activation_checkpointing is True
+    assert config.ci.nproc_per_node == 1


### PR DESCRIPTION
## What changed

* Remove the single-device custom-safetensors exception that routed custom models through a full host state dict.
* Restore the standard DCP path for custom models on both single and multiple devices.
* Add a strict single-GPU BF16 LoRA recipe for NVIDIA Nemotron 3.5 Lightning 30B-A3B and a configuration contract test.

## Root cause

The single-GPU exception was added when DCP conversion transiently materialized a second copy of merged expert weights on device. Later in-place loading support writes split HF expert tensors through views into the final grouped parameters, but the exception continued to bypass DCP and retained a full 61.31 GiB checkpoint state dict in host memory.

On a system with separate host and device memory this loaded with a measured peak of 62.71 GiB host RSS plus 61.40 GiB CUDA allocation. Restoring DCP reduced measured host RSS to 6.11 GiB while keeping CUDA reserved memory at 62.36 GiB.

Fixes NVIDIA-NeMo/Automodel#3532

## Validation

* `34 passed`: checkpoint routing, Nemotron V3 adapter, and recipe configuration tests
* YAML recipe lint
* Ruff
* `git diff --check`
* Single H100 BF16 LoRA training step with the 30B checkpoint: loss `2.9446`, 7,072,256 trainable parameters, 62.01 GiB reported GPU memory