### PR TITLE
fix(perf): honor configured peak in MFU logging

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "YAML Configuration"
-description: ""
+description: "Configure NeMo AutoModel recipes with YAML, including target instantiation, distributed settings, prewarm options, and environment variable interpolation."
 position: 4
 ---
 NeMo AutoModel recipes use YAML configs. The YAML parser creates a `ConfigNode` that performs the following actions:
@@ -113,7 +113,9 @@ mfu:
 `peak_tflops` takes precedence over `device`. A device name alone selects an
 entry from AutoMFU's table; omitting both fields uses the current CUDA device.
 Hardware detection cannot determine the effective training precision, so FP8
-and structured-sparse runs must provide the appropriate peak explicitly.
+and structured-sparse runs must provide the appropriate peak explicitly. An
+unknown device emits a warning and reports 0% MFU until you configure a
+supported `device` value or an explicit `peak_tflops` value.
 
 ## Repair Near-Zero Input Embeddings
 
@@ -144,9 +146,9 @@ distributed:
 
 The supported policies are:
 
-- `root` (default): the always-run outer FSDP root owns frozen multimodal parameters. This keeps collective ordering aligned when some ranks execute a modality branch and others skip it.
-- `per_layer`: layers inside the frozen multimodal module get their normal FSDP units. This can reduce peak unshard memory, but it is an expert option: every rank in the FSDP group must execute or skip those units the same number of times and in the same order on every microbatch.
-- `replicate`: frozen multimodal parameters are excluded from FSDP and copied on every rank. This removes their collectives at the cost of higher per-rank parameter memory.
+- `root` (default): The always-run outer FSDP root owns frozen multimodal parameters. This keeps collective ordering aligned when some ranks execute a modality branch and others skip it.
+- `per_layer`: Layers inside the frozen multimodal module get their normal FSDP units. This can reduce peak unshard memory, but it is an expert option: every rank in the FSDP group must execute or skip those units the same number of times and in the same order on every microbatch.
+- `replicate`: Frozen multimodal parameters are excluded from FSDP and copied on every rank. This removes their collectives at the cost of higher per-rank parameter memory.
 
 This setting does not change modules that contain any trainable parameters. For nested MoE or VLM models, `root` requires `distributed.moe.wrap_outer_model: true` when a fully frozen multimodal module is outside the inner text-model FSDP root. Use `per_layer` or `replicate` if the outer model must remain unwrapped.
 

--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -95,6 +95,26 @@ Triton reuses an autotuned configuration according to each kernel's explicit cac
 
 {/* docs-review-end: mamba-ssd-prewarm */}
 
+## Configure the MFU Reference Peak
+
+Recipes that report model FLOP utilization automatically detect the current
+device and use its dense-BF16 peak from AutoMFU's device table. Ordinary BF16
+training does not need an `mfu:` section.
+
+Use an explicit override when the hardware is not in the table or when the
+training precision has a different theoretical peak, such as dense FP8:
+
+```yaml
+mfu:
+  device: h100
+  peak_tflops: 1979.0
+```
+
+`peak_tflops` takes precedence over `device`. A device name alone selects an
+entry from AutoMFU's table; omitting both fields uses the current CUDA device.
+Hardware detection cannot determine the effective training precision, so FP8
+and structured-sparse runs must provide the appropriate peak explicitly.
+
 ## Repair Near-Zero Input Embeddings
 
 The LLM training and fine-tuning recipe can repair a small number of damaged input-embedding rows after loading the base checkpoint and before creating the optimizer.

--- a/nemo_automodel/_transformers/mfu.py
+++ b/nemo_automodel/_transformers/mfu.py
@@ -18,9 +18,13 @@ Similar interface to HuggingFace AutoModel, this module provides automatic
 MFU calculation for various model architectures.
 """
 
+from __future__ import annotations
+
 import logging
+import math
+from dataclasses import dataclass
 from os import PathLike
-from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any
 
 import torch
 
@@ -35,7 +39,7 @@ from nemo_automodel.components.utils.flops_utils import (
 logger = logging.getLogger(__name__)
 
 # Device theoretical FLOPS (FLOPs/s) adapted from https://github.com/verl-project/verl/blob/main/verl/utils/flops_counter.py#L22-L85
-_DEVICE_FLOPS: Dict[str, float] = {
+_DEVICE_FLOPS: dict[str, float] = {
     "CPU": 448e9,
     "GB200": 2.5e15,
     "B200": 2.25e15,
@@ -74,7 +78,7 @@ _CONFIG_ALIAS_ATTRS = (
 )
 
 
-def get_device_flops(unit: str = "T", device_name: Optional[str] = None) -> float:
+def get_device_flops(unit: str = "T", device_name: str | None = None) -> float:
     """Get theoretical device FLOPS in a requested unit.
 
     Args:
