### PR TITLE
fix(kimi_linear): make long-context recipe CP8

### DIFF
--- a/docs/model-coverage/llm/moonshotai/kimi-linear.mdx
+++ b/docs/model-coverage/llm/moonshotai/kimi-linear.mdx
@@ -53,7 +53,7 @@ NeMo AutoModel already carry the distinct identity and load without that overrid
 | Recipe | Description |
 |---|---|
 | [kimi_linear_48b_a3b_hellaswag.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_finetune/kimi/kimi_linear_48b_a3b_hellaswag.yaml) | SFT: Kimi Linear 48B A3B on HellaSwag with EP=8 |
-| [kimi_linear_48b_a3b_longcontext_cp2.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_finetune/kimi/kimi_linear_48b_a3b_longcontext_cp2.yaml) | SFT: 32k packed sequences with CP=2 and EP=8 |
+| [kimi_linear_48b_a3b_longcontext_cp8.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_finetune/kimi/kimi_linear_48b_a3b_longcontext_cp8.yaml) | SFT: 32k packed sequences with CP=8 and EP=8 |
 
 ## Try with NeMo AutoModel
 

--- a/docs/model-coverage/llm/moonshotai/kimi-linear.mdx
+++ b/docs/model-coverage/llm/moonshotai/kimi-linear.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Kimi Linear"
-description: ""
+description: "Fine-tune Moonshot AI Kimi Linear 48B A3B with hybrid KDA and MLA attention on NeMo AutoModel."
 slug: model-coverage/large-language-models/moonshotai/kimi-linear
 ---
 [Kimi Linear](https://huggingface.co/moonshotai/Kimi-Linear-48B-A3B-Instruct) is a hybrid-attention Mixture-of-Experts language model from Moonshot AI. Most layers use Kimi Delta Attention (KDA), a gated linear-attention variant with a recurrent state, and the remaining layers use full Multi-Head Latent Attention (MLA). NeMo AutoModel ships a native `KimiLinear48BForCausalLM` implementation with expert parallelism, packed sequences, and context parallelism.

--- a/examples/llm_finetune/kimi/kimi_linear_48b_a3b_longcontext_cp8.yaml
+++ b/examples/llm_finetune/kimi/kimi_linear_48b_a3b_longcontext_cp8.yaml
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 # Long-context Kimi Linear fine-tuning: 32k packed sequences split across a
-# context-parallel group of 2, with EP=8 over the same 8 GPUs.
+# context-parallel group of 8, with EP=8 over the same 8 GPUs.
 #
 # Kimi Linear shards the sequence into contiguous per-rank slices (KDA's recurrent
 # state is passed rank to rank by FLA, MLA gathers the compressed KV latent), and
 # document boundaries from the packed collater are honored by both layer types.
 #
 # To run this recipe:
-#   HF_HOME=$PWD/.hf_cache automodel examples/llm_finetune/kimi/kimi_linear_48b_a3b_longcontext_cp2.yaml --nproc-per-node 8
+#   HF_HOME=$PWD/.hf_cache automodel examples/llm_finetune/kimi/kimi_linear_48b_a3b_longcontext_cp8.yaml --nproc-per-node 8
 
 recipe: TrainFinetuneRecipeForNextTokenPrediction
 
@@ -59,6 +59,7 @@ model:
   trust_remote_code: true
   torch_dtype: bfloat16
   load_base_model: true
+  output_hidden_states: true
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
     attn: eager
@@ -73,14 +74,14 @@ model:
 
 checkpoint:
   enabled: false
-  checkpoint_dir: checkpoints/kimi_linear_48b_a3b_longcontext_cp2
+  checkpoint_dir: checkpoints/kimi_linear_48b_a3b_longcontext_cp8
   model_save_format: safetensors
   save_consolidated: false
 
 distributed:
   strategy: fsdp2
   tp_size: 1
-  cp_size: 2                 # 32k tokens -> 16k per rank
+  cp_size: 8                 # 32k tokens -> 4k per rank
   pp_size: 1
   ep_size: 8                 # EP and CP overlap on the device mesh
   sequence_parallel: false
@@ -90,7 +91,7 @@ distributed:
     wrap_outer_model: false
 
 loss_fn:
-  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  _target_: nemo_automodel.components.loss.linear_ce.FusedLinearCrossEntropy
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
@@ -139,7 +140,7 @@ optimizer:
 wandb:
   enable: false
   project: automodel-kimi-linear
-  name: kimi_linear_48b_a3b_longcontext_cp2
+  name: kimi_linear_48b_a3b_longcontext_cp8
   mode: online
   dir: result/wandb
 


### PR DESCRIPTION
## What changed

- Change the 32K Kimi Linear long-context recipe from CP2 to CP8.
- Use `FusedLinearCrossEntropy` with `output_hidden_states: true` to avoid materializing full vocabulary logits.
- Rename the recipe and its checkpoint/W&B identifiers to CP8, and update the model coverage documentation.

## Why

The existing eight-GPU recipe used CP2, leaving 16K tokens on each context-parallel rank, and used regular masked cross entropy over full logits. CP8 reduces the local sequence to 4K tokens per rank, while fused linear cross entropy reduces loss-side memory use.

## Impact

The shipped 32K Kimi Linear recipe now exercises CP8 and EP8 on the same eight-GPU mesh. This changes only the example recipe and its documentation; model code is unchanged.

## Validation

- Parsed the updated recipe with PyYAML.
- Passed `tests/ci_tests/utils/validate_new_recipe_ci.py` using Python 3.10.
- Passed `git diff --check`.
- Passed the full eight-GPU release run in [NeMo-CI pipeline 63342180](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/63342180) ([job 402299981](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/402299981)):
  - Used `nvcr.io/nvidian/nemo-automodel:nightly` with AutoModel source mounted at `82e3aad0ac7613228880158b4018df8900182f9e`.
  - Slurm job `5876921` completed successfully.
  - Validated finite loss and `grad_norm` for all 27 executed training steps; final train loss was `1.8757`, final `grad_norm` was `0.8709`, and validation loss was `2.9318`.
