### PR TITLE
fix(fsdp): uniform reduce dtype and EP-local expert gradients

### DIFF
--- a/nemo_automodel/components/distributed/parallelizer_utils.py
+++ b/nemo_automodel/components/distributed/parallelizer_utils.py
@@ -43,8 +43,9 @@ def configure_fsdp_unused_param_reduction(module: nn.Module) -> int:
     sequence everywhere; otherwise a rank with ``grad is None`` can omit a
     collective and discard peer contributions. PyTorch's public API fills the
     missing local contribution with zero, analogous to DDP unused-parameter
-    handling. AutoModel keeps a compatibility fallback for supported PyTorch
-    versions that predate that public API.
+    handling. AutoModel keeps a compatibility shim both for versions that
+    predate that API and for versions whose API passes an unsharded ``DTensor``
+    directly to ``foreach_reduce`` instead of its local tensor.
 
     Args:
         module: Root module containing the FSDP units to configure.
@@ -60,11 +61,15 @@ def configure_fsdp_unused_param_reduction(module: nn.Module) -> int:
     # dtype and must be aligned with the peers' reduce-dtype accumulations before
     # the group reaches ``foreach_reduce``.
     _patch_fsdp_uniform_reduce_dtype()
+    # Install even when the public API exists. PyTorch 2.13 nightlies before
+    # ``FSDPParam.unsharded_zero_grad_data`` passed ``zeros_like(DTensor)``
+    # directly to ``foreach_reduce``, which sizes its copy-in buffer from the
+    # global tensor shape. The shim populates ``param.grad`` first so upstream's
+    # normal gradient path unwraps the EP-local tensor.
+    _patch_fsdp_unused_param_reduction()
     if hasattr(fsdp_modules[0], "set_reduce_scatter_unused_params"):
         for fsdp_module in fsdp_modules:
             fsdp_module.set_reduce_scatter_unused_params(True, recurse=False)
-    else:
-        _patch_fsdp_unused_param_reduction()
     return len(fsdp_modules)
 
 

--- a/nemo_automodel/components/distributed/parallelizer_utils.py
+++ b/nemo_automodel/components/distributed/parallelizer_utils.py
@@ -43,9 +43,8 @@ def configure_fsdp_unused_param_reduction(module: nn.Module) -> int:
     sequence everywhere; otherwise a rank with ``grad is None`` can omit a
     collective and discard peer contributions. PyTorch's public API fills the
     missing local contribution with zero, analogous to DDP unused-parameter
-    handling. AutoModel keeps a compatibility shim both for versions that
-    predate that API and for versions whose API passes an unsharded ``DTensor``
-    directly to ``foreach_reduce`` instead of its local tensor.
+    handling. AutoModel keeps a compatibility fallback for supported PyTorch
+    versions that predate that public API.
 
     Args:
         module: Root module containing the FSDP units to configure.
@@ -61,15 +60,11 @@ def configure_fsdp_unused_param_reduction(module: nn.Module) -> int:
     # dtype and must be aligned with the peers' reduce-dtype accumulations before
     # the group reaches ``foreach_reduce``.
     _patch_fsdp_uniform_reduce_dtype()
-    # Install even when the public API exists. PyTorch 2.13 nightlies before
-    # ``FSDPParam.unsharded_zero_grad_data`` passed ``zeros_like(DTensor)``
-    # directly to ``foreach_reduce``, which sizes its copy-in buffer from the
-    # global tensor shape. The shim populates ``param.grad`` first so upstream's
-    # normal gradient path unwraps the EP-local tensor.
-    _patch_fsdp_unused_param_reduction()
     if hasattr(fsdp_modules[0], "set_reduce_scatter_unused_params"):
         for fsdp_module in fsdp_modules:
             fsdp_module.set_reduce_scatter_unused_params(True, recurse=False)
+    else:
+        _patch_fsdp_unused_param_reduction()
     return len(fsdp_modules)
 
 

--- a/nemo_automodel/components/distributed/parallelizer_utils.py
+++ b/nemo_automodel/components/distributed/parallelizer_utils.py
@@ -26,6 +26,9 @@ from torch.distributed.fsdp import (
 )
 
 from nemo_automodel.shared.torch_patches import (
+    patch_fsdp_uniform_reduce_dtype as _patch_fsdp_uniform_reduce_dtype,
+)
+from nemo_automodel.shared.torch_patches import (
     patch_fsdp_unused_param_reduction as _patch_fsdp_unused_param_reduction,
 )
 
@@ -53,6 +56,10 @@ def configure_fsdp_unused_param_reduction(module: nn.Module) -> int:
     if not fsdp_modules:
         return 0
 
+    # Install first so the zero fill below wraps it: the filled zero is in param
+    # dtype and must be aligned with the peers' reduce-dtype accumulations before
+    # the group reaches ``foreach_reduce``.
+    _patch_fsdp_uniform_reduce_dtype()
     if hasattr(fsdp_modules[0], "set_reduce_scatter_unused_params"):
         for fsdp_module in fsdp_modules:
             fsdp_module.set_reduce_scatter_unused_params(True, recurse=False)

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -55,6 +55,9 @@ from nemo_automodel.shared.tied_weights import ensure_tied_lm_head
 from nemo_automodel.shared.torch_patches import (
     patch_fsdp_accumulated_grad_guard as _patch_fsdp_accumulated_grad_guard,
 )
+from nemo_automodel.shared.torch_patches import (
+    patch_fsdp_uniform_reduce_dtype as _patch_fsdp_uniform_reduce_dtype,
+)
 from nemo_automodel.shared.utils import dtype_from_str
 
 logger = logging.getLogger(__name__)