@@ -116,10 +120,10 @@ class AutoMFU:
 
     def __init__(
         self,
-        config: "PretrainedConfig",
-        device: Optional[str] = None,
-        peak_tflops: Optional[float] = None,
-    ):
+        config: PretrainedConfig,
+        device: str | None = None,
+        peak_tflops: float | None = None,
+    ) -> None:
         """Initialize AutoMFU with a model config.
 
         Args:
@@ -130,8 +134,17 @@ class AutoMFU:
         self.config = config
         self.flops_formula = get_flops_formula_for_hf_config(config)
         self.reference_mfu = (
-            float(peak_tflops) if peak_tflops is not None else get_device_flops(unit="T", device_name=device)
+            _validate_peak_tflops(peak_tflops)
+            if peak_tflops is not None
+            else get_device_flops(unit="T", device_name=device)
         )
+        if not math.isfinite(self.reference_mfu):
+            device_description = repr(device) if device is not None else "the current device"
+            logger.warning(
+                "Unable to determine the theoretical peak for %s; MFU will be reported as 0%%. "
+                "Pass a supported device or peak_tflops directly, or set mfu.device or mfu.peak_tflops in recipe YAML.",
+                device_description,
+            )
 
     @classmethod
     def register_device(cls, device: str, peak_tflops: float) -> None:
@@ -141,11 +154,11 @@ class AutoMFU:
     @classmethod
     def from_config(
         cls,
-        config_or_path_or_model: Union["PretrainedConfig", str, PathLike[str], object],
-        device: Optional[str] = None,
-        peak_tflops: Optional[float] = None,
-        **kwargs,
-    ) -> "AutoMFU":
+        config_or_path_or_model: PretrainedConfig | str | PathLike[str] | object,
+        device: str | None = None,
+        peak_tflops: float | None = None,
+        **kwargs: Any,
+    ) -> AutoMFU:
         """Create AutoMFU from a config object, model object, or model path/ID.
 
         Args:
@@ -172,11 +185,11 @@ class AutoMFU:
     @classmethod
     def from_pretrained(
         cls,
-        model_id_or_local_path_or_model: Union[str, PathLike[str], object],
-        device: Optional[str] = None,
-        peak_tflops: Optional[float] = None,
-        **kwargs,
-    ) -> "AutoMFU":
+        model_id_or_local_path_or_model: str | PathLike[str] | object,
+        device: str | None = None,
+        peak_tflops: float | None = None,
+        **kwargs: Any,
+    ) -> AutoMFU:
         """Create AutoMFU from model ID, local path, or a model object.
 
         Args:
@@ -198,10 +211,10 @@ class AutoMFU:
 
     def __call__(
         self,
-        input_ids_or_tensor: Union[torch.Tensor, Tuple[int, int]],
+        input_ids_or_tensor: torch.Tensor | tuple[int, int],
         time_delta: float,
         world_size: int,
-    ) -> Optional[float]:
+    ) -> float | None:
         """Calculate MFU percentage.
 
         Args:
@@ -221,8 +234,8 @@ class AutoMFU:
 
     def get_flops(
         self,
-        input_ids_or_tensor: Union[torch.Tensor, Tuple[int, int]],
-    ) -> Optional[float]:
+        input_ids_or_tensor: torch.Tensor | tuple[int, int],
+    ) -> float | None:
         """Calculate FLOPs for given input shape.
 
         Args:
@@ -235,14 +248,14 @@ class AutoMFU:
         if self.flops_formula is None:
             return None
 
-        if hasattr(input_ids_or_tensor, "shape"):
+        if isinstance(input_ids_or_tensor, torch.Tensor):
             batch_size, seq_len = input_ids_or_tensor.shape[:2]
         else:
             batch_size, seq_len = input_ids_or_tensor
 
         try:
             # Explicitly gate transformer fallback on required attributes.
-            if self.flops_formula.__name__ == "transformer_flops":
+            if getattr(self.flops_formula, "__name__", None) == "transformer_flops":
                 required = (
                     "hidden_size",
                     "num_hidden_layers",
@@ -292,3 +305,39 @@ class AutoMFU:
                     # Some config objects may block dynamic attrs; fallback
                     # behavior will return None if attrs remain unavailable.
                     pass
+
+
+@dataclass(frozen=True)
+class MFUConfig:
+    """Typed settings for constructing an :class:`AutoMFU` calculator.
+
+    Attributes:
+        device: Optional device name used to look up the theoretical peak.
+        peak_tflops: Optional theoretical peak TFLOPs/s for the training precision.
+            When set, this takes precedence over ``device``.
+    """
+
+    device: str | None = None
+    peak_tflops: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.peak_tflops is not None:
+            _validate_peak_tflops(self.peak_tflops)
+
+    def build(self, *, model: torch.nn.Module) -> AutoMFU:
+        """Build the calculator for an initialized model.
+
+        Args:
+            model: Model whose Hugging Face configuration supplies the FLOPs formula.
+
+        Returns:
+            The configured MFU calculator.
+        """
+        return AutoMFU.from_config(model, device=self.device, peak_tflops=self.peak_tflops)
+
+
+def _validate_peak_tflops(peak_tflops: float) -> float:
+    peak = float(peak_tflops)
+    if not math.isfinite(peak) or peak <= 0:
+        raise ValueError("peak_tflops must be a finite value greater than zero")
+    return peak

--- a/nemo_automodel/_transformers/mfu.py
+++ b/nemo_automodel/_transformers/mfu.py
@@ -114,16 +114,24 @@ class AutoMFU:
     Model FLOPs Utilization (MFU) during training.
     """
 
