### PR TITLE
fix(mtp): support context-parallel caller inputs

### DIFF
--- a/nemo_automodel/_transformers/capabilities.py
+++ b/nemo_automodel/_transformers/capabilities.py
@@ -191,11 +191,14 @@ class ModelSupports:
             "cp",
             "ep",
             "sequence_packing",
+            "mtp_cp",
+            "mtp_cp_pp",
             "cp_vision_frame_sharding",
             "gradient_checkpointing",
             "generate",
         )
         flags = ", ".join("{}={}".format(name, getattr(self, "supports_" + name)) for name in names)
+        flags += ", mtp_enabled={}".format(self.mtp_enabled)
         flags += ", is_custom_model={}".format(self.is_custom_model)
         return "ModelSupports({})".format(flags)
 
@@ -304,6 +307,30 @@ class ModelSupports:
         except AttributeError:
             return False
         return capabilities.supports_thd
+
+    @property
+    def supports_mtp_cp(self) -> bool:
+        """Model owns a verified MTP training path under context parallelism."""
+        try:
+            capabilities = query_capabilities(self._model)
+        except AttributeError:
+            return False
+        return capabilities.supports_mtp_cp
+
+    @property
+    def supports_mtp_cp_pp(self) -> bool:
+        """Model owns a verified MTP training path with both CP and PP."""
+        try:
+            capabilities = query_capabilities(self._model)
+        except AttributeError:
+            return False
+        return capabilities.supports_mtp_cp_pp
+
+    @property
+    def mtp_enabled(self) -> bool:
+        """Whether MTP is active for this configured model instance."""
+        mtp_config = getattr(self._model, "mtp_config", None)
+        return bool(getattr(mtp_config, "enabled", False))
 
     @property
     def supports_cp_vision_frame_sharding(self) -> bool:

--- a/nemo_automodel/_transformers/model_capabilities.py
+++ b/nemo_automodel/_transformers/model_capabilities.py
@@ -55,6 +55,8 @@ class ModelCapabilities:
         supports_pp: Pipeline parallelism.
         supports_ep: Expert parallelism (MoE).
         supports_thd: THD packed-sequence inputs.
+        supports_mtp_cp: MTP training with context parallelism.
+        supports_mtp_cp_pp: MTP training with context and pipeline parallelism.
         supports_cp_vision_frame_sharding: Frame-level vision-tower sharding over
             context-parallel ranks.
     """
@@ -64,6 +66,8 @@ class ModelCapabilities:
     supports_pp: bool = False
     supports_ep: bool = False
     supports_thd: bool = False
+    supports_mtp_cp: bool = False
+    supports_mtp_cp_pp: bool = False
     supports_cp_vision_frame_sharding: bool = False
 
 
@@ -82,6 +86,8 @@ def _to_canonical(caps_obj) -> ModelCapabilities:
         supports_pp=bool(caps_obj.supports_pp),
         supports_ep=bool(caps_obj.supports_ep),
         supports_thd=bool(getattr(caps_obj, "supports_thd", False)),
+        supports_mtp_cp=bool(getattr(caps_obj, "supports_mtp_cp", False)),
+        supports_mtp_cp_pp=bool(getattr(caps_obj, "supports_mtp_cp_pp", False)),
         supports_cp_vision_frame_sharding=bool(getattr(caps_obj, "supports_cp_vision_frame_sharding", False)),
     )
 

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -542,6 +542,7 @@ class NemotronHParallelizationStrategy(ParallelizationStrategy):
             mtp_layers = getattr(mtp_module, "layers", None)
             mtp_enabled = bool(getattr(getattr(model, "mtp_config", None), "enabled", False))
             parallelizer_utils.reject_unsupported_mtp_cp_pp(model)
+            parallelizer_utils.reject_unsupported_mtp_cp(model)
             if mtp_enabled and mtp_layers is None:
                 raise RuntimeError(
                     "MTP is enabled but model.mtp.layers is unavailable; cannot configure context parallelism for MTP"

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -536,8 +536,22 @@ class NemotronHParallelizationStrategy(ParallelizationStrategy):
         cp_mesh = device_mesh["cp"] if "cp" in device_mesh.mesh_dim_names else None
         if cp_mesh is not None and cp_mesh.size() > 1:
             cp_group = cp_mesh.get_group()
+            cp_global_ranks = torch.distributed.get_process_group_ranks(cp_group)
+            cp_layers = list(layers)
+            mtp_module = getattr(model, "mtp", None)
+            mtp_layers = getattr(mtp_module, "layers", None)
+            mtp_enabled = bool(getattr(getattr(model, "mtp_config", None), "enabled", False))
+            parallelizer_utils.reject_unsupported_mtp_cp_pp(model)
+            if mtp_enabled and mtp_layers is None:
+                raise RuntimeError(
+                    "MTP is enabled but model.mtp.layers is unavailable; cannot configure context parallelism for MTP"
+                )
+            if mtp_enabled and mtp_layers is not None:
+                # MTP blocks live outside the backbone container but execute
+                # the same attention/Mamba CP collectives.
+                cp_layers.extend(mtp_layers)
 
-            for layer in layers:
+            for layer in cp_layers:
                 if hasattr(layer, "block_type") and layer.block_type == "mamba":
                     from nemo_automodel.components.distributed.context_parallel.mamba import MambaContextParallel
 
@@ -557,7 +571,7 @@ class NemotronHParallelizationStrategy(ParallelizationStrategy):
                     if isinstance(attn_module, DotProductAttention):
                         attn_module.set_context_parallel_group(
                             cp_group,
-                            torch.distributed.get_process_group_ranks(cp_group),
+                            cp_global_ranks,
                             torch.cuda.Stream(),
                             cp_comm_type="p2p",
                         )

--- a/nemo_automodel/components/distributed/parallelizer_utils.py
+++ b/nemo_automodel/components/distributed/parallelizer_utils.py
@@ -37,7 +37,9 @@ UniformSubtreeItem = Union[Tuple[nn.Module, torch.dtype], Tuple[str, nn.Module, 
 
 def reject_unsupported_mtp_cp_pp(model: nn.Module) -> None:
     """Reject MTP+CP on every trimmed pipeline stage before CP collectives."""
-    supports = model.supports
+    supports = getattr(model, "supports", None)
+    if supports is None:
+        return
     is_pp_stage_fn = getattr(model, "_is_pipeline_parallel_stage", None)
     if supports.mtp_enabled and not supports.supports_mtp_cp_pp and callable(is_pp_stage_fn) and is_pp_stage_fn():
         raise NotImplementedError(

--- a/nemo_automodel/components/distributed/parallelizer_utils.py
+++ b/nemo_automodel/components/distributed/parallelizer_utils.py
@@ -35,6 +35,14 @@ from nemo_automodel.shared.torch_patches import (
 UniformSubtreeItem = Union[Tuple[nn.Module, torch.dtype], Tuple[str, nn.Module, torch.dtype]]
 
 
+def reject_unsupported_mtp_cp(model: nn.Module) -> None:
+    """Reject enabled MTP when the model has not declared CP support."""
+    supports = getattr(model, "supports", None)
+    mtp_enabled = bool(getattr(supports, "mtp_enabled", getattr(getattr(model, "mtp_config", None), "enabled", False)))
+    if mtp_enabled and not bool(getattr(supports, "supports_mtp_cp", False)):
+        raise RuntimeError(f"{type(model).__name__} does not support MTP with context parallelism")
+
+
 def reject_unsupported_mtp_cp_pp(model: nn.Module) -> None:
     """Reject MTP+CP on every trimmed pipeline stage before CP collectives."""
     supports = getattr(model, "supports", None)

--- a/nemo_automodel/components/distributed/parallelizer_utils.py
+++ b/nemo_automodel/components/distributed/parallelizer_utils.py
@@ -35,6 +35,16 @@ from nemo_automodel.shared.torch_patches import (
 UniformSubtreeItem = Union[Tuple[nn.Module, torch.dtype], Tuple[str, nn.Module, torch.dtype]]
 
 
+def reject_unsupported_mtp_cp_pp(model: nn.Module) -> None:
+    """Reject MTP+CP on every trimmed pipeline stage before CP collectives."""
+    supports = model.supports
+    is_pp_stage_fn = getattr(model, "_is_pipeline_parallel_stage", None)
+    if supports.mtp_enabled and not supports.supports_mtp_cp_pp and callable(is_pp_stage_fn) and is_pp_stage_fn():
+        raise NotImplementedError(
+            "MTP with context and pipeline parallelism is not supported; use PP size 1 or CP size 1"
+        )
+
+
 def configure_fsdp_unused_param_reduction(module: nn.Module) -> int:
     """Reduce zero gradients for FSDP parameters unused on a local CP rank.
 

--- a/nemo_automodel/components/loss/mtp.py
+++ b/nemo_automodel/components/loss/mtp.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal, Optional, overload
 