@@ -618,6 +621,10 @@ def apply_fsdp(
     # but trainable multimodal towers still get standalone FSDP units. Install
     # the same lazy-state guard as dense FSDP for modality-free batches.
     _patch_fsdp_accumulated_grad_guard()
+    # ``moe/fsdp_mixin`` drives post-backward by hand under pipeline parallelism,
+    # so a group can reach the reduction holding both reduce-dtype accumulations
+    # and a param-dtype gradient that arrived after its last no-sync reduction.
+    _patch_fsdp_uniform_reduce_dtype()
 
     if isinstance(lm_head_precision, str):
         lm_head_precision = dtype_from_str(lm_head_precision, default=None)

--- a/nemo_automodel/shared/torch_patches.py
+++ b/nemo_automodel/shared/torch_patches.py
@@ -50,7 +50,7 @@ def patch_fsdp_uniform_reduce_dtype() -> None:
 
     Gradient accumulation leaves a group holding ``reduce_dtype`` accumulations
     for the parameters used so far, while any parameter whose gradient joins
-    later -- a locally unused parameter zero-filled by
+    later -- a locally unused parameter zero-filled by PyTorch's public API or
     :func:`patch_fsdp_unused_param_reduction`, or one whose gradient lands after
     its group's post-backward already ran -- contributes ``param_dtype``.
     ``foreach_reduce`` then aborts with ``FSDP reduce-scatter expects uniform
@@ -108,16 +108,13 @@ def patch_fsdp_uniform_reduce_dtype() -> None:
 
 
 def patch_fsdp_unused_param_reduction() -> None:
-    """Make FSDP2 unused-parameter reduction safe across PyTorch versions.
+    """Backport FSDP2 unused-parameter reduction when the public API is absent.
 
     The patch is process-global and idempotent. It only fills a missing local
     gradient with zeros immediately before FSDP2 post-backward reduction, so
     ranks that skipped a parameter still participate in the same collective as
-    ranks that used it. This backports the behavior when
-    ``FSDPModule.set_reduce_scatter_unused_params`` is absent. It also works
-    around earlier public implementations that passed ``zeros_like`` of an
-    unsharded ``DTensor`` directly to ``foreach_reduce``: assigning the zero to
-    ``param.grad`` makes upstream use its normal local-tensor extraction path.
+    ranks that used it. Callers must first prefer the public
+    ``FSDPModule.set_reduce_scatter_unused_params`` API.
 
     Raises:
         RuntimeError: If the installed PyTorch exposes neither the public API
@@ -138,12 +135,7 @@ def patch_fsdp_unused_param_reduction() -> None:
         return
 
     def _post_backward_with_unused_param_reduction(self, *args, **kwargs):
-        # Newer versions expose this flag on the parameter group. Respect it so
-        # installing the process-global compatibility wrapper does not change
-        # unconfigured FSDP units. Versions predating the public API have no
-        # flag and are configured by installing this wrapper itself.
-        reduce_unused = getattr(self, "reduce_scatter_unused_params", True)
-        if self.reduce_grads and reduce_unused and self._training_state == TrainingState.PRE_BACKWARD:
+        if self.reduce_grads and self._training_state == TrainingState.PRE_BACKWARD:
             for fsdp_param in self.fsdp_params:
                 if not hasattr(fsdp_param, "_unsharded_param"):
                     continue
@@ -152,10 +144,10 @@ def patch_fsdp_unused_param_reduction() -> None:
                 param = fsdp_param.unsharded_param
                 if param.requires_grad and param.grad is None:
                     # ``zeros_like`` on the *unsharded* parameter is the dtype
-                    # autograd would have produced under any precision policy.
-                    # For a DTensor this still allocates only local storage;
-                    # upstream then unwraps that local tensor through the same
-                    # path as a real gradient before calling ``foreach_reduce``.
+                    # autograd would have produced under any precision policy
+                    # (bf16 compute over fp32 storage, an fp32-pinned unit, or no
+                    # casting at all). ``_align_accumulated_grad_dtype`` then
+                    # promotes it to ``reduce_dtype`` if the group is accumulating.
                     param.grad = torch.zeros_like(param, memory_format=torch.preserve_format)
         return original_post_backward(self, *args, **kwargs)
 

--- a/nemo_automodel/shared/torch_patches.py
+++ b/nemo_automodel/shared/torch_patches.py
@@ -46,7 +46,7 @@ def _widest_float_dtype(dtypes: Iterable[Any]) -> Any:
 
 
 def patch_fsdp_uniform_reduce_dtype() -> None:
-    """Give every FSDP2 reduce-scatter group a single gradient dtype.
+    """Give every FSDP2 reduce-scatter group local gradients of one dtype.
 
     Gradient accumulation leaves a group holding ``reduce_dtype`` accumulations
     for the parameters used so far, while any parameter whose gradient joins
@@ -56,12 +56,14 @@ def patch_fsdp_uniform_reduce_dtype() -> None:
     ``foreach_reduce`` then aborts with ``FSDP reduce-scatter expects uniform
     gradient dtype``.
 
-    Widen the minority gradients at the last possible moment, inside
+    Normalize and widen gradients at the last possible moment, inside
     ``foreach_reduce`` itself. That placement matters:
 
-    * the gradients are already plain local tensors here (``FSDPParam``'s
-      ``_get_grad_inner_tensor`` has unwrapped any ``DTensor``), so nothing has
-      to reason about distributed wrappers;
+    * ``FSDPParam`` normally unwraps gradients through
+      ``_get_grad_inner_tensor``. PyTorch versions whose public unused-parameter
+      API appends ``zeros_like(unsharded_param)`` directly can still leave a
+      ``DTensor`` in this list, so unwrap that residual value before sizing the
+      reduce-scatter buffer;
     * FSDP2's own bookkeeping (``unsharded_param.grad`` /
       ``unsharded_accumulated_grad``) is left exactly as upstream leaves it, so
       no later reader of that state sees anything unusual;
@@ -83,6 +85,15 @@ def patch_fsdp_uniform_reduce_dtype() -> None:
         return
 
     def foreach_reduce_uniform_dtype(fsdp_params, unsharded_grads, *args, **kwargs):
+        from torch.distributed.tensor import DTensor
+
+        # PyTorch 2.13a0's unused-parameter branch can append a DTensor zero
+        # directly, while gradients from used parameters are already local
+        # tensors. Besides making ``fsdp.chunk_cat`` reject the mixed list, the
+        # DTensor's global numel makes FSDP size a global-shape staging buffer.
+        # Current PyTorch routes the zero through ``_get_grad_inner_tensor``;
+        # localizing here is the equivalent compatibility path for that build.
+        unsharded_grads[:] = [grad.to_local() if isinstance(grad, DTensor) else grad for grad in unsharded_grads]
         dtypes = {grad.dtype for grad in unsharded_grads}
         if len(dtypes) > 1 and all(dtype.is_floating_point for dtype in dtypes):
             target = _widest_float_dtype(dtypes)

--- a/nemo_automodel/shared/torch_patches.py
+++ b/nemo_automodel/shared/torch_patches.py
@@ -22,10 +22,78 @@ that already depend on torch (training / distributed / dataloading).
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
+from typing import Any
 
 _logger = logging.getLogger(__name__)
 
 _TORCH_PATCHES_APPLIED = False