-    def __init__(self, config: "PretrainedConfig", device: str = "h100"):
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        device: Optional[str] = None,
+        peak_tflops: Optional[float] = None,
+    ):
         """Initialize AutoMFU with a model config.
 
         Args:
             config: HuggingFace PretrainedConfig object
-            device: Device name (e.g. ``"h100"``)
+            device: Optional device name override. By default, infer the current device.
+            peak_tflops: Optional peak TFLOPs/s override for the training precision.
         """
         self.config = config
         self.flops_formula = get_flops_formula_for_hf_config(config)
-        self.reference_mfu = get_device_flops(unit="T", device_name=device)
+        self.reference_mfu = (
+            float(peak_tflops) if peak_tflops is not None else get_device_flops(unit="T", device_name=device)
+        )
 
     @classmethod
     def register_device(cls, device: str, peak_tflops: float) -> None:
@@ -134,7 +142,8 @@ class AutoMFU:
     def from_config(
         cls,
         config_or_path_or_model: Union["PretrainedConfig", str, PathLike[str], object],
-        device: str = "h100",
+        device: Optional[str] = None,
+        peak_tflops: Optional[float] = None,
         **kwargs,
     ) -> "AutoMFU":
         """Create AutoMFU from a config object, model object, or model path/ID.
@@ -142,7 +151,8 @@ class AutoMFU:
         Args:
             config_or_path_or_model: Either a PretrainedConfig object, a model object
                 (the .config attribute will be extracted), or a model ID/local path.
-            device: Device name (e.g. ``"h100"``)
+            device: Optional device name override. By default, infer the current device.
+            peak_tflops: Optional peak TFLOPs/s override for the training precision.
             **kwargs: Additional arguments passed to AutoConfig.from_pretrained
                 when loading from model ID/path.
 
@@ -157,13 +167,14 @@ class AutoMFU:
         else:
             config = cls._unwrap_config(config)
             cls._ensure_common_config_aliases(config)
-        return cls(config, device=device)
+        return cls(config, device=device, peak_tflops=peak_tflops)
 
     @classmethod
     def from_pretrained(
         cls,
         model_id_or_local_path_or_model: Union[str, PathLike[str], object],
-        device: str = "h100",
+        device: Optional[str] = None,
+        peak_tflops: Optional[float] = None,
         **kwargs,
     ) -> "AutoMFU":
         """Create AutoMFU from model ID, local path, or a model object.
@@ -171,13 +182,19 @@ class AutoMFU:
         Args:
             model_id_or_local_path_or_model: Model ID (e.g., "meta-llama/llama-3-70b"),
                 local path, or model object (the .config attribute will be extracted)
-            device: Device name (e.g. ``"h100"``)
+            device: Optional device name override. By default, infer the current device.
+            peak_tflops: Optional peak TFLOPs/s override for the training precision.
             **kwargs: Additional arguments passed to AutoConfig.from_pretrained
 
         Returns:
             AutoMFU instance
         """
-        return cls.from_config(model_id_or_local_path_or_model, device=device, **kwargs)
+        return cls.from_config(
+            model_id_or_local_path_or_model,
+            device=device,
+            peak_tflops=peak_tflops,
+            **kwargs,
+        )
 
     def __call__(
         self,

--- a/nemo_automodel/components/utils/flops_utils.py
+++ b/nemo_automodel/components/utils/flops_utils.py
@@ -15,14 +15,14 @@
 from typing import Any, Callable, Optional
 
 
-def calculate_mfu(tflops, world_size, time_seconds, reference_mfu=1979.0):
+def calculate_mfu(tflops, world_size, time_seconds, reference_mfu):
     """Calculate Model FLOPs Utilization (MFU).
 
     Args:
         tflops: TFLOPs per GPU
         world_size: Total number of GPUs
         time_seconds: Time taken for computation
-        reference_mfu: Peak TFLOPs of the hardware (default: dense FP8 or sparse BF16 on H100 SXM)
+        reference_mfu: Peak TFLOPs/s per device for the training precision
 
     Returns:
         MFU as a percentage

--- a/nemo_automodel/components/utils/flops_utils.py
+++ b/nemo_automodel/components/utils/flops_utils.py
@@ -12,21 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from typing import Any, Callable, Optional
 
 
-def calculate_mfu(tflops, world_size, time_seconds, reference_mfu):
+def calculate_mfu(
+    tflops: float,
+    world_size: int,
+    time_seconds: float,
+    reference_mfu: float | None = None,
+) -> float:
     """Calculate Model FLOPs Utilization (MFU).
 
     Args:
-        tflops: TFLOPs per GPU
-        world_size: Total number of GPUs
-        time_seconds: Time taken for computation
-        reference_mfu: Peak TFLOPs/s per device for the training precision
+        tflops: Total TFLOPs across all devices for the measured step.
+        world_size: Total number of GPUs.
+        time_seconds: Time taken for computation.
+        reference_mfu: Peak TFLOPs/s per device for the training precision. The
+            legacy default is the H100 dense-FP8 peak.
 
     Returns:
-        MFU as a percentage
+        MFU as a percentage.
     """