@@ -49,6 +50,7 @@ def calculate_mtp_loss(
     *,
     mtp_per_depth_h: list[torch.Tensor] | None = None,
     mtp_per_depth_logits: list[torch.Tensor] | None = None,
+    mtp_per_depth_targets: Sequence[torch.Tensor] | None = None,
     labels: torch.Tensor,
     model: nn.Module,
     scaling_factor: float = 0.1,
@@ -68,6 +70,7 @@ def calculate_mtp_loss(
     *,
     mtp_per_depth_h: list[torch.Tensor] | None = None,
     mtp_per_depth_logits: list[torch.Tensor] | None = None,
+    mtp_per_depth_targets: Sequence[torch.Tensor] | None = None,
     labels: torch.Tensor,
     model: nn.Module,
     scaling_factor: float = 0.1,
@@ -87,6 +90,7 @@ def calculate_mtp_loss(
     *,
     mtp_per_depth_h: list[torch.Tensor] | None = None,
     mtp_per_depth_logits: list[torch.Tensor] | None = None,
+    mtp_per_depth_targets: Sequence[torch.Tensor] | None = None,
     labels: torch.Tensor,
     model: nn.Module,
     scaling_factor: float = 0.1,
@@ -105,6 +109,7 @@ def calculate_mtp_loss(
     *,
     mtp_per_depth_h: list[torch.Tensor] | None = None,
     mtp_per_depth_logits: list[torch.Tensor] | None = None,
+    mtp_per_depth_targets: Sequence[torch.Tensor] | None = None,
     labels: torch.Tensor,
     model: nn.Module,
     scaling_factor: float = 0.1,
@@ -131,6 +136,12 @@ def calculate_mtp_loss(
         mtp_per_depth_logits: Per-depth logit tensors of shape
             ``[batch, sequence, vocab]``, or ``[1, tokens, vocab]`` for a
             flattened THD-packed stream.
+        mtp_per_depth_targets: Optional precomputed target tensors, one per
+            MTP depth, with the same local shape and token layout as ``labels``.
+            Context-parallel callers must shift and boundary-mask them in global
+            sequence order before applying the model input shard. These targets
+            are authoritative: this function cannot infer or repair global
+            packed-sequence boundaries from a rank-local CP shard.
         labels: Original unshifted label tensor of shape ``[batch, sequence]``
             or ``[tokens]`` for a flattened THD-packed stream.
         model: The wrapped model; used to fetch the shared LM head when the
@@ -181,6 +192,20 @@ def calculate_mtp_loss(
         mtp_outputs = [h.squeeze(0) if (h.dim() == 3 and h.shape[0] == 1) else h for h in mtp_outputs]
 
     D = len(mtp_outputs)
+    if mtp_per_depth_targets is not None:
+        if cu_seqlens is not None or seq_idx is not None:
+            raise ValueError("mtp_per_depth_targets cannot be combined with cu_seqlens or seq_idx")
+        if len(mtp_per_depth_targets) != D:
+            raise ValueError(
+                f"Expected {D} mtp_per_depth_targets for {D} MTP outputs, got {len(mtp_per_depth_targets)}"
+            )
+        for depth, targets in enumerate(mtp_per_depth_targets, start=1):
+            if targets.shape != labels.shape:
+                raise ValueError(
+                    f"MTP depth {depth} target shape {tuple(targets.shape)} does not match "
+                    f"labels shape {tuple(labels.shape)}"
+                )
+
     cur_labels = labels
     total = mtp_outputs[0].new_zeros(())
     per_depth_losses = []
@@ -226,18 +251,21 @@ def calculate_mtp_loss(
             )
 
     for k, mtp_output in enumerate(mtp_outputs):
-        cur_labels = roll_tensor(cur_labels, shifts=-1, dim=-1)
-        masked = cur_labels.clone()
-        n_invalid = min(k + 1, masked.shape[-1])
-        masked[..., -n_invalid:] = ignore_index
+        if mtp_per_depth_targets is None:
+            cur_labels = roll_tensor(cur_labels, shifts=-1, dim=-1)
+            masked = cur_labels.clone()
+            n_invalid = min(k + 1, masked.shape[-1])
+            masked[..., -n_invalid:] = ignore_index
 
-        # Mask labels whose rolled source (position t+k+1) lives in a
-        # different sub-seq than position t — predictions across sub-seq
-        # boundaries are nonsensical.
-        if seq_idx is not None:
-            rolled_seq_idx = roll_tensor(seq_idx, shifts=-(k + 1), dim=-1)
-            cross_seq = rolled_seq_idx != seq_idx
-            masked = torch.where(cross_seq, torch.full_like(masked, ignore_index), masked)
+            # Mask labels whose rolled source (position t+k+1) lives in a
+            # different sub-seq than position t — predictions across sub-seq
+            # boundaries are nonsensical.
+            if seq_idx is not None:
+                rolled_seq_idx = roll_tensor(seq_idx, shifts=-(k + 1), dim=-1)
+                cross_seq = rolled_seq_idx != seq_idx
+                masked = torch.where(cross_seq, torch.full_like(masked, ignore_index), masked)
+        else:
+            masked = mtp_per_depth_targets[k]
 
         if mtp_per_depth_logits is not None:
             if isinstance(loss_fn, FusedLinearCrossEntropy):

--- a/nemo_automodel/components/models/common/mtp/__init__.py
+++ b/nemo_automodel/components/models/common/mtp/__init__.py
@@ -29,6 +29,7 @@ from nemo_automodel.components.models.common.mtp.mtp import (
     MTPModule,
     get_mtp_loss_scaling_factor,
     roll_tensor,
+    shift_packed_tensor,
 )
 
 __all__ = [
@@ -36,4 +37,5 @@ __all__ = [
     "MTPModule",
     "get_mtp_loss_scaling_factor",
     "roll_tensor",
+    "shift_packed_tensor",
 ]

--- a/nemo_automodel/components/models/common/mtp/mtp.py
+++ b/nemo_automodel/components/models/common/mtp/mtp.py
@@ -51,6 +51,49 @@ def roll_tensor(t: torch.Tensor, shifts: int = -1, dim: int = -1) -> torch.Tenso
     return rolled
 
 
+def shift_packed_tensor(
+    tensor: torch.Tensor,
+    *,
+    depth: int,
+    seq_idx: torch.Tensor | None = None,
+    fill_value: float | int = 0,
+) -> torch.Tensor:
+    """Shift a token-aligned tensor left without crossing sequence boundaries.
+
+    Args:
+        tensor: Tensor of shape ``[batch, sequence, ...]`` in global token
+            order. The sequence axis is dimension 1.
+        depth: Number of future-token positions to shift; must be positive.
+        seq_idx: Optional sequence IDs of shape ``[batch, sequence]``. Tokens
+            whose shifted source has a different ID are filled.
+        fill_value: Scalar used for trailing and cross-sequence positions.
+
+    Returns:
+        Tensor with the same shape, dtype, and device as ``tensor``. The output
+        owns independent storage and positions without a valid future source
+        contain ``fill_value``.
+    """
+    if tensor.dim() < 2:
+        raise ValueError(f"tensor must have shape [batch, sequence, ...], got {tuple(tensor.shape)}")
+    if depth <= 0:
+        raise ValueError(f"depth must be positive, got {depth}")
+    if seq_idx is not None and seq_idx.shape != tensor.shape[:2]:
+        raise ValueError(
+            f"seq_idx shape {tuple(seq_idx.shape)} must match tensor token shape {tuple(tensor.shape[:2])}"
+        )
+
+    shifted = torch.roll(tensor, shifts=-depth, dims=1)
+    sequence = tensor.shape[1]
+    positions = torch.arange(sequence, device=tensor.device)
+    valid = (positions + depth < sequence).unsqueeze(0).expand(tensor.shape[0], -1)
+    if seq_idx is not None:
+        shifted_seq_idx = torch.roll(seq_idx, shifts=-depth, dims=1)
+        valid = valid & (shifted_seq_idx == seq_idx)
+    while valid.dim() < shifted.dim():
+        valid = valid.unsqueeze(-1)
+    return torch.where(valid, shifted, torch.as_tensor(fill_value, dtype=tensor.dtype, device=tensor.device))
+
+
 def get_mtp_loss_scaling_factor(model: nn.Module, default: float = 0.1) -> float:
     """Return the model's configured MTP auxiliary-loss scaling factor."""
     mtp_config = getattr(model, "mtp_config", None)
@@ -177,6 +220,7 @@ class MTPModule(nn.Module):
         embed_fn: Callable[[torch.LongTensor], torch.Tensor] | None = None,
         embed_inputs: tuple[torch.Tensor, ...] | None = None,
         position_ids: torch.LongTensor | None = None,
+        position_ids_per_depth: tuple[torch.LongTensor, ...] | None = None,
         **block_kwargs,
     ) -> list[torch.Tensor]:
         """Iterate over MTP depths and return per-depth hidden states.
@@ -213,6 +257,12 @@ class MTPModule(nn.Module):
                 token) and forwarded to each sublayer via ``block_kwargs``.
                 Required for RoPE-using sublayers; ignored by sublayers that
                 don't consume it.
+            position_ids_per_depth: Optional tuple of ``num_depths``
+                pre-computed future-token position tensors. Each tensor has
+                shape [batch, sequence], or [tokens] for THD, matching
+                ``position_ids``. When supplied, these tensors are forwarded
+                directly instead of rolling rank-local ``position_ids``. Use
+                this when context parallelism has already sharded the sequence.
             **block_kwargs: Forwarded to each sublayer's ``__call__`` (e.g.
                 ``attention_mask``).
 
@@ -228,6 +278,27 @@ class MTPModule(nn.Module):
         else:
             if input_ids is None or embed_fn is None:
                 raise ValueError("MTPModule.forward requires either embed_inputs or (input_ids, embed_fn)")
+        if position_ids_per_depth is not None:
+            if len(position_ids_per_depth) != self.num_depths:
+                raise ValueError(
+                    f"position_ids_per_depth length {len(position_ids_per_depth)} "
+                    f"does not match num_depths {self.num_depths}"
+                )
+            if position_ids is not None:
+                expected_position_shape = position_ids.shape
+                expected_position_source = "base position_ids"
+            elif input_ids is not None:
+                expected_position_shape = input_ids.shape
+                expected_position_source = "input_ids"
+            else:
+                expected_position_shape = embed_inputs[0].shape[:-1]
+                expected_position_source = "embed_inputs token shape"
+            for depth, depth_position_ids in enumerate(position_ids_per_depth, start=1):
+                if depth_position_ids.shape != expected_position_shape:
+                    raise ValueError(
+                        f"MTP depth {depth} position_ids shape {tuple(depth_position_ids.shape)} "
+                        f"does not match {expected_position_source} {tuple(expected_position_shape)}"
+                    )
 
         num_iterations = self.num_depths
         num_sublayers_per_depth = self.pattern_length
@@ -241,15 +312,20 @@ class MTPModule(nn.Module):
             else:
                 cur_input_ids = roll_tensor(cur_input_ids, shifts=-1, dim=-1)
                 decoder_input = embed_fn(cur_input_ids)
-            if cur_position_ids is not None:
+            if position_ids_per_depth is not None:
+                depth_position_ids = position_ids_per_depth[depth]
+            elif cur_position_ids is not None:
                 cur_position_ids = roll_tensor(cur_position_ids, shifts=-1, dim=-1)
+                depth_position_ids = cur_position_ids
+            else:
+                depth_position_ids = None
 
             physical_depth = 0 if use_repeated else depth
             for sublayer_idx in range(num_sublayers_per_depth):
                 sublayer = self.layers[physical_depth * num_sublayers_per_depth + sublayer_idx]
                 kwargs = dict(block_kwargs)
-                if cur_position_ids is not None:
-                    kwargs["position_ids"] = cur_position_ids
+                if depth_position_ids is not None:
+                    kwargs["position_ids"] = depth_position_ids
                 if sublayer_idx == 0:
                     kwargs["embed_input"] = decoder_input
                 hidden_states = sublayer(hidden_states, **kwargs)

--- a/nemo_automodel/components/models/common/mtp/mtp.py
+++ b/nemo_automodel/components/models/common/mtp/mtp.py
@@ -278,6 +278,11 @@ class MTPModule(nn.Module):
         else:
             if input_ids is None or embed_fn is None:
                 raise ValueError("MTPModule.forward requires either embed_inputs or (input_ids, embed_fn)")
+        if position_ids_per_depth is not None and embed_inputs is None:
+            raise ValueError(
+                "position_ids_per_depth requires precomputed embed_inputs; "
+                "rank-local input_ids rolling cannot be combined with globally shifted positions"
+            )
         if position_ids_per_depth is not None:
             if len(position_ids_per_depth) != self.num_depths:
                 raise ValueError(

--- a/nemo_automodel/components/models/nemotron_v3/layers.py
+++ b/nemo_automodel/components/models/nemotron_v3/layers.py
@@ -386,7 +386,13 @@ class NemotronV3Mamba2Mixer(nn.Module):
             dt_limit_kwargs = {} if self.time_step_limit == (0.0, float("inf")) else {"dt_limit": self.time_step_limit}
 
             if self.cp is not None:
-                cu_seqlens_cp = kwargs.get("cu_seqlens")
+                # ``MambaContextParallel`` uses a non-None ``cu_seqlens`` to
+                # select its packed 2D THD transport. SDPA/flex attention
+                # keeps qkv_format="thd" inputs in 3D BSHD, where the CP
+                # transport must instead reorder along the sequence dimension.
+                # Keep global cu_seqlens above for constructing seq_idx, but
+                # only pass it to the transport for genuinely squeezed THD.
+                cu_seqlens_cp = kwargs.get("cu_seqlens") if squeezed else None
                 # CP reorder helpers expect 2D [T, H] when cu_seqlens is provided (THD format).
                 # The mixer unsqueezes 2D input to [1, T, H] above, so squeeze back for CP methods.
                 if squeezed and cu_seqlens_cp is not None:

--- a/nemo_automodel/components/models/nemotron_v3/model.py
+++ b/nemo_automodel/components/models/nemotron_v3/model.py
@@ -734,6 +734,16 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
         has_lm_head = self.lm_head is not None
         mtp_depth = int(getattr(self.mtp_config, "num_layers", 0) or 0)
         pp_mtp_enabled = is_pp_stage and self.mtp_config.enabled
+        # CP shards are not contiguous sequence slices. MTP therefore cannot
+        # derive future-token embeddings or positions by rolling rank-local
+        # tensors; callers must provide both globally shifted tensors.
+        mtp_active = self.mtp is not None and (self.training or (self.compute_mtp_in_eval and not use_cache))
+        cp_size = int(kwargs.get("cp_size", 1) or 1)
+        if cp_size > 1 and mtp_active:
+            if not mtp_embed_inputs or mtp_per_depth_position_ids is None:
+                raise ValueError(
+                    "Context-parallel MTP requires precomputed per-depth embeddings and position IDs together"
+                )
 
         # Neat-packed SDPA: convert _packed_seq_ids (1-based [B,S] int, 0=pad)
         # to mamba's seq_idx and derive a 2D padding_mask. The neat collater
@@ -823,7 +833,6 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
         # Run the MTP heads in training, or in eval when explicitly requested for
         # validation acceptance metrics. Never on the cached generation path —
         # decoding feeds one token at a time and must not pay the MTP cost.
-        mtp_active = self.mtp is not None and (self.training or (self.compute_mtp_in_eval and not use_cache))
         if mtp_active:
             mtp_attention_mask = (
                 causal_mask_mapping.get("full_attention") if causal_mask_mapping is not None else attention_mask

--- a/nemo_automodel/components/models/nemotron_v3/model.py
+++ b/nemo_automodel/components/models/nemotron_v3/model.py
@@ -325,7 +325,7 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
         is_moe = getattr(config, "n_routed_experts", None) is not None or "moe" in (
             getattr(config, "layers_block_type", None) or []
         )
-        return ModelCapabilities(supports_cp=True, supports_pp=True, supports_ep=is_moe)
+        return ModelCapabilities(supports_cp=True, supports_pp=True, supports_ep=is_moe, supports_mtp_cp=True)
 
     @classmethod
     def from_config(
@@ -663,6 +663,7 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
         use_cache: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
+        mtp_per_depth_position_ids: tuple[torch.LongTensor, ...] | None = None,
         padding_mask: Optional[torch.Tensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         output_hidden_states: Optional[bool] = None,
@@ -701,6 +702,11 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
             use_cache: Whether to return ``past_key_values`` for subsequent steps.
             cache_position: Token position indices for cache updates.
             position_ids: Position IDs (forwarded into MTP sublayer kwargs).
+            mtp_per_depth_position_ids: Optional pre-computed future-token
+                position IDs, one tensor per MTP depth. Each tensor has shape
+                [batch, sequence], or [tokens] for THD, matching the local CP
+                layout of ``position_ids``. When supplied, MTP consumes these
+                tensors directly instead of rolling rank-local positions.
             padding_mask: Padding mask ``[B, S]`` used by the THD squeeze helper
                 and as the MoE / mamba 2D mask source.
             logits_to_keep: If > 0, only compute logits for the last
@@ -862,6 +868,7 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
             # tensors for the same reason.
             mtp_hidden = hidden_states
             mtp_embeds_for_call = tuple(mtp_embed_inputs) if mtp_embed_inputs else ()
+            mtp_position_ids_for_call = mtp_per_depth_position_ids
             # SALM / multimodal: when inputs_embeds (pre-fused audio+text) are present
             # and no PP embeddings were provided, pre-roll them per depth so audio
             # positions carry the correct audio embedding rather than embed_fn(padding_id).
@@ -874,12 +881,18 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
                     cur_emb = roll_tensor(cur_emb, shifts=-1, dim=-2)
                     salm_embed_inputs.append(cur_emb)
                 mtp_embeds_for_call = tuple(salm_embed_inputs)
-            if is_thd:
+            if squeeze_for_thd:
                 if mtp_hidden.dim() == 3 and mtp_hidden.shape[0] == 1:
                     mtp_hidden = mtp_hidden.squeeze(0)
                 mtp_embeds_for_call = tuple(
                     e.squeeze(0) if (e.dim() == 3 and e.shape[0] == 1) else e for e in mtp_embeds_for_call
                 )
+                if mtp_position_ids_for_call is not None:
+                    mtp_position_ids_for_call = tuple(
+                        p.squeeze(0) if (p.dim() == 2 and p.shape[0] == 1) else p for p in mtp_position_ids_for_call
+                    )
+            if mtp_position_ids_for_call is not None:
+                mtp_kwargs["position_ids_per_depth"] = mtp_position_ids_for_call
 
             if mtp_embeds_for_call:
                 # Final PP stage: embeddings produced upstream.
@@ -896,7 +909,7 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
                     embed_fn=self.model.embed_tokens,
                     **mtp_kwargs,
                 )
-            if is_thd and mtp_per_depth_h is not None:
+            if squeeze_for_thd and mtp_per_depth_h is not None:
                 mtp_per_depth_h = [h.unsqueeze(0) if h.dim() == 2 else h for h in mtp_per_depth_h]
         elif pp_mtp_enabled and has_lm_head:
             # Eval, or no MTP on this rank — emit empties to keep tuple arity.

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -1011,6 +1011,7 @@ def parallelize_model(
 
     cp_enabled = cp_axis_name is not None and world_mesh[cp_axis_name].size() > 1
     if cp_enabled:
+        parallelizer_utils.reject_unsupported_mtp_cp_pp(model)
         apply_cp(model, world_mesh[cp_axis_name])
 
     ep_enabled = ep_axis_name is not None and moe_mesh is not None and moe_mesh[ep_axis_name].size() > 1

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -1012,6 +1012,7 @@ def parallelize_model(
     cp_enabled = cp_axis_name is not None and world_mesh[cp_axis_name].size() > 1
     if cp_enabled:
         parallelizer_utils.reject_unsupported_mtp_cp_pp(model)
+        parallelizer_utils.reject_unsupported_mtp_cp(model)
         apply_cp(model, world_mesh[cp_axis_name])
 
     ep_enabled = ep_axis_name is not None and moe_mesh is not None and moe_mesh[ep_axis_name].size() > 1

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -1025,8 +1025,18 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             )
             for k, v in batch.items()
         }
+        model = self.model_parts[0] if hasattr(self, "model_parts") else None
+        supports = getattr(model, "supports", None)
+        mtp_enabled = bool(
+            getattr(supports, "mtp_enabled", getattr(getattr(model, "mtp_config", None), "enabled", False))
+        )
+        if not self.pp_enabled and self._get_cp_group_size() > 1 and mtp_enabled:
+            raise NotImplementedError(
+                "train_ft does not yet support MTP with context parallelism because it cannot prepare "
+                "globally shifted per-depth targets; use CP size 1"
+            )
         cp_sharder = ContextParallelSharder(
-            self.model_parts[0] if hasattr(self, "model_parts") else None,
+            model,
             self.device_mesh,
             batch,
             padding_token_id=self.tokenizer.pad_token_id if self.tokenizer else 0,

--- a/tests/functional_tests/context_parallel/run_hybrid_nemotron_v3_cp.py
+++ b/tests/functional_tests/context_parallel/run_hybrid_nemotron_v3_cp.py
@@ -16,13 +16,14 @@
 """End-to-end hybrid NemotronV3 CP test.
 
 Validates that a hybrid model with interleaved attention and mamba layers
-produces matching outputs/gradients between CP=1 and CP=2 across four
+produces matching outputs/gradients between CP=1 and CP=N across five
 configurations:
 
   Config 1 (bshd_te):        3D BSHD input, TE p2p CP, DualChunkSwap
   Config 2 (thd_te):         2D THD input, TE p2p CP, DualChunkSwap, cu_seqlens
   Config 3 (thd_te_packed):  2D THD input, TE p2p CP, multi-sequence packing, seq_idx
   Config 4 (bshd_sdpa):      3D BSHD input, DTensor context_parallel(), SDPA backend
+  Config 5 (thd_te_mtp):     packed THD MTP loss, activations, gradients, optimizer step
 
 Usage:
     torchrun --nproc_per_node=2 tests/functional_tests/context_parallel/run_hybrid_nemotron_v3_cp.py
@@ -33,6 +34,8 @@ import sys
 
 import torch
 import torch.distributed as dist
+
+from nemo_automodel.components.models.common.mtp import shift_packed_tensor
 
 
 def dual_chunk_swap_unsplit(chunks_per_rank, cp_size, seq_dim=1):
@@ -62,7 +65,7 @@ class MockHybridConfig:
     values that avoid errors without activating MoE layers.
     """
 
-    def __init__(self):
+    def __init__(self, cp_size=2):
         # Attention config
         self.num_attention_heads = 8
         self.num_key_value_heads = 4
@@ -72,10 +75,13 @@ class MockHybridConfig:
         self.attention_dropout = 0.0
 
         # Mamba config
-        self.mamba_num_heads = 8
+        # Preserve the established 8-head CP=2/4 test topology. Odd CP sizes
+        # need a synthetic divisible topology to exercise the generic MTP path.
+        uses_default_mamba_topology = 8 % cp_size == 0
+        self.mamba_num_heads = 8 if uses_default_mamba_topology else 2 * cp_size
         self.mamba_head_dim = 32
         self.ssm_state_size = 16
-        self.n_groups = 2  # must be >= cp_size for non-replicated mode
+        self.n_groups = 2 if uses_default_mamba_topology else cp_size
         self.chunk_size = 256
         self.conv_kernel = 4
         self.use_conv_bias = True
@@ -104,14 +110,22 @@ class MockHybridConfig:
         self.mlp_hidden_act = "silu"
 
         # MoE config fields
-        self.n_routed_experts = 1
-        self.num_experts_per_tok = 1
+        self.n_routed_experts = 4
+        self.num_experts_per_tok = 2
         self.n_group = 1
         self.topk_group = 1
         self.routed_scaling_factor = 1.0
         self.moe_intermediate_size = self.intermediate_size
         self.norm_topk_prob = False
         self.moe_shared_expert_intermediate_size = self.intermediate_size
+
+        # MTP config: one native Nemotron depth (attention + MoE).
+        self.num_nextn_predict_layers = 1
+        self.mtp_hybrid_override_pattern = "*E"
+
+    def to_dict(self):
+        """Return the config fields expected by the Hugging Face-compatible wrapper."""
+        return vars(self)
 
 
 def _create_baseline_model(config, backend, device):
@@ -142,7 +156,8 @@ def _wire_te_cp(model, cp_group, config):
 
     from nemo_automodel.components.distributed.context_parallel.mamba import MambaContextParallel
 
-    for layer in model.layers.values():
+    layers = model.layers.values() if hasattr(model.layers, "values") else model.layers
+    for layer in layers:
         if layer.block_type == "mamba":
             mixer = layer.mixer
             mixer.cp = MambaContextParallel(
@@ -549,28 +564,347 @@ def run_bshd_sdpa(rank, world_size, device, config):
     )
 
 
+# ---------------------------------------------------------------------------
+# Config 5: THD + TE + packed MTP
+# ---------------------------------------------------------------------------
+def _gather_te_partition(local_tensor, local_indices, full_tokens, cp_group):
+    """Restore a tensor sharded with TE packed-CP indices to global order.
+
+    Args:
+        local_tensor: Per-rank tensor of shape [local_tokens, ...].
+        local_indices: Tensor of shape [local_tokens] containing global positions.
+        full_tokens: Global packed-token count.
+        cp_group: Context-parallel process group.
+
+    Returns:
+        Tensor of shape [full_tokens, ...] in global packed-token order.
+    """
+    cp_size = dist.get_world_size(group=cp_group)
+    gathered_tensors = [torch.empty_like(local_tensor) for _ in range(cp_size)]
+    gathered_indices = [torch.empty_like(local_indices) for _ in range(cp_size)]
+    dist.all_gather(gathered_tensors, local_tensor.contiguous(), group=cp_group)
+    dist.all_gather(gathered_indices, local_indices.contiguous(), group=cp_group)
+    output = local_tensor.new_empty((full_tokens, *local_tensor.shape[1:]))
+    for indices, tensor in zip(gathered_indices, gathered_tensors):
+        output.index_copy_(0, indices.to(torch.long), tensor)
+    return output
+
+
+def _create_mtp_model(config, backend, device):
+    """Create a synchronized causal LM with its native Nemotron MTP head."""
+    from nemo_automodel.components.models.nemotron_v3.model import NemotronHForCausalLM
+
+    model = NemotronHForCausalLM(config, backend=backend).to(device=device, dtype=torch.bfloat16)
+    model.initialize_weights(buffer_device=device, dtype=torch.bfloat16)
+    model.train()
+    for parameter in model.parameters():
+        dist.broadcast(parameter.data, src=0)
+    return model
+
+
+def run_thd_te_mtp(rank, world_size, device, config):
+    """Config 5: packed THD MTP CP=1/CP=N numerical training parity."""
+    import transformer_engine.pytorch  # noqa: F401
+    import transformer_engine_torch as tex
+    from torch.distributed.device_mesh import init_device_mesh
+
+    from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
+    from nemo_automodel.components.loss.mtp import calculate_mtp_loss
+    from nemo_automodel.components.models.common import BackendConfig
+
+    backend = BackendConfig(
+        linear="torch",
+        attn="te",
+        rms_norm="torch",
+        experts="torch",
+        dispatcher="torch",
+        fake_balanced_gate=False,
+        enable_hf_state_dict_adapter=False,
+    )
+    model_baseline = _create_mtp_model(config, backend, device)
+
+    # Two unequal documents expose both packed-document boundaries and TE's
+    # head/tail CP partition boundaries. Each length remains divisible by
+    # 2 * CP, so unequal sequence lengths must still contribute the same
+    # aggregate token count to every rank.
+    # TE's DualChunkSwap needs each packed sequence divisible by 2 * CP.
+    # Keeping 32 aggregate tokens per rank also gives every tested size the
+    # same amount of local work (12 from the first document, 20 from the second).
+    seq_len_a = 12 * world_size
+    seq_len_b = 20 * world_size
+    total_len = seq_len_a + seq_len_b
+    cu_seqlens = torch.tensor([0, seq_len_a, total_len], dtype=torch.int32, device=device)
+    seq_idx = torch.repeat_interleave(
+        torch.arange(2, dtype=torch.int32, device=device),
+        torch.tensor([seq_len_a, seq_len_b], device=device),
+    )
+    position_ids = torch.cat([torch.arange(seq_len_a, device=device), torch.arange(seq_len_b, device=device)])
+
+    torch.manual_seed(2026)
+    input_ids = torch.randint(0, config.vocab_size, (1, total_len), device=device)
+    dist.broadcast(input_ids, src=0)
+
+    # SALM labels are already next-token targets. MTP depth 1 therefore needs
+    # one additional global shift, with the final two positions in each
+    # document ignored.
+    seq_idx_batched = seq_idx.unsqueeze(0)
+    labels_full = shift_packed_tensor(input_ids, depth=1, seq_idx=seq_idx_batched, fill_value=-100).squeeze(0)
+    mtp_targets_full = shift_packed_tensor(
+        labels_full.unsqueeze(0), depth=1, seq_idx=seq_idx_batched, fill_value=-100
+    ).squeeze(0)
+    mtp_position_ids_full = shift_packed_tensor(
+        position_ids.unsqueeze(0),
+        depth=1,
+        seq_idx=seq_idx_batched,
+    ).squeeze(0)
+    num_label_tokens = int((labels_full != -100).sum().item())
+    max_seqlen = torch.tensor(max(seq_len_a, seq_len_b), dtype=torch.int32, device=device)
+
+    embeddings_full = model_baseline.model.embed_tokens(input_ids).squeeze(0)
+    mtp_embeddings_full = shift_packed_tensor(
+        embeddings_full.unsqueeze(0),
+        depth=1,
+        seq_idx=seq_idx_batched,
+    ).squeeze(0)
+    output_baseline = model_baseline(
+        None,
+        mtp_embeddings_full,
+        inputs_embeds=embeddings_full,
+        position_ids=position_ids,
+        mtp_per_depth_position_ids=(mtp_position_ids_full,),
+        qkv_format="thd",
+        cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen,
+        cp_rank=0,
+        cp_size=1,
+    )
+    mtp_hidden_baseline = output_baseline.mtp_per_depth_h[0].squeeze(0)
+    loss_fn = MaskedCrossEntropy(reduction="sum")
+    mtp_loss_baseline = calculate_mtp_loss(
+        loss_fn,
+        mtp_per_depth_h=output_baseline.mtp_per_depth_h,
+        mtp_per_depth_targets=(mtp_targets_full,),
+        labels=labels_full,
+        model=model_baseline,
+        scaling_factor=1.0,
+        num_label_tokens=num_label_tokens,
+    )
+    mtp_loss_baseline.backward()
+
+    selected_names = (
+        "model.embed_tokens.weight",
+        "lm_head.weight",
+        "mtp.layers.0.eh_proj.weight",
+        "mtp.layers.0.mixer.q_proj.weight",
+    )
+    baseline_params = dict(model_baseline.named_parameters())
+    baseline_grads = {name: baseline_params[name].grad.detach().clone() for name in selected_names}
+    baseline_before_step = {name: baseline_params[name].detach().clone() for name in selected_names}
+
+    model_cp = _create_mtp_model(config, backend, device)
+    model_cp.load_state_dict(model_baseline.state_dict())
+    model_cp.zero_grad(set_to_none=True)
+    cp_mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("cp",))
+    cp_group = cp_mesh["cp"].get_group()
+    _wire_te_cp(model_cp.model, cp_group, config)
+    _wire_te_cp(model_cp.mtp, cp_group, config)
+
+    local_indices = tex.thd_get_partitioned_indices(cu_seqlens, total_len, world_size, rank).to(torch.long)
+    local_token_count = torch.tensor(local_indices.numel(), dtype=torch.int64, device=device)
+    token_counts = [torch.empty_like(local_token_count) for _ in range(world_size)]
+    dist.all_gather(token_counts, local_token_count, group=cp_group)
+    token_counts = [int(count.item()) for count in token_counts]
+    if len(set(token_counts)) != 1:
+        raise AssertionError(f"TE packed CP assigned unequal aggregate token counts across ranks: {token_counts}")
+    if token_counts[0] != total_len // world_size:
+        raise AssertionError(
+            f"TE packed CP assigned {token_counts[0]} tokens per rank; expected {total_len // world_size}"
+        )
+    embeddings_cp_full = model_cp.model.embed_tokens(input_ids).squeeze(0)
+    mtp_embeddings_cp_full = shift_packed_tensor(
+        embeddings_cp_full.unsqueeze(0),
+        depth=1,
+        seq_idx=seq_idx_batched,
+    ).squeeze(0)
+    embeddings_local = embeddings_cp_full.index_select(0, local_indices)
+    mtp_embeddings_local = mtp_embeddings_cp_full.index_select(0, local_indices)
+    position_ids_local = position_ids.index_select(0, local_indices)
+    mtp_position_ids_local = mtp_position_ids_full.index_select(0, local_indices)
+    labels_local = labels_full.index_select(0, local_indices)
+    mtp_targets_local = mtp_targets_full.index_select(0, local_indices)
+
+    output_cp = model_cp(
+        None,
+        mtp_embeddings_local,
+        inputs_embeds=embeddings_local,
+        position_ids=position_ids_local,
+        mtp_per_depth_position_ids=(mtp_position_ids_local,),
+        qkv_format="thd",
+        cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen,
+        cp_rank=rank,
+        cp_size=world_size,
+    )
+    mtp_loss_cp = calculate_mtp_loss(
+        loss_fn,
+        mtp_per_depth_h=output_cp.mtp_per_depth_h,
+        mtp_per_depth_targets=(mtp_targets_local,),
+        labels=labels_local,
+        model=model_cp,
+        scaling_factor=1.0,
+        num_label_tokens=num_label_tokens,
+    )
+    mtp_loss_cp.backward()
+
+    mtp_hidden_cp = _gather_te_partition(
+        output_cp.mtp_per_depth_h[0].squeeze(0).detach(),
+        local_indices,
+        total_len,
+        cp_group,
+    )
+    logits_cp = _gather_te_partition(
+        output_cp.logits.squeeze(0).detach(),
+        local_indices,
+        total_len,
+        cp_group,
+    )
+    targets_cp = _gather_te_partition(mtp_targets_local, local_indices, total_len, cp_group)
+    mtp_loss_cp_global = mtp_loss_cp.detach().clone()
+    dist.all_reduce(mtp_loss_cp_global, op=dist.ReduceOp.SUM, group=cp_group)
+
+    for parameter in model_cp.parameters():
+        if parameter.grad is not None:
+            dist.all_reduce(parameter.grad, op=dist.ReduceOp.SUM, group=cp_group)
+
+    cp_params = dict(model_cp.named_parameters())
+
+    logits_baseline = output_baseline.logits.squeeze(0).detach()
+    if rank == 0:
+        logits_diff = (logits_cp - logits_baseline).abs()
+        hidden_diff = (mtp_hidden_cp - mtp_hidden_baseline.detach()).abs()
+        logits_cosine = torch.nn.functional.cosine_similarity(
+            logits_cp.float().flatten(), logits_baseline.float().flatten(), dim=0
+        )
+        hidden_cosine = torch.nn.functional.cosine_similarity(
+            mtp_hidden_cp.float().flatten(), mtp_hidden_baseline.detach().float().flatten(), dim=0
+        )
+        print("\n" + "=" * 70)
+        print("Config: thd_te_mtp - packed Nemotron MTP training parity")
+        print("=" * 70)
+        print(f"Targets: exact global reconstruction = {torch.equal(targets_cp, mtp_targets_full)}")
+        print(
+            f"Backbone logits diff - mean: {logits_diff.mean().item():.6f}, "
+            f"max: {logits_diff.max().item():.6f}, cosine: {logits_cosine.item():.8f}"
+        )
+        print(
+            f"MTP hidden diff - mean: {hidden_diff.mean().item():.6f}, "
+            f"max: {hidden_diff.max().item():.6f}, cosine: {hidden_cosine.item():.8f}"
+        )
+        print(f"MTP loss: CP={mtp_loss_cp_global.item():.6f}, baseline={mtp_loss_baseline.detach().item():.6f}")
+        for name in selected_names:
+            grad_diff = (cp_params[name].grad - baseline_grads[name]).abs()
+            print(f"Grad {name} - mean: {grad_diff.mean().item():.6f}, max: {grad_diff.max().item():.6f}")
+    try:
+        torch.testing.assert_close(targets_cp, mtp_targets_full, rtol=0, atol=0)
+        torch.testing.assert_close(
+            logits_cp,
+            logits_baseline,
+            rtol=2e-2,
+            atol=5e-2,
+            msg="CP backbone logits differ from CP=1",
+        )
+        torch.testing.assert_close(
+            mtp_hidden_cp,
+            mtp_hidden_baseline.detach(),
+            rtol=2e-2,
+            # BF16 P2P accumulation error grows slightly with CP rank count;
+            # loss and gradient parity below provide stricter end-result checks.
+            atol=1.25e-1,
+            msg="CP MTP hidden states differ from CP=1",
+        )
+        torch.testing.assert_close(
+            mtp_loss_cp_global,
+            mtp_loss_baseline.detach(),
+            rtol=2e-2,
+            atol=3e-2,
+            msg="global CP MTP loss differs from CP=1",
+        )
+        for name in selected_names:
+            torch.testing.assert_close(
+                cp_params[name].grad,
+                baseline_grads[name],
+                rtol=5e-2,
+                atol=1e-2,
+                msg=f"CP MTP gradient differs for {name}",
+            )
+
+        learning_rate = 0.25
+        torch.optim.SGD(model_baseline.parameters(), lr=learning_rate).step()
+        torch.optim.SGD(model_cp.parameters(), lr=learning_rate).step()
+        for name in selected_names:
+            before = baseline_before_step[name].float()
+            baseline_update = baseline_params[name].detach().float() - before
+            cp_update = cp_params[name].detach().float() - before
+            if not torch.count_nonzero(baseline_update):
+                raise AssertionError(f"baseline optimizer did not update {name}")
+            if not torch.count_nonzero(cp_update):
+                raise AssertionError(f"CP optimizer did not update {name}")
+            if rank == 0:
+                update_diff = (cp_update - baseline_update).abs()
+                print(
+                    f"Update {name} - mean diff: {update_diff.mean().item():.6f}, "
+                    f"max diff: {update_diff.max().item():.6f}"
+                )
+            # Compare update vectors, not final BF16 parameters. The old
+            # parameter atol (5e-2) exactly equaled learning_rate * old grad_atol
+            # (0.25 * 2e-1). The update atol below is also stricter than
+            # learning_rate * current grad_atol (0.25 * 1e-2 = 2.5e-3).
+            torch.testing.assert_close(
+                cp_update,
+                baseline_update,
+                rtol=5e-2,
+                atol=2e-3,
+                msg=f"CP optimizer update differs for {name}",
+            )
+    except AssertionError as error:
+        if rank == 0:
+            print(f"  thd_te_mtp: FAILED - {error}")
+        return 1
+
+    if rank == 0:
+        print("  PASSED")
+        print("=" * 70)
+    return 0
+
+
 def main():
     init_distributed()
     rank = dist.get_rank()
     world_size = dist.get_world_size()
     device = torch.device(f"cuda:{rank}")
 
-    if world_size != 2:
+    if world_size < 2:
         if rank == 0:
-            print(f"ERROR: This test requires exactly 2 GPUs, got {world_size}", file=sys.stderr)
+            print(f"ERROR: This test requires at least 2 GPUs, got {world_size}", file=sys.stderr)
         sys.exit(1)
 
     torch.manual_seed(42)
     torch.cuda.manual_seed_all(42)
 
-    config = MockHybridConfig()
+    config = MockHybridConfig(cp_size=world_size)
 
     configs = {
         "bshd_te": lambda: run_bshd_te(rank, world_size, device, config),
         "thd_te": lambda: run_thd_te(rank, world_size, device, config),
         "thd_te_packed": lambda: run_thd_te_packed(rank, world_size, device, config),
         "bshd_sdpa": lambda: run_bshd_sdpa(rank, world_size, device, config),
+        "thd_te_mtp": lambda: run_thd_te_mtp(rank, world_size, device, config),
     }
+    requested_config = os.environ.get("NEMOTRON_CP_TEST_CONFIG")
+    if requested_config:
+        if requested_config not in configs:
+            raise ValueError(f"Unknown NEMOTRON_CP_TEST_CONFIG={requested_config!r}; choose from {tuple(configs)}")
+        configs = {requested_config: configs[requested_config]}
 
     results = {}
     for name, fn in configs.items():

--- a/tests/unit_tests/_transformers/test_model_capabilities.py
+++ b/tests/unit_tests/_transformers/test_model_capabilities.py
@@ -230,6 +230,8 @@ def test_query_returns_canonical_type_for_static_class():
     assert caps.supports_cp is False
     assert caps.supports_ep is False
     assert caps.supports_thd is True
+    assert caps.supports_mtp_cp is False
+    assert caps.supports_mtp_cp_pp is False
     assert caps.supports_cp_vision_frame_sharding is False
 
 

--- a/tests/unit_tests/distributed/test_parallelization_strategies.py
+++ b/tests/unit_tests/distributed/test_parallelization_strategies.py
@@ -86,6 +86,7 @@ class MockNemotronHModel(nn.Module):
         class MockSupports:
             def __init__(self, model):
                 self.model = model
+                self.supports_mtp_cp = True
                 self.supports_mtp_cp_pp = False
 
             @property
@@ -637,6 +638,34 @@ class TestNemotronHParallelizationStrategy:
         monkeypatch.setattr(parallelizer_mod.torch.distributed, "get_process_group_ranks", lambda _group: [0, 1])
 
         with pytest.raises(RuntimeError, match=r"MTP is enabled but model\.mtp\.layers is unavailable"):
+            strategy.parallelize(model=nemotron_model, device_mesh=mesh)
+
+    def test_cp_rejects_enabled_mtp_without_capability(
+        self,
+        strategy,
+        mock_device_mesh,
+        nemotron_model,
+        monkeypatch,
+    ):
+        mesh, dp_replicate_mesh, dp_shard_mesh, tp_mesh = mock_device_mesh
+        cp_mesh = MagicMock()
+        cp_mesh.size.return_value = 2
+        cp_mesh.get_group.return_value = object()
+        mesh.mesh_dim_names = ("dp_replicate", "dp_shard_cp", "cp", "tp")
+        mesh.__getitem__.side_effect = lambda key: {
+            "dp_replicate": dp_replicate_mesh,
+            "dp_shard_cp": dp_shard_mesh,
+            "cp": cp_mesh,
+            "tp": tp_mesh,
+            ("dp_replicate", "dp_shard_cp"): dp_shard_mesh,
+        }[key]
+        nemotron_model.mtp_config = SimpleNamespace(enabled=True)
+        nemotron_model.mtp = nn.Module()
+        nemotron_model.mtp.layers = nn.ModuleList([nn.Module()])
+        nemotron_model.supports.supports_mtp_cp = False
+        monkeypatch.setattr(parallelizer_mod.torch.distributed, "get_process_group_ranks", lambda _group: [0, 1])
+
+        with pytest.raises(RuntimeError, match="does not support MTP with context parallelism"):
             strategy.parallelize(model=nemotron_model, device_mesh=mesh)
 
     def test_sequence_parallel_not_supported(self, strategy, mock_device_mesh, nemotron_model):

--- a/tests/unit_tests/distributed/test_parallelization_strategies.py
+++ b/tests/unit_tests/distributed/test_parallelization_strategies.py
@@ -15,8 +15,9 @@
 """Tests for the parallelization strategy pattern."""
 
 import logging
+import sys
 from abc import ABC
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -81,6 +82,17 @@ class MockNemotronHModel(nn.Module):
 
     def __init__(self):
         super().__init__()
+
+        class MockSupports:
+            def __init__(self, model):
+                self.model = model
+                self.supports_mtp_cp_pp = False
+
+            @property
+            def mtp_enabled(self):
+                return bool(getattr(getattr(self.model, "mtp_config", None), "enabled", False))
+
+        self.supports = MockSupports(self)
         self.config = SimpleNamespace(
             num_attention_heads=8,
             num_key_value_heads=8,
@@ -459,6 +471,173 @@ class TestNemotronHParallelizationStrategy:
         """Test that NemotronHParallelizationStrategy can be instantiated."""
         assert isinstance(strategy, NemotronHParallelizationStrategy)
         assert isinstance(strategy, ParallelizationStrategy)
+
+    @pytest.mark.parametrize("mtp_enabled", [True, False])
+    def test_configures_only_enabled_mtp_attention_and_mamba_for_cp(
+        self,
+        strategy,
+        mock_device_mesh,
+        nemotron_model,
+        monkeypatch,
+        mtp_enabled,
+    ):
+        """The strategy installs CP collectives only on enabled MTP blocks."""
+        mesh, dp_replicate_mesh, dp_shard_mesh, tp_mesh = mock_device_mesh
+        cp_group = object()
+        cp_mesh = MagicMock()
+        cp_mesh.size.return_value = 2
+        cp_mesh.get_group.return_value = cp_group
+        mesh.mesh_dim_names = ("dp_replicate", "dp_shard_cp", "cp", "tp")
+        mesh.__getitem__.side_effect = lambda key: {
+            "dp_replicate": dp_replicate_mesh,
+            "dp_shard_cp": dp_shard_mesh,
+            "cp": cp_mesh,
+            "tp": tp_mesh,
+            ("dp_replicate", "dp_shard_cp"): dp_shard_mesh,
+        }[key]
+
+        class FakeDotProductAttention(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.set_context_parallel_group = MagicMock()
+
+        attention_module = FakeDotProductAttention()
+        attention_layer = nn.Module()
+        attention_layer.block_type = "attention"
+        attention_layer.mixer = nn.Module()
+        attention_layer.mixer.attn_module = attention_module
+        attention_module_2 = FakeDotProductAttention()
+        attention_layer_2 = nn.Module()
+        attention_layer_2.block_type = "attention"
+        attention_layer_2.mixer = nn.Module()
+        attention_layer_2.mixer.attn_module = attention_module_2
+
+        mamba_layer = nn.Module()
+        mamba_layer.block_type = "mamba"
+        mamba_layer.mixer = nn.Module()
+        mamba_layer.mixer.num_heads = 8
+        mamba_layer.mixer.head_dim = 16
+        mamba_layer.mixer.n_groups = 2
+        mamba_layer.mixer.ssm_state_size = 64
+
+        nemotron_model.mtp_config = SimpleNamespace(enabled=mtp_enabled)
+        nemotron_model.mtp = nn.Module()
+        nemotron_model.mtp.layers = nn.ModuleList([attention_layer, attention_layer_2, mamba_layer])
+
+        transformer_engine = ModuleType("transformer_engine")
+        transformer_engine.__path__ = []
+        transformer_engine_pytorch = ModuleType("transformer_engine.pytorch")
+        transformer_engine_pytorch.__path__ = []
+        transformer_engine_attention = ModuleType("transformer_engine.pytorch.attention")
+        transformer_engine_attention.DotProductAttention = FakeDotProductAttention
+        monkeypatch.setitem(sys.modules, "transformer_engine", transformer_engine)
+        monkeypatch.setitem(sys.modules, "transformer_engine.pytorch", transformer_engine_pytorch)
+        monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.attention", transformer_engine_attention)
+
+        from nemo_automodel.components.distributed.context_parallel import mamba as mamba_module
+
+        mamba_cp = object()
+        mamba_cp_ctor = MagicMock(return_value=mamba_cp)
+        monkeypatch.setattr(mamba_module, "MambaContextParallel", mamba_cp_ctor)
+        cp_ranks = [0, 1]
+        get_cp_ranks = MagicMock(return_value=cp_ranks)
+        cp_stream = object()
+        monkeypatch.setattr(parallelizer_mod.torch.distributed, "get_process_group_ranks", get_cp_ranks)
+        monkeypatch.setattr(parallelizer_mod.torch.cuda, "Stream", lambda: cp_stream)
+        monkeypatch.setattr(parallelizer_mod, "fully_shard", lambda model, **_kwargs: model)
+        monkeypatch.setattr(
+            parallelizer_mod.parallelizer_utils,
+            "fully_shard_by_dtype",
+            lambda model, **_kwargs: model,
+        )
+
+        strategy.parallelize(model=nemotron_model, device_mesh=mesh)
+
+        if not mtp_enabled:
+            attention_module.set_context_parallel_group.assert_not_called()
+            attention_module_2.set_context_parallel_group.assert_not_called()
+            mamba_cp_ctor.assert_not_called()
+            assert not hasattr(mamba_layer.mixer, "cp")
+            return
+
+        attention_module.set_context_parallel_group.assert_called_once_with(
+            cp_group,
+            cp_ranks,
+            cp_stream,
+            cp_comm_type="p2p",
+        )
+        attention_module_2.set_context_parallel_group.assert_called_once_with(
+            cp_group,
+            cp_ranks,
+            cp_stream,
+            cp_comm_type="p2p",
+        )
+        get_cp_ranks.assert_called_once_with(cp_group)
+        mamba_cp_ctor.assert_called_once_with(
+            cp_group=cp_group,
+            num_heads=8,
+            head_dim=16,
+            n_groups=2,
+            d_state=64,
+            mixer=mamba_layer.mixer,
+        )
+        assert mamba_layer.mixer.cp is mamba_cp
+
+    def test_cp_mtp_pipeline_stage_raises_explicit_unsupported_topology(
+        self,
+        strategy,
+        mock_device_mesh,
+        nemotron_model,
+        monkeypatch,
+    ):
+        """Every trimmed PP stage must fail before stage-specific CP wiring."""
+        mesh, dp_replicate_mesh, dp_shard_mesh, tp_mesh = mock_device_mesh
+        cp_group = object()
+        cp_mesh = MagicMock()
+        cp_mesh.size.return_value = 2
+        cp_mesh.get_group.return_value = cp_group
+        mesh.mesh_dim_names = ("dp_replicate", "dp_shard_cp", "cp", "tp")
+        mesh.__getitem__.side_effect = lambda key: {
+            "dp_replicate": dp_replicate_mesh,
+            "dp_shard_cp": dp_shard_mesh,
+            "cp": cp_mesh,
+            "tp": tp_mesh,
+            ("dp_replicate", "dp_shard_cp"): dp_shard_mesh,
+        }[key]
+        nemotron_model.mtp_config = SimpleNamespace(enabled=True)
+        nemotron_model.mtp = None
+        nemotron_model._is_pipeline_parallel_stage = lambda: True
+        monkeypatch.setattr(parallelizer_mod.torch.distributed, "get_process_group_ranks", lambda _group: [0, 1])
+
+        with pytest.raises(NotImplementedError, match="MTP with context and pipeline parallelism"):
+            strategy.parallelize(model=nemotron_model, device_mesh=mesh)
+
+    def test_cp_raises_when_enabled_mtp_layers_are_unavailable(
+        self,
+        strategy,
+        mock_device_mesh,
+        nemotron_model,
+        monkeypatch,
+    ):
+        mesh, dp_replicate_mesh, dp_shard_mesh, tp_mesh = mock_device_mesh
+        cp_group = object()
+        cp_mesh = MagicMock()
+        cp_mesh.size.return_value = 2
+        cp_mesh.get_group.return_value = cp_group
+        mesh.mesh_dim_names = ("dp_replicate", "dp_shard_cp", "cp", "tp")
+        mesh.__getitem__.side_effect = lambda key: {
+            "dp_replicate": dp_replicate_mesh,
+            "dp_shard_cp": dp_shard_mesh,
+            "cp": cp_mesh,
+            "tp": tp_mesh,
+            ("dp_replicate", "dp_shard_cp"): dp_shard_mesh,
+        }[key]
+        nemotron_model.mtp_config = SimpleNamespace(enabled=True)
+        nemotron_model.mtp = nn.Module()
+        monkeypatch.setattr(parallelizer_mod.torch.distributed, "get_process_group_ranks", lambda _group: [0, 1])
+
+        with pytest.raises(RuntimeError, match=r"MTP is enabled but model\.mtp\.layers is unavailable"):
+            strategy.parallelize(model=nemotron_model, device_mesh=mesh)
 
     def test_sequence_parallel_not_supported(self, strategy, mock_device_mesh, nemotron_model):
         """Test that sequence parallelism raises assertion error."""

--- a/tests/unit_tests/distributed/test_parallelizer_utils.py
+++ b/tests/unit_tests/distributed/test_parallelizer_utils.py
@@ -30,11 +30,16 @@ from nemo_automodel.components.distributed.parallelizer_utils import (
     configure_fsdp_unused_param_reduction,
     fully_shard_by_dtype,
     iter_maximal_uniform_dtype_subtrees,
+    reject_unsupported_mtp_cp_pp,
 )
 from nemo_automodel.shared.torch_patches import (
     patch_fsdp_uniform_reduce_dtype,
     patch_fsdp_unused_param_reduction,
 )
+
+
+def test_reject_unsupported_mtp_cp_pp_ignores_model_without_capabilities():
+    reject_unsupported_mtp_cp_pp(nn.Linear(2, 2))
 
 
 def test_configure_fsdp_unused_param_reduction_uses_public_fsdp_api(monkeypatch):

--- a/tests/unit_tests/distributed/test_parallelizer_utils.py
+++ b/tests/unit_tests/distributed/test_parallelizer_utils.py
@@ -30,6 +30,7 @@ from nemo_automodel.components.distributed.parallelizer_utils import (
     configure_fsdp_unused_param_reduction,
     fully_shard_by_dtype,
     iter_maximal_uniform_dtype_subtrees,
+    reject_unsupported_mtp_cp,
     reject_unsupported_mtp_cp_pp,
 )
 from nemo_automodel.shared.torch_patches import (
@@ -40,6 +41,27 @@ from nemo_automodel.shared.torch_patches import (
 
 def test_reject_unsupported_mtp_cp_pp_ignores_model_without_capabilities():
     reject_unsupported_mtp_cp_pp(nn.Linear(2, 2))
+
+
+def test_reject_unsupported_mtp_cp_rejects_enabled_unsupported_model():
+    model = nn.Module()
+    model.mtp_config = SimpleNamespace(enabled=True)
+    model.supports = SimpleNamespace(mtp_enabled=True, supports_mtp_cp=False)
+
+    with pytest.raises(RuntimeError, match="does not support MTP with context parallelism"):
+        reject_unsupported_mtp_cp(model)
+
+
+def test_reject_unsupported_mtp_cp_allows_supported_or_disabled_model():
+    model = nn.Module()
+    model.mtp_config = SimpleNamespace(enabled=True)
+    model.supports = SimpleNamespace(mtp_enabled=True, supports_mtp_cp=True)
+    reject_unsupported_mtp_cp(model)
+
+    model.mtp_config.enabled = False
+    model.supports.mtp_enabled = False
+    model.supports.supports_mtp_cp = False
+    reject_unsupported_mtp_cp(model)
 
 
 def test_configure_fsdp_unused_param_reduction_uses_public_fsdp_api(monkeypatch):

--- a/tests/unit_tests/loss/test_mtp_cross_boundary.py
+++ b/tests/unit_tests/loss/test_mtp_cross_boundary.py
@@ -162,7 +162,14 @@ def test_precomputed_target_shape_must_match_local_labels():
         )
 
 
-def test_precomputed_targets_are_mutually_exclusive_with_sequence_metadata():
+@pytest.mark.parametrize(
+    "sequence_metadata",
+    [
+        {"cu_seqlens": torch.tensor([0, 4], dtype=torch.int32)},
+        {"seq_idx": torch.zeros(4, dtype=torch.long)},
+    ],
+)
+def test_precomputed_targets_are_mutually_exclusive_with_sequence_metadata(sequence_metadata):
     labels = torch.zeros(4, dtype=torch.long)
 
     with pytest.raises(ValueError, match="cannot be combined"):
@@ -172,7 +179,7 @@ def test_precomputed_targets_are_mutually_exclusive_with_sequence_metadata():
             mtp_per_depth_targets=[torch.zeros(4, dtype=torch.long)],
             labels=labels,
             model=mock.MagicMock(),
-            cu_seqlens=torch.tensor([0, 4], dtype=torch.int32),
+            **sequence_metadata,
         )
 
 

--- a/tests/unit_tests/loss/test_mtp_cross_boundary.py
+++ b/tests/unit_tests/loss/test_mtp_cross_boundary.py
@@ -111,6 +111,71 @@ def _run_capture(
     return cap.captured_labels
 
 
+def test_precomputed_targets_preserve_global_shift_after_context_parallel_sharding():
+    """CP-local targets are consumed directly instead of rolled in local order."""
+    labels = torch.tensor([10, 12, 21, 23], dtype=torch.long)
+    mtp_per_depth_h = [torch.zeros((4, 3), requires_grad=True) for _ in range(2)]
+    precomputed_targets = [
+        torch.tensor([11, IGNORE, 22, IGNORE]),
+        torch.tensor([12, IGNORE, 23, IGNORE]),
+    ]
+    cap = _CaptureLoss()
+
+    with mock.patch("nemo_automodel.components.loss.mtp.calculate_loss", side_effect=lambda loss_fn, **kw: cap(**kw)):
+        calculate_mtp_loss(
+            loss_fn=mock.MagicMock(),
+            mtp_per_depth_h=mtp_per_depth_h,
+            mtp_per_depth_targets=precomputed_targets,
+            labels=labels,
+            model=mock.MagicMock(),
+            scaling_factor=1.0,
+        )
+
+    assert len(cap.captured_labels) == 2
+    for actual, expected in zip(cap.captured_labels, precomputed_targets):
+        torch.testing.assert_close(actual, expected)
+
+
+def test_precomputed_target_count_must_match_mtp_depth():
+    labels = torch.zeros(4, dtype=torch.long)
+
+    with pytest.raises(ValueError, match="Expected 2 mtp_per_depth_targets"):
+        calculate_mtp_loss(
+            loss_fn=mock.MagicMock(),
+            mtp_per_depth_h=[torch.zeros(4, 3), torch.zeros(4, 3)],
+            mtp_per_depth_targets=[torch.zeros(4, dtype=torch.long)],
+            labels=labels,
+            model=mock.MagicMock(),
+        )
+
+
+def test_precomputed_target_shape_must_match_local_labels():
+    labels = torch.zeros(4, dtype=torch.long)
+
+    with pytest.raises(ValueError, match="target shape .* does not match labels shape"):
+        calculate_mtp_loss(
+            loss_fn=mock.MagicMock(),
+            mtp_per_depth_h=[torch.zeros(4, 3)],
+            mtp_per_depth_targets=[torch.zeros(5, dtype=torch.long)],
+            labels=labels,
+            model=mock.MagicMock(),
+        )
+
+
+def test_precomputed_targets_are_mutually_exclusive_with_sequence_metadata():
+    labels = torch.zeros(4, dtype=torch.long)
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        calculate_mtp_loss(
+            loss_fn=mock.MagicMock(),
+            mtp_per_depth_h=[torch.zeros(4, 3)],
+            mtp_per_depth_targets=[torch.zeros(4, dtype=torch.long)],
+            labels=labels,
+            model=mock.MagicMock(),
+            cu_seqlens=torch.tensor([0, 4], dtype=torch.int32),
+        )
+
+
 def test_cross_boundary_masked_via_seq_idx_1d():
     """Two 4-token sub-seqs in an 8-token packed sample. With seq_idx supplied
     directly, depth-0 must mask position 3 (rolls into sub-seq 1); depth-1 must

--- a/tests/unit_tests/models/common/test_mtp_rolling.py
+++ b/tests/unit_tests/models/common/test_mtp_rolling.py
@@ -221,6 +221,18 @@ def test_precomputed_position_ids_skip_rank_local_rolling():
         torch.testing.assert_close(mtp.layers[depth].calls[0]["position_ids"], position_ids_per_depth[depth])
 
 
+def test_precomputed_position_ids_reject_rank_local_token_rolling():
+    mtp = _build_module(num_depths=2, pattern_length=1)
+
+    with pytest.raises(ValueError, match="position_ids_per_depth requires precomputed embed_inputs"):
+        mtp(
+            torch.zeros(4, 3),
+            input_ids=torch.arange(4),
+            embed_fn=_embed_fn_identity,
+            position_ids_per_depth=(torch.arange(4), torch.arange(4)),
+        )
+
+
 def test_precomputed_position_id_count_must_match_depth():
     mtp = _build_module(num_depths=2, pattern_length=1)
 

--- a/tests/unit_tests/models/common/test_mtp_rolling.py
+++ b/tests/unit_tests/models/common/test_mtp_rolling.py
@@ -26,10 +26,16 @@ covered separately by ``tests/unit_tests/loss/test_mtp_cross_boundary.py``.
 
 from __future__ import annotations
 
+import pytest
 import torch
 import torch.nn as nn
 
-from nemo_automodel.components.models.common.mtp.mtp import MTPConfig, MTPModule, roll_tensor
+from nemo_automodel.components.models.common.mtp.mtp import (
+    MTPConfig,
+    MTPModule,
+    roll_tensor,
+    shift_packed_tensor,
+)
 
 
 class _RecordingSublayer(nn.Module):
@@ -192,6 +198,41 @@ def test_precomputed_embed_inputs_path_skips_token_rolling():
         assert got_pos == expected_pos, f"depth {depth}: position_ids rolling expected on embed_inputs path"
 
 
+def test_precomputed_position_ids_skip_rank_local_rolling():
+    """CP callers can provide globally shifted positions in local shard order."""
+    mtp = _build_module(num_depths=2, pattern_length=1)
+    embeddings = (torch.full((4, 3), 11.0), torch.full((4, 3), 22.0))
+    local_position_ids = torch.tensor([0, 1, 6, 7], dtype=torch.long)
+    position_ids_per_depth = (
+        torch.tensor([1, 2, 7, 8], dtype=torch.long),
+        torch.tensor([2, 3, 8, 9], dtype=torch.long),
+    )
+    hidden = torch.zeros(4, 3)
+
+    mtp(
+        hidden,
+        embed_inputs=embeddings,
+        position_ids=local_position_ids,
+        position_ids_per_depth=position_ids_per_depth,
+    )
+
+    for depth in range(2):
+        torch.testing.assert_close(mtp.layers[depth].calls[0]["embed_input"], embeddings[depth])
+        torch.testing.assert_close(mtp.layers[depth].calls[0]["position_ids"], position_ids_per_depth[depth])
+
+
+def test_precomputed_position_id_count_must_match_depth():
+    mtp = _build_module(num_depths=2, pattern_length=1)
+
+    with pytest.raises(ValueError, match="position_ids_per_depth length 1 does not match num_depths 2"):
+        mtp(
+            torch.zeros(4, 3),
+            embed_inputs=(torch.zeros(4, 3), torch.zeros(4, 3)),
+            position_ids=torch.arange(4),
+            position_ids_per_depth=(torch.arange(4),),
+        )
+
+
 def test_trailing_positions_zero_after_roll():
     """The roll is left-shift with trailing zeros (not wrap-around). At depth
     k, the last ``k+1`` slots of the rolled tensor are zero — these are the
@@ -211,3 +252,34 @@ def test_trailing_positions_zero_after_roll():
         )
         # The remaining prefix should match the original IDs shifted by n_trailing.
         assert ids[:-n_trailing] == input_ids[n_trailing:].tolist()
+
+
+def test_precomputed_position_id_shape_checked_without_base_positions():
+    mtp = _build_module(num_depths=2, pattern_length=1)
+    embeddings = (torch.zeros(4, 3), torch.zeros(4, 3))
+
+    with pytest.raises(ValueError, match=r"MTP depth 2 position_ids shape \(1, 4\).*token shape \(4,\)"):
+        mtp(
+            torch.zeros(4, 3),
+            embed_inputs=embeddings,
+            position_ids_per_depth=(torch.arange(4), torch.arange(4).unsqueeze(0)),
+        )
+
+
+def test_shift_packed_tensor_masks_trailing_and_cross_sequence_positions():
+    values = torch.tensor([[10, 11, 12, 20, 21, 22]])
+    seq_idx = torch.tensor([[0, 0, 0, 1, 1, 1]])
+
+    depth_1 = shift_packed_tensor(values, depth=1, seq_idx=seq_idx, fill_value=-1)
+    depth_2 = shift_packed_tensor(values, depth=2, seq_idx=seq_idx, fill_value=-1)
+
+    assert depth_1.tolist() == [[11, 12, -1, 21, 22, -1]]
+    assert depth_2.tolist() == [[12, -1, -1, 22, -1, -1]]
+
+
+def test_shift_packed_tensor_supports_trailing_feature_dimensions():
+    values = torch.arange(12).reshape(1, 3, 4)
+    shifted = shift_packed_tensor(values, depth=1, fill_value=-1)
+
+    assert torch.equal(shifted[:, :2], values[:, 1:])
+    assert shifted[:, -1].tolist() == [[-1, -1, -1, -1]]

--- a/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_layers.py
+++ b/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_layers.py
@@ -709,6 +709,81 @@ class TestMambaMixerSeqIdxConstruction:
         assert seq_idx[0, :8].tolist() == [0] * 8
         assert seq_idx[0, 8:].tolist() == [1] * 8
 
+    def test_cp_bshd_uses_sequence_transport_while_preserving_packed_seq_idx(self, monkeypatch, config):
+        """BSHD packing metadata must not select the CP helper's 2D THD path."""
+        import sys
+        import types
+
+        from nemo_automodel.components.models.nemotron_v3.layers import NemotronV3Mamba2Mixer
+
+        mixer = NemotronV3Mamba2Mixer(config, layer_idx=0)
+        calls: dict[str, object] = {}
+
+        class FakeCP:
+            cp_size = 2
+            n_groups_local = mixer.n_groups
+
+            def pre_conv_ssm(self, tensor, *, cu_seqlens=None):
+                calls["pre_cu_seqlens"] = cu_seqlens
+                calls["pre_shape"] = tensor.shape
+                return tensor
+
+            def post_conv_ssm(self, tensor, *, cu_seqlens=None):
+                calls["post_cu_seqlens"] = cu_seqlens
+                return tensor
+
+            @staticmethod
+            def get_A_log(tensor):
+                return tensor
+
+            @staticmethod
+            def get_dt_bias(tensor):
+                return tensor
+
+            @staticmethod
+            def get_D(tensor):
+                return tensor
+
+            def get_conv1d_weight(self):
+                return mixer.conv1d.weight.squeeze(1)
+
+            def get_conv1d_bias(self):
+                return mixer.conv1d.bias
+
+        def fake_kernel(projected_states, *args, **kwargs):
+            del args
+            calls["seq_idx"] = kwargs["seq_idx"]
+            return projected_states[..., : mixer.intermediate_size]
+
+        for name in ("mamba_ssm", "mamba_ssm.ops", "mamba_ssm.ops.triton"):
+            if name not in sys.modules:
+                monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+        fake_ssd = types.ModuleType("mamba_ssm.ops.triton.ssd_combined")
+        fake_ssd.mamba_split_conv1d_scan_combined = fake_kernel
+        monkeypatch.setitem(sys.modules, "mamba_ssm.ops.triton.ssd_combined", fake_ssd)
+
+        class GateIdentity(torch.nn.Module):
+            def forward(self, tensor, gate=None):
+                del gate
+                return tensor
+
+        mixer.norm = GateIdentity()
+        mixer.cp = FakeCP()
+        hidden_states = torch.randn(1, 8, config.hidden_size)
+        cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)
+
+        output = mixer(hidden_states, cu_seqlens=cu_seqlens)
+
+        assert output.shape == hidden_states.shape
+        assert calls["pre_shape"] == mixer.in_proj(hidden_states).shape
+        assert calls["pre_cu_seqlens"] is None
+        assert calls["post_cu_seqlens"] is None
+        # The local BSHD shard has 8 positions, while CP=2 transport presents
+        # 16 positions to the kernel. cu_seqlens describes 8 real packed tokens;
+        # searchsorted assigns the trailing 8 CP-padding positions the sentinel
+        # sequence ID immediately after the two real documents.
+        assert calls["seq_idx"].tolist() == [[0] * 4 + [1] * 4 + [2] * 8]
+
     def test_bshd_b_gt_1_passes_through_upstream_seq_idx(self, monkeypatch, config):
         """If seq_idx is supplied upstream (e.g. via _packed_seq_ids), the
         construction path must NOT override it — neat-packing semantics."""

--- a/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_model.py
+++ b/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_model.py
@@ -187,6 +187,8 @@ class TestNemotronV3Model:
         assert caps.supports_ep is False
         assert caps.supports_cp is True
         assert caps.supports_pp is True
+        assert caps.supports_mtp_cp is True
+        assert caps.supports_mtp_cp_pp is False
         assert caps.supports_tp is False
 
     def test_model_embedding_dimensions(self, config, backend):

--- a/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_pp_mtp.py
+++ b/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_pp_mtp.py
@@ -295,7 +295,14 @@ class TestPPForward:
 
         activation = torch.zeros(1, 4, cfg.hidden_size, dtype=torch.bfloat16)
         mtp_embed = torch.randn(1, 4, cfg.hidden_size, dtype=torch.bfloat16)
-        out = model(activation, mtp_embed)
+        position_ids = torch.arange(4).unsqueeze(0)
+        mtp_position_ids = (torch.tensor([[1, 2, 3, 0]]),)
+        out = model(
+            activation,
+            mtp_embed,
+            position_ids=position_ids,
+            mtp_per_depth_position_ids=mtp_position_ids,
+        )
 
         assert isinstance(out, tuple)
         assert len(out) == 3  # (logits, mtp_per_depth_h[0], seq_idx)
@@ -305,8 +312,48 @@ class TestPPForward:
         # NOT via the input_ids/embed_fn path.
         assert "embed_inputs" in captured
         torch.testing.assert_close(captured["embed_inputs"][0], mtp_embed)
+        torch.testing.assert_close(captured["position_ids_per_depth"][0], mtp_position_ids[0])
         assert captured.get("input_ids") is None
         assert captured.get("embed_fn") is None
+
+    def test_sdpa_thd_keeps_mtp_tensors_batched(self, backend):
+        model, cfg = _make_model(
+            backend,
+            mtp_layers=1,
+            mtp_layers_block_type=["attention", "moe"],
+        )
+        model.train()
+        model.model.embed_tokens = None
+        captured = {}
+
+        def fake_inner(self, input_ids, **kwargs):
+            del self, kwargs
+            return torch.ones(input_ids.shape[0], input_ids.shape[1], cfg.hidden_size, dtype=torch.bfloat16)
+
+        def fake_mtp_forward(self, **kwargs):
+            captured.update(kwargs)
+            return [kwargs["hidden_states"].clone()]
+
+        model.model.forward = types.MethodType(fake_inner, model.model)
+        model.mtp.forward = types.MethodType(fake_mtp_forward, model.mtp)
+
+        activation = torch.zeros(1, 4, cfg.hidden_size, dtype=torch.bfloat16)
+        mtp_embed = torch.randn(1, 4, cfg.hidden_size, dtype=torch.bfloat16)
+        position_ids = torch.arange(4).unsqueeze(0)
+        mtp_position_ids = (torch.tensor([[1, 2, 3, 0]]),)
+
+        model(
+            activation,
+            mtp_embed,
+            position_ids=position_ids,
+            mtp_per_depth_position_ids=mtp_position_ids,
+            qkv_format="thd",
+        )
+
+        assert captured["hidden_states"].shape == (1, 4, cfg.hidden_size)
+        assert captured["embed_inputs"][0].shape == (1, 4, cfg.hidden_size)
+        assert captured["position_ids"].shape == (1, 4)
+        assert captured["position_ids_per_depth"][0].shape == (1, 4)
 
     def test_final_stage_eval_emits_placeholders(self, backend):
         """In eval mode, the last stage keeps the (1 + D + seq_idx) tuple arity."""

--- a/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_pp_mtp.py
+++ b/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_pp_mtp.py
@@ -316,6 +316,35 @@ class TestPPForward:
         assert captured.get("input_ids") is None
         assert captured.get("embed_fn") is None
 
+    @pytest.mark.parametrize("missing", ["embeddings", "position_ids"])
+    def test_context_parallel_requires_paired_mtp_embeddings_and_positions(self, backend, missing):
+        model, cfg = _make_model(
+            backend,
+            mtp_layers=1,
+            mtp_layers_block_type=["attention", "moe"],
+        )
+        model.train()
+
+        def fake_inner(self, input_ids, **kwargs):
+            del self, kwargs
+            source = input_ids if input_ids is not None else inputs_embeds
+            return torch.ones(source.shape[0], source.shape[1], cfg.hidden_size, dtype=torch.bfloat16)
+
+        inputs_embeds = torch.zeros(1, 4, cfg.hidden_size, dtype=torch.bfloat16)
+        model.model.forward = types.MethodType(fake_inner, model.model)
+        mtp_embed_inputs = () if missing == "embeddings" else (inputs_embeds.clone(),)
+        mtp_position_ids = None if missing == "position_ids" else (torch.tensor([[1, 2, 3, 0]]),)
+
+        with pytest.raises(ValueError, match="requires precomputed per-depth embeddings and position IDs together"):
+            model(
+                None,
+                *mtp_embed_inputs,
+                inputs_embeds=inputs_embeds,
+                position_ids=torch.arange(4).unsqueeze(0),
+                mtp_per_depth_position_ids=mtp_position_ids,
+                cp_size=2,
+            )
+
     def test_sdpa_thd_keeps_mtp_tensors_batched(self, backend):
         model, cfg = _make_model(
             backend,

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -424,6 +424,16 @@ def _import_parallelizer_with_stubs(monkeypatch):
     parallelizer_utils_stub.fully_shard_by_dtype = fully_shard_by_dtype
     parallelizer_utils_stub.configure_fsdp_unused_param_reduction = lambda module: 0
 
+    def reject_unsupported_mtp_cp(model):
+        supports = getattr(model, "supports", None)
+        mtp_enabled = bool(
+            getattr(supports, "mtp_enabled", getattr(getattr(model, "mtp_config", None), "enabled", False))
+        )
+        if mtp_enabled and not bool(getattr(supports, "supports_mtp_cp", False)):
+            raise RuntimeError("Model does not support MTP with context parallelism")
+
+    parallelizer_utils_stub.reject_unsupported_mtp_cp = reject_unsupported_mtp_cp
+
     def reject_unsupported_mtp_cp_pp(model):
         supports = getattr(model, "supports", None)
         is_pp_stage_fn = getattr(model, "_is_pipeline_parallel_stage", None)
@@ -1647,6 +1657,44 @@ def test_parallelize_model_rejects_cp_mtp_pipeline_stage_before_ep_or_cp(monkeyp
     )()
 
     with pytest.raises(NotImplementedError, match="MTP with context and pipeline parallelism"):
+        P.parallelize_model(
+            model=model,
+            world_mesh=world_mesh,
+            moe_mesh=moe_mesh,
+            dp_axis_names=("dp",),
+            cp_axis_name="cp",
+            ep_axis_name="ep",
+        )
+
+    apply_cp_mock.assert_not_called()
+    apply_ep_mock.assert_not_called()
+
+
+def test_parallelize_model_rejects_cp_mtp_without_capability_before_ep_or_cp(monkeypatch):
+    """The MoE/EP path must enforce the same MTP+CP capability as the dense path."""
+    P = _import_parallelizer_with_stubs(monkeypatch)
+    apply_cp_mock = MagicMock()
+    apply_ep_mock = MagicMock()
+    monkeypatch.setattr(P, "apply_cp", apply_cp_mock)
+    monkeypatch.setattr(P, "apply_ep", apply_ep_mock)
+
+    world_mesh = FakeWorldMesh({"cp": 2, ("dp",): 2}, mesh_dim_names=["dp", "cp"])
+    moe_mesh = FakeMoeMesh({"ep": 2})
+    model = type(
+        "UnsupportedMTPModel",
+        (),
+        {
+            "supports": types.SimpleNamespace(
+                mtp_enabled=True,
+                supports_mtp_cp=False,
+                supports_mtp_cp_pp=False,
+            ),
+            "mtp_config": type("MTP", (), {"enabled": True})(),
+            "moe_config": type("MC", (), {"n_routed_experts": 4})(),
+        },
+    )()
+
+    with pytest.raises(RuntimeError, match="does not support MTP with context parallelism"):
         P.parallelize_model(
             model=model,
             world_mesh=world_mesh,

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -423,6 +423,21 @@ def _import_parallelizer_with_stubs(monkeypatch):
 
     parallelizer_utils_stub.fully_shard_by_dtype = fully_shard_by_dtype
     parallelizer_utils_stub.configure_fsdp_unused_param_reduction = lambda module: 0
+
+    def reject_unsupported_mtp_cp_pp(model):
+        supports = getattr(model, "supports", None)
+        is_pp_stage_fn = getattr(model, "_is_pipeline_parallel_stage", None)
+        if (
+            supports is not None
+            and supports.mtp_enabled
+            and not supports.supports_mtp_cp_pp
+            and callable(is_pp_stage_fn)
+            and is_pp_stage_fn()
+        ):
+            raise NotImplementedError("MTP with context and pipeline parallelism is not supported")
+
+    parallelizer_utils_stub.reject_unsupported_mtp_cp_pp = reject_unsupported_mtp_cp_pp
+
     monkeypatch.setitem(
         sys.modules,
         "nemo_automodel.components.distributed.parallelizer_utils",
@@ -1605,6 +1620,44 @@ def test_parallelize_model_applies_tp_before_cp_ep_ac_and_fsdp(monkeypatch):
         tp_shard_plan=None,
         tp_size=2,
     )
+
+
+def test_parallelize_model_rejects_cp_mtp_pipeline_stage_before_ep_or_cp(monkeypatch):
+    """The MoE/EP path must reject the same unsupported topology on every PP stage."""
+    P = _import_parallelizer_with_stubs(monkeypatch)
+    apply_cp_mock = MagicMock()
+    apply_ep_mock = MagicMock()
+    monkeypatch.setattr(P, "apply_cp", apply_cp_mock)
+    monkeypatch.setattr(P, "apply_ep", apply_ep_mock)
+
+    world_mesh = FakeWorldMesh(
+        {"cp": 2, ("dp",): 2},
+        mesh_dim_names=["dp", "cp"],
+    )
+    moe_mesh = FakeMoeMesh({"ep": 2})
+    model = type(
+        "PipelineStage",
+        (),
+        {
+            "supports": types.SimpleNamespace(mtp_enabled=True, supports_mtp_cp_pp=False),
+            "mtp_config": type("MTP", (), {"enabled": True})(),
+            "moe_config": type("MC", (), {"n_routed_experts": 4})(),
+            "_is_pipeline_parallel_stage": lambda self: True,
+        },
+    )()
+
+    with pytest.raises(NotImplementedError, match="MTP with context and pipeline parallelism"):
+        P.parallelize_model(
+            model=model,
+            world_mesh=world_mesh,
+            moe_mesh=moe_mesh,
+            dp_axis_names=("dp",),
+            cp_axis_name="cp",
+            ep_axis_name="ep",
+        )
+
+    apply_cp_mock.assert_not_called()
+    apply_ep_mock.assert_not_called()
 
 
 def test_parallelize_model_forwards_offload_policy_to_fsdp(monkeypatch):

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -2583,3 +2583,27 @@ def test_forward_backward_step_model_cp_hook(monkeypatch, cp_size, uses_thd, sup
     # backward through the local loss populated grads
     assert model.lin.weight.grad is not None
     assert torch.isfinite(model.lin.weight.grad).all()
+
+
+def test_forward_backward_step_rejects_mtp_with_cp_before_sharding():
+    recipe = TrainFinetuneRecipeForNextTokenPrediction.__new__(TrainFinetuneRecipeForNextTokenPrediction)
+    model = nn.Module()
+    model.mtp_config = SimpleNamespace(enabled=True)
+    model.supports = SimpleNamespace(mtp_enabled=True, supports_mtp_cp=True)
+    object.__setattr__(recipe, "dist_env", SimpleNamespace(device=torch.device("cpu")))
+    object.__setattr__(recipe, "pp_enabled", False)
+    object.__setattr__(recipe, "model_parts", [model])
+    object.__setattr__(recipe, "_get_cp_group_size", lambda: 2)
+
+    with pytest.raises(NotImplementedError, match="globally shifted per-depth targets"):
+        recipe._forward_backward_step(
+            idx=0,
+            batch={
+                "input_ids": torch.tensor([[10, 11, 12, 13]]),
+                "labels": torch.tensor([[11, 12, 13, -100]]),
+            },
+            loss_buffer=[],
+            num_label_tokens=3,
+            num_batches=1,
+            is_train=True,
+        )

--- a/tests/unit_tests/test_validation.py
+++ b/tests/unit_tests/test_validation.py
@@ -413,6 +413,19 @@ class TestModelSupportsEP:
         assert model.supports.supports_ep is False
 
 
+class TestModelSupportsMTP:
+    def test_mtp_enabled_reflects_live_config(self):
+        model = _Bare()
+        model.mtp_config = SimpleNamespace(enabled=False)
+        _attach(model)
+
+        assert model.supports.mtp_enabled is False
+        model.mtp_config.enabled = True
+        assert model.supports.mtp_enabled is True
+        assert model.supports.supports_mtp_cp is False
+        assert model.supports.supports_mtp_cp_pp is False
+
+
 class TestModelSupportsSequencePacking:
     def test_true_with_seq_lens(self):
         model = _WithSeqLens()


### PR DESCRIPTION
# What does this PR do?

Adds opt-in interfaces that allow callers to prepare MTP future-token inputs and targets in global sequence order before context-parallel sharding.

Without these interfaces, MTP rolls rank-local token IDs, position IDs, and labels after CP sharding, producing incorrect values around CP shard and packed-sequence boundaries.

This is an enabling interface PR. Native `train_ft` integration is provided by the stacked follow-up #3544.

# Changelog

- Allow `calculate_mtp_loss` to consume authoritative precomputed per-depth targets.
  - Targets must match the local label shape and CP token layout.
  - Target count must match the number of MTP outputs.
  - Precomputed targets are mutually exclusive with local `cu_seqlens`/`seq_idx` rolling because rank-local metadata cannot repair a global CP shift.
- Allow `MTPModule` to consume precomputed per-depth position IDs instead of rolling rank-local positions.
  - Validate their shape even when base `position_ids` are absent.
- Expose precomputed MTP position IDs through `NemotronHForCausalLM`.
  - Keep SDPA/flex MTP tensors in BSHD when a packed batch carries `qkv_format="thd"`; only TE uses the THD squeeze.
- Configure Nemotron MTP attention and Mamba layers with the same CP collectives as the backbone layers.
  - Fail explicitly if MTP is enabled but its layers cannot be wired.
  - Resolve CP process-group ranks once rather than once per attention layer.
- Add a shared packed-sequence shift helper and use it in the hybrid functional test.
- Extend the hybrid Nemotron CP functional test with packed-THD MTP parity coverage for exact targets, logits, hidden states, loss, gradients, and an optimizer update.

# Scope

This PR intentionally does not integrate MTP preprocessing into the native Automodel `train_ft` recipe.

Callers must shift and boundary-mask MTP inputs and targets in global sequence order, apply the same CP partition used for the model inputs, and pass the resulting local tensors through the new interfaces.

The new arguments are optional, so existing non-CP MTP behavior remains unchanged. No additional all-gather is introduced.

# Validation

- [x] Focused unit tests: 87 passed, 2 skipped
- [x] Ruff formatting and lint
- [x] Python compilation and `git diff --check`
- [x] Two-GPU IAD packed-THD MTP parity test
  - exact global target reconstruction
  - logits, hidden-state, loss, and gradient parity
  - optimizer-step parity

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

- Follow-up: #3544 adds native `train_ft` MTP + CP integration.
- MTP + CP + PP transport remains a separate follow-up.
- This PR is independent of the per-depth MTP metric API in #3525.