+
+
+def _widest_float_dtype(dtypes: Iterable[Any]) -> Any:
+    """Return the float dtype among ``dtypes`` that every other one converts into losslessly.
+
+    Args:
+        dtypes: Gradient dtypes from a single reduce-scatter group.
+
+    Returns:
+        The dtype with the largest element size; ties resolve to float32 over
+        the 2-byte float types.
+    """
+    import torch
+
+    return max(dtypes, key=lambda dtype: (torch.finfo(dtype).bits, dtype is torch.float32))
+
+
+def patch_fsdp_uniform_reduce_dtype() -> None:
+    """Give every FSDP2 reduce-scatter group a single gradient dtype.
+
+    Gradient accumulation leaves a group holding ``reduce_dtype`` accumulations
+    for the parameters used so far, while any parameter whose gradient joins
+    later -- a locally unused parameter zero-filled by
+    :func:`patch_fsdp_unused_param_reduction`, or one whose gradient lands after
+    its group's post-backward already ran -- contributes ``param_dtype``.
+    ``foreach_reduce`` then aborts with ``FSDP reduce-scatter expects uniform
+    gradient dtype``.
+
+    Widen the minority gradients at the last possible moment, inside
+    ``foreach_reduce`` itself. That placement matters:
+
+    * the gradients are already plain local tensors here (``FSDPParam``'s
+      ``_get_grad_inner_tensor`` has unwrapped any ``DTensor``), so nothing has
+      to reason about distributed wrappers;
+    * FSDP2's own bookkeeping (``unsharded_param.grad`` /
+      ``unsharded_accumulated_grad``) is left exactly as upstream leaves it, so
+      no later reader of that state sees anything unusual;
+    * ``foreach_reduce`` immediately copies these gradients into a
+      ``reduce_dtype`` buffer anyway, so widening first changes no value.
+
+    Uniform groups are passed straight through, so the upstream assertion still
+    fires for genuinely inconsistent gradients such as fp8 weights that fail to
+    produce higher-precision ones. The patch is process-global and idempotent.
+    """
+    try:
+        import torch.distributed.fsdp._fully_shard._fsdp_collectives as collectives
+        import torch.distributed.fsdp._fully_shard._fsdp_param_group as param_group
+    except ImportError:
+        return
+
+    original_foreach_reduce = collectives.foreach_reduce
+    if getattr(original_foreach_reduce, "_automodel_uniform_reduce_dtype", False):
+        return
+
+    def foreach_reduce_uniform_dtype(fsdp_params, unsharded_grads, *args, **kwargs):
+        dtypes = {grad.dtype for grad in unsharded_grads}
+        if len(dtypes) > 1 and all(dtype.is_floating_point for dtype in dtypes):
+            target = _widest_float_dtype(dtypes)
+            # Mutate in place: ``foreach_reduce`` frees the gradients by clearing
+            # this list, and that must still release the caller's references.
+            unsharded_grads[:] = [grad if grad.dtype is target else grad.to(target) for grad in unsharded_grads]
+        return original_foreach_reduce(fsdp_params, unsharded_grads, *args, **kwargs)
+
+    foreach_reduce_uniform_dtype._automodel_uniform_reduce_dtype = True
+    collectives.foreach_reduce = foreach_reduce_uniform_dtype
+    param_group.foreach_reduce = foreach_reduce_uniform_dtype
 
 
 def patch_fsdp_unused_param_reduction() -> None:
@@ -64,6 +132,11 @@ def patch_fsdp_unused_param_reduction() -> None:
                     continue
                 param = fsdp_param.unsharded_param
                 if param.requires_grad and param.grad is None:
+                    # ``zeros_like`` on the *unsharded* parameter is the dtype
+                    # autograd would have produced under any precision policy
+                    # (bf16 compute over fp32 storage, an fp32-pinned unit, or no
+                    # casting at all). ``_align_accumulated_grad_dtype`` then
+                    # promotes it to ``reduce_dtype`` if the group is accumulating.
                     param.grad = torch.zeros_like(param, memory_format=torch.preserve_format)
         return original_post_backward(self, *args, **kwargs)
 

--- a/nemo_automodel/shared/torch_patches.py
+++ b/nemo_automodel/shared/torch_patches.py
@@ -97,13 +97,16 @@ def patch_fsdp_uniform_reduce_dtype() -> None:
 
 
 def patch_fsdp_unused_param_reduction() -> None:
-    """Backport FSDP2 unused-parameter reduction when the public API is absent.
+    """Make FSDP2 unused-parameter reduction safe across PyTorch versions.
 
     The patch is process-global and idempotent. It only fills a missing local
     gradient with zeros immediately before FSDP2 post-backward reduction, so
     ranks that skipped a parameter still participate in the same collective as
-    ranks that used it. Callers must first prefer the public
-    ``FSDPModule.set_reduce_scatter_unused_params`` API.
+    ranks that used it. This backports the behavior when
+    ``FSDPModule.set_reduce_scatter_unused_params`` is absent. It also works
+    around earlier public implementations that passed ``zeros_like`` of an
+    unsharded ``DTensor`` directly to ``foreach_reduce``: assigning the zero to
+    ``param.grad`` makes upstream use its normal local-tensor extraction path.
 
     Raises:
         RuntimeError: If the installed PyTorch exposes neither the public API
@@ -124,7 +127,12 @@ def patch_fsdp_unused_param_reduction() -> None:
         return
 
     def _post_backward_with_unused_param_reduction(self, *args, **kwargs):
-        if self.reduce_grads and self._training_state == TrainingState.PRE_BACKWARD:
+        # Newer versions expose this flag on the parameter group. Respect it so
+        # installing the process-global compatibility wrapper does not change
+        # unconfigured FSDP units. Versions predating the public API have no
+        # flag and are configured by installing this wrapper itself.
+        reduce_unused = getattr(self, "reduce_scatter_unused_params", True)
+        if self.reduce_grads and reduce_unused and self._training_state == TrainingState.PRE_BACKWARD:
             for fsdp_param in self.fsdp_params:
                 if not hasattr(fsdp_param, "_unsharded_param"):
                     continue
@@ -133,10 +141,10 @@ def patch_fsdp_unused_param_reduction() -> None:
                 param = fsdp_param.unsharded_param
                 if param.requires_grad and param.grad is None:
                     # ``zeros_like`` on the *unsharded* parameter is the dtype
-                    # autograd would have produced under any precision policy
-                    # (bf16 compute over fp32 storage, an fp32-pinned unit, or no
-                    # casting at all). ``_align_accumulated_grad_dtype`` then
-                    # promotes it to ``reduce_dtype`` if the group is accumulating.
+                    # autograd would have produced under any precision policy.
+                    # For a DTensor this still allocates only local storage;
+                    # upstream then unwraps that local tensor through the same
+                    # path as a real gradient before calling ``foreach_reduce``.
                     param.grad = torch.zeros_like(param, memory_format=torch.preserve_format)
         return original_post_backward(self, *args, **kwargs)
 