+    if reference_mfu is None:
+        warnings.warn(
+            "Omitting reference_mfu is deprecated; pass the peak TFLOPs/s for the training precision.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        reference_mfu = 1979.0
     mfu = tflops / (world_size * time_seconds)
     mfu = mfu / reference_mfu
     return mfu * 100

--- a/nemo_automodel/components/utils/flops_utils.py
+++ b/nemo_automodel/components/utils/flops_utils.py
@@ -22,7 +22,7 @@ def calculate_mfu(tflops, world_size, time_seconds, reference_mfu=1979.0):
         tflops: TFLOPs per GPU
         world_size: Total number of GPUs
         time_seconds: Time taken for computation
-        reference_mfu: Peak TFLOPs of the hardware (default: H100)
+        reference_mfu: Peak TFLOPs of the hardware (default: dense FP8 or sparse BF16 on H100 SXM)
 
     Returns:
         MFU as a percentage

--- a/nemo_automodel/recipes/_typed_config.py
+++ b/nemo_automodel/recipes/_typed_config.py
@@ -21,7 +21,7 @@ recipe body only ever sees typed component configs and calls
 
 Known sections are exposed as cached, typed attributes that own a ``build()`` or
 ``apply()``: ``wandb``/``mlflow``/``step_scheduler``/``lr_scheduler``/``prewarm``/
-``embedding_row_repair`` map to component config dataclasses; the ``optimizer``
+``embedding_row_repair``/``mfu`` map to component config dataclasses; the ``optimizer``
 and ``loss_fn`` blocks resolve to a component
 :class:`~nemo_automodel.components.optim.optimizer.OptimizerConfig` /
 :class:`~nemo_automodel.components.loss.loss.LossConfig` via
@@ -51,6 +51,7 @@ from nemo_automodel.components.optim.optimizer import LRSchedulerConfig
 from nemo_automodel.components.training.step_scheduler import StepSchedulerConfig
 
 if TYPE_CHECKING:
+    from nemo_automodel._transformers.mfu import MFUConfig
     from nemo_automodel.components.checkpoint.config import CheckpointingConfig
     from nemo_automodel.components.config.loader import ConfigNode
     from nemo_automodel.components.datasets.diffusion.loader import DiffusionDataloaderConfig
@@ -618,6 +619,13 @@ class RecipeConfig:
 
         node = self._raw.get("prewarm", None)
         return PrewarmConfig(**_section_kwargs(node)) if node else None
+
+    @cached_property
+    def mfu(self) -> "MFUConfig":
+        from nemo_automodel._transformers.mfu import MFUConfig
+
+        node = self._raw.get("mfu", None)
+        return MFUConfig(**_section_kwargs(node)) if node else MFUConfig()
 
     @cached_property
     def embedding_row_repair(self) -> "EmbeddingRowRepairConfig | None":

--- a/nemo_automodel/recipes/dllm/train_ft.py
+++ b/nemo_automodel/recipes/dllm/train_ft.py
@@ -599,7 +599,12 @@ class DiffusionLMSFTRecipe(TrainFinetuneRecipeForNextTokenPrediction):
                 step_flops = self._dp_allreduce(
                     torch.tensor(step_flops, dtype=torch.float64, device=self.dist_env.device), include_cp=True
                 ).item()
-                mfu = calculate_mfu(step_flops / 1e12, self.dist_env.world_size, time_delta)
+                mfu = calculate_mfu(
+                    step_flops / 1e12,
+                    self.dist_env.world_size,
+                    time_delta,
+                    reference_mfu=mfu_calculator.reference_mfu,
+                )
 
         total_loss = torch.sum(torch.stack(loss_buffer))
         total_loss = self._dp_allreduce(total_loss, include_cp=True).cpu().item()

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -1281,7 +1281,12 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                 step_flops = self._dp_allreduce(
                     torch.tensor(step_flops, dtype=torch.float64, device=self.dist_env.device), include_cp=True
                 ).item()
-                mfu = calculate_mfu(step_flops / 1e12, self.dist_env.world_size, time_delta)
+                mfu = calculate_mfu(
+                    step_flops / 1e12,
+                    self.dist_env.world_size,
+                    time_delta,
+                    reference_mfu=mfu_calculator.reference_mfu,
+                )
 
         reporting_loss = torch.sum(torch.stack(loss_buffer))
         reporting_loss = self._dp_allreduce(reporting_loss, include_cp=True)

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -52,7 +52,6 @@ from nemo_automodel._transformers.infrastructure import (
     apply_model_infrastructure,
     instantiate_infrastructure,
 )
-from nemo_automodel._transformers.mfu import AutoMFU
 from nemo_automodel._transformers.utils import apply_cache_compatibility_patches
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.cuda_graphs import PartialCudaGraphManager
@@ -777,11 +776,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             for mp in self.model_parts:
                 enable_load_balance_tracking(mp)
 
-        self.mfu_calculator = AutoMFU.from_config(
-            self.model_parts[0],
-            device=self.cfg.get("mfu.device", None),
-            peak_tflops=self.cfg.get("mfu.peak_tflops", None),
-        )
+        self.mfu_calculator = self.cfg.mfu.build(model=self.model_parts[0])
 
         # NEFTune: noisy embeddings for improved instruction fine-tuning
         neftune_cfg = self.cfg.get("neftune", None)

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -777,7 +777,11 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             for mp in self.model_parts:
                 enable_load_balance_tracking(mp)
 
-        self.mfu_calculator = AutoMFU.from_config(self.model_parts[0])
+        self.mfu_calculator = AutoMFU.from_config(
+            self.model_parts[0],
+            device=self.cfg.get("mfu.device", None),
+            peak_tflops=self.cfg.get("mfu.peak_tflops", None),
+        )
 
         # NEFTune: noisy embeddings for improved instruction fine-tuning
         neftune_cfg = self.cfg.get("neftune", None)

--- a/nemo_automodel/recipes/llm/train_seq_cls.py
+++ b/nemo_automodel/recipes/llm/train_seq_cls.py
@@ -299,7 +299,12 @@ class TrainFinetuneRecipeForSequenceClassification(BaseRecipe):
                 step_flops = self._dp_allreduce(
                     torch.tensor(step_flops, dtype=torch.float64, device=self.dist_env.device), include_cp=True
                 ).item()
-                mfu = calculate_mfu(step_flops / 1e12, self.dist_env.world_size, time_delta)
+                mfu = calculate_mfu(
+                    step_flops / 1e12,
+                    self.dist_env.world_size,
+                    time_delta,
+                    reference_mfu=mfu_calculator.reference_mfu,
+                )
 
         total_loss = torch.sum(torch.stack(losses))
         total_loss = self._dp_allreduce(total_loss, include_cp=True).detach()

--- a/nemo_automodel/recipes/llm/train_seq_cls.py
+++ b/nemo_automodel/recipes/llm/train_seq_cls.py
@@ -22,7 +22,6 @@ from contextlib import nullcontext
 import torch
 import wandb
 
-from nemo_automodel._transformers.mfu import AutoMFU
 from nemo_automodel._transformers.utils import apply_cache_compatibility_patches
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.distributed.init_utils import initialize_distributed
@@ -124,11 +123,7 @@ class TrainFinetuneRecipeForSequenceClassification(BaseRecipe):
         )
 
         self.model_parts = [model]
