### PR TITLE
test(checkpoint): improve resume correctness diagnostics

### DIFF
--- a/examples/llm_finetune/nemotron/llama3_3_nemotron_super_49B_squad.yaml
+++ b/examples/llm_finetune/nemotron/llama3_3_nemotron_super_49B_squad.yaml
@@ -126,6 +126,9 @@ ci:
     kl_threshold: 5e-3  # 49B bf16 consolidated round-trip drifts ~3e-4; the 1e-5 tp>1 default is too tight
     hf_kl_threshold: 5e-3
     training_reproducibility_loss_threshold: 5e-2
+    # TP8/PP2 shared-trajectory runs show ~0.35-0.55% first-forward loss drift.
+    # Exact pre-update parameters and optimizer state are still required.
+    resume_tolerance_profile: relaxed
     distributed.tp_size: 8
     tokenizer_name: nvidia/Llama-3_3-Nemotron-Super-49B-v1_5
     hf_device_map_auto: true

--- a/tests/ci_tests/README.md
+++ b/tests/ci_tests/README.md
@@ -85,10 +85,20 @@ LLM recipes use the causal-LM harness, while `examples/vlm_finetune/` recipes us
 `AutoModelForImageTextToText`. VLM parity currently exercises the language path with text-only `input_ids`; real-image
 multimodal parity is a separate follow-up.
 
-The resume oracle is deliberately distinct from independent-run reproducibility. It checks exact optimizer/scheduler
-position, LR and weight decay, RNG state, stateful-dataloader state, and per-rank batch identity before comparing the
-first post-resume loss with `resume_first_loss_threshold` (default `1e-6`) and later BF16 optimizer steps with
-`resume_loss_threshold` (default `5e-3`). Use `no_check_resume: true` only for an explicitly documented restore blocker.
+The resume oracle is deliberately distinct from independent-run reproducibility. It checks scheduler position,
+complete optimizer parameter-group settings, LR and weight decay, RNG state, and per-rank batch identity. On the first
+shared step, after both branches have entered the same FSDP unshard/reshard lifecycle but before the optimizer update,
+it requires exact rank-local model parameters and optimizer tensors. Persistent buffers and gradients at that point,
+plus post-update model/optimizer fingerprints, are recorded diagnostically so a numerical divergence can be localized.
+Exact loss deltas and diagnostic comparisons are written for successful and failed runs.
+
+Select a shared scale-aware loss envelope with `resume_tolerance_profile`. Each stage allows
+`atol + rtol * max(abs(uninterrupted_loss), abs(resumed_loss))`: `strict` uses `1e-6 + 0%` for both stages;
+`standard` (default) uses `1e-5 + 0.2%` for the first step and `5e-3 + 0.2%` later; `relaxed` uses
+`1e-4 + 0.75%` first and `1e-2 + 0.75%` later. Prefer profiles over model-specific calibration, and use `relaxed`
+only for demonstrated distributed or low-precision drift after the exact state gates pass. `resume_first_loss_threshold`
+and `resume_loss_threshold` remain authoritative absolute-only overrides for exceptional cases. Use
+`no_check_resume: true` only for an explicitly documented restore blocker.
 
 CI also reuses the normal finetune that already precedes checkpoint robustness as a separate, non-blocking training-
 reproducibility metric; it does not launch another baseline. Normal finetune and checkpoint Phase 1 record per-rank

--- a/tests/ci_tests/scripts/config_templates/ci_config.yaml
+++ b/tests/ci_tests/scripts/config_templates/ci_config.yaml
@@ -135,9 +135,11 @@ fixture_keys:
     # Independent normal-finetune versus checkpoint-Phase-1 metric. This is
     # reported separately and never gates checkpoint resume correctness.
     - training_reproducibility_loss_threshold
-    # The first threshold gates the exact first loss after restoring state and
-    # batch identity. The existing resume_loss_threshold is only the numerical
-    # envelope for later optimizer steps on the same shared trajectory.
+    # Named profiles provide scale-aware absolute-plus-relative envelopes for
+    # the first forward and later optimizer steps. Prefer
+    # resume_tolerance_profile (strict, standard, or relaxed) over numeric
+    # overrides; the numeric fields remain absolute-only and authoritative.
+    - resume_tolerance_profile
     - resume_first_loss_threshold
     - resume_loss_threshold
     - skip_hf_reload

--- a/tests/functional_tests/checkpoint_robustness/STATUS.md
+++ b/tests/functional_tests/checkpoint_robustness/STATUS.md
@@ -1,6 +1,6 @@
 # Checkpoint Robustness Test Status
 
-Resume policy last updated: 2026-08-04 UTC
+Resume policy last updated: 2026-08-17 UTC
 
 Historical model matrix last measured: 2026-04-02 UTC
 
@@ -10,12 +10,16 @@ Historical model matrix last measured: 2026-04-02 UTC
 
 Enabled LLM, VLM, and retrieval resume coverage now compares a restored trainer
 with the uninterrupted continuation of the same checkpoint-producing training
-trajectory. The check requires exact optimizer/scheduler position, LR and
-weight-decay state, and RNG state. Stateful-dataloader position is verified by
-exact per-rank post-resume batch identity because a loader may normalize its
-equivalent serialized state during restore. The first post-resume loss uses a
-separate strict threshold; the existing `resume_loss_threshold` applies only to
-later BF16 optimizer steps. Independently calibrated historical envelopes are
+trajectory. The check requires exact optimizer/scheduler position, complete
+optimizer parameter-group settings, and RNG state. Stateful-dataloader position
+is verified by exact per-rank post-resume batch identity because a loader may
+normalize its equivalent serialized state during restore. On the first shared
+step, exact rank-local model parameters and optimizer tensors are required
+immediately before the update. Gradients, persistent buffers, and post-update
+state are recorded diagnostically. Loss thresholds use scale-aware absolute
+plus relative envelopes selected by the shared `strict`, `standard`, and
+`relaxed` profiles; the existing numeric fields remain authoritative
+absolute-only overrides. Independently calibrated historical envelopes are
 retained as the non-blocking `training_reproducibility_loss_threshold` metric
 instead of weakening the shared-trajectory resume oracle.
 
@@ -95,7 +99,7 @@ parameters); they require focused fixes before resume coverage is enabled.
 8. **Mistral3 3B** — FP8 scalar params vs FSDP2
 
 ### Infrastructure improvements:
-10. **`--resume_loss_threshold`** flag — DONE (added, default 5e-3)
+10. **Shared resume tolerance profiles and numeric overrides** — DONE
 11. **Memory thresholds** for remaining models (Llama, GPT-OSS, Nano V3 still missing)
 
 ## Commits on branch `adil-a/checkpoint-robustness-test`

--- a/tests/functional_tests/checkpoint_robustness/resume_trajectory.py
+++ b/tests/functional_tests/checkpoint_robustness/resume_trajectory.py
@@ -59,6 +59,91 @@ class _ResumePlan:
         return self.artifact_dir / "resumed_checkpoints"
 
 
