### PR TITLE
ci: route DGX Spark recipes to GB10

### DIFF
--- a/examples/llm_finetune/gpt_oss/gpt_oss_20b_single_gpu_peft.yaml
+++ b/examples/llm_finetune/gpt_oss/gpt_oss_20b_single_gpu_peft.yaml
@@ -111,4 +111,4 @@ optimizer:
 ci:
   recipe_owner: adil-a
   nproc_per_node: 1
-  cluster_tag: digits
+  cluster_tag: gb10

--- a/examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft_qlora_spark.yaml
+++ b/examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft_qlora_spark.yaml
@@ -108,4 +108,4 @@ ci:
   recipe_owner: akoumpa
   time: "00:30:00"
   nproc_per_node: 1
-  cluster_tag: digits
+  cluster_tag: gb10

--- a/examples/llm_finetune/qwen/qwen3_8b_squad_spark.yaml
+++ b/examples/llm_finetune/qwen/qwen3_8b_squad_spark.yaml
@@ -34,6 +34,10 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen3-8B
+  # Keep packed training on the HF FlashAttention path for GB10. TE's packed THD
+  # backward requests ragged LSE, which cuDNN does not support on SM12x GPUs.
+  force_hf: true
+  attn_implementation: flash_attention_2
 
 # torch.compile configuration
 compile:

--- a/examples/llm_finetune/qwen/qwen3_8b_squad_spark.yaml
+++ b/examples/llm_finetune/qwen/qwen3_8b_squad_spark.yaml
@@ -100,4 +100,4 @@ ci:
   recipe_owner: akoumpa
   time: "00:20:00"
   nproc_per_node: 1
-  cluster_tag: digits
+  cluster_tag: gb10


### PR DESCRIPTION
# What does this PR do ?

Route the DGX Spark finetuning recipes to GB10 CI runners.
https://nv/nemoci/-/pipelines/62580587

# Changelog

- Set `ci.cluster_tag: gb10` for the GPT-OSS 20B DGX Spark recipe.
- Set `ci.cluster_tag: gb10` for the Llama 3.3 70B DGX Spark recipe.
- Set `ci.cluster_tag: gb10` for the Qwen3 8B DGX Spark recipe.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] No new test is needed for this declarative CI routing change; validated the example YAMLs and generated CI configuration.
- [x] No documentation update is needed.

# Validation

- `python tools/lint_example_yamls.py <three changed recipes>`
- `python tests/ci_tests/utils/validate_generate_ci.py --automodel-dir .`
- Confirmed all three generated release jobs set `RESERVED_CLUSTER_TAG=/gb10/`.

# Additional Information

- Qwen3 8B focused GB10 validation: [job 396504522](https://nv/nemoci/-/jobs/396504522) — passed all 50/50 training steps with validation loss `0.0925` and Docker exit code `0`.