-        self.mfu_calculator = AutoMFU.from_config(
-            self.model_parts[0],
-            device=self.cfg.get("mfu.device", None),
-            peak_tflops=self.cfg.get("mfu.peak_tflops", None),
-        )
+        self.mfu_calculator = self.cfg.mfu.build(model=self.model_parts[0])
 
         _, self.tokenizer = _build_tokenizer(self.cfg.model, self.cfg.dataset)
 

--- a/nemo_automodel/recipes/llm/train_seq_cls.py
+++ b/nemo_automodel/recipes/llm/train_seq_cls.py
@@ -124,7 +124,11 @@ class TrainFinetuneRecipeForSequenceClassification(BaseRecipe):
         )
 
         self.model_parts = [model]
-        self.mfu_calculator = AutoMFU.from_config(self.model_parts[0])
+        self.mfu_calculator = AutoMFU.from_config(
+            self.model_parts[0],
+            device=self.cfg.get("mfu.device", None),
+            peak_tflops=self.cfg.get("mfu.peak_tflops", None),
+        )
 
         _, self.tokenizer = _build_tokenizer(self.cfg.model, self.cfg.dataset)
 

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -30,6 +30,7 @@ from nemo_automodel.components.config.loader import ConfigNode
 requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 from torch.utils.data import IterableDataset
 