+@dataclass(frozen=True)
+class _ResumeLossTolerance:
+    """Resolved loss envelope for one shared-trajectory resume check."""
+
+    profile: str
+    first_step_atol: float
+    first_step_rtol: float
+    later_step_atol: float
+    later_step_rtol: float
+
+
+_RESUME_LOSS_TOLERANCE_PROFILES = {
+    "strict": _ResumeLossTolerance(
+        profile="strict",
+        first_step_atol=1e-6,
+        first_step_rtol=0.0,
+        later_step_atol=1e-6,
+        later_step_rtol=0.0,
+    ),
+    "standard": _ResumeLossTolerance(
+        profile="standard",
+        first_step_atol=1e-5,
+        first_step_rtol=2e-3,
+        later_step_atol=5e-3,
+        later_step_rtol=2e-3,
+    ),
+    "relaxed": _ResumeLossTolerance(
+        profile="relaxed",
+        first_step_atol=1e-4,
+        first_step_rtol=7.5e-3,
+        later_step_atol=1e-2,
+        later_step_rtol=7.5e-3,
+    ),
+}
+
+
+def _resolve_resume_loss_tolerance(
+    profile: str = "standard",
+    *,
+    first_step_override: str | float | None = None,
+    later_step_override: str | float | None = None,
+) -> _ResumeLossTolerance:
+    """Resolve a named resume-loss profile with optional numeric overrides."""
+    normalized_profile = profile.strip().lower()
+    if normalized_profile not in _RESUME_LOSS_TOLERANCE_PROFILES:
+        valid_profiles = ", ".join(sorted(_RESUME_LOSS_TOLERANCE_PROFILES))
+        raise ValueError(f"unknown resume tolerance profile {profile!r}; expected one of: {valid_profiles}")
+
+    selected = _RESUME_LOSS_TOLERANCE_PROFILES[normalized_profile]
+    tolerance = _ResumeLossTolerance(
+        profile=normalized_profile,
+        first_step_atol=selected.first_step_atol if first_step_override is None else float(first_step_override),
+        first_step_rtol=selected.first_step_rtol if first_step_override is None else 0.0,
+        later_step_atol=selected.later_step_atol if later_step_override is None else float(later_step_override),
+        later_step_rtol=selected.later_step_rtol if later_step_override is None else 0.0,
+    )
+    for label, threshold in (
+        ("first-step absolute", tolerance.first_step_atol),
+        ("first-step relative", tolerance.first_step_rtol),
+        ("later-step absolute", tolerance.later_step_atol),
+        ("later-step relative", tolerance.later_step_rtol),
+    ):
+        if not math.isfinite(threshold) or threshold < 0:
+            raise ValueError(f"resume {label} loss threshold must be finite and non-negative, got {threshold}")
+    return tolerance
+
+
+def _loss_tolerance_for_step(
+    tolerance: _ResumeLossTolerance,
+    *,
+    first_step: bool,
+    reference_loss: float,
+    resumed_loss: float,
+) -> tuple[float, float, float]:
+    """Return the absolute term, relative term, and effective loss allowance."""
+    if first_step:
+        absolute = tolerance.first_step_atol
+        relative = tolerance.first_step_rtol
+    else:
+        absolute = tolerance.later_step_atol
+        relative = tolerance.later_step_rtol
+    scale = max(abs(reference_loss), abs(resumed_loss))
+    return absolute, relative, absolute + relative * scale
+
+
 class _TrajectoryRecorder:
     """Record checkpoint state plus the exact post-checkpoint batches and metrics."""
 
