### PR TITLE
perf(glm): skip top-k pipeline carry without IndexShare

### DIFF
--- a/nemo_automodel/components/models/glm_moe_dsa/model.py
+++ b/nemo_automodel/components/models/glm_moe_dsa/model.py
@@ -44,6 +44,12 @@ from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 
+def _uses_indexshare(config: GlmMoeDsaConfig) -> bool:
+    """Return whether the model has layers that reuse another layer's DSA indices."""
+    indexer_types = getattr(config, "indexer_types", None)
+    return indexer_types is not None and "shared" in indexer_types
+
+
 class Block(nn.Module):
     def __init__(self, layer_idx: int, config: GlmMoeDsaConfig, moe_config: MoEConfig, backend: BackendConfig):
         super().__init__()
@@ -228,18 +234,21 @@ class GlmMoeDsaModel(nn.Module):
         h = self.embed_tokens(input_ids) if self.embed_tokens is not None else input_ids
 
         # IndexShare: thread the most recent "full" layer's top-k selection forward so the
-        # following "shared" layers can reuse it. Seeded from `prev_topk_indices` (carried from
-        # the previous pipeline stage); `None` on the first stage / all-"full" configs (GLM-5.1).
-        topk_indices = prev_topk_indices
+        # following "shared" layers can reuse it. Legacy GLM configs have no shared layers, so
+        # avoid retaining and propagating their per-layer selections.
+        uses_indexshare = _uses_indexshare(self.config)
+        topk_indices = prev_topk_indices if uses_indexshare else None
         for layer in self.layers.values():
-            h, topk_indices = layer(
+            h, layer_topk_indices = layer(
                 x=h,
                 freqs_cis=freqs_cis,
                 attention_mask=attention_mask,
                 padding_mask=padding_mask,
-                prev_topk_indices=topk_indices,
+                prev_topk_indices=topk_indices if uses_indexshare else None,
                 **attn_kwargs,
             )
+            if uses_indexshare:
+                topk_indices = layer_topk_indices
 
         h = self.norm(h) if self.norm else h
         return h, topk_indices
@@ -398,11 +407,11 @@ class GlmMoeDsaForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         seq_len: int,
         dtype: torch.dtype,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]]:
-        """Declare PP inter-stage I/O metas, threading the IndexShare top-k as a carry tensor.
+        """Declare PP inter-stage I/O metas, adding a top-k carry only for IndexShare models.
 
