### PR TITLE
chore(debug): probe EP-split expert reduce size (do not merge)

### DIFF
--- a/nemo_automodel/_transformers/infrastructure.py
+++ b/nemo_automodel/_transformers/infrastructure.py
@@ -386,6 +386,14 @@ def instantiate_infrastructure(
     autopipeline = _instantiate_pipeline(pipeline_config, mesh, device, distributed_config)
 
     parallelize_fn = None
+    import torch.distributed as _dist
+
+    if not _dist.is_initialized() or _dist.get_rank() == 0:
+        print(
+            f"NVBUG6599894 mesh: ep_size={mesh.ep_size} moe_mesh={mesh.moe_mesh} "
+            f"pp_size={mesh.pp_size} cp_size={mesh.cp_size} tp_size={mesh.tp_size} dp_size={mesh.dp_size}",
+            flush=True,
+        )
     if mesh.ep_size > 1:
         from nemo_automodel.components.moe.parallelizer import parallelize_model
 
@@ -428,6 +436,8 @@ def instantiate_infrastructure(
         )
     elif autopipeline is not None and model_wrapper is not None:
         parallelize_fn = partial(parallelize_for_pp, model_wrapper=model_wrapper)
+        if not _dist.is_initialized() or _dist.get_rank() == 0:
+            print("NVBUG6599894 parallelize_fn=parallelize_for_pp (DENSE path, EP dropped)", flush=True)
 
     qat_quantizer = _instantiate_qat(qat_config)
 

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -618,6 +618,9 @@ def apply_fsdp(
     # but trainable multimodal towers still get standalone FSDP units. Install
     # the same lazy-state guard as dense FSDP for modality-free batches.
     _patch_fsdp_accumulated_grad_guard()
+    from nemo_automodel.shared.torch_patches import patch_fsdp_log_reduce_groups
+
+    patch_fsdp_log_reduce_groups()
 
     if isinstance(lm_head_precision, str):
         lm_head_precision = dtype_from_str(lm_head_precision, default=None)

--- a/nemo_automodel/shared/torch_patches.py
+++ b/nemo_automodel/shared/torch_patches.py
@@ -244,11 +244,12 @@ def apply_torch_patches() -> None:
 
 
 def patch_fsdp_log_reduce_groups(limit: int = 3) -> None:
-    """DEBUG ONLY (NVBug 6599894): print reduce-group composition, including the failing one.
+    """DEBUG ONLY (NVBug 6599894 / AMINT-274): identify the reduce group that fails.
 
-    Prints from EVERY rank: under pipeline parallelism rank 0 reduces last, so a
-    rank-0-only print never fires when a mid-pipeline rank dies first. Also prints
-    the group whose reduction raised, which is the one that OOMs.
+    Only rank 0's stdout reaches the CI log, and under pipeline parallelism rank 0
+    reduces last, so a print never survives a mid-pipeline failure. Fold the group
+    description into the raised exception instead: torch elastic propagates
+    tracebacks from every rank.
     """
     import torch.distributed as dist
     import torch.distributed.fsdp._fully_shard._fsdp_collectives as coll
@@ -266,6 +267,7 @@ def patch_fsdp_log_reduce_groups(limit: int = 3) -> None:
             (
                 getattr(p, "_param_fqn", None) or p._module_info.param_name,
                 tuple(g.shape),
+                str(g.dtype),
                 type(g).__name__,
                 getattr(p, "is_dtensor", None),
             )
@@ -280,11 +282,11 @@ def patch_fsdp_log_reduce_groups(limit: int = 3) -> None:
         try:
             return original(fsdp_params, unsharded_grads, *args, **kwargs)
         except Exception as error:
-            print(
-                f"NVBUG6599894 FAILING GROUP ({type(error).__name__}): {describe(fsdp_params, unsharded_grads)}",
-                flush=True,
-            )
-            raise
+            # Re-raise with the group identity embedded so it survives to the log.
+            raise RuntimeError(
+                f"NVBUG6599894 FAILING GROUP: {describe(fsdp_params, unsharded_grads)} "
+                f"orig={type(error).__name__}: {error}"
+            ) from error
 
     logged._nvbug6599894 = True
     coll.foreach_reduce = logged

--- a/nemo_automodel/shared/torch_patches.py
+++ b/nemo_automodel/shared/torch_patches.py
@@ -241,3 +241,35 @@ def apply_torch_patches() -> None:
         _logger.debug(f"Could not apply aten.alias.default sharding strategy patch: {e}")
 
     _TORCH_PATCHES_APPLIED = True
+
+
+def patch_fsdp_log_reduce_groups(limit: int = 10) -> None:
+    """DEBUG ONLY (NVBug 6599894): print what each reduce-scatter group contains."""
+    import torch.distributed as dist
+    import torch.distributed.fsdp._fully_shard._fsdp_collectives as coll
+    import torch.distributed.fsdp._fully_shard._fsdp_param_group as pg
+
+    original = coll.foreach_reduce
+    if getattr(original, "_nvbug6599894", False):
+        return
+    seen = {"n": 0}
+
+    def logged(fsdp_params, unsharded_grads, *args, **kwargs):
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        if rank == 0 and seen["n"] < limit:
+            seen["n"] += 1
+            total = sum(g.numel() for g in unsharded_grads)
+            names = [
+                (getattr(p, "_param_fqn", None) or p._module_info.param_name, tuple(g.shape))
+                for p, g in zip(fsdp_params, unsharded_grads)
+            ]
+            print(
+                f"NVBUG6599894 reduce-group {seen['n']}: numel={total} "
+                f"({total * 4 / 1024**3:.2f} GiB fp32) params={names}",
+                flush=True,
+            )
+        return original(fsdp_params, unsharded_grads, *args, **kwargs)
+
+    logged._nvbug6599894 = True
+    coll.foreach_reduce = logged
+    pg.foreach_reduce = logged

--- a/nemo_automodel/shared/torch_patches.py
+++ b/nemo_automodel/shared/torch_patches.py
@@ -243,8 +243,13 @@ def apply_torch_patches() -> None:
     _TORCH_PATCHES_APPLIED = True
 
 
-def patch_fsdp_log_reduce_groups(limit: int = 10) -> None:
-    """DEBUG ONLY (NVBug 6599894): print what each reduce-scatter group contains."""
+def patch_fsdp_log_reduce_groups(limit: int = 3) -> None:
+    """DEBUG ONLY (NVBug 6599894): print reduce-group composition, including the failing one.
+
+    Prints from EVERY rank: under pipeline parallelism rank 0 reduces last, so a
+    rank-0-only print never fires when a mid-pipeline rank dies first. Also prints
+    the group whose reduction raised, which is the one that OOMs.
+    """
     import torch.distributed as dist
     import torch.distributed.fsdp._fully_shard._fsdp_collectives as coll
     import torch.distributed.fsdp._fully_shard._fsdp_param_group as pg
@@ -254,21 +259,32 @@ def patch_fsdp_log_reduce_groups(limit: int = 10) -> None:
         return
     seen = {"n": 0}
 
+    def describe(fsdp_params, unsharded_grads):
+        rank = dist.get_rank() if dist.is_initialized() else -1
+        total = sum(g.numel() for g in unsharded_grads)
+        rows = [
+            (
+                getattr(p, "_param_fqn", None) or p._module_info.param_name,
+                tuple(g.shape),
+                type(g).__name__,
+                getattr(p, "is_dtensor", None),
+            )
+            for p, g in zip(fsdp_params, unsharded_grads)
+        ]
+        return f"rank={rank} numel={total} ({total * 4 / 1024**3:.2f} GiB fp32) params={rows}"
+
     def logged(fsdp_params, unsharded_grads, *args, **kwargs):
-        rank = dist.get_rank() if dist.is_initialized() else 0
-        if rank == 0 and seen["n"] < limit:
+        if seen["n"] < limit:
             seen["n"] += 1
-            total = sum(g.numel() for g in unsharded_grads)
-            names = [
-                (getattr(p, "_param_fqn", None) or p._module_info.param_name, tuple(g.shape))
-                for p, g in zip(fsdp_params, unsharded_grads)
-            ]
+            print(f"NVBUG6599894 group {seen['n']}: {describe(fsdp_params, unsharded_grads)}", flush=True)
+        try:
+            return original(fsdp_params, unsharded_grads, *args, **kwargs)
+        except Exception as error:
             print(
-                f"NVBUG6599894 reduce-group {seen['n']}: numel={total} "
-                f"({total * 4 / 1024**3:.2f} GiB fp32) params={names}",
+                f"NVBUG6599894 FAILING GROUP ({type(error).__name__}): {describe(fsdp_params, unsharded_grads)}",
                 flush=True,
             )
-        return original(fsdp_params, unsharded_grads, *args, **kwargs)
+            raise
 
     logged._nvbug6599894 = True
     coll.foreach_reduce = logged

--- a/tests/unit_tests/distributed/test_ep_reduce_size_probe.py
+++ b/tests/unit_tests/distributed/test_ep_reduce_size_probe.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DEBUG (NVBug 6599894 / AMINT-274): what size does FSDP2 reduce for EP-split experts?
+
+On GLM-5.2 the reduce-scatter input was the GLOBAL 256-expert gradient (36 GiB fp32)
+rather than the per-rank EP shard. This runs the same object graph -- ExpertParallel
+over an ep mesh, then fully_shard over an ep_shard mesh -- on 4 gloo/CPU ranks, so it
+executes the container's torch without needing a 64-node allocation.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_MARKER = "EP_REDUCE_PROBE "
+N_EXPERTS, EXPERT_DIM, MOE_INTER_DIM = 8, 32, 16
+
+
+def _worker() -> None:
+    import torch
+    import torch.distributed as dist
+    import torch.distributed.fsdp._fully_shard._fsdp_collectives as collectives
+    import torch.distributed.fsdp._fully_shard._fsdp_param_group as param_group
+    import torch.nn as nn
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
+    from torch.distributed.tensor import DTensor
+    from torch.distributed.tensor.parallel import parallelize_module
+
+    from nemo_automodel.components.moe.parallelizer import ExpertParallel, _moe_shard_placement
+
+    seen = []
+    original = collectives.foreach_reduce
+
+    def spy(fsdp_params, unsharded_grads, *args, **kwargs):
+        seen.append(
+            [
+                (tuple(g.shape), g.numel(), type(g).__name__, getattr(p, "is_dtensor", None))
+                for p, g in zip(fsdp_params, unsharded_grads)
+            ]
+        )
+        return original(fsdp_params, unsharded_grads, *args, **kwargs)
+
+    collectives.foreach_reduce = spy
+    param_group.foreach_reduce = spy
+
+    class Experts(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.gate_and_up_projs = nn.Parameter(torch.randn(N_EXPERTS, EXPERT_DIM, 2 * MOE_INTER_DIM))
+            self.down_projs = nn.Parameter(torch.randn(N_EXPERTS, MOE_INTER_DIM, EXPERT_DIM))
+
+        def forward(self) -> torch.Tensor:
+            """Consume both params via ``.to_local()``, as GroupedExperts does."""
+            gate = self.gate_and_up_projs
+            down = self.down_projs
+            gate = gate.to_local() if isinstance(gate, DTensor) else gate
+            down = down.to_local() if isinstance(down, DTensor) else down
+            return gate.float().pow(2).sum() + down.float().pow(2).sum()
+
+    dist.init_process_group("gloo")
+    world = dist.get_world_size()
+    mesh = init_device_mesh("cpu", (2, world // 2), mesh_dim_names=("ep_shard", "ep"))
+    ep_size = mesh["ep"].size()
+
+    torch.manual_seed(0)
+    experts = Experts()
+    parallelize_module(module=experts, device_mesh=mesh["ep"], parallelize_plan=ExpertParallel())
+    fully_shard(
+        experts,
+        mesh=mesh["ep_shard"],
+        shard_placement_fn=_moe_shard_placement,
+        mp_policy=MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=torch.float32),
+    )
+    experts().backward()
+
+    if dist.get_rank() == 0:
+        per_expert = EXPERT_DIM * 2 * MOE_INTER_DIM + MOE_INTER_DIM * EXPERT_DIM
+        glob = N_EXPERTS * per_expert
+        for rows in seen:
+            total = sum(r[1] for r in rows)
+            verdict = "EP-LOCAL" if total == glob // ep_size else "GLOBAL-INFLATED" if total == glob else "OTHER"
+            print(
+                f"{_MARKER}torch={torch.__version__} ep_size={ep_size} numel={total} "
+                f"global={glob} ep_local={glob // ep_size} verdict={verdict} rows={rows}",
+                flush=True,
+            )
+    dist.destroy_process_group()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="requires gloo")
+def test_ep_split_experts_reduce_local_shard() -> None:
+    """The reduce-scatter input must be the per-rank EP shard, not the global parameter."""
+    command = [
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
+        "--standalone",
+        "--nproc_per_node=4",
+        str(Path(__file__).resolve()),
+        "--worker",
+    ]
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[3])}
+    completed = subprocess.run(
+        command, env=env, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=600, check=False
+    )
+    print(completed.stdout)
+    assert completed.returncode == 0, completed.stdout
+    lines = [line for line in completed.stdout.splitlines() if _MARKER in line]
+    assert lines, completed.stdout
+    assert all("verdict=EP-LOCAL" in line for line in lines), "\n".join(lines)
+
+
+if __name__ == "__main__":
+    if "--worker" in sys.argv:
+        _worker()


### PR DESCRIPTION
Debug-only. Runs a 4-rank gloo probe of `ExpertParallel` + `fully_shard` inside the CI container to determine whether FSDP2 reduces the per-rank EP shard or the global expert parameter (NVBug 6599894 / AMINT-274, 36 GiB `reduce_scatter_input`).

Local torch 2.10 reports `verdict=EP-LOCAL`; the container runs torch 2.13.0a0, whose `_get_grad_inner_tensor` gained a `redistribute()` step that can all-gather across the EP mesh. This PR exists only to execute that probe in the container. Not for merge.