@@ -75,6 +160,30 @@ class _TrajectoryRecorder:
             trainer: Recipe whose optimizer-step and checkpoint calls are recorded.
         """
         original_train_step = trainer._run_train_optim_step
+        optimizers = trainer.optimizer if isinstance(trainer.optimizer, (list, tuple)) else [trainer.optimizer]
+        first_comparison_step = min(self.plan.comparison_steps)
+        first_step_pre_update_model_digests: dict[str, str] | None = None
+        first_step_pre_update_optimizer_digests: dict[str, str] | None = None
+        first_step_gradient_digests: dict[str, str] | None = None
+
+        if optimizers:
+            original_optimizer_step = optimizers[0].step
+
+            @wraps(original_optimizer_step)
+            def recorded_optimizer_step(*args, **kwargs):
+                nonlocal first_step_gradient_digests
+                nonlocal first_step_pre_update_model_digests
+                nonlocal first_step_pre_update_optimizer_digests
+                if int(trainer.step_scheduler.step) == first_comparison_step:
+                    first_step_pre_update_model_digests = _model_state_digests(trainer.model_parts)
+                    first_step_pre_update_optimizer_digests = _optimizer_state_digests(
+                        trainer.optimizer,
+                        trainer.model_parts,
+                    )
+                    first_step_gradient_digests = _gradient_state_digests(trainer.model_parts)
+                return original_optimizer_step(*args, **kwargs)
+
+            optimizers[0].step = recorded_optimizer_step
 
         @wraps(original_train_step)
         def recorded_train_step(batches, *args, **kwargs):
@@ -89,11 +198,29 @@ class _TrajectoryRecorder:
                 )
             log_data = original_train_step(batches, *args, **kwargs)
             if batch_digest is not None:
-                self.steps[step] = {
+                step_record = {
                     "batch_digest": batch_digest,
                     "loss": float(log_data.metrics["loss"]),
                     "lr": float(log_data.metrics["lr"]),
                 }
+                if step == first_comparison_step:
+                    if (
+                        first_step_pre_update_model_digests is None
+                        or first_step_pre_update_optimizer_digests is None
+                        or first_step_gradient_digests is None
+                    ):
+                        raise AssertionError("first resume comparison step did not execute an optimizer update")
+                    step_record["diagnostics"] = {
+                        "pre_update_model_digests": first_step_pre_update_model_digests,
+                        "pre_update_optimizer_digests": first_step_pre_update_optimizer_digests,
+                        "gradient_digests": first_step_gradient_digests,
+                        "post_step_model_digests": _model_state_digests(trainer.model_parts),
+                        "post_step_optimizer_digests": _optimizer_state_digests(
+                            trainer.optimizer,
+                            trainer.model_parts,
+                        ),
+                    }
+                self.steps[step] = step_record
             return log_data
 
         trainer._run_train_optim_step = recorded_train_step
@@ -255,7 +382,7 @@ def _state_digest(value: object) -> str:
         if isinstance(item, torch.Tensor):
             tensor = item.detach().contiguous().cpu()
             digest.update(f"tensor:{tensor.dtype}:{tuple(tensor.shape)}:".encode())
-            digest.update(tensor.view(torch.uint8).numpy())
+            digest.update(tensor.reshape(-1).view(torch.uint8).numpy())
             return
         if isinstance(item, dict):
             digest.update(b"dict{")
@@ -521,6 +648,83 @@ def _optimizer_step_summary(optimizers: object) -> list[dict[str, int]]:
     return summaries
 
 
+def _model_parameter_names(model_parts: object) -> dict[int, str]:
+    """Map optimizer parameter identities to stable model-part names."""
+    if not isinstance(model_parts, (list, tuple)):
+        model_parts = [model_parts]
+    names: dict[int, str] = {}
+    for part_index, model in enumerate(model_parts):
+        for name, parameter in model.named_parameters():
+            names.setdefault(id(parameter), f"model_part_{part_index}.parameter.{name}")
+    return names
+
+
+def _model_state_digests(model_parts: object) -> dict[str, str]:
+    """Fingerprint every rank-local parameter and persistent buffer without gathering full tensors."""
+    if not isinstance(model_parts, (list, tuple)):
+        model_parts = [model_parts]
+    digests: dict[str, str] = {}
+    for part_index, model in enumerate(model_parts):
+        prefix = f"model_part_{part_index}"
+        for name, parameter in model.named_parameters():
+            digests[f"{prefix}.parameter.{name}"] = _state_digest(parameter)
+        for module_name, module in model.named_modules():
+            module_prefix = f"{prefix}.buffer"
+            if module_name:
+                module_prefix = f"{module_prefix}.{module_name}"
+            for name, buffer in module._buffers.items():
+                if buffer is None or name in module._non_persistent_buffers_set:
+                    continue
+                digests[f"{module_prefix}.{name}"] = _state_digest(buffer)
+    return dict(sorted(digests.items()))
+
+
+def _gradient_state_digests(model_parts: object) -> dict[str, str]:
+    """Fingerprint every rank-local parameter gradient immediately before the optimizer update."""
+    if not isinstance(model_parts, (list, tuple)):
+        model_parts = [model_parts]
+    digests: dict[str, str] = {}
+    for part_index, model in enumerate(model_parts):
+        for name, parameter in model.named_parameters():
+            key = f"model_part_{part_index}.gradient.{name}"
+            digests[key] = "none" if parameter.grad is None else _state_digest(parameter.grad)
+    return dict(sorted(digests.items()))
+
+
+def _optimizer_state_digests(optimizers: object, model_parts: object) -> dict[str, str]:
+    """Fingerprint every rank-local optimizer state value using stable parameter names."""
+    if not isinstance(optimizers, (list, tuple)):
+        optimizers = [optimizers]
+    parameter_names = _model_parameter_names(model_parts)
+    digests: dict[str, str] = {}
+    for optimizer_index, optimizer in enumerate(optimizers):
+        for group_index, group in enumerate(optimizer.param_groups):
+            for parameter_index, parameter in enumerate(group["params"]):
+                parameter_name = parameter_names.get(
+                    id(parameter),
+                    f"group_{group_index}.parameter_{parameter_index}",
+                )
+                prefix = f"optimizer_{optimizer_index}.{parameter_name}"
+                state = optimizer.state.get(parameter, {})
+                if not state:
+                    digests[f"{prefix}.<empty>"] = _state_digest({})
+                    continue
+                for name, value in sorted(state.items(), key=lambda item: str(item[0])):
+                    digests[f"{prefix}.{name}"] = _state_digest(value)
+    return dict(sorted(digests.items()))
+
+
+def _optimizer_group_digest(optimizers: object) -> str:
+    """Fingerprint complete optimizer parameter-group settings except parameter identities."""
+    if not isinstance(optimizers, (list, tuple)):
+        optimizers = [optimizers]
+    groups = [
+        [{key: value for key, value in group.items() if key != "params"} for group in optimizer.param_groups]
+        for optimizer in optimizers
+    ]
+    return _state_digest(groups)
+
+
 def _optimizer_group_state(optimizers: object) -> list[list[dict[str, float | None]]]:
     """Capture LR and weight-decay values that must resume at the checkpoint boundary."""
     if not isinstance(optimizers, (list, tuple)):
@@ -538,7 +742,7 @@ def _optimizer_group_state(optimizers: object) -> list[list[dict[str, float | No
 
 
 def _checkpoint_state_snapshot(trainer: object, *, state_is_being_saved: bool) -> dict[str, object]:
-    """Capture discrete checkpoint state without materializing model or optimizer tensors."""
+    """Capture discrete optimizer, scheduler, and RNG checkpoint state."""
     step_scheduler = trainer.step_scheduler
     if state_is_being_saved:
         scheduler_state = step_scheduler.state_dict()
@@ -555,9 +759,40 @@ def _checkpoint_state_snapshot(trainer: object, *, state_is_being_saved: bool) -
         "step_scheduler": scheduler_position,
         "optimizer_steps": _optimizer_step_summary(trainer.optimizer),
         "optimizer_groups": _optimizer_group_state(trainer.optimizer),
+        "optimizer_group_digest": _optimizer_group_digest(trainer.optimizer),
         "lr_scheduler_digest": _state_digest(lr_scheduler_state),
         "rng_digest": _state_digest(trainer.rng.state_dict()),
     }
+
+
+def _digest_manifest_mismatch(reference: object, restored: object, *, label: str) -> str | None:
+    """Describe missing, unexpected, and changed entries in a state-digest manifest."""
+    if not isinstance(reference, dict) or not isinstance(restored, dict):
+        return f"{label} must be a digest mapping"
+    missing = sorted(set(reference) - set(restored))
+    unexpected = sorted(set(restored) - set(reference))
+    mismatched = sorted(key for key in set(reference) & set(restored) if reference[key] != restored[key])
+    if not missing and not unexpected and not mismatched:
+        return None
+    return (
+        f"{label} differs: "
+        f"missing={missing[:5]}, unexpected={unexpected[:5]}, mismatched={mismatched[:5]} "
+        f"(counts: {len(missing)}/{len(unexpected)}/{len(mismatched)})"
+    )
+
+
+def _parameter_digest_subset(model_digests: object) -> object:
+    """Return only parameter entries from a combined model parameter/buffer digest manifest."""
+    if not isinstance(model_digests, dict):
+        return model_digests
+    return {key: value for key, value in model_digests.items() if ".parameter." in key}
+
+
+def _buffer_digest_subset(model_digests: object) -> object:
+    """Return only buffer entries from a combined model parameter/buffer digest manifest."""
+    if not isinstance(model_digests, dict):
+        return model_digests
+    return {key: value for key, value in model_digests.items() if ".buffer." in key}
 
 
 def _restored_state_mismatch(reference: dict[str, object], restored: dict[str, object]) -> str | None:
@@ -566,6 +801,7 @@ def _restored_state_mismatch(reference: dict[str, object], restored: dict[str, o
         "step_scheduler": "step scheduler position",
         "optimizer_steps": "optimizer step counters",
         "optimizer_groups": "learning-rate/weight-decay state",
+        "optimizer_group_digest": "complete optimizer parameter-group state",
         "lr_scheduler_digest": "LR scheduler state",
         "rng_digest": "RNG state",
     }
@@ -583,12 +819,9 @@ def _trajectory_mismatch(
     reference: dict[str, object],
     resumed: dict[str, object],
     *,
-    first_loss_threshold: float,
-    later_loss_threshold: float,
+    tolerance: _ResumeLossTolerance,
 ) -> str | None:
     """Compare exact batches/LRs and bounded losses for the resumed continuation."""
-    if first_loss_threshold < 0 or later_loss_threshold < 0:
-        return "resume loss thresholds must be non-negative"
     reference_steps = {int(step): values for step, values in reference["steps"].items()}
     resumed_steps = {int(step): values for step, values in resumed["steps"].items()}
     if set(reference_steps) != set(resumed_steps):
@@ -602,16 +835,225 @@ def _trajectory_mismatch(
             return f"resumed batch identity differs at step {step}; stateful dataloader position was not restored"
         if expected["lr"] != actual["lr"]:
             return f"resumed learning rate differs at step {step}: {expected['lr']} != {actual['lr']}"
-        difference = abs(float(expected["loss"]) - float(actual["loss"]))
-        threshold = first_loss_threshold if step == first_step else later_loss_threshold
-        if not math.isfinite(difference) or difference > threshold:
-            threshold_label = "first-step" if step == first_step else "later-step"
+        if step == first_step:
+            expected_diagnostics = expected.get("diagnostics", {})
+            actual_diagnostics = actual.get("diagnostics", {})
+            for key, label in (
+                ("pre_update_model_digests", "pre-update model parameters"),
+                ("pre_update_optimizer_digests", "pre-update optimizer tensor state"),
+            ):
+                if key not in expected_diagnostics:
+                    return f"uninterrupted trajectory omitted required {label} diagnostics ({key})"
+                if key not in actual_diagnostics:
+                    return f"resumed trajectory omitted required {label} diagnostics ({key})"
+                reference_manifest = expected_diagnostics[key]
+                resumed_manifest = actual_diagnostics[key]
+                if key == "pre_update_model_digests":
+                    reference_manifest = _parameter_digest_subset(reference_manifest)
+                    resumed_manifest = _parameter_digest_subset(resumed_manifest)
+                mismatch = _digest_manifest_mismatch(reference_manifest, resumed_manifest, label=label)
+                if mismatch is not None:
+                    return f"shared-trajectory state mismatch at step {step}: {mismatch}"
+        reference_loss = float(expected["loss"])
+        resumed_loss = float(actual["loss"])
+        difference = abs(reference_loss - resumed_loss)
+        absolute, relative, allowed_difference = _loss_tolerance_for_step(
+            tolerance,
+            first_step=step == first_step,
+            reference_loss=reference_loss,
+            resumed_loss=resumed_loss,
+        )
+        if not math.isfinite(difference) or difference > allowed_difference:
+            scale = max(abs(reference_loss), abs(resumed_loss))
+            relative_difference = 0.0 if scale == 0 and difference == 0 else difference / scale
             return (
                 f"shared-trajectory loss mismatch at step {step}: uninterrupted={expected['loss']:.6f}, "
-                f"resumed={actual['loss']:.6f}, diff={difference:.6e}, "
-                f"{threshold_label}_threshold={threshold:.6e}"
+                f"resumed={actual['loss']:.6f}, abs_diff={difference:.6e}, "
+                f"relative_diff={relative_difference:.6e}, allowed_diff={allowed_difference:.6e}, "
+                f"atol={absolute:.6e}, rtol={relative:.6e}"
             )
     return None
+
+
+def _digest_manifest_comparison(reference: object, resumed: object) -> dict[str, object]:
+    """Return a compact comparison of two state-digest manifests."""
+    if not isinstance(reference, dict) or not isinstance(resumed, dict):
+        return {
+            "matches": False,
+            "reason": "diagnostic digest manifest missing or malformed",
+        }
+    missing = sorted(set(reference) - set(resumed))
+    unexpected = sorted(set(resumed) - set(reference))
+    mismatched = sorted(key for key in set(reference) & set(resumed) if reference[key] != resumed[key])
+    return {
+        "matches": not missing and not unexpected and not mismatched,
+        "reference_count": len(reference),
+        "resumed_count": len(resumed),
+        "missing_count": len(missing),
+        "unexpected_count": len(unexpected),
+        "mismatched_count": len(mismatched),
+        "missing": missing[:20],
+        "unexpected": unexpected[:20],
+        "mismatched": mismatched[:20],
+    }
+
+
+def _resume_comparison_report(
+    reference: dict[str, object],
+    resumed: dict[str, object],
+    tolerance: _ResumeLossTolerance,
+) -> dict[str, object]:
+    """Build a structured loss and first-update diagnostic report for one rank."""
+    reference_steps = {int(step): values for step, values in reference["steps"].items()}
+    resumed_steps = {int(step): values for step, values in resumed["steps"].items()}
+    first_step = min(reference_steps)
+    step_reports = []
+    for step in sorted(set(reference_steps) | set(resumed_steps)):
+        if step not in reference_steps or step not in resumed_steps:
+            step_reports.append(
+                {
+                    "step": step,
+                    "status": "missing",
+                    "present_in_reference": step in reference_steps,
+                    "present_in_resumed": step in resumed_steps,
+                }
+            )
+            continue
+        expected = reference_steps[step]
+        actual = resumed_steps[step]
+        reference_loss = float(expected["loss"])
+        resumed_loss = float(actual["loss"])
+        difference = abs(reference_loss - resumed_loss)
+        scale = max(abs(reference_loss), abs(resumed_loss))
+        relative_difference = 0.0 if scale == 0 and difference == 0 else difference / scale
+        absolute, relative, allowed_difference = _loss_tolerance_for_step(
+            tolerance,
+            first_step=step == first_step,
+            reference_loss=reference_loss,
+            resumed_loss=resumed_loss,
+        )
+        step_reports.append(
+            {
+                "step": step,
+                "stage": "first_forward_before_resumed_update" if step == first_step else "after_resumed_update",
+                "reference_loss": reference_loss,
+                "resumed_loss": resumed_loss,
+                "absolute_difference": difference,
+                "relative_difference": relative_difference,
+                "loss_atol": absolute,
+                "loss_rtol": relative,
+                "allowed_loss_difference": allowed_difference,
+                "within_loss_tolerance": math.isfinite(difference) and difference <= allowed_difference,
+                "batch_matches": expected["batch_digest"] == actual["batch_digest"],
+                "lr_matches": expected["lr"] == actual["lr"],
+            }
+        )
+
+    diagnostic_report: dict[str, object] = {}
+    if first_step in reference_steps and first_step in resumed_steps:
+        reference_diagnostics = reference_steps[first_step].get("diagnostics", {})
+        resumed_diagnostics = resumed_steps[first_step].get("diagnostics", {})
+        reference_model_digests = reference_diagnostics.get("pre_update_model_digests")
+        resumed_model_digests = resumed_diagnostics.get("pre_update_model_digests")
+        diagnostic_report["pre_update_model_parameter_digests"] = _digest_manifest_comparison(
+            _parameter_digest_subset(reference_model_digests),
+            _parameter_digest_subset(resumed_model_digests),
+        )
+        diagnostic_report["pre_update_model_buffer_digests"] = _digest_manifest_comparison(
+            _buffer_digest_subset(reference_model_digests),
+            _buffer_digest_subset(resumed_model_digests),
+        )
+        for key in (
+            "pre_update_optimizer_digests",
+            "gradient_digests",
+            "post_step_model_digests",
+            "post_step_optimizer_digests",
+        ):
+            diagnostic_report[key] = _digest_manifest_comparison(
+                reference_diagnostics.get(key),
+                resumed_diagnostics.get(key),
+            )
+
+    failure = _trajectory_mismatch(
+        reference,
+        resumed,
+        tolerance=tolerance,
+    )
+    return {
+        "status": "passed" if failure is None else "failed",
+        "tolerance": {
+            "profile": tolerance.profile,
+            "first_step_atol": tolerance.first_step_atol,
+            "first_step_rtol": tolerance.first_step_rtol,
+            "later_step_atol": tolerance.later_step_atol,
+            "later_step_rtol": tolerance.later_step_rtol,
+        },
+        "steps": step_reports,
+        "first_step_diagnostics": diagnostic_report,
+        "blocking_failure": failure,
+    }
+
+
+def _report_resume_comparison(
+    plan: _ResumePlan,
+    reference: dict[str, object],
+    resumed: dict[str, object],
+    tolerance: _ResumeLossTolerance,
+) -> dict[str, object]:
+    """Persist exact per-rank resume metrics and print a combined rank-0 summary."""
+    resumed_path = plan.artifact_dir / f"resumed_trajectory_rank_{_rank()}.json"
+    resumed_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = resumed_path.with_suffix(".tmp")
+    temporary_path.write_text(json.dumps(resumed, sort_keys=True))
+    temporary_path.replace(resumed_path)
+
+    local_report = _resume_comparison_report(reference, resumed, tolerance)
+    report_path = plan.artifact_dir / f"resume_comparison_rank_{_rank()}.json"
+    temporary_path = report_path.with_suffix(".tmp")
+    temporary_path.write_text(json.dumps(local_report, indent=2, sort_keys=True))
+    temporary_path.replace(report_path)
+
+    reports = [local_report]
+    if dist.is_initialized():
+        reports = [None] * dist.get_world_size()
+        dist.all_gather_object(reports, local_report)
+    if _rank() != 0:
+        return local_report
+
+    combined_path = plan.artifact_dir / "resume_comparison.json"
+    temporary_path = combined_path.with_suffix(".tmp")
+    temporary_path.write_text(json.dumps({"reports": reports}, indent=2, sort_keys=True))
+    temporary_path.replace(combined_path)
+    print(
+        f"[Resume correctness] tolerance_profile={tolerance.profile} "
+        f"first_step_atol={tolerance.first_step_atol:.6e} first_step_rtol={tolerance.first_step_rtol:.6e} "
+        f"later_step_atol={tolerance.later_step_atol:.6e} later_step_rtol={tolerance.later_step_rtol:.6e}"
+    )
+    for rank, report in enumerate(reports):
+        for step_report in report["steps"]:
+            if step_report.get("status") == "missing":
+                print(f"[Resume correctness] rank={rank} {json.dumps(step_report, sort_keys=True)}")
+                continue
+            print(
+                f"[Resume correctness] rank={rank} step={step_report['step']} stage={step_report['stage']} "
+                f"reference_loss={step_report['reference_loss']:.9f} "
+                f"resumed_loss={step_report['resumed_loss']:.9f} "
+                f"abs_diff={step_report['absolute_difference']:.9e} "
+                f"relative_diff={step_report['relative_difference']:.9e} "
+                f"allowed_diff={step_report['allowed_loss_difference']:.9e}"
+            )
+        for name, diagnostic in report["first_step_diagnostics"].items():
+            print(
+                f"[Resume correctness] rank={rank} diagnostic={name} matches={diagnostic['matches']} "
+                f"mismatched={diagnostic.get('mismatched_count', 0)} "
+                f"missing={diagnostic.get('missing_count', 0)} "
+                f"unexpected={diagnostic.get('unexpected_count', 0)} "
+                f"mismatched_names={json.dumps(diagnostic.get('mismatched', [])[:5])} "
+                f"missing_names={json.dumps(diagnostic.get('missing', [])[:5])} "
+                f"unexpected_names={json.dumps(diagnostic.get('unexpected', [])[:5])}"
+            )
+    print(f"[Resume correctness] detailed comparison report={combined_path}")
+    return local_report
 
 
 def _gather_rank_failures(local_failure: str | None, *, check: str) -> str | None:

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_biencoder.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_biencoder.py
@@ -21,6 +21,8 @@ KL divergence.
 Launch: torchrun --nproc-per-node=<N> -m <this_module> --config <config.yaml>
     [--cosine_threshold <float>] [--hf_cosine_threshold <float>]
     [--check_hf_reload] [--check_resume]
+    [--resume_tolerance_profile <strict|standard|relaxed>]
+    [--resume_first_loss_threshold <float>] [--resume_loss_threshold <float>]
 """
 
 from __future__ import annotations