--- a/tests/functional_tests/training/test_cp_flce_fsdp_correctness.py
+++ b/tests/functional_tests/training/test_cp_flce_fsdp_correctness.py
@@ -25,7 +25,7 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.device_mesh import init_device_mesh
-from torch.distributed.fsdp import fully_shard
+from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
 from torch.distributed.tensor import DTensor, Shard, distribute_tensor
 
 from nemo_automodel.components.distributed.parallelizer_utils import configure_fsdp_unused_param_reduction
@@ -130,9 +130,9 @@ def _assert_empty_rank_fsdp_grad_parity(device: torch.device) -> None:
     use_conditional = rank == 0
     model(inputs[rank], use_conditional=use_conditional).sum().backward()
 
-    reference_loss = sum(
-        reference(batch, use_conditional=data_rank == 0).sum() for data_rank, batch in enumerate(inputs)
-    ) / world
+    reference_loss = (
+        sum(reference(batch, use_conditional=data_rank == 0).sum() for data_rank, batch in enumerate(inputs)) / world
+    )
     reference_loss.backward()
 
     torch.testing.assert_close(
@@ -141,6 +141,88 @@ def _assert_empty_rank_fsdp_grad_parity(device: torch.device) -> None:
         rtol=1e-5,
         atol=1e-6,
     )
+
+
+class _PartiallyUsedFSDPModel(nn.Module):
+    """One FSDP unit whose second branch never runs, so it never gets a local gradient."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.used = nn.Linear(8, 8, bias=False)
+        self.unused = nn.Linear(8, 8, bias=False)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        """Run only the `used` branch.
+
+        Args:
+            inputs: Tensor of shape [batch, sequence, hidden].
+
+        Returns:
+            Tensor of shape [batch, sequence, hidden].
+        """
+        return self.used(inputs)
+
+
+def _assert_accumulated_unused_param_grad_dtype(device: torch.device) -> None:
+    """Reduce one dtype when CP zero-fill meets mixed-precision gradient accumulation.
+
+    Regression for NVBug 6599894: `used` carries an fp32 accumulation from the
+    first micro-batch while the CP unused-parameter fill contributes a bf16 zero
+    for `unused`, and FSDP2's `foreach_reduce` rejects a mixed-dtype group with
+    "FSDP reduce-scatter expects uniform gradient dtype".
+    """
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    mesh = init_device_mesh("cuda", (world,), mesh_dim_names=("dp_cp",))
+
+    torch.manual_seed(6599894)
+    model = _PartiallyUsedFSDPModel().to(device)
+    reference = _PartiallyUsedFSDPModel().to(device)
+    reference.load_state_dict(model.state_dict())
+
+    fully_shard(
+        model,
+        mesh=mesh,
+        mp_policy=MixedPrecisionPolicy(
+            param_dtype=torch.bfloat16,
+            reduce_dtype=torch.float32,
+            output_dtype=torch.bfloat16,
+            cast_forward_inputs=True,
+        ),
+        reshard_after_forward=True,
+    )
+    configured_units = configure_fsdp_unused_param_reduction(model)
+    assert configured_units >= 1
+
+    def _micro_batch(micro_index: int, data_rank: int) -> torch.Tensor:
+        generator = torch.Generator(device=device).manual_seed(5000 + 17 * micro_index + data_rank)
+        return torch.randn(2, 3, 8, device=device, generator=generator)
+
+    micro_batches = 2
+    for micro_index in range(micro_batches):
+        # Defer reduction to the final micro-batch, as fsdp_mixin does.
+        is_final = micro_index == micro_batches - 1
+        model.set_is_last_backward(is_final)
+        model.set_reshard_after_backward(is_final)
+        model.set_requires_gradient_sync(is_final)
+        model(_micro_batch(micro_index, rank)).float().sum().backward()
+
+    # FSDP2 computes in param dtype and averages the reduction over the mesh, so
+    # mirror both to keep the reference comparable.
+    reference_bf16 = reference.to(torch.bfloat16)
+    expected_used = torch.zeros_like(reference_bf16.used.weight, dtype=torch.float32)
+    for micro_index in range(micro_batches):
+        for data_rank in range(world):
+            (grad,) = torch.autograd.grad(
+                reference_bf16(_micro_batch(micro_index, data_rank).to(torch.bfloat16)).float().sum(),
+                reference_bf16.used.weight,
+            )
+            expected_used += grad.float()
+    expected_used /= world
+
+    unused_grad = _full_grad(model.unused.weight)
+    torch.testing.assert_close(unused_grad, torch.zeros_like(unused_grad), rtol=0, atol=0)
+    torch.testing.assert_close(_full_grad(model.used.weight), expected_used, rtol=2e-2, atol=2e-2)
 
 
 def _run_worker() -> None:
@@ -155,6 +237,8 @@ def _run_worker() -> None:
         _assert_flce_weight_grad_parity(device)
         dist.barrier()
         _assert_empty_rank_fsdp_grad_parity(device)
+        dist.barrier()
+        _assert_accumulated_unused_param_grad_dtype(device)
         dist.barrier()
 
         if dist.get_rank() == 0:

--- a/tests/unit_tests/distributed/test_parallelizer_utils.py
+++ b/tests/unit_tests/distributed/test_parallelizer_utils.py
@@ -48,13 +48,13 @@ def test_configure_fsdp_unused_param_reduction_uses_public_fsdp_api(monkeypatch)
         def set_reduce_scatter_unused_params(self, enabled, *, recurse):
             self.calls.append((enabled, recurse))
 
-    install_compat = Mock()
+    install_fallback = Mock()
     monkeypatch.setattr(parallelizer_utils, "FSDPModule", FakeFSDPModule)
-    monkeypatch.setattr(parallelizer_utils, "_patch_fsdp_unused_param_reduction", install_compat)
+    monkeypatch.setattr(parallelizer_utils, "_patch_fsdp_unused_param_reduction", install_fallback)
     model = nn.Sequential(FakeFSDPModule(), nn.Sequential(FakeFSDPModule()))
 
     assert configure_fsdp_unused_param_reduction(model) == 2
-    install_compat.assert_called_once_with()
+    install_fallback.assert_not_called()
     assert model[0].calls == [(True, False)]
     assert model[1][0].calls == [(True, False)]
 
@@ -74,7 +74,7 @@ def test_configure_fsdp_unused_param_reduction_uses_legacy_fallback(monkeypatch)
     install_fallback.assert_called_once_with()
 
 
-def test_fsdp_unused_param_reduction_fills_missing_local_grad(monkeypatch):
+def test_legacy_fsdp_unused_param_reduction_fills_missing_local_grad(monkeypatch):
     from torch.distributed.fsdp._fully_shard._fsdp_common import TrainingState
     from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPParamGroup
 
@@ -107,85 +107,6 @@ def test_fsdp_unused_param_reduction_fills_missing_local_grad(monkeypatch):
     assert torch.equal(param.grad, torch.zeros_like(param))
     assert calls == [(param_group, ("arg",), {"flag": True})]
     assert FSDPParamGroup.post_backward is patched_post_backward
-
-
-def test_fsdp_unused_param_reduction_routes_dtensor_zero_through_local_grad(monkeypatch):
-    """The compatibility fill avoids the old public API's global-DTensor buffer."""
-    from torch.distributed.fsdp._fully_shard._fsdp_common import TrainingState
-    from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPParamGroup
-
-    class FakeDTensor(torch.Tensor):
-        @staticmethod
-        def __new__(cls, tensor):
-            return torch.Tensor._make_subclass(cls, tensor, False)
-
-        def to_local(self):
-            # Model an EP-local tensor with half of the global expert storage.
-            return self.as_subclass(torch.Tensor)[:2]
-
-    class FakeFSDPParam:
-        def __init__(self):
-            self._unsharded_param = torch.nn.Parameter(FakeDTensor(torch.ones(4)))
-            self.unsharded_accumulated_grad = None
-
-        @property
-        def unsharded_param(self):
-            return self._unsharded_param
-
-        @property
-        def unsharded_grad_data(self):
-            return self.unsharded_param.grad.to_local()
-
-    reduced = []
-
-    def old_public_post_backward(self):
-        fsdp_param = self.fsdp_params[0]
-        if fsdp_param.unsharded_param.grad is not None:
-            reduced.append(fsdp_param.unsharded_grad_data)
-        elif self.reduce_scatter_unused_params:
-            # PyTorch 2.13a0 used this branch, passing the global-shape wrapper
-            # directly to foreach_reduce instead of extracting its local tensor.
-            reduced.append(torch.zeros_like(fsdp_param.unsharded_param))
-
-    monkeypatch.setattr(FSDPParamGroup, "post_backward", old_public_post_backward)
-    patch_fsdp_unused_param_reduction()
-    param_group = SimpleNamespace(
-        reduce_grads=True,
-        reduce_scatter_unused_params=True,
-        _training_state=TrainingState.PRE_BACKWARD,
-        fsdp_params=[FakeFSDPParam()],
-    )
-
-    FSDPParamGroup.post_backward(param_group)
-
-    assert len(reduced) == 1
-    assert type(reduced[0]) is torch.Tensor
-    assert reduced[0].numel() == 2
-
-
-def test_fsdp_unused_param_reduction_respects_public_api_flag(monkeypatch):
-    from torch.distributed.fsdp._fully_shard._fsdp_common import TrainingState
-    from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPParamGroup
-
-    monkeypatch.setattr(FSDPParamGroup, "post_backward", lambda self: None)
-    patch_fsdp_unused_param_reduction()
-
-    param = torch.nn.Parameter(torch.ones(2))
-    fsdp_param = SimpleNamespace(
-        _unsharded_param=param,
-        unsharded_accumulated_grad=None,
-        unsharded_param=param,
-    )
-    param_group = SimpleNamespace(
-        reduce_grads=True,
-        reduce_scatter_unused_params=False,
-        _training_state=TrainingState.PRE_BACKWARD,
-        fsdp_params=[fsdp_param],
-    )
-
-    FSDPParamGroup.post_backward(param_group)
-
-    assert param.grad is None
 
 
 def _install_uniform_reduce_dtype(monkeypatch, recorder):

