### PR TITLE
fix(retrieval): support canonical Sentence Transformers metadata

### DIFF
--- a/nemo_automodel/_transformers/sentence_transformer_export.py
+++ b/nemo_automodel/_transformers/sentence_transformer_export.py
@@ -26,6 +26,11 @@ from transformers import PretrainedConfig
 from transformers.utils import logging
 
 _SENTENCE_TRANSFORMER_POOLING_KEYS = {
+    "avg": "mean",
+    "cls": "cls",
+    "last": "lasttoken",
+}
+_SENTENCE_TRANSFORMER_LEGACY_POOLING_KEYS = {
     "avg": "pooling_mode_mean_tokens",
     "cls": "pooling_mode_cls_token",
     "last": "pooling_mode_lasttoken",
@@ -47,6 +52,25 @@ _SOURCE_LEGAL_ASSET_PATTERNS = (
 )
 _SOURCE_LEGAL_ASSET_PREFIXES = ("license", "notice")
 _TEXT_EXPORT_STALE_PROCESSOR_ASSETS = ("processor_config.json", "preprocessor_config.json")
+_SENTENCE_TRANSFORMER_MODULE_TYPES = {
+    "transformer": {
+        "sentence_transformers.models.Transformer",
+        "sentence_transformers.base.modules.transformer.Transformer",
+    },
+    "pooling": {
+        "sentence_transformers.models.Pooling",
+        "sentence_transformers.sentence_transformer.modules.pooling.Pooling",
+    },
+    "normalize": {
+        "sentence_transformers.models.Normalize",
+        "sentence_transformers.sentence_transformer.modules.normalize.Normalize",
+    },
+}
+_SENTENCE_TRANSFORMER_EXPORT_MODULE_TYPES = {
+    "transformer": "sentence_transformers.base.modules.transformer.Transformer",
+    "pooling": "sentence_transformers.sentence_transformer.modules.pooling.Pooling",
+    "normalize": "sentence_transformers.sentence_transformer.modules.normalize.Normalize",
+}
 
 
 logger = logging.get_logger(__name__)
@@ -130,11 +154,17 @@ def _load_sentence_transformer_wrapper_options(
     if not isinstance(modules, list):
         raise ValueError("Sentence Transformers modules.json must contain a list of modules.")
 
-    transformer_type = "sentence_transformers.models.Transformer"
-    pooling_type = "sentence_transformers.models.Pooling"
-    normalize_type = "sentence_transformers.models.Normalize"
+    expected_module_types = [
+        _SENTENCE_TRANSFORMER_MODULE_TYPES["transformer"],
+        _SENTENCE_TRANSFORMER_MODULE_TYPES["pooling"],
+    ]
     module_types = [module.get("type") if isinstance(module, dict) else None for module in modules]
-    if module_types not in ([transformer_type, pooling_type], [transformer_type, pooling_type, normalize_type]):
+    if len(module_types) == 3:
+        expected_module_types.append(_SENTENCE_TRANSFORMER_MODULE_TYPES["normalize"])
+    if len(module_types) not in (2, 3) or any(
+        module_type not in allowed_types
+        for module_type, allowed_types in zip(module_types, expected_module_types, strict=True)
+    ):
         raise ValueError(
             "Sentence Transformers metadata must use the exact supported module stack: "
             "Transformer, Pooling, and optional Normalize."
@@ -169,18 +199,30 @@ def _load_sentence_transformer_wrapper_options(
             "the NeMo pooling path includes prompt tokens."
         )
 
-    active_pooling_keys = {
-        key for key, value in pooling_config.items() if key.startswith("pooling_mode_") and bool(value)
-    }
-    matching_pooling = [
-        pooling
-        for pooling, metadata_key in _SENTENCE_TRANSFORMER_POOLING_KEYS.items()
-        if metadata_key in active_pooling_keys
-    ]
-    if len(active_pooling_keys) != 1 or len(matching_pooling) != 1:
-        raise ValueError(
-            "Sentence Transformers pooling metadata cannot be represented by a single NeMo avg, cls, or last mode."
-        )
+    pooling_mode = pooling_config.get("pooling_mode")
+    if pooling_mode is not None:
+        if not isinstance(pooling_mode, str) or pooling_mode not in _SENTENCE_TRANSFORMER_POOLING_KEYS.values():
+            raise ValueError(
+                "Sentence Transformers pooling metadata cannot be represented by a single NeMo avg, cls, or last mode."
+            )
+        matching_pooling = [
+            pooling
+            for pooling, sentence_transformer_mode in _SENTENCE_TRANSFORMER_POOLING_KEYS.items()
+            if sentence_transformer_mode == pooling_mode
+        ]
+    else:
+        active_pooling_keys = {
+            key for key, value in pooling_config.items() if key.startswith("pooling_mode_") and bool(value)
+        }
+        matching_pooling = [
+            pooling
+            for pooling, metadata_key in _SENTENCE_TRANSFORMER_LEGACY_POOLING_KEYS.items()
+            if metadata_key in active_pooling_keys
+        ]
+        if len(active_pooling_keys) != 1 or len(matching_pooling) != 1:
+            raise ValueError(
+                "Sentence Transformers pooling metadata cannot be represented by a single NeMo avg, cls, or last mode."
+            )
 
     sentence_transformer_config = _load_sentence_transformer_json(
         model_name_or_path,
@@ -468,13 +510,13 @@ def _save_generated_sentence_transformer_assets(
             "idx": 0,
             "name": "0",
             "path": "",
-            "type": "sentence_transformers.models.Transformer",
+            "type": _SENTENCE_TRANSFORMER_EXPORT_MODULE_TYPES["transformer"],
         },
         {
             "idx": 1,
             "name": "1",
             "path": "1_Pooling",
-            "type": "sentence_transformers.models.Pooling",
+            "type": _SENTENCE_TRANSFORMER_EXPORT_MODULE_TYPES["pooling"],
         },
     ]
     if normalize:
@@ -483,21 +525,15 @@ def _save_generated_sentence_transformer_assets(
                 "idx": 2,
                 "name": "2",
                 "path": "2_Normalize",
-                "type": "sentence_transformers.models.Normalize",
+                "type": _SENTENCE_TRANSFORMER_EXPORT_MODULE_TYPES["normalize"],
             }
         )
 
     pooling_config = {
-        "word_embedding_dimension": embedding_dimension,
-        "pooling_mode_cls_token": False,
-        "pooling_mode_max_tokens": False,
-        "pooling_mode_mean_tokens": False,
-        "pooling_mode_mean_sqrt_len_tokens": False,
-        "pooling_mode_weightedmean_tokens": False,
-        "pooling_mode_lasttoken": False,
+        "embedding_dimension": embedding_dimension,
+        "pooling_mode": _SENTENCE_TRANSFORMER_POOLING_KEYS[pooling],
         "include_prompt": True,
     }
-    pooling_config[_SENTENCE_TRANSFORMER_POOLING_KEYS[pooling]] = True
 
     max_seq_length = _resolve_sentence_transformer_max_seq_length(model_part, tokenizer, original_model_path)
 

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -693,9 +693,24 @@ def test_ministral_embedding_uses_stock_bidirectional_model(tmp_path):
     reloaded = AutoModel.from_pretrained(save_dir)
     assert (save_dir / "tokenizer.json").exists()
     assert json.loads((save_dir / "modules.json").read_text()) == [
-        {"idx": 0, "name": "0", "path": "", "type": "sentence_transformers.models.Transformer"},
-        {"idx": 1, "name": "1", "path": "1_Pooling", "type": "sentence_transformers.models.Pooling"},
-        {"idx": 2, "name": "2", "path": "2_Normalize", "type": "sentence_transformers.models.Normalize"},
+        {
+            "idx": 0,
+            "name": "0",
+            "path": "",
+            "type": "sentence_transformers.base.modules.transformer.Transformer",
+        },
+        {
+            "idx": 1,
+            "name": "1",
+            "path": "1_Pooling",
+            "type": "sentence_transformers.sentence_transformer.modules.pooling.Pooling",
+        },
+        {
+            "idx": 2,
+            "name": "2",
+            "path": "2_Normalize",
+            "type": "sentence_transformers.sentence_transformer.modules.normalize.Normalize",
+        },
     ]
     assert json.loads((save_dir / "config_sentence_transformers.json").read_text())["prompts"]["query"] == "query: "
 

--- a/tests/unit_tests/_transformers/test_sentence_transformer_export.py
+++ b/tests/unit_tests/_transformers/test_sentence_transformer_export.py
@@ -70,14 +70,24 @@ def test_generated_sentence_transformer_assets_regenerate_semantics_and_preserve
         "max_seq_length": 8192,
         "do_lower_case": False,
     }
-    assert json.loads((metadata_dir / "modules.json").read_text())[-1] == {
+    modules = json.loads((metadata_dir / "modules.json").read_text())
+    assert [module["type"] for module in modules] == [
+        "sentence_transformers.base.modules.transformer.Transformer",
+        "sentence_transformers.sentence_transformer.modules.pooling.Pooling",
+        "sentence_transformers.sentence_transformer.modules.normalize.Normalize",
+    ]
+    assert modules[-1] == {
         "idx": 2,
         "name": "2",
         "path": "2_Normalize",
-        "type": "sentence_transformers.models.Normalize",
+        "type": "sentence_transformers.sentence_transformer.modules.normalize.Normalize",
     }
     pooling_config = json.loads((metadata_dir / "1_Pooling" / "config.json").read_text())
-    assert pooling_config["pooling_mode_mean_tokens"] is True
+    assert pooling_config == {
+        "embedding_dimension": 8,
+        "pooling_mode": "mean",
+        "include_prompt": True,
+    }
 
 
 def test_inferred_sentence_transformer_max_seq_length_uses_smallest_finite_capability():
@@ -375,6 +385,168 @@ def test_sentence_transformer_source_with_unsupported_module_is_rejected(tmp_pat
     (tmp_path / "1_Pooling" / "config.json").write_text(json.dumps({"pooling_mode_mean_tokens": True}))
 
     with pytest.raises(ValueError, match="exact supported module stack"):
+        sentence_transformer_export._load_sentence_transformer_wrapper_options(str(tmp_path), {})
+
+
+@pytest.mark.parametrize("module_count", [0, 1, 4])
+def test_sentence_transformer_source_with_invalid_stack_length_is_rejected(tmp_path, module_count):
+    (tmp_path / "1_Pooling").mkdir()
+    module_types = [
+        "sentence_transformers.models.Transformer",
+        "sentence_transformers.models.Pooling",
+        "sentence_transformers.models.Normalize",
+        "sentence_transformers.models.Dense",
+    ]
+    modules = [
+        {
+            "idx": index,
+            "path": "" if index == 0 else ("1_Pooling" if index == 1 else str(index)),
+            "type": module_type,
+        }
+        for index, module_type in enumerate(module_types[:module_count])
+    ]
+    (tmp_path / "modules.json").write_text(json.dumps(modules))
+    (tmp_path / "1_Pooling" / "config.json").write_text(json.dumps({"pooling_mode_mean_tokens": True}))
+
+    with pytest.raises(ValueError, match="exact supported module stack"):
+        sentence_transformer_export._load_sentence_transformer_wrapper_options(str(tmp_path), {})
+
+
+@pytest.mark.parametrize(
+    "module_types, expected_normalize",
+    [
+        (
+            [
+                "sentence_transformers.base.modules.transformer.Transformer",
+                "sentence_transformers.sentence_transformer.modules.pooling.Pooling",
+            ],
+            False,
+        ),
+        (
+            [
+                "sentence_transformers.base.modules.transformer.Transformer",
+                "sentence_transformers.sentence_transformer.modules.pooling.Pooling",
+                "sentence_transformers.sentence_transformer.modules.normalize.Normalize",
+            ],
+            True,
+        ),
+    ],
+)
+def test_sentence_transformer_source_accepts_canonical_module_paths(tmp_path, module_types, expected_normalize):
+    (tmp_path / "1_Pooling").mkdir()
+    modules = [
+        {
+            "idx": index,
+            "path": "" if index == 0 else ("1_Pooling" if index == 1 else "2_Normalize"),
+            "type": module_type,
+        }
+        for index, module_type in enumerate(module_types)
+    ]
+    (tmp_path / "modules.json").write_text(json.dumps(modules))
+    (tmp_path / "1_Pooling" / "config.json").write_text(json.dumps({"pooling_mode_mean_tokens": True}))
+
+    options = sentence_transformer_export._load_sentence_transformer_wrapper_options(str(tmp_path), {})
+
+    assert options is not None
+    assert options.pooling == "avg"
+    assert options.l2_normalize is expected_normalize
+
+
+@pytest.mark.parametrize(
+    "module_types",
+    [
+        [
+            "sentence_transformers.base.modules.transformer.Transformer",
+            "sentence_transformers.models.Pooling",
+        ],
+        [
+            "sentence_transformers.models.Transformer",
+            "sentence_transformers.sentence_transformer.modules.pooling.Pooling",
+        ],
+    ],
+)
+def test_sentence_transformer_source_accepts_mixed_module_path_generations(tmp_path, module_types):
+    (tmp_path / "1_Pooling").mkdir()
+    (tmp_path / "modules.json").write_text(
+        json.dumps(
+            [
+                {"idx": 0, "path": "", "type": module_types[0]},
+                {"idx": 1, "path": "1_Pooling", "type": module_types[1]},
+            ]
+        )
+    )
+    (tmp_path / "1_Pooling" / "config.json").write_text(json.dumps({"pooling_mode_mean_tokens": True}))
+
+    options = sentence_transformer_export._load_sentence_transformer_wrapper_options(str(tmp_path), {})
+
+    assert options is not None
+    assert options.pooling == "avg"
+    assert options.l2_normalize is False
+
+
+@pytest.mark.parametrize(
+    "pooling_config, expected_pooling",
+    [
+        ({"pooling_mode": "mean"}, "avg"),
+        ({"pooling_mode": "cls"}, "cls"),
+        ({"pooling_mode": "lasttoken"}, "last"),
+    ],
+)
+def test_sentence_transformer_source_accepts_canonical_pooling_config(tmp_path, pooling_config, expected_pooling):
+    (tmp_path / "1_Pooling").mkdir()
+    (tmp_path / "modules.json").write_text(
+        json.dumps(
+            [
+                {
+                    "idx": 0,
+                    "path": "",
+                    "type": "sentence_transformers.base.modules.transformer.Transformer",
+                },
+                {
+                    "idx": 1,
+                    "path": "1_Pooling",
+                    "type": "sentence_transformers.sentence_transformer.modules.pooling.Pooling",
+                },
+            ]
+        )
+    )
+    (tmp_path / "1_Pooling" / "config.json").write_text(json.dumps(pooling_config))
+
+    options = sentence_transformer_export._load_sentence_transformer_wrapper_options(str(tmp_path), {})
+
+    assert options is not None
+    assert options.pooling == expected_pooling
+    assert options.l2_normalize is False
+
+
+@pytest.mark.parametrize(
+    "pooling_config",
+    [
+        {"pooling_mode": ["mean", "cls"]},
+        {"pooling_mode": "max"},
+    ],
+)
+def test_sentence_transformer_source_rejects_unrepresentable_canonical_pooling_config(tmp_path, pooling_config):
+    (tmp_path / "1_Pooling").mkdir()
+    (tmp_path / "modules.json").write_text(
+        json.dumps(
+            [
+                {
+                    "idx": 0,
+                    "path": "",
+                    "type": "sentence_transformers.base.modules.transformer.Transformer",
+                },
+                {
+                    "idx": 1,
+                    "path": "1_Pooling",
+                    "type": "sentence_transformers.sentence_transformer.modules.pooling.Pooling",
+                },
+            ]
+        )
+    )
+    (tmp_path / "1_Pooling" / "config.json").write_text(json.dumps(pooling_config))
+
+    with pytest.raises(ValueError, match="single NeMo avg, cls, or last mode"):
         sentence_transformer_export._load_sentence_transformer_wrapper_options(str(tmp_path), {})
 
 


### PR DESCRIPTION
## Summary

- accept canonical Sentence Transformers 5.x module paths when restoring retrieval wrapper settings
- preserve compatibility with legacy AutoModel-generated module paths, including mixed-generation metadata
- export canonical module paths for Transformer, Pooling, and Normalize

## Root cause

The metadata reader compared `modules.json` entries against only the legacy `sentence_transformers.models.*` aliases. Sentence Transformers 5.x checkpoints serialize the concrete implementation paths instead, so valid official checkpoint metadata was rejected before model construction.

## Why the existing test did not catch this

Existing tests generated metadata with AutoModel's own legacy aliases and read those aliases back. They did not cover canonical Sentence Transformers 5.x paths or mixed metadata written across versions.

## Verification testing script

A standalone no-GPU reproducer creates minimal local `modules.json` metadata and checks three cases:

1. legacy aliases remain accepted;
2. an unsupported `Dense` module remains rejected;
3. canonical Sentence Transformers 5.x paths are accepted.

## Test command (functional / e2e)

```bash
python -m pytest \
  tests/unit_tests/_transformers/test_retrieval.py \
  tests/unit_tests/_transformers/test_sentence_transformer_export.py -q
```

## Before fix — run output

```text
5 failed, 15 deselected

ValueError: Sentence Transformers metadata must use the exact supported module stack: Transformer, Pooling, and optional Normalize.
```

The focused failures cover canonical Transformer/Pooling, optional Normalize, mixed canonical/legacy metadata, and canonical export paths.

## After fix — run output

```text
70 passed, 18 warnings in 3.27s
```

The exact existing Nemotron-VL POR testcase also passed with the reviewed product file overlaid on the rc7 image:

```text
PR2596_EQUIV=PASS
PR2596_POR=PASS lanes=ddp,fsdp2,megatron_fsdp_zero2 steps=3
```

An official-checkpoint metadata probe resolved the intended values before the GPU run:

```text
SentenceTransformerWrapperOptions(
    pooling='avg',
    l2_normalize=False,
    query_prompt='query: ',
    document_prompt='passage: '
)
```

The standalone no-GPU reproducer also changed from `RESULT: REPRODUCED` (exit 1) to `RESULT: FIXED` (exit 0).

## Detected by

The AutoModel RC regression suite detected the issue while loading the official `nvidia/llama-nemotron-embed-vl-1b-v2` checkpoint. The failure first appears in 26.08 rc6 after the Sentence Transformers metadata-export backport and reproduces in rc7.

## Test plan

- [x] canonical Transformer + Pooling metadata
- [x] canonical optional Normalize metadata
- [x] legacy aliases remain accepted
- [x] mixed canonical/legacy paths remain accepted
- [x] unsupported extra modules remain rejected
- [x] generated metadata uses canonical 5.x paths
- [x] Sentence Transformers 5.6.0 round-trip tests
- [x] `ruff check` on changed files
- [x] `git diff --check`

## Pre-checks

- [x] DCO sign-off will be included
- [x] no dependency or lockfile changes
- [x] no public API expansion
