### PR TITLE
fix(training): correct dataloader annotation and modernize Optional syntax

### DIFF
--- a/nemo_automodel/components/training/step_scheduler.py
+++ b/nemo_automodel/components/training/step_scheduler.py
@@ -63,7 +63,7 @@ class StepScheduler(Stateful):
         global_batch_size: int,
         local_batch_size: int,
         dp_size: int,
-        dataloader: int | None,
+        dataloader: DataLoader | None,
         ckpt_every_steps: int | None = None,
         save_checkpoint_every_epoch: bool = True,
         val_every_steps: int | None = None,

--- a/nemo_automodel/components/training/step_scheduler.py
+++ b/nemo_automodel/components/training/step_scheduler.py
@@ -18,7 +18,7 @@ import logging
 import signal
 from dataclasses import asdict, dataclass
 from math import ceil
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from torch.distributed.checkpoint.stateful import Stateful
 
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 def _calculate_max_steps(
     num_epochs: int,
-    epoch_len: Optional[int],
+    epoch_len: int | None,
     default_max_steps: int = 9223372036854775807,
 ) -> int:
     """
@@ -44,7 +44,7 @@ def _calculate_max_steps(
     return num_epochs * epoch_len
 
 
-def _calculate_num_epochs(max_steps: Optional[int], epoch_len: Optional[int], default_num_epochs: int = 10) -> int:
+def _calculate_num_epochs(max_steps: int | None, epoch_len: int | None, default_num_epochs: int = 10) -> int:
     """
     Calculate the number of epochs out of maximum number of steps.
     """
@@ -63,17 +63,17 @@ class StepScheduler(Stateful):
         global_batch_size: int,
         local_batch_size: int,
         dp_size: int,
-        dataloader: Optional[int],
-        ckpt_every_steps: Optional[int] = None,
+        dataloader: int | None,
+        ckpt_every_steps: int | None = None,
         save_checkpoint_every_epoch: bool = True,
-        val_every_steps: Optional[int] = None,
+        val_every_steps: int | None = None,
         log_remote_every_steps: int = 1,
         loss_average_window_steps: int = 50,
-        gc_every_steps: Optional[int] = None,
+        gc_every_steps: int | None = None,
         start_step: int = 0,
         start_epoch: int = 0,
-        num_epochs: Optional[int] = None,
-        max_steps: Optional[int] = None,
+        num_epochs: int | None = None,
+        max_steps: int | None = None,
         preemption_signal: SignalLike | list[SignalLike] | None = signal.SIGTERM,
         process_group: ProcessGroup | None = None,
     ):
@@ -85,20 +85,20 @@ class StepScheduler(Stateful):
             local_batch_size (int): Number of samples per micro-batch per GPU. This is the batch size for a single forward/backward pass on one GPU.
             dp_size (int): Number of GPUs for data parallelism.
             dataloader: The training dataloader.
-            ckpt_every_steps (Optional[int]): Frequency of checkpoint steps.
+            ckpt_every_steps (int | None): Frequency of checkpoint steps.
             save_checkpoint_every_epoch (bool): Whether to save checkpoints at epoch boundaries.
                 When True, checkpoints are saved at the end of each epoch (is_last_batch).
                 When False, only periodic, last-step, and SIGTERM checkpoints are saved.
                 Default: True.
-            val_every_steps (Optional[int]): Number of training steps between validation.
+            val_every_steps (int | None): Number of training steps between validation.
             log_remote_every_steps (int): Frequency of remote logging (e.g., WandB, MLflow). Default: 1 (every step).
             loss_average_window_steps (int): Rolling window size for averaged training loss metrics.
-            gc_every_steps (Optional[int]): Frequency of manual garbage collection steps.
+            gc_every_steps (int | None): Frequency of manual garbage collection steps.
             start_step (int): Initial global step. Used when resuming from checkpoint. Default: 0.
             start_epoch (int): Initial epoch. Used when resuming from checkpoint. Default: 0.
-            num_epochs (Optional[int]): Total number of epochs. Default: None or calculated from max_steps if num_epochs is None or 10 if max_steps and num_epochs are both None.
-            max_steps (Optional[int]): Maximum number of steps to run. If None, calculated from num_epochs.
-            preemption_signal (Optional[SignalLike | list[SignalLike]]): Signal(s) that trigger a graceful
+            num_epochs (int | None): Total number of epochs. Default: None or calculated from max_steps if num_epochs is None or 10 if max_steps and num_epochs are both None.
+            max_steps (int | None): Maximum number of steps to run. If None, calculated from num_epochs.
+            preemption_signal (SignalLike | list[SignalLike] | None): Signal(s) that trigger a graceful
                 preemption checkpoint, each given as a signal number, name (e.g. "SIGTERM"), or
                 ``signal.Signals`` member. When ``None``, no signal handler is installed and preemption
                 checkpointing is disabled. Default: ``signal.SIGTERM``.
@@ -183,7 +183,7 @@ class StepScheduler(Stateful):
         else:
             self.sig_handler = DistributedSignalHandler(sig=preemption_signal, group=process_group).__enter__()
         self.sigterm_flag = False
-        self._sig_polled_step: Optional[int] = None
+        self._sig_polled_step: int | None = None
 
     def __iter__(self):
         """


### PR DESCRIPTION
# What does this PR do ?

Correct the `StepScheduler` dataloader annotation and replace legacy `Optional[...]` annotations with modern `| None` syntax to satisfy repository type-hint guidance.

# Changelog

- Correct `StepScheduler` so `dataloader` is typed as `DataLoader | None`
- Replace remaining legacy `Optional[...]` annotations with `| None` in `nemo_automodel/components/training/step_scheduler.py`
- Remove the now-unused `Optional` import
- Keep scheduler runtime behavior unchanged

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

I was reading `StepScheduler` to understand the SIGTERM/preemption-checkpoint path for large Slurm runs, and noticed the `dataloader` annotation was incorrect while updating the legacy `Optional[...]` syntax. The parameter is used as a dataloader throughout the class: the scheduler computes `len(dataloader)`, iterates batches from it, and accesses `dataloader.sampler`. This change corrects that type hint and aligns the rest of the touched annotations with the repository's modern `| None` style. The runtime behavior is unchanged.