--- a/tests/unit_tests/distributed/test_parallelizer_utils.py
+++ b/tests/unit_tests/distributed/test_parallelizer_utils.py
@@ -48,10 +48,13 @@ def test_configure_fsdp_unused_param_reduction_uses_public_fsdp_api(monkeypatch)
         def set_reduce_scatter_unused_params(self, enabled, *, recurse):
             self.calls.append((enabled, recurse))
 
+    install_compat = Mock()
     monkeypatch.setattr(parallelizer_utils, "FSDPModule", FakeFSDPModule)
+    monkeypatch.setattr(parallelizer_utils, "_patch_fsdp_unused_param_reduction", install_compat)
     model = nn.Sequential(FakeFSDPModule(), nn.Sequential(FakeFSDPModule()))
 
     assert configure_fsdp_unused_param_reduction(model) == 2
+    install_compat.assert_called_once_with()
     assert model[0].calls == [(True, False)]
     assert model[1][0].calls == [(True, False)]
 
@@ -71,7 +74,7 @@ def test_configure_fsdp_unused_param_reduction_uses_legacy_fallback(monkeypatch)
     install_fallback.assert_called_once_with()
 
 
-def test_legacy_fsdp_unused_param_reduction_fills_missing_local_grad(monkeypatch):
+def test_fsdp_unused_param_reduction_fills_missing_local_grad(monkeypatch):
     from torch.distributed.fsdp._fully_shard._fsdp_common import TrainingState
     from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPParamGroup
 
