### PR TITLE
fix(minimax): declare packed-sequence and CP attention ownership

### DIFF
--- a/nemo_automodel/_transformers/capabilities.py
+++ b/nemo_automodel/_transformers/capabilities.py
@@ -283,6 +283,9 @@ class ModelSupports:
             or _uses_te_attention(model)
             or _uses_magi_attention(model)
             or (self.supports_thd and backend_attn == "tilelang")
+            # Models that build their own per-document masks (MiniMax M3's
+            # document-blocked FlexAttention mask) need no packing-aware backend.
+            or getattr(model, "_owns_packed_attention", False)
         )
         return _supports_seq_lens(model) and sp_attn_backend
 
@@ -359,6 +362,8 @@ class ModelSupports:
         if model_owned_backends is not None:
             backend_attn = getattr(getattr(model, "backend", None), "attn", None)
             return _supports_seq_lens(model) and backend_attn in model_owned_backends
+        if getattr(model, "_owns_cp_attention", False):
+            return True
         if self.supports_thd:
             backend_attn = getattr(getattr(model, "backend", None), "attn", None)
             return backend_attn == "tilelang"

--- a/nemo_automodel/components/models/minimax_m3_vl/model.py
+++ b/nemo_automodel/components/models/minimax_m3_vl/model.py
@@ -397,6 +397,12 @@ class MiniMaxM3SparseForConditionalGeneration(HFCheckpointingMixin, nn.Module, M
     # the standard CP path (mask-strip hook + is_causal); sparse layers require the
     # CP-aware indexer attention for a correct global-sequence bias.
     _supports_cp_sdpa = True
+    # MiniMaxM3CPSparseAttention derives per-document ids from the packed position ids
+    # and builds its own block mask, so packing needs no packing-aware attention backend.
+    _owns_packed_attention = True
+    # The same attention shards the packed sequence in forward and carries the document
+    # boundaries into every layer, so it owns the packed CP path end to end.
+    _owns_cp_attention = True
     # The state-dict adapter fully populates every tensor from the checkpoint
     # (MXFP8 -> bf16), so skip HF random init on load. This also avoids the
     # stage-divergent DTensor collectives in initialize_weights() under sharding/PP.

--- a/tests/unit_tests/models/minimax_m3_vl/test_cp_packing_docmask.py
+++ b/tests/unit_tests/models/minimax_m3_vl/test_cp_packing_docmask.py
@@ -79,3 +79,49 @@ def test_multi_batch_independent_docids():
     pos = torch.tensor([[0, 1, 0, 1], [0, 1, 2, 3]])  # batch row 0 packed (2 docs), row 1 single
     doc = cp_document_ids(pos)
     assert doc.tolist() == [[0, 0, 1, 1], [0, 0, 0, 0]]
+
+
+class TestPackedCpCapability:
+    """The packed-CP path this module tests must be visible to the capability gate.
+
+    ``_validate_cp_packing_support`` rejects CP + VLM sequence packing unless the
+    model advertises a packed-CP route. MiniMax M3 owns both halves -- it builds
+    its own per-document mask (above) and shards the packed sequence in ``forward``
+    -- so it must declare the flags that describe that, or a supported recipe such
+    as ``minimax_m3_vl_sft_tulu3_text_cp8_16k`` is refused before training starts.
+    """
+
+    def _supports_at_cp8(self, model):
+        """Build a capability view at the failing job's mesh (cp8/pp4/ep32).
+
+        Args:
+            model: Live MiniMax VLM instance; the caller must keep it referenced,
+                since ``ModelSupports`` only holds a weak reference to it.
+
+        Returns:
+            The ``ModelSupports`` view for that model at cp_size=8.
+        """
+        import types
+
+        from nemo_automodel._transformers.capabilities import ModelSupports
+
+        return ModelSupports(model, types.SimpleNamespace(cp_size=8, tp_size=1, pp_size=4, ep_size=32))
+
+    def test_declares_packed_and_cp_attention_ownership(self):
+        from nemo_automodel.components.models.minimax_m3_vl.model import (
+            MiniMaxM3SparseForConditionalGeneration,
+        )
+
+        assert MiniMaxM3SparseForConditionalGeneration._owns_packed_attention is True
+        assert MiniMaxM3SparseForConditionalGeneration._owns_cp_attention is True
+
+    def test_packed_cp_is_accepted_on_the_sdpa_backend(self, vlm_model):
+        """cp_size>1 with packing must be allowed, as the tulu3 cp8 recipe needs."""
+        from nemo_automodel.recipes.vlm.finetune import _validate_cp_packing_support
+
+        supports = self._supports_at_cp8(vlm_model)
+
+        assert supports.supports_sequence_packing is True
+        assert supports.supports_cp_with_sequence_packing is True
+        # The recipe-level gate that rejected the nemo-ci job must now pass.
+        _validate_cp_packing_support(supports, packing_enabled=True, cp_size=8)


### PR DESCRIPTION
**Release-blocking.** `minimax_m3_vl_sft_tulu3_text_cp8_16k` currently fails in nemo-ci on r0.6.0. Fixes: AMINT-271

# What does this PR do ?

Lets MiniMax M3 VL run context parallelism with sequence packing again on the release branch.

# The bug

The job dies at `recipe.setup()`, before any training:

```
ValueError: Context parallelism (cp_size=8) with VLM sequence packing is not supported
for ... with its active attention backend.
```

The gate comes from #3414 (backported as #3479). It asks the model whether it has a packed-CP route and MiniMax answers no — even though `MiniMaxM3CPSparseAttention` derives per-document ids from packed position ids, builds its own FlexAttention block mask, and shards the packed sequence inside `forward`.

MiniMax declares only `_supports_cp_sdpa`, which the *unpacked* CP capability honors and the *packed* one ignores:

```
supports_cp                       : True
supports_sequence_packing         : False   <- fails at the first gate
supports_cp_with_sequence_packing : False   -> ValueError
```

Last good run: job 390379833 (Aug 9). First failure: job 394555315 (Aug 12).

# The fix

Two capability clauses that recognise a model-owned packed / CP attention path, plus the matching flags on the model.

# Why this differs from the main PR

Main gets the model flags **only** — https://github.com/NVIDIA-NeMo/Automodel/pull/3547.

The capability clauses those flags feed (`_owns_packed_attention`, `_owns_cp_attention`) already exist on main; they arrived with Kimi Linear (#3243), which is not on r0.6.0. So a straight cherry-pick of the main PR would be inert here — the flags would be declared and never read. This PR carries the two clauses as well, which is why its diff is larger.

The alternative on r0.6.0 was to set `_supports_sdpa = True` instead. Rejected: that flag also gates `_verify_sdpa_support` in `kernel_patches.py`, so it would change unrelated HF-model CP validation.

# Changelog

- `supports_sequence_packing` honors `_owns_packed_attention`
- `supports_cp_with_sequence_packing` honors `_owns_cp_attention`
- `MiniMaxM3SparseForConditionalGeneration` declares both
- 2 unit tests in the existing MiniMax CP packing suite

# Verified

- The exact failing check now passes: `supports_cp_with_sequence_packing` True, recipe gate accepts cp_size=8 + packing
- Without the fix, both new tests fail
- `tests/unit_tests/models/minimax_m3_vl` + `test_validation.py` + `_transformers`: 795 passed, 2 skipped

A nemo-ci pipeline running `minimax_m3_vl_sft_tulu3_text_cp8_16k` on this branch is required before merge: [https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/62633348](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/62633348)

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?