@@ -45,11 +47,12 @@ from tests.functional_tests.checkpoint_robustness.resume_trajectory import (
     _load_reference_trajectory,
     _persist_reference_trajectory,
     _persist_training_reproducibility,
+    _report_resume_comparison,
     _report_training_reproducibility,
+    _resolve_resume_loss_tolerance,
     _restored_state_mismatch,
     _resume_plan_from_config,
     _TrainingReproducibilityRecorder,
-    _trajectory_mismatch,
     _TrajectoryRecorder,
 )
 from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm import (
@@ -70,6 +73,7 @@ def _extract_custom_args(argv: list[str]) -> tuple[dict[str, str | bool], list[s
         "--training_reproducibility_loss_threshold",
         "--resume_first_loss_threshold",
         "--resume_loss_threshold",
+        "--resume_tolerance_profile",
     }
     boolean_keys = {"--check_hf_reload", "--check_resume"}
     custom: dict[str, str | bool] = {}
@@ -169,8 +173,11 @@ def test_checkpoint_robustness_biencoder():
     check_hf_reload = bool(custom_args.get("check_hf_reload", False))
     check_resume = bool(custom_args.get("check_resume", False))
     training_reproducibility_loss_threshold = float(custom_args.get("training_reproducibility_loss_threshold", "5e-2"))
-    resume_first_loss_threshold = float(custom_args.get("resume_first_loss_threshold", "1e-6"))
-    resume_loss_threshold = float(custom_args.get("resume_loss_threshold", "5e-3"))
+    resume_tolerance = _resolve_resume_loss_tolerance(
+        str(custom_args.get("resume_tolerance_profile", "standard")),
+        first_step_override=custom_args.get("resume_first_loss_threshold"),
+        later_step_override=custom_args.get("resume_loss_threshold"),
+    )
 
     # ------------------------------------------------------------------
     # Phase 1: Train biencoder and checkpoint
@@ -337,19 +344,22 @@ def test_checkpoint_robustness_biencoder():
         resumed_recorder.attach(resume_trainer)
         resume_trainer.run_train_validation_loop()
         resumed_trajectory = resumed_recorder.to_dict()
-        local_failure = _trajectory_mismatch(
+        comparison_report = _report_resume_comparison(
+            resume_plan,
             reference_trajectory,
             resumed_trajectory,
-            first_loss_threshold=resume_first_loss_threshold,
-            later_loss_threshold=resume_loss_threshold,
+            resume_tolerance,
         )
+        local_failure = comparison_report["blocking_failure"]
         failure_message = _gather_rank_failures(local_failure, check="shared_trajectory")
         _raise_distributed_failure(failure_message)
         if _rank0():
             print(
                 f"[Resume correctness] Retrieval shared trajectory verified for "
-                f"{resume_plan.continuation_steps} steps; first-step threshold={resume_first_loss_threshold:.3e}, "
-                f"later-step threshold={resume_loss_threshold:.3e}"
+                f"{resume_plan.continuation_steps} steps; profile={resume_tolerance.profile}, "
+                f"first-step atol/rtol={resume_tolerance.first_step_atol:.3e}/"
+                f"{resume_tolerance.first_step_rtol:.3e}, later-step atol/rtol="
+                f"{resume_tolerance.later_step_atol:.3e}/{resume_tolerance.later_step_rtol:.3e}"
             )
 
         del resume_trainer

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -21,6 +21,8 @@ Launch: torchrun --nproc-per-node=<N> -m <this_module> --config <config.yaml>
     [--tokenizer_name <str>]
     [--source_load_kl_threshold <float>] [--source_load_mean_kl_threshold <float>]
     [--check_source_load_parity] [--check_fused_qkv_keys] [--check_phantom_keys] [--check_resume]
+    [--resume_tolerance_profile <strict|standard|relaxed>]
+    [--resume_first_loss_threshold <float>] [--resume_loss_threshold <float>]
     [--skip_automodel_logit_parity] [--skip_hf_logit_parity] [--hf_adapter_ignored_key_prefix <str>]
     [--hf_source_post_load_dequantize]
     [--max_vram_gb <float>] [--max_cpu_gb <float>]
@@ -69,11 +71,12 @@ from tests.functional_tests.checkpoint_robustness.resume_trajectory import (
     _load_reference_trajectory,
     _persist_reference_trajectory,
     _persist_training_reproducibility,
+    _report_resume_comparison,
     _report_training_reproducibility,
+    _resolve_resume_loss_tolerance,
     _restored_state_mismatch,
     _resume_plan_from_config,
     _TrainingReproducibilityRecorder,
-    _trajectory_mismatch,
     _TrajectoryRecorder,
 )
 
@@ -101,6 +104,7 @@ def _extract_custom_args(argv):
         "--training_reproducibility_loss_threshold",
         "--resume_first_loss_threshold",
         "--resume_loss_threshold",
+        "--resume_tolerance_profile",
         "--source_load_cosine_threshold",
         "--source_load_kl_threshold",
         "--source_load_mean_kl_threshold",
@@ -2161,8 +2165,9 @@ def _run_process_isolated_checkpoint_phase(
     _raise_distributed_failure(failure_message)
     if _rank0():
         print(
-            "[Resume correctness] Model-adjacent checkpoint state matched exactly: optimizer, "
-            "LR/weight-decay schedulers, and RNG; dataloader position is verified by exact resumed batch identity"
+            "[Resume correctness] Optimizer counters/groups, LR scheduler, and RNG matched exactly after load; "
+            "model parameters and optimizer tensors are compared at the first pre-update point, after both "
+            "branches have entered the same FSDP lifecycle"
         )
 
     resume_recorder = _TrajectoryRecorder(resume_plan, capture_boundary_state=False)
@@ -2172,12 +2177,18 @@ def _run_process_isolated_checkpoint_phase(
     _report_phase("Isolated resume: training complete")
 
     resumed_trajectory = resume_recorder.to_dict()
-    local_failure = _trajectory_mismatch(
+    resume_tolerance = _resolve_resume_loss_tolerance(
+        custom_args.get("resume_tolerance_profile", "standard"),
+        first_step_override=custom_args.get("resume_first_loss_threshold"),
+        later_step_override=custom_args.get("resume_loss_threshold"),
+    )
+    comparison_report = _report_resume_comparison(
+        resume_plan,
         reference_trajectory,
         resumed_trajectory,
-        first_loss_threshold=float(custom_args.get("resume_first_loss_threshold", "1e-6")),
-        later_loss_threshold=float(custom_args.get("resume_loss_threshold", "5e-3")),
+        resume_tolerance,
     )
+    local_failure = comparison_report["blocking_failure"]
     failure_message = _gather_rank_failures(local_failure, check="shared_trajectory")
     _raise_distributed_failure(failure_message)
     _report_phase("Isolated resume: shared-trajectory checkpoint continuation verified; exiting phase")
@@ -2226,8 +2237,11 @@ def run_checkpoint_robustness(
     max_cpu_gb = float(custom_args.get("max_cpu_gb", "0"))
     check_phantom_keys = bool(custom_args.get("check_phantom_keys", False))
     check_resume = bool(custom_args.get("check_resume", False))
-    resume_first_loss_threshold = float(custom_args.get("resume_first_loss_threshold", "1e-6"))
-    resume_loss_threshold = float(custom_args.get("resume_loss_threshold", "5e-3"))
+    resume_tolerance = _resolve_resume_loss_tolerance(
+        custom_args.get("resume_tolerance_profile", "standard"),
+        first_step_override=custom_args.get("resume_first_loss_threshold"),
+        later_step_override=custom_args.get("resume_loss_threshold"),
+    )
     training_reproducibility_loss_threshold = float(custom_args.get("training_reproducibility_loss_threshold", "5e-2"))
     hf_device_map_auto = bool(custom_args.get("hf_device_map_auto", False))
     hf_source_post_load_dequantize = bool(custom_args.get("hf_source_post_load_dequantize", False))
@@ -2502,8 +2516,9 @@ def run_checkpoint_robustness(
         _raise_distributed_failure(failure_message)
         if _rank0():
             print(
-                "[Resume correctness] Restored optimizer, LR/weight-decay schedulers, and RNG exactly at the "
-                "Phase 1 boundary; dataloader position is verified by exact resumed batch identity"
+                "[Resume correctness] Restored optimizer counters/groups, LR scheduler, and RNG exactly at the "
+                "Phase 1 boundary; model parameters and optimizer tensors are compared at the first pre-update "
+                "point after both branches have entered the same FSDP lifecycle"
             )
 
         resumed_recorder = _TrajectoryRecorder(resume_plan, capture_boundary_state=False)
@@ -2513,19 +2528,22 @@ def run_checkpoint_robustness(
         _report_phase("Phase 6: resumed training complete")
 
         resumed_trajectory = resumed_recorder.to_dict()
-        local_failure = _trajectory_mismatch(
+        comparison_report = _report_resume_comparison(
+            resume_plan,
             reference_trajectory,
             resumed_trajectory,
-            first_loss_threshold=resume_first_loss_threshold,
-            later_loss_threshold=resume_loss_threshold,
+            resume_tolerance,
         )
+        local_failure = comparison_report["blocking_failure"]
         failure_message = _gather_rank_failures(local_failure, check="shared_trajectory")
         _raise_distributed_failure(failure_message)
         if _rank0():
             print(
                 f"[Resume correctness] Shared-trajectory continuation verified for "
-                f"{resume_plan.continuation_steps} steps; first-step threshold={resume_first_loss_threshold:.3e}, "
-                f"later-step threshold={resume_loss_threshold:.3e}"
+                f"{resume_plan.continuation_steps} steps; profile={resume_tolerance.profile}, "
+                f"first-step atol/rtol={resume_tolerance.first_step_atol:.3e}/"
+                f"{resume_tolerance.first_step_rtol:.3e}, later-step atol/rtol="
+                f"{resume_tolerance.later_step_atol:.3e}/{resume_tolerance.later_step_rtol:.3e}"
             )
 
         _release_recipe_memory(resume_trainer)

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -120,6 +120,7 @@ _OVERRIDES = [
     "deploy_mode",
     "max_new_tokens",
     "hf_adapter_ignored_key_prefix",
+    "resume_tolerance_profile",
 ]
 
 _BOOLEAN_OVERRIDES = [

--- a/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
+++ b/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
@@ -617,6 +617,16 @@ def test_extract_custom_args_accepts_isolated_phase():
     assert remaining == ["--other-arg"]
 
 
+def test_extract_custom_args_accepts_resume_tolerance_profile_and_numeric_override():
+    custom, remaining = _extract_custom_args(
+        ["--resume_tolerance_profile", "relaxed", "--resume_loss_threshold", "0.02", "--other-arg"]
+    )
+
+    assert custom["resume_tolerance_profile"] == "relaxed"
+    assert custom["resume_loss_threshold"] == "0.02"
+    assert remaining == ["--other-arg"]
+
+
 def test_extract_custom_args_accepts_skip_hf_logit_parity():
     custom, remaining = _extract_custom_args(["--skip_hf_logit_parity", "--other-arg"])
 
@@ -1184,6 +1194,7 @@ def test_biencoder_robustness_reads_hf_reload_settings_from_config(tmp_path):
         "    check_resume: true\n"
         "    cosine_threshold: 0.998\n"
         "    hf_cosine_threshold: 0.997\n"
+        "    resume_tolerance_profile: relaxed\n"
         "    dataloader.num_workers: 0\n"
     )
 
@@ -1194,6 +1205,7 @@ def test_biencoder_robustness_reads_hf_reload_settings_from_config(tmp_path):
         "check_resume": True,
         "cosine_threshold": "0.998",
         "hf_cosine_threshold": "0.997",
+        "resume_tolerance_profile": "relaxed",
     }
     assert remaining == ["--config", str(config_path)]
 

--- a/tests/unit_tests/ci_tests/test_config_resolver.py
+++ b/tests/unit_tests/ci_tests/test_config_resolver.py
@@ -345,6 +345,7 @@ def test_end_to_end_fixture_keys_not_applied_as_overrides(tmp_path):
         "    hf_adapter_ignored_key_prefix: base_model.model.mtp.  # fixture arg, must NOT become top-level\n"
         "    hf_kl_threshold: 5e-3                       # fixture arg, must NOT become top-level\n"
         "    training_reproducibility_loss_threshold: 1e-2  # fixture arg, must NOT become top-level\n"
+        "    resume_tolerance_profile: relaxed             # fixture arg, must NOT become top-level\n"
         "    resume_first_loss_threshold: 1e-6           # fixture arg, must NOT become top-level\n"
         "    source_load_kl_threshold: 1e-2              # fixture arg, must NOT become top-level\n"
         "    source_load_mean_kl_threshold: 1e-3         # fixture arg, must NOT become top-level\n"
@@ -367,6 +368,7 @@ def test_end_to_end_fixture_keys_not_applied_as_overrides(tmp_path):
     assert "skip_hf_logit_parity" not in resolved
     assert "hf_adapter_ignored_key_prefix" not in resolved
     assert "training_reproducibility_loss_threshold" not in resolved
+    assert "resume_tolerance_profile" not in resolved
     assert "resume_first_loss_threshold" not in resolved
     assert "source_load_kl_threshold" not in resolved
     assert "source_load_mean_kl_threshold" not in resolved
@@ -378,6 +380,7 @@ def test_end_to_end_fixture_keys_not_applied_as_overrides(tmp_path):
     assert resolved["ci"]["checkpoint_robustness"]["skip_hf_logit_parity"] is True
     assert resolved["ci"]["checkpoint_robustness"]["hf_adapter_ignored_key_prefix"] == "base_model.model.mtp."
     assert resolved["ci"]["checkpoint_robustness"]["training_reproducibility_loss_threshold"] == 1e-2
+    assert resolved["ci"]["checkpoint_robustness"]["resume_tolerance_profile"] == "relaxed"
     assert resolved["ci"]["checkpoint_robustness"]["resume_first_loss_threshold"] == 1e-6
     assert resolved["ci"]["checkpoint_robustness"]["source_load_kl_threshold"] == 1e-2
     assert resolved["ci"]["checkpoint_robustness"]["source_load_mean_kl_threshold"] == 1e-3

--- a/tests/unit_tests/ci_tests/test_resume_trajectory.py
+++ b/tests/unit_tests/ci_tests/test_resume_trajectory.py
@@ -16,6 +16,7 @@ import json
 from copy import deepcopy
 from types import SimpleNamespace
 
+import pytest
 import torch
 from torch.utils.data import TensorDataset
 from torchdata.stateful_dataloader import StatefulDataLoader
@@ -28,7 +29,9 @@ from tests.functional_tests.checkpoint_robustness.resume_trajectory import (
     _compare_training_reproducibility,
     _configure_resumed_run,
     _configure_uninterrupted_run,
+    _report_resume_comparison,
     _report_training_reproducibility,
+    _resolve_resume_loss_tolerance,
     _restored_state_mismatch,
     _resume_plan_from_config,
     _ResumePlan,
@@ -57,7 +60,15 @@ def _trajectory(*, first_loss: float, second_loss: float, first_batch: str = "ba
         "continuation_steps": 2,
         "boundary_state": {},
         "steps": {
-            "5": {"batch_digest": first_batch, "loss": first_loss, "lr": 1e-4},
+            "5": {
+                "batch_digest": first_batch,
+                "loss": first_loss,
+                "lr": 1e-4,
+                "diagnostics": {
+                    "pre_update_model_digests": {"model_part_0.parameter.weight": "model"},
+                    "pre_update_optimizer_digests": {"optimizer_0.model_part_0.parameter.weight.step": "optimizer"},
+                },
+            },
             "6": {"batch_digest": "batch-6", "loss": second_loss, "lr": 5e-5},
         },
     }
@@ -105,6 +116,7 @@ def test_resume_state_check_detects_omitted_rng_state():
         "step_scheduler": {"step": 5, "epoch": 0},
         "optimizer_steps": [{"5.0": 2}],
         "optimizer_groups": [[{"lr": 1e-4, "weight_decay": 0.01}]],
+        "optimizer_group_digest": "optimizer-groups",
         "lr_scheduler_digest": "lr",
         "rng_digest": "rng",
     }
@@ -113,6 +125,51 @@ def test_resume_state_check_detects_omitted_rng_state():
     mismatch = _restored_state_mismatch(reference, restored)
 
     assert mismatch == "restored snapshot omitted required RNG state (rng_digest)"
+
+
+@pytest.mark.parametrize(
+    ("profile", "expected"),
+    [
+        ("strict", (1e-6, 0.0, 1e-6, 0.0)),
+        ("standard", (1e-5, 2e-3, 5e-3, 2e-3)),
+        ("relaxed", (1e-4, 7.5e-3, 1e-2, 7.5e-3)),
+    ],
+)
+def test_resume_loss_tolerance_profiles(profile, expected):
+    tolerance = _resolve_resume_loss_tolerance(profile)
+
+    assert tolerance.profile == profile
+    assert (
+        tolerance.first_step_atol,
+        tolerance.first_step_rtol,
+        tolerance.later_step_atol,
+        tolerance.later_step_rtol,
+    ) == expected
+
+
+def test_resume_loss_tolerance_numeric_overrides_take_precedence():
+    tolerance = _resolve_resume_loss_tolerance(
+        "relaxed",
+        first_step_override="2e-4",
+        later_step_override=3e-2,
+    )
+
+    assert tolerance.profile == "relaxed"
+    assert tolerance.first_step_atol == 2e-4
+    assert tolerance.first_step_rtol == 0.0
+    assert tolerance.later_step_atol == 3e-2
+    assert tolerance.later_step_rtol == 0.0
+
+
+def test_resume_loss_tolerance_rejects_unknown_profile():
+    with pytest.raises(ValueError, match="unknown resume tolerance profile 'model_specific'"):
+        _resolve_resume_loss_tolerance("model_specific")
+
+
+@pytest.mark.parametrize("override", [-1e-4, float("nan"), float("inf")])
+def test_resume_loss_tolerance_rejects_invalid_numeric_override(override):
+    with pytest.raises(ValueError, match="must be finite and non-negative"):
+        _resolve_resume_loss_tolerance("standard", first_step_override=override)
 
 
 def test_stateful_sampler_restore_uses_next_batch_instead_of_raw_state_digest():
@@ -159,11 +216,15 @@ def test_shared_trajectory_harness_runs_checkpoint_and_resume_locally(tmp_path):
             shuffle=True,
         )
         dataloader = StatefulDataLoader(dataset, batch_size=2, sampler=sampler, num_workers=0)
-        parameter = torch.nn.Parameter(torch.tensor(1.0))
+        model = torch.nn.Linear(1, 1, bias=False)
+        parameter = model.weight
+        with torch.no_grad():
+            parameter.fill_(1.0)
         optimizer = torch.optim.Adam([parameter], lr=1e-3)
         lr_scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lambda _: 1.0)
         trainer = SimpleNamespace(
             dataloader=dataloader,
+            model_parts=[model],
             parameter=parameter,
             optimizer=optimizer,
             lr_scheduler=lr_scheduler,
@@ -252,15 +313,56 @@ def test_shared_trajectory_harness_runs_checkpoint_and_resume_locally(tmp_path):
     resumed_recorder = _TrajectoryRecorder(plan, capture_boundary_state=False)
     resumed_recorder.attach(resumed)
     run(resumed)
+    resumed_trajectory = resumed_recorder.to_dict()
+    exact_tolerance = _resolve_resume_loss_tolerance(
+        "strict",
+        first_step_override=0.0,
+        later_step_override=0.0,
+    )
     assert (
         _trajectory_mismatch(
             reference,
-            resumed_recorder.to_dict(),
-            first_loss_threshold=0.0,
-            later_loss_threshold=0.0,
+            resumed_trajectory,
+            tolerance=exact_tolerance,
         )
         is None
     )
+    comparison = _report_resume_comparison(
+        plan,
+        reference,
+        resumed_trajectory,
+        exact_tolerance,
+    )
+    assert comparison["status"] == "passed"
+    assert comparison["steps"][0]["absolute_difference"] == 0.0
+    assert all(diagnostic["matches"] for diagnostic in comparison["first_step_diagnostics"].values())
+    assert (plan.artifact_dir / "resumed_trajectory_rank_0.json").exists()
+    assert (plan.artifact_dir / "resume_comparison.json").exists()
+
+    changed_trajectory = deepcopy(resumed_trajectory)
+    first_step = str(plan.comparison_steps[0])
+    model_digests = changed_trajectory["steps"][first_step]["diagnostics"]["pre_update_model_digests"]
+    changed_model_key = next(key for key in model_digests if ".parameter." in key)
+    model_digests[changed_model_key] = "changed"
+    mismatch = _trajectory_mismatch(
+        reference,
+        changed_trajectory,
+        tolerance=exact_tolerance,
+    )
+    assert "pre-update model parameters" in mismatch
+    assert changed_model_key in mismatch
+
+    changed_trajectory = deepcopy(resumed_trajectory)
+    optimizer_digests = changed_trajectory["steps"][first_step]["diagnostics"]["pre_update_optimizer_digests"]
+    changed_optimizer_key = next(iter(optimizer_digests))
+    optimizer_digests[changed_optimizer_key] = "changed"
+    mismatch = _trajectory_mismatch(
+        reference,
+        changed_trajectory,
+        tolerance=exact_tolerance,
+    )
+    assert "pre-update optimizer tensor state" in mismatch
+    assert changed_optimizer_key in mismatch
 
 
 def test_shared_trajectory_detects_shifted_dataloader_position():
@@ -270,8 +372,7 @@ def test_shared_trajectory_detects_shifted_dataloader_position():
     mismatch = _trajectory_mismatch(
         reference,
         resumed,
-        first_loss_threshold=1e-6,
-        later_loss_threshold=5e-3,
+        tolerance=_resolve_resume_loss_tolerance("standard"),
     )
 
     assert mismatch == "resumed batch identity differs at step 5; stateful dataloader position was not restored"
@@ -280,13 +381,17 @@ def test_shared_trajectory_detects_shifted_dataloader_position():
 def test_shared_trajectory_uses_stricter_first_loss_threshold():
     reference = _trajectory(first_loss=1.0, second_loss=0.9)
     resumed = _trajectory(first_loss=1.0 + 5e-7, second_loss=0.904)
+    tolerance = _resolve_resume_loss_tolerance(
+        "standard",
+        first_step_override=1e-6,
+        later_step_override=5e-3,
+    )
 
     assert (
         _trajectory_mismatch(
             reference,
             resumed,
-            first_loss_threshold=1e-6,
-            later_loss_threshold=5e-3,
+            tolerance=tolerance,
         )
         is None
     )
@@ -295,10 +400,41 @@ def test_shared_trajectory_uses_stricter_first_loss_threshold():
     mismatch = _trajectory_mismatch(
         reference,
         resumed,
-        first_loss_threshold=1e-6,
-        later_loss_threshold=5e-3,
+        tolerance=tolerance,
     )
-    assert "first-step_threshold=1.000000e-06" in mismatch
+    assert "allowed_diff=1.000000e-06" in mismatch
+    assert "rtol=0.000000e+00" in mismatch
+
+
+def test_scale_aware_profiles_classify_observed_49b_loss_drift():
+    full_model_reference = _trajectory(first_loss=0.165309, second_loss=0.9)
+    full_model_resumed = _trajectory(first_loss=0.165890, second_loss=0.9)
+
+    standard_mismatch = _trajectory_mismatch(
+        full_model_reference,
+        full_model_resumed,
+        tolerance=_resolve_resume_loss_tolerance("standard"),
+    )
+    assert "shared-trajectory loss mismatch at step 5" in standard_mismatch
+    assert (
+        _trajectory_mismatch(
+            full_model_reference,
+            full_model_resumed,
+            tolerance=_resolve_resume_loss_tolerance("relaxed"),
+        )
+        is None
+    )
+
+    peft_reference = _trajectory(first_loss=1.0, second_loss=3.608548)
+    peft_resumed = _trajectory(first_loss=1.0, second_loss=3.603262)
+    assert (
+        _trajectory_mismatch(
+            peft_reference,
+            peft_resumed,
+            tolerance=_resolve_resume_loss_tolerance("standard"),
+        )
+        is None
+    )
 
 
 def test_training_reproducibility_requires_matching_configuration_fingerprint():


### PR DESCRIPTION
# What does this PR do ?

Improve checkpoint-resume correctness coverage by separating exact restored-state checks from expected numerical trajectory drift and by replacing per-model loss thresholds with named, scale-aware tolerance profiles.

# Changelog

- Add `strict`, `standard`, and `relaxed` resume tolerance profiles using `atol + rtol * loss_scale` (note akoumpa@: scenario is non-deterministic model, e.g., due fa's bwd etc).
- Preserve numeric first-step and later-step thresholds as explicit absolute-only overrides for exceptional models.
- Require exact batch and learning-rate continuity across the checkpoint boundary.
- Require exact optimizer groups, scheduler state, RNG state, model parameters, and optimizer tensor state before the first resumed update.
- Report gradient, post-update model, and post-update optimizer divergence as diagnostics.
- Persist a detailed per-rank JSON comparison report on both success and failure.
- Reuse the shared trajectory checks for LLM, VLM, and biencoder checkpoint tests.
- Document the profiles and configure the 49B TP8/PP2 recipe to use the relaxed profile.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Validation

- Main-based focused unit suite: 131 passed.
- Main-based Ruff formatting and lint checks passed.
- A 16-GPU 49B TP8/PP2 checkpoint-resume run confirmed that all 16 rank reports passed, the first resumed forward loss was identical, and pre-update model parameters and optimizer tensor state matched exactly. Numerical divergence appeared only during backward/update and stayed inside the configured envelope.
- Main-based scoped CI passed both 49B TP8/PP2 configurations associated with the original alerts on validated revision `facb71ee2`:
  - [`llama3_3_nemotron_super_49B_squad`](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/400655555)
  - [`llama3_3_nemotron_super_49B_squad_peft`](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/400655571)
  - [Parent pipeline 63139079](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/63139079)
- After scoped CI, the unchanged PR patch was rebased onto one newer, unrelated `main` commit to refresh the stale DCO commit range.

# Additional Information

This addresses the recurring resume-loss alerts tracked in AMINT-269, AMINT-270, and AMINT-278. A follow-up change will address long-sequence mean/p95 KL parity and phase-level configuration from AMINT-260.