@@ -104,6 +107,85 @@ def test_legacy_fsdp_unused_param_reduction_fills_missing_local_grad(monkeypatch
     assert torch.equal(param.grad, torch.zeros_like(param))
     assert calls == [(param_group, ("arg",), {"flag": True})]
     assert FSDPParamGroup.post_backward is patched_post_backward
+
+
+def test_fsdp_unused_param_reduction_routes_dtensor_zero_through_local_grad(monkeypatch):
+    """The compatibility fill avoids the old public API's global-DTensor buffer."""
+    from torch.distributed.fsdp._fully_shard._fsdp_common import TrainingState
+    from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPParamGroup
+
+    class FakeDTensor(torch.Tensor):
+        @staticmethod
+        def __new__(cls, tensor):
+            return torch.Tensor._make_subclass(cls, tensor, False)
+
+        def to_local(self):
+            # Model an EP-local tensor with half of the global expert storage.
+            return self.as_subclass(torch.Tensor)[:2]
+
+    class FakeFSDPParam:
+        def __init__(self):
+            self._unsharded_param = torch.nn.Parameter(FakeDTensor(torch.ones(4)))
+            self.unsharded_accumulated_grad = None
+
+        @property
+        def unsharded_param(self):
+            return self._unsharded_param
+
+        @property
+        def unsharded_grad_data(self):
+            return self.unsharded_param.grad.to_local()
+
+    reduced = []
+
+    def old_public_post_backward(self):
+        fsdp_param = self.fsdp_params[0]
+        if fsdp_param.unsharded_param.grad is not None:
+            reduced.append(fsdp_param.unsharded_grad_data)
+        elif self.reduce_scatter_unused_params:
+            # PyTorch 2.13a0 used this branch, passing the global-shape wrapper
+            # directly to foreach_reduce instead of extracting its local tensor.
+            reduced.append(torch.zeros_like(fsdp_param.unsharded_param))
+
+    monkeypatch.setattr(FSDPParamGroup, "post_backward", old_public_post_backward)
+    patch_fsdp_unused_param_reduction()
+    param_group = SimpleNamespace(
+        reduce_grads=True,
+        reduce_scatter_unused_params=True,
+        _training_state=TrainingState.PRE_BACKWARD,
+        fsdp_params=[FakeFSDPParam()],
+    )
+
+    FSDPParamGroup.post_backward(param_group)
+
+    assert len(reduced) == 1
+    assert type(reduced[0]) is torch.Tensor
+    assert reduced[0].numel() == 2
+
+
+def test_fsdp_unused_param_reduction_respects_public_api_flag(monkeypatch):
+    from torch.distributed.fsdp._fully_shard._fsdp_common import TrainingState
+    from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPParamGroup
+
+    monkeypatch.setattr(FSDPParamGroup, "post_backward", lambda self: None)
+    patch_fsdp_unused_param_reduction()
+
+    param = torch.nn.Parameter(torch.ones(2))
+    fsdp_param = SimpleNamespace(
+        _unsharded_param=param,
+        unsharded_accumulated_grad=None,
+        unsharded_param=param,
+    )
+    param_group = SimpleNamespace(
+        reduce_grads=True,
+        reduce_scatter_unused_params=False,
+        _training_state=TrainingState.PRE_BACKWARD,
+        fsdp_params=[fsdp_param],
+    )
+
+    FSDPParamGroup.post_backward(param_group)
+
+    assert param.grad is None
 
 
 def _install_uniform_reduce_dtype(monkeypatch, recorder):

--- a/tests/unit_tests/distributed/test_parallelizer_utils.py
+++ b/tests/unit_tests/distributed/test_parallelizer_utils.py
@@ -218,6 +218,40 @@ def test_uniform_reduce_dtype_widens_mixed_group(monkeypatch):
     assert torch.equal(grads[1], torch.full((2,), 5.0))
 
 
+def test_uniform_reduce_dtype_localizes_residual_dtensor(monkeypatch):
+    """The old public unused-param zero is localized before ``chunk_cat``."""
+    import torch.distributed.fsdp._fully_shard._fsdp_collectives as collectives
+    import torch.distributed.fsdp._fully_shard._fsdp_param_group as param_group
+    import torch.distributed.tensor as tensor_module
+
+    class FakeDTensor(torch.Tensor):
+        @staticmethod
+        def __new__(cls, tensor):
+            return torch.Tensor._make_subclass(cls, tensor, False)
+
+        def to_local(self):
+            # Model an EP-local tensor with half of the global expert storage.
+            return self.as_subclass(torch.Tensor)[:2]
+
+    seen = []
+
+    def stub(fsdp_params, unsharded_grads, *args, **kwargs):
+        seen.append([(type(grad), grad.numel()) for grad in unsharded_grads])
+        return "reduced"
+
+    monkeypatch.setattr(tensor_module, "DTensor", FakeDTensor)
+    monkeypatch.setattr(collectives, "foreach_reduce", stub)
+    monkeypatch.setattr(param_group, "foreach_reduce", stub)
+    patch_fsdp_uniform_reduce_dtype()
+
+    grads = [torch.ones(2), FakeDTensor(torch.ones(4))]
+    result = collectives.foreach_reduce(["used", "unused"], grads)
+
+    assert result == "reduced"
+    assert seen == [[(torch.Tensor, 2), (torch.Tensor, 2)]]
+    assert all(type(grad) is torch.Tensor for grad in grads)
+
+
 def test_uniform_reduce_dtype_leaves_uniform_group_untouched(monkeypatch):
     """Uniform groups pass straight through, preserving upstream's own checks."""
     seen = []

--- a/tests/unit_tests/distributed/test_parallelizer_utils.py
+++ b/tests/unit_tests/distributed/test_parallelizer_utils.py
@@ -31,7 +31,10 @@ from nemo_automodel.components.distributed.parallelizer_utils import (
     fully_shard_by_dtype,
     iter_maximal_uniform_dtype_subtrees,
 )
-from nemo_automodel.shared.torch_patches import patch_fsdp_unused_param_reduction
+from nemo_automodel.shared.torch_patches import (
+    patch_fsdp_uniform_reduce_dtype,
+    patch_fsdp_unused_param_reduction,
+)
 
 
 def test_configure_fsdp_unused_param_reduction_uses_public_fsdp_api(monkeypatch):
@@ -101,6 +104,87 @@ def test_legacy_fsdp_unused_param_reduction_fills_missing_local_grad(monkeypatch
     assert torch.equal(param.grad, torch.zeros_like(param))
     assert calls == [(param_group, ("arg",), {"flag": True})]
     assert FSDPParamGroup.post_backward is patched_post_backward
+
+
+def _install_uniform_reduce_dtype(monkeypatch, recorder):
+    """Install the patch over a stub foreach_reduce that records what it receives."""
+    import torch.distributed.fsdp._fully_shard._fsdp_collectives as collectives
+    import torch.distributed.fsdp._fully_shard._fsdp_param_group as param_group
+
+    def stub(fsdp_params, unsharded_grads, *args, **kwargs):
+        recorder.append([g.dtype for g in unsharded_grads])
+        return "reduced"
+
+    monkeypatch.setattr(collectives, "foreach_reduce", stub)
+    monkeypatch.setattr(param_group, "foreach_reduce", stub)
+    patch_fsdp_uniform_reduce_dtype()
+    return collectives
+
+
+def test_uniform_reduce_dtype_widens_mixed_group(monkeypatch):
+    """A bf16 straggler is widened to match its fp32 peers before the reduce."""
+    seen = []
+    collectives = _install_uniform_reduce_dtype(monkeypatch, seen)
+
+    grads = [torch.ones(2, dtype=torch.float32), torch.full((2,), 5.0, dtype=torch.bfloat16)]
+    result = collectives.foreach_reduce(["p0", "p1"], grads)
+
+    assert result == "reduced"
+    assert seen == [[torch.float32, torch.float32]]
+    # Mutated in place so foreach_reduce's list.clear() still frees the caller's refs.
+    assert [g.dtype for g in grads] == [torch.float32, torch.float32]
+    assert torch.equal(grads[1], torch.full((2,), 5.0))
+
+
+def test_uniform_reduce_dtype_leaves_uniform_group_untouched(monkeypatch):
+    """Uniform groups pass straight through, preserving upstream's own checks."""
+    seen = []
+    collectives = _install_uniform_reduce_dtype(monkeypatch, seen)
+
+    grads = [torch.ones(2, dtype=torch.bfloat16), torch.ones(2, dtype=torch.bfloat16)]
+    original = [g for g in grads]
+    collectives.foreach_reduce(["p0", "p1"], grads)
+
+    assert seen == [[torch.bfloat16, torch.bfloat16]]
+    assert all(a is b for a, b in zip(grads, original))
+
+
+def test_uniform_reduce_dtype_ignores_non_float_mixtures(monkeypatch):
+    """Non-float gradients are left alone so the upstream assertion still fires."""
+    seen = []
+    collectives = _install_uniform_reduce_dtype(monkeypatch, seen)
+
+    grads = [torch.ones(2, dtype=torch.float32), torch.ones(2, dtype=torch.int32)]
+    collectives.foreach_reduce(["p0", "p1"], grads)
+
+    assert seen == [[torch.float32, torch.int32]]
+
+
+def test_uniform_reduce_dtype_patch_is_idempotent(monkeypatch):
+    """Re-installing must not stack a second wrapper."""
+    seen = []
+    collectives = _install_uniform_reduce_dtype(monkeypatch, seen)
+    wrapped = collectives.foreach_reduce
+
+    patch_fsdp_uniform_reduce_dtype()
+
+    assert collectives.foreach_reduce is wrapped
+
+
+def test_configure_fsdp_unused_param_reduction_installs_dtype_alignment_first(monkeypatch):
+    """The zero fill must wrap the alignment so filled zeros are aligned too."""
+    from nemo_automodel.components.distributed import parallelizer_utils
+
+    class LegacyFSDPModule(nn.Module):
+        pass
+
+    order = []
+    monkeypatch.setattr(parallelizer_utils, "FSDPModule", LegacyFSDPModule)
+    monkeypatch.setattr(parallelizer_utils, "_patch_fsdp_uniform_reduce_dtype", lambda: order.append("uniform_dtype"))
+    monkeypatch.setattr(parallelizer_utils, "_patch_fsdp_unused_param_reduction", lambda: order.append("zero_fill"))
+
+    assert configure_fsdp_unused_param_reduction(nn.Sequential(LegacyFSDPModule())) == 1
+    assert order == ["uniform_dtype", "zero_fill"]
 
 
 def _tag_hf_compute_dtype(model: nn.Module) -> None:


### PR DESCRIPTION
# What

Makes the shipped `glm_5.2_tulu3_32k_tilelang_cp8` recipe train. It hit three defects stacked in one code path — FSDP2's post-backward reduce — each masking the next:

1. `AssertionError: FSDP reduce-scatter expects uniform gradient dtype but got {torch.bfloat16, torch.float32}` — **NVBug 6599894**
2. `Tried to allocate 36.00 GiB` in `foreach_reduce`'s `reduce_scatter_input` — **AMINT-274**
3. `chunk_cat: mixed Tensor and DTensor` — **AMINT-273**

All three are fixed here. The recipe now runs to completion at its full 512-GPU configuration (see CI evidence).

# Why

### 1. Mixed gradient dtype

`FSDPParamGroup.post_backward` builds the reduce-scatter input from two slots that hold different dtypes:

| source | dtype | when |
| --- | --- | --- |
| `unsharded_accumulated_grad` | `reduce_dtype` (fp32) | parameter received a gradient during an earlier no-sync micro-batch; `FSDPParam.to_accumulated_grad_if_needed` upcast it |
| `unsharded_param.grad` | `param_dtype` (bf16) | parameter's gradient joined only at the reducing post-backward |

`foreach_reduce` requires one dtype for the whole group, so a group holding both aborts.

Context parallelism makes this reachable: `configure_fsdp_unused_param_reduction` installs a zero fill for locally unused parameters, and that zero is a `param_dtype` gradient sitting next to peers that already hold `reduce_dtype` accumulations. Any `cp_size > 1` recipe with gradient accumulation can land there.

This is not a model or dtype-pinning problem. The fp32 gradients are FSDP2's normal accumulation; the bf16 one is the intruder.

### 2 & 3. Unsharded `DTensor` zeros reaching the reduce

The remaining two failures are the same root cause. On this PyTorch build, the *public* unused-parameter API — `FSDPModule.set_reduce_scatter_unused_params(True)` — appends `zeros_like(unsharded_param)` where the unsharded parameter is still a **`DTensor`**, and hands it to `foreach_reduce` directly instead of routing it through `FSDPParam._get_grad_inner_tensor`.

Two consequences, and which one you get depends only on group composition:

* `fsdp.chunk_cat` rejects a list mixing `Tensor` and `DTensor` → **AMINT-273**.
* When the group is uniformly `DTensor`, nothing rejects it, and FSDP sizes the copy-in buffer from the `DTensor`'s **global** numel instead of the EP-local shard → **AMINT-274**.

The 36 GiB is uniquely identified by arithmetic. GLM-5.2: hidden 6144, moe_inter 2048, 256 routed experts, gated:

```
256×6144×4096 + 256×2048×6144 = 9,663,676,416 elem × 4 B = 36.00 GiB
```

That is exactly **one MoE layer's global, un-EP-split expert gradient**. At the recipe's `ep_size=64` the local shard is 4 experts = 0.56 GiB — a 64× inflation. Instrumentation on [job 396644320](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/396644320) confirmed it directly: the failing group is `layers.76…mlp.experts.{gate_and_up_projs (512,3072,4096), down_projs (512,1024,6144)}`, all 256 logged bf16 entries are `DTensor`, while every *passing* group in the same run is a plain `Tensor`.

# What changed

Three commits, each addressing one defect.

**1. `patch_fsdp_uniform_reduce_dtype`** widens the minority gradients inside `foreach_reduce`, the last point before the reduction:

```python
dtypes = {grad.dtype for grad in unsharded_grads}
if len(dtypes) > 1 and all(dtype.is_floating_point for dtype in dtypes):
    unsharded_grads[:] = [g if g.dtype is target else g.to(target) for g in unsharded_grads]
```

FSDP2's own bookkeeping (`unsharded_param.grad` / `unsharded_accumulated_grad`) is left exactly as upstream leaves it, and `foreach_reduce` copies these gradients into a `reduce_dtype` buffer immediately afterwards, so widening first changes no value. The in-place `[:]` assignment is deliberate: `foreach_reduce` frees gradients by clearing that list, and replacing the list object would defeat it. Uniform groups pass straight through, so the upstream assertion still fires for genuinely inconsistent gradients such as fp8 weights that fail to produce higher-precision ones.

**2. Always install the unused-parameter shim**, rather than only as a fallback when the public API is absent. The shim assigns the zero to `param.grad`, so upstream's *normal* gradient path runs and unwraps the EP-local tensor via `_get_grad_inner_tensor`. A `reduce_scatter_unused_params` guard keeps the process-global wrapper from changing FSDP units that were never configured for unused-param reduction.

**3. Localize any residual `DTensor`** in the reduce list, covering paths that reach `foreach_reduce` without going through the shim.

An earlier revision of this PR instead re-slotted gradients via `to_accumulated_grad_if_needed()` in `post_backward`. That mutates FSDP2's bookkeeping and regressed two checkpoint-robustness tests. The current design does not touch those slots.

# CI evidence

All runs on `eos` / `x86`, `release` scope, via `nemo-ci` `main-mirror`.

### The recipe now trains — scale-matched before/after

Same recipe, same cluster, differing only by commit:

| Config | before (`1065b1d26`, defect 3 present) | after (`f22d96361`, this PR head) |
| --- | --- | --- |
| **512 GPU** — `cp8 / ep64 / pp4` (the NVBug configuration) | OOM **36.00 GiB**, no step completed — [396812951](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/396812951), [396817606](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/396817606) | ✅ **step 49, loss 0.5900, 2 epochs** — [396937806](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/396937806) |
| **256 GPU** — `cp8 / ep32 / pp4` | `chunk_cat` mixed `DTensor`, no step completed — [396902549](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/396902549), [396926560](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/396926560) | ✅ **step 1/2, loss 0.7167** — [396944715](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/396944715) |

The 512-GPU passing run shows `mem 25.26 → 35.16 GiB` and no OOM or assertion anywhere in its log.

For reference, the un-patched baseline fails the same way: the 36 GiB OOM reproduces on plain `main` ([job 396279513](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/396279513)) and on an earlier `main` from before this work began ([job 394555501](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/394555501)).

### Earlier assertion-only verification (defect 1)

| Pipeline | Ref | Result |
| --- | --- | --- |
| [62399126](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/62399126) | fix (initial) | `uniform gradient dtype` assertion: **0 occurrences** (QA saw it on 36 ranks) |
| [62431917](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/62431917) | fix (scope-reduced) | assertion still absent |
| [62569328](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/62569328) | fix (current design) | assertion absent; `gpt_oss_20b` and `qwen3_moe_30b_te_deepep` both pass |

### Validated on r0.6.0 and on current `main`

The same 512-GPU recipe passes on every variant of the change, with final loss agreeing to four decimals:

| branch | head | 512-GPU result |
| --- | --- | --- |
| this PR | `f22d96361` | [396937806](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/396937806) loss 0.5900 · [397299768](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/397299768) loss 0.5898 |
| `…-r060` (r0.6.0 backport) | `b8f6282c` | [397401915](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/397401915) loss 0.5898 |
| `…-rebased` (onto current `main`) | `dbbb2db7` | [397429251](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/397429251) loss 0.5897 |

All 50 steps, `cp8/ep64/pp4`, zero OOM / assertion / `chunk_cat` occurrences.

### `gpt_oss_20b` — resolved: pre-existing flakiness, not caused by this PR

`gpt_oss_20b` intermittently fails its checkpoint-robustness *Phase 4 HF reload parity* check against the recipe's hand-tuned `hf_kl_threshold: 1e-1`. Two things were needed to settle it, because an early 6-sample comparison looked like a real regression.

**1. The wrapper provably never fires for this recipe.** An instrumented build counted every entry into the patched `foreach_reduce` and every branch taken. Across 66–73 observations on all 8 ranks of two independent runs ([397799636](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/397799636), [397824828](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/397824828)), every line reads:

```
WIDENPROBE calls=100 localized=0 widened=0 dtypes_seen=['torch.float32'] this_call_dtensors=0
```

Zero `DTensor` localizations, zero widenings, every reduce group uniformly `float32`. The patch is a strict pass-through here — as the topology predicts (`WORLD_SIZE=8, ep_size=8, cp=pp=tp=1` ⇒ `ep_shard == 1`, so `configure_fsdp_unused_param_reduction` is skipped under `if cp_enabled:` and experts land in `ignored_params`).

**2. Unmodified `main` fails the same check.** Extending the paired comparison:

| arm | measured Phase-4 max KL (×1e-2) |
| --- | --- |
| current `main` (8 runs) | 2.11, 3.06, 4.04, 4.49, 5.97, 8.50, **11.00** ❌, **23.87** ❌ |
| with this change (10 runs) | 0.095, 4.77, 5.80, 9.57, **10.4** ❌, **13.5** ❌, **15.0** ❌, **20.1** ❌, **29.3** ❌, **32.0** ❌ |

Both arms straddle the gate, and the baseline reaches 2.4e-01 — inside the range this branch produces. The metric spans roughly 1e-3 to 3e-1 run-to-run on identical code, so a fixed `1e-1` constant sits in the middle of the noise band.

Phase 3 (`Automodel-from-consolidated max KL`) is **exactly `0.000000e+00`** in every run of both arms, so the deterministic reload path is bit-identical; only the HF-reload path moves.

This is the known class of problem with the hand-tuned `ci.checkpoint_robustness` constants and is out of scope here; the fix belongs in the metric (gate a scale-free panel against a per-recipe baseline band) rather than in this PR. An earlier revision of this description first dismissed these failures as noise on n=3, then over-corrected and called them a regression on n=6; both readings were premature.

# Tests

* `tests/functional_tests/training/test_cp_flce_fsdp_correctness.py` — 2-rank regression. Reverting the change reproduces the exact bug string.
* `tests/unit_tests/distributed/test_parallelizer_utils.py` — widening a mixed group, uniform groups untouched, non-float mixtures left for the upstream assertion, `DTensor` localization, patch idempotency, and install ordering relative to the zero fill. 34 pass.
* Local: 1306 unit tests pass; DTensor/expert-parallel probes confirm reduce groups stay EP-local.

# Known limitation (pre-existing, unchanged)

A unit skipped *entirely* on a rank still cannot be filled: FSDP2 creates `_unsharded_param` lazily in the forward pre-hook, so there is no tensor to shape a zero from, and no local signal that peers used it. That applies equally to the non-pipeline path today.