-        Non-first stages additionally receive the previous "full" layer's top-k selection, and
-        non-last stages emit the running selection, so a stage that begins with a "shared" layer
-        has the top-k it needs (correct at any sequence length).
+        IndexShare models additionally receive and emit the previous "full" layer's top-k
+        selection so a stage that begins with a "shared" layer has the indices it needs. Models
+        with all-full indexers need only the hidden-state channel.
         """
         hidden_size = self.config.hidden_size
         vocab_size = self.config.vocab_size
@@ -432,16 +441,21 @@ class GlmMoeDsaForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
             hidden_meta = meta((microbatch_size, seq_len, hidden_size), dtype)
             topk_meta = meta((microbatch_size, seq_len, topk), torch.float32)
 
+        uses_indexshare = _uses_indexshare(self.config)
         if is_first:
             inputs_meta = (meta((microbatch_size, seq_len), torch.long),)
-        else:
+        elif uses_indexshare:
             inputs_meta = (hidden_meta, topk_meta)
+        else:
+            inputs_meta = (hidden_meta,)
 
         if self.lm_head is not None:
             # The last stage emits logits; compute_lm_head_logits restores [1, T, V] under THD.
             outputs_meta = (meta((microbatch_size, seq_len, vocab_size), dtype),)
-        else:
+        elif uses_indexshare:
             outputs_meta = (hidden_meta, topk_meta)
+        else:
+            outputs_meta = (hidden_meta,)
 
         return inputs_meta, outputs_meta
 
@@ -462,9 +476,10 @@ class GlmMoeDsaForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         :class:`~transformers.modeling_outputs.CausalLMOutputWithPast`, threading the IndexShare
         top-k internally (seeded ``None``).
 
-        Pipeline parallelism: ``input_ids`` is the upstream hidden state on non-first stages and
-        ``*carry`` holds the previous stage's running top-k selection. Non-last stages return
-        ``(hidden_states, topk_indices)`` and the last stage returns the ``logits`` tensor.
+        Pipeline parallelism: ``input_ids`` is the upstream hidden state on non-first stages.
+        IndexShare models additionally use ``*carry`` for the previous stage's running top-k
+        selection. Non-last stages return the declared pipeline outputs and the last stage returns
+        the ``logits`` tensor.
 
         Args:
             input_ids: Token IDs (BSHD ``[B, S]`` / THD ``[1, T]``) on the first stage, or the
@@ -482,9 +497,11 @@ class GlmMoeDsaForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
             else getattr(self.config, "output_hidden_states", False)
         )
 
+        uses_indexshare = _uses_indexshare(self.config)
+
         # Carry-in arrives as float32 (see get_pipeline_stage_metas, where the pipeline recv
         # buffer must be a grad-capable dtype); restore the int64 index values.
-        carry_in = carry[0] if carry else None
+        carry_in = carry[0] if uses_indexshare and carry else None
         is_thd = attn_kwargs.get("qkv_format") == "thd"
 
         prev_topk_indices = None
@@ -519,6 +536,11 @@ class GlmMoeDsaForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         )
 
         if self._is_pipeline_parallel_stage():
+            if not uses_indexshare:
+                if self.lm_head is not None:
+                    return compute_lm_head_logits(self.lm_head, hidden, logits_to_keep, is_thd=is_thd).logits
+                return hidden
+
             # The top-k carry is non-differentiable (integer indices transported as float32), but
             # torch.distributed.pipelining treats every float inter-stage tensor as an activation
             # and demands a gradient for it on backward. We add zero-weight autograd links so the

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_model.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_model.py
@@ -512,6 +512,21 @@ class TestIndexShare:
         # Layer 0 starts from None; each later layer receives the previous layer's returned selection.
         assert seen_prev == [None, "topk-0", "topk-1", "topk-2"]
 
+    def test_model_does_not_thread_topk_without_shared_layers(self, config, backend_config):
+        model = GlmMoeDsaModel(config, backend=backend_config)
+        input_ids = torch.randint(0, config.vocab_size, (1, 4))
+        seen_prev = []
+
+        def fake_forward(self, x, *, freqs_cis, attention_mask=None, padding_mask=None, prev_topk_indices=None, **kw):
+            seen_prev.append(prev_topk_indices)
+            return x, f"topk-{self.layer_idx}"
+
+        with patch.object(Block, "forward", new=fake_forward):
+            _hidden, out_topk = model(input_ids)
+
+        assert seen_prev == [None] * config.num_hidden_layers
+        assert out_topk is None
+
     def test_model_forward_seeds_and_returns_topk(self, config, backend_config):
         # GlmMoeDsaModel.forward must seed the loop from prev_topk_indices (PP carry-in) and
         # return the running selection (PP carry-out).
@@ -531,6 +546,7 @@ class TestIndexShare:
         assert out_topk == "carry-in"  # and it is returned for the next stage
 
     def test_get_pipeline_stage_metas_threads_topk(self, config, backend_config):
+        config.indexer_types = ["full", "shared", "full", "shared"]
         model = GlmMoeDsaForCausalLM(config, backend=backend_config)
         mbs, seq_len = 2, 16
         topk = min(config.index_topk, seq_len)
@@ -558,9 +574,23 @@ class TestIndexShare:
         assert mid_out[0].shape == (mbs, seq_len, config.hidden_size)
         assert mid_out[1].shape == (mbs, seq_len, topk) and mid_out[1].dtype == torch.float32
 
+    def test_get_pipeline_stage_metas_omit_topk_without_shared_layers(self, config, backend_config):
+        model = GlmMoeDsaForCausalLM(config, backend=backend_config)
+        model.lm_head = None
+
+        inputs_meta, outputs_meta = model.get_pipeline_stage_metas(
+            is_first=False, microbatch_size=2, seq_len=16, dtype=torch.bfloat16
+        )
+
+        assert len(inputs_meta) == 1
+        assert inputs_meta[0].shape == (2, 16, config.hidden_size)
+        assert len(outputs_meta) == 1
+        assert outputs_meta[0].shape == (2, 16, config.hidden_size)
+
     def test_pp_stage_topk_carry_dtype_roundtrip(self, config, backend_config):
         # A non-first/non-last PP stage receives a float32 carry, casts it to int64 before the
         # inner model, and emits the running selection back as float32.
+        config.indexer_types = ["full", "shared", "full", "shared"]
         model = GlmMoeDsaForCausalLM(config, backend=backend_config)
         model.model.embed_tokens = None  # not first stage
         model.lm_head = None  # not last stage
@@ -580,6 +610,17 @@ class TestIndexShare:
         assert captured["prev_dtype"] == torch.int64  # carry-in cast float32 -> int64 before model
         assert isinstance(out, tuple) and len(out) == 2
         assert out[1].dtype == torch.float32  # carry-out emitted as float32
+
+    def test_pp_stage_returns_only_hidden_without_shared_layers(self, config, backend_config):
+        model = GlmMoeDsaForCausalLM(config, backend=backend_config)
+        model.model.embed_tokens = None
+        model.lm_head = None
+        hidden = torch.zeros(1, 4, config.hidden_size)
+
+        with patch.object(model.model, "forward", return_value=(hidden, None)):
+            out = model(hidden)
+
+        assert out is hidden
 
 
 class TestUpdateMoeGateBias:

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_tilelang.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_tilelang.py
@@ -1181,6 +1181,7 @@ def test_glm_dsa_tilelang_declares_validation_packing():
 
 def test_glm_dsa_tilelang_pipeline_metas_use_thd_shapes():
     config = _small_dsa_config()
+    config.indexer_types = ["shared"]
     backend = BackendConfig(attn="tilelang", linear="torch", rms_norm="torch", rope_fusion=False)
     model = GlmMoeDsaForCausalLM(config, backend=backend)
     model.lm_head = None
@@ -1206,6 +1207,7 @@ def test_glm_dsa_tilelang_pipeline_metas_use_thd_shapes():
 
 def test_glm_dsa_sdpa_pipeline_metas_cap_topk_by_seq_len():
     config = _small_dsa_config()
+    config.indexer_types = ["shared"]
     backend = BackendConfig(attn="sdpa", linear="torch", rms_norm="torch", rope_fusion=False)
     model = GlmMoeDsaForCausalLM(config, backend=backend)
     model.lm_head = None
@@ -1220,6 +1222,39 @@ def test_glm_dsa_sdpa_pipeline_metas_cap_topk_by_seq_len():
 
     assert inputs_meta[1].shape == (4, seq_len, seq_len)
     assert outputs_meta[1].shape == (4, seq_len, seq_len)
+
+
+def test_glm_dsa_pipeline_metas_omit_topk_without_indexshare():
+    config = _small_dsa_config()
+    backend = BackendConfig(attn="sdpa", linear="torch", rms_norm="torch", rope_fusion=False)
+    model = GlmMoeDsaForCausalLM(config, backend=backend)
+    model.lm_head = None
+
+    inputs_meta, outputs_meta = model.get_pipeline_stage_metas(
+        is_first=False,
+        microbatch_size=4,
+        seq_len=32,
+        dtype=torch.bfloat16,
+    )
+
+    assert len(inputs_meta) == 1
+    assert inputs_meta[0].shape == (4, 32, config.hidden_size)
+    assert len(outputs_meta) == 1
+    assert outputs_meta[0].shape == (4, 32, config.hidden_size)
+
+
+def test_glm_dsa_pipeline_stage_returns_only_hidden_without_indexshare(monkeypatch):
+    config = _small_dsa_config()
+    backend = BackendConfig(attn="sdpa", linear="torch", rms_norm="torch", rope_fusion=False)
+    model = GlmMoeDsaForCausalLM(config, backend=backend)
+    model.model.embed_tokens = None
+    model.lm_head = None
+    hidden = torch.zeros(1, 4, config.hidden_size)
+    monkeypatch.setattr(model.model, "forward", lambda *args, **kwargs: (hidden, None))
+
+    output = model(hidden)
+
+    assert output is hidden
 
 
 def test_glm_dsa_prepare_model_inputs_for_cp_binds_batch_sharder():


### PR DESCRIPTION
# What does this PR do ?

Avoid carrying GLM DSA top-k indices across pipeline stages when the model does not use IndexShare. Legacy GLM configurations such as GLM-5.1 run a full indexer in every layer, so every stage recomputes the selection and the inter-stage carry is unused.

# Changelog

- Detect whether the model actually contains any `shared` indexer layers.
- Use hidden-state-only pipeline metadata and stage outputs when IndexShare is absent.
- Preserve the top-k carry, dtype conversion, and zero-gradient links for real IndexShare models.
- Add coverage for dense and TileLang pipeline metadata and forwarding behavior.

# Root cause

IndexShare support made every GLM DSA pipeline stage transport the latest top-k selection. For GLM-5.1, `indexer_types` has no shared layers, so this transported a tensor that no downstream layer consumed. At sequence length 4096 with `index_topk=2048`, the float32 pipeline representation is 32 MiB per microbatch per boundary and is also treated as a pipeline activation during backward.

# Validation

- Current main-based head `1f77fb9bc30d8beb7694e9c627122c7387586f1d`: `pytest tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_model.py tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_tilelang.py -q`: 35 passed, 50 skipped.
- Current main-based head: `ruff format --check` and `ruff check` on the three changed files: passed.
- Performance validation ran on the identical patch before it was transplanted from r0.6.0 onto main: [NeMo CI](https://nv/nemoci), commit `37f4c09b098a281546978179d426f621326a29df`, root pipeline `63184546`, benchmark pipeline `63184655`, job `401027177`, Slurm job `5870422`, completed successfully.

| GLM-5 TE + DeepEP SFT | Step time | TPS | Peak allocated memory |
|---|---:|---:|---:|
| r0.6.0 before this fix, job `399228163` | 16.176 s | 259,292 | 51.48 GB |
| Identical patch, job `401027177` | 11.195 s | 374,659 | 46.19 GB |
| Change | -30.8% | +44.5% | -5.29 GB |

## Remaining approximately 7% versus 26.06

The 26.06 reference, job `350800962`, measured 10.388 s and 403,764 TPS, so the fixed run remains 7.2% below that TPS level.

The residual is inside `forward_backward` and shifts both the fastest and slowest ranks by roughly 0.8 s without increasing rank spread, which does not look like pipeline imbalance or a communication straggler. Across 47 exact-shape release comparisons, the median 26.06-to-r0.6.0 TPS delta is approximately flat, so the evidence does not support a blanket PyTorch 2.13 regression.

The leading source-level candidate is the corrected GLM DSA path introduced with IndexShare support, particularly the explicit causal masking of index scores and the expanded TE sparse-attention bias. For GLM-5 at sequence length 4096 and 64 heads, the expanded BF16 bias is 2 GiB and `masked_fill` materializes another full pass; activation checkpointing repeats that work during backward. Those correctness changes are intentionally left intact here. A follow-up should optimize causal sparse-mask construction rather than remove causality.

# Before your PR is "Ready for review"

- [x] Followed the contributor guidelines and included a signed-off commit.
- [x] Added focused tests for the changed behavior.
- [x] No user-facing documentation change is required.

# Additional Information

This PR is a single commit on current `main`. Its patch ID is identical to the r0.6.0 commit used for the performance run; only the commit parent and resulting SHA changed when the PR was retargeted.