+from nemo_automodel._transformers.mfu import MFUConfig
 from nemo_automodel._transformers.model_init import resolve_sdpa_method
 from nemo_automodel.components.datasets.loader import (
     DataloaderConfig,
@@ -47,6 +48,16 @@ from nemo_automodel.recipes.llm.train_ft import (
     build_model,
     compute_trust_remote_code_from_model,
 )
+
+
+def test_recipe_config_resolves_mfu_settings():
+    config = RecipeConfig(ConfigNode({"mfu": {"device": "h100", "peak_tflops": 1979.0}}))
+
+    assert config.mfu == MFUConfig(device="h100", peak_tflops=1979.0)
+
+
+def test_recipe_config_defaults_mfu_settings():
+    assert RecipeConfig(ConfigNode({})).mfu == MFUConfig()
 
 
 def _build_loader(

--- a/tests/unit_tests/utils/test_flops_utils.py
+++ b/tests/unit_tests/utils/test_flops_utils.py
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 import pytest
 
 from nemo_automodel._transformers import mfu as mfu_module
-from nemo_automodel._transformers.mfu import AutoMFU, get_device_flops
+from nemo_automodel._transformers.mfu import AutoMFU, MFUConfig, get_device_flops
 from nemo_automodel.components.utils import flops_utils
 
 
@@ -278,17 +278,17 @@ def test_gpt_oss_flops_uses_head_dim_from_hf_config():
 @pytest.mark.parametrize(
     "tflops, world_size, time_seconds, reference_mfu, expected_mfu",
     [
-        # Basic test: 1 TFLOPs per GPU, 1 GPU, 1 second, reference 1 TFLOPs -> 100% MFU
+        # Basic test: 1 total TFLOPs, 1 GPU, 1 second, reference 1 TFLOPs/s -> 100% MFU
         (1.0, 1, 1.0, 1.0, 100.0),
-        # Half efficiency: 0.5 TFLOPs per GPU, 1 GPU, 1 second, reference 1 TFLOPs -> 50% MFU
+        # Half efficiency: 0.5 total TFLOPs, 1 GPU, 1 second, reference 1 TFLOPs/s -> 50% MFU
         (0.5, 1, 1.0, 1.0, 50.0),
-        # Multiple GPUs: 1 TFLOPs per GPU, 8 GPUs, 1 second, reference 1 TFLOPs -> 12.5% MFU
+        # Multiple GPUs: 1 total TFLOPs, 8 GPUs, 1 second, reference 1 TFLOPs/s -> 12.5% MFU
         (1.0, 8, 1.0, 1.0, 12.5),
-        # Longer time: 10 TFLOPs per GPU, 1 GPU, 10 seconds, reference 1 TFLOPs -> 100% MFU
+        # Longer time: 10 total TFLOPs, 1 GPU, 10 seconds, reference 1 TFLOPs/s -> 100% MFU
         (10.0, 1, 10.0, 1.0, 100.0),
-        # Sparse BF16 or dense FP8 H100 reference: 989 TFLOPs per GPU, 8 GPUs, reference 1979 TFLOPs
+        # Sparse BF16 or dense FP8 H100 reference: 989 total TFLOPs, 8 GPUs, reference 1979 TFLOPs/s
         (989.0, 8, 1.0, 1979.0, 6.2468418393127845),
-        # Real-world scenario: 500 TFLOPs per GPU, 64 GPUs, 2 seconds, H100 reference -> 0.197% MFU
+        # Real-world scenario: 500 total TFLOPs, 64 GPUs, 2 seconds, H100 reference -> 0.197% MFU
         (500.0, 64, 2.0, 1979.0, 0.19738504295098536),
     ],
 )
@@ -303,10 +303,12 @@ def test_calculate_mfu(tflops, world_size, time_seconds, reference_mfu, expected
     assert pytest.approx(actual_mfu, rel=1e-3) == expected_mfu
 
 
-def test_calculate_mfu_requires_explicit_reference():
-    """A hidden hardware or precision assumption must not enter MFU."""
-    with pytest.raises(TypeError, match="reference_mfu"):
-        flops_utils.calculate_mfu(tflops=989.0, world_size=1, time_seconds=1.0)
+def test_calculate_mfu_warns_for_legacy_default_reference():
+    """Keep the former H100 default temporarily while directing callers to an explicit peak."""
+    with pytest.warns(FutureWarning, match="reference_mfu"):
+        actual_mfu = flops_utils.calculate_mfu(tflops=1979.0, world_size=1, time_seconds=1.0)
+
+    assert actual_mfu == 100.0
 
 
 def test_automfu_h100_reference_uses_dense_bf16_peak():
@@ -347,4 +349,38 @@ def test_automfu_accepts_precision_peak_override(monkeypatch):
 
     calculator = AutoMFU(SimpleNamespace(), peak_tflops=1979.0)
 
+    assert calculator.reference_mfu == 1979.0
+
+
+def test_automfu_warns_and_reports_zero_for_unknown_device(monkeypatch, caplog):
+    monkeypatch.setattr(
+        mfu_module,
+        "get_flops_formula_for_hf_config",
+        lambda config: lambda config, gbs, seq_len: 1e12,
+    )
+
+    with caplog.at_level("WARNING", logger=mfu_module.__name__):
+        calculator = AutoMFU(SimpleNamespace(), device="NVIDIA Example GPU")
+
+    assert calculator.reference_mfu == float("inf")
+    assert "MFU will be reported as 0%" in caplog.text
+    assert calculator((1, 1), time_delta=1.0, world_size=1) == 0.0
+
+
+@pytest.mark.parametrize("peak_tflops", [0.0, -1.0, float("inf"), float("nan")])
+def test_automfu_rejects_invalid_precision_peak(monkeypatch, peak_tflops):
+    monkeypatch.setattr(mfu_module, "get_flops_formula_for_hf_config", lambda config: None)
+
+    with pytest.raises(ValueError, match="finite value greater than zero"):
+        AutoMFU(SimpleNamespace(), peak_tflops=peak_tflops)
+
+
+def test_mfu_config_builds_calculator(monkeypatch):
+    monkeypatch.setattr(mfu_module, "get_flops_formula_for_hf_config", lambda config: None)
+    model_config = SimpleNamespace()
+    model = SimpleNamespace(config=model_config)
+
+    calculator = MFUConfig(device="h100", peak_tflops=1979.0).build(model=model)
+
+    assert calculator.config is model_config
     assert calculator.reference_mfu == 1979.0

--- a/tests/unit_tests/utils/test_flops_utils.py
+++ b/tests/unit_tests/utils/test_flops_utils.py
@@ -16,7 +16,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from nemo_automodel._transformers.mfu import get_device_flops
+from nemo_automodel._transformers import mfu as mfu_module
+from nemo_automodel._transformers.mfu import AutoMFU, get_device_flops
 from nemo_automodel.components.utils import flops_utils
 
 
@@ -221,10 +222,34 @@ def _nemotronh_super_v3_cfg() -> SimpleNamespace:
         ("transformer", flops_utils.transformer_flops, _transformer_cfg, dict(gbs=1, seq_len=1024), 8363320541184),
         ("gpt_oss", flops_utils.gpt_oss_flops, _gpt_oss_cfg, dict(gbs=1, seq_len=1024), 7356800827392),
         ("glm4_moe", flops_utils.glm4_moe_flops, _glm4_moe_cfg, dict(gbs=1, seq_len=2048), 120277337899008),
-        ("deepseekv3_moonlight", flops_utils.deepseekv3_flops, _moonlight_16b_config, dict(gbs=1, seq_len=2048), 30625801175040),
-        ("deepseekv3_dsv3", flops_utils.deepseekv3_flops, _deepseek_v3_config, dict(gbs=1, seq_len=1024), 233225179889664),
-        ("nemotronh_nano_v3", flops_utils.nemotronh_flops, _nemotronh_nano_v3_cfg, dict(gbs=1, seq_len=2048), 39982504869888),
-        ("nemotronh_super_v3", flops_utils.nemotronh_flops, _nemotronh_super_v3_cfg, dict(gbs=1, seq_len=2048), 152918015606784),
+        (
+            "deepseekv3_moonlight",
+            flops_utils.deepseekv3_flops,
+            _moonlight_16b_config,
+            dict(gbs=1, seq_len=2048),
+            30625801175040,
+        ),
+        (
+            "deepseekv3_dsv3",
+            flops_utils.deepseekv3_flops,
+            _deepseek_v3_config,
+            dict(gbs=1, seq_len=1024),
+            233225179889664,
+        ),
+        (
+            "nemotronh_nano_v3",
+            flops_utils.nemotronh_flops,
+            _nemotronh_nano_v3_cfg,
+            dict(gbs=1, seq_len=2048),
+            39982504869888,
+        ),
+        (
+            "nemotronh_super_v3",
+            flops_utils.nemotronh_flops,
+            _nemotronh_super_v3_cfg,
+            dict(gbs=1, seq_len=2048),
+            152918015606784,
+        ),
     ],
 )
 def test_flops_formulas_with_precomputed_values(name, func, cfg_factory, kwargs, expected):
@@ -269,19 +294,57 @@ def test_gpt_oss_flops_uses_head_dim_from_hf_config():
 )
 def test_calculate_mfu(tflops, world_size, time_seconds, reference_mfu, expected_mfu):
     """Test calculate_mfu function with various scenarios."""
