### PR TITLE
fix(docker): build bitsandbytes for SM121

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -108,13 +108,14 @@ RUN apt-get update && apt-get install -y --allow-change-held-packages \
 # Install Bitsandbytes
 ARG INSTALL_BITSANDBYTES=True
 ARG BITSANDBYTES_COMMIT=0.49.2
+# Include native Blackwell targets, especially SM121 for DGX Spark, instead of relying on forward-compatible PTX.
 RUN if [ $INSTALL_BITSANDBYTES = "True" ]; then \
     git clone https://github.com/bitsandbytes-foundation/bitsandbytes.git && \
     cd bitsandbytes && \
     git pull && \
     git fetch origin $BITSANDBYTES_COMMIT && \
     git checkout FETCH_HEAD && \
-    cmake -DCOMPUTE_BACKEND=cuda -DCOMPUTE_CAPABILITY="80;86;90;100;110" -S . && \
+    cmake -DCOMPUTE_BACKEND=cuda -DCOMPUTE_CAPABILITY="80;86;90;100;110;120;121" -S . && \
     make && \
     cmake -DCOMPUTE_BACKEND=cpu -S . && \
     make && \


### PR DESCRIPTION
# What does this PR do?

Build BitsAndBytes with native SM120 and SM121 CUDA targets, including DGX Spark GB10.

The container already pins BitsAndBytes 0.49.2, whose CMake configuration supports SM121, but our custom `COMPUTE_CAPABILITY` list stopped at SM110. Because BitsAndBytes emits PTX only for the highest selected target, GB10 was forced to use forward-compatible SM110 PTX instead of a native SM121 cubin.

# Changelog

- Add SM120 and SM121 to the BitsAndBytes source-build target list.
- Document why SM121 must remain in the custom build configuration.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] No unit test is applicable to this Docker build-target-only change; the container build is the authoritative validation.
- [x] No user documentation change is required.

Validation:

- `git diff --check`
- `docker buildx build --check --progress=plain -f docker/Dockerfile .`

# Additional Information

This follows the SM121 support already present in [BitsAndBytes 0.49.2](https://github.com/bitsandbytes-foundation/bitsandbytes/blob/0.49.2/CMakeLists.txt).