-    actual_mfu = flops_utils.calculate_mfu(tflops, world_size, time_seconds, reference_mfu)
+    actual_mfu = flops_utils.calculate_mfu(
+        tflops,
+        world_size,
+        time_seconds,
+        reference_mfu=reference_mfu,
+    )
     assert pytest.approx(actual_mfu, rel=1e-3) == expected_mfu
 
 
-def test_calculate_mfu_default_reference():
-    """Test calculate_mfu with the legacy dense FP8 H100 reference."""
-    actual_mfu = flops_utils.calculate_mfu(tflops=1979.0, world_size=1, time_seconds=1.0)
-
-    assert pytest.approx(actual_mfu, rel=1e-6) == 100.0
+def test_calculate_mfu_requires_explicit_reference():
+    """A hidden hardware or precision assumption must not enter MFU."""
+    with pytest.raises(TypeError, match="reference_mfu"):
+        flops_utils.calculate_mfu(tflops=989.0, world_size=1, time_seconds=1.0)
 
 
 def test_automfu_h100_reference_uses_dense_bf16_peak():
-    """Test AutoMFU's default H100 training-precision convention."""
+    """Test AutoMFU's H100 dense-BF16 training convention."""
     h100_tflops = get_device_flops(unit="T", device_name="H100")
 
     assert h100_tflops == 989.0
+
+
+def test_get_device_flops_detects_current_cuda_device(monkeypatch):
+    monkeypatch.setattr(mfu_module.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(mfu_module.torch.cuda, "current_device", lambda: 3)
+    monkeypatch.setattr(
+        mfu_module.torch.cuda,
+        "get_device_name",
+        lambda device: "NVIDIA H100 80GB HBM3" if device == 3 else "unexpected",
+    )
+
+    assert get_device_flops(unit="T") == 989.0
+
+
+def test_automfu_defaults_to_detected_device_peak(monkeypatch):
+    monkeypatch.setattr(mfu_module, "get_flops_formula_for_hf_config", lambda config: None)
+    monkeypatch.setattr(mfu_module, "get_device_flops", lambda *, unit, device_name: 989.0)
+
+    calculator = AutoMFU(SimpleNamespace())
+
+    assert calculator.reference_mfu == 989.0
+
+
+def test_automfu_accepts_precision_peak_override(monkeypatch):
+    monkeypatch.setattr(mfu_module, "get_flops_formula_for_hf_config", lambda config: None)
+    monkeypatch.setattr(
+        mfu_module,
+        "get_device_flops",
+        lambda **kwargs: pytest.fail("explicit peak must bypass device lookup"),
+    )
+
+    calculator = AutoMFU(SimpleNamespace(), peak_tflops=1979.0)
+
+    assert calculator.reference_mfu == 1979.0

--- a/tests/unit_tests/utils/test_flops_utils.py
+++ b/tests/unit_tests/utils/test_flops_utils.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from nemo_automodel._transformers.mfu import get_device_flops
 from nemo_automodel.components.utils import flops_utils
 
 
@@ -260,7 +261,7 @@ def test_gpt_oss_flops_uses_head_dim_from_hf_config():
         (1.0, 8, 1.0, 1.0, 12.5),
         # Longer time: 10 TFLOPs per GPU, 1 GPU, 10 seconds, reference 1 TFLOPs -> 100% MFU
         (10.0, 1, 10.0, 1.0, 100.0),
-        # H100 reference (default): 989 TFLOPs per GPU, 8 GPUs, 1 second, reference 1979 TFLOPs -> 6.25% MFU
+        # Sparse BF16 or dense FP8 H100 reference: 989 TFLOPs per GPU, 8 GPUs, reference 1979 TFLOPs
         (989.0, 8, 1.0, 1979.0, 6.2468418393127845),
         # Real-world scenario: 500 TFLOPs per GPU, 64 GPUs, 2 seconds, H100 reference -> 0.197% MFU
         (500.0, 64, 2.0, 1979.0, 0.19738504295098536),
@@ -273,7 +274,14 @@ def test_calculate_mfu(tflops, world_size, time_seconds, reference_mfu, expected
 
 
 def test_calculate_mfu_default_reference():
-    """Test calculate_mfu with default H100 reference."""
-    # Using default reference_mfu (1979.0 for H100)
+    """Test calculate_mfu with the legacy dense FP8 H100 reference."""
     actual_mfu = flops_utils.calculate_mfu(tflops=1979.0, world_size=1, time_seconds=1.0)
+
     assert pytest.approx(actual_mfu, rel=1e-6) == 100.0
+
+
+def test_automfu_h100_reference_uses_dense_bf16_peak():
+    """Test AutoMFU's default H100 training-precision convention."""
+    h100_tflops = get_device_flops(unit="T", device_name="H100")
+
+    assert h100_tflops == 989.0

--- a/tests/unit_tests/utils/test_flops_utils_new_models.py
+++ b/tests/unit_tests/utils/test_flops_utils_new_models.py
@@ -233,6 +233,29 @@ class TestQwen35Flops:
         r2 = flops_utils.qwen3_5_flops(cfg, gbs=4, seq_len=1024)
         assert r2 == pytest.approx(4 * r1, rel=1e-6)
 
+    def test_moe_counts_activated_experts_not_total_experts(self):
+        cfg = _qwen3_5_moe_cfg()
+        base = flops_utils.qwen3_5_flops(cfg, gbs=1, seq_len=1024)
+
+        cfg.num_experts *= 2
+        more_total_experts = flops_utils.qwen3_5_flops(cfg, gbs=1, seq_len=1024)
+        cfg.num_experts_per_tok *= 2
+        more_activated_experts = flops_utils.qwen3_5_flops(cfg, gbs=1, seq_len=1024)
+
+        assert more_total_experts == base
+        assert more_activated_experts > more_total_experts
+
+    def test_moe_counts_shared_expert_width(self):
+        cfg = _qwen3_5_moe_cfg()
+        base = flops_utils.qwen3_5_flops(cfg, gbs=1, seq_len=1024)
+        added_width = 512
+
+        cfg.shared_expert_intermediate_size += added_width
+        with_wider_shared_expert = flops_utils.qwen3_5_flops(cfg, gbs=1, seq_len=1024)
+
+        expected_delta = 6 * 1 * cfg.num_hidden_layers * 1024 * cfg.hidden_size * 3 * added_width
+        assert with_wider_shared_expert - base == expected_delta
+
     def test_vl_text_config_fallback(self):
         """VL composite config should extract text_config when num_hidden_layers is missing."""
         text_cfg = _qwen3_5_moe_cfg()


### PR DESCRIPTION
## Summary

- require every low-level `calculate_mfu` caller to provide an explicit reference peak instead of inheriting the ambiguous `1979` default
- make `AutoMFU` detect the current device by default and use its dense-BF16 peak from the device table
- allow `mfu.device` and `mfu.peak_tflops` recipe overrides when hardware detection or the dense-BF16 convention is not appropriate
- pass AutoMFU's selected peak through the LLM, sequence-classification, and diffusion-LM training recipes
- add Qwen3.5 MoE FLOP-accounting coverage for activated and shared experts

Before this change, the standard recipes constructed AutoMFU with an H100 dense-BF16 peak of 989 TFLOP/s but discarded it and called `calculate_mfu` with the unrelated 1979 TFLOP/s default. That under-reported dense-BF16 MFU by about 2x. Hardware detection now covers the ordinary BF16 path without YAML; FP8, structured sparsity, and unknown devices can provide an explicit peak.

Tracking: [AM-659](https://linear.app/nvidia/issue/AM-659/tracking-large-scale-moe-vlm-training-improvements)

## Tests

- `pytest tests/unit_tests/utils/test_flops_utils.py tests/unit_tests/utils/test_flops_utils_new_models.py -q` (66 passed)
- `pytest tests/unit_tests/recipes/test_train_ft.py -q` (88 passed, 7 skipped)
- `ruff check` and `ruff format --check` on changed Python files
- `git diff --check`