### PR TITLE
feat(diffusion): periodic validation loss during training

### DIFF
--- a/docs/guides/diffusion/finetune.mdx
+++ b/docs/guides/diffusion/finetune.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Diffusion Model Fine-Tuning with NeMo AutoModel"
-description: ""
+description: "Fine-tune text-to-image and text-to-video diffusion models with NeMo AutoModel using flow matching, from dataset prep through multi-node training and inference."
 position: 16
 ---
 ## Introduction
@@ -46,7 +46,7 @@ All models use FSDP2 for distributed training and flow matching for loss computa
 ## Install NeMo AutoModel
 
 Diffusion fine-tuning needs the `diffusion` extra plus `diffusion-media` (OpenCV
-Diffusion fine-tuning requires the `diffusion` and `diffusion-media` extras. The `diffusion-media` extra provides OpenCV for image and video preprocessing and imageio-ffmpeg for T2V export:
+Diffusion fine-tuning requires the `diffusion` and `diffusion-media` extras. The `diffusion-media` extra provides OpenCV for image and video preprocessing, and `imageio-ffmpeg` for text-to-video export:
 
 ```bash
 uv venv
@@ -80,7 +80,7 @@ For the full set of installation methods, see the [installation guide](/get-star
 ## Prepare Your Dataset
 
 Diffusion models operate in latent space — a compressed representation of visual data — rather than directly on raw images or videos. To avoid re-encoding data on every training step, the preprocessing
-  pipeline encodes all inputs ahead of time and saves them as `.meta` or `.pt` cache files.
+Diffusion models operate in latent space (a compressed representation of visual data) rather than directly on raw images or videos. To avoid re-encoding data on every training step, the preprocessing pipeline encodes all inputs ahead of time and saves them as `.meta` or `.pt` cache files.
 
 Each cache file contains:
 
@@ -142,7 +142,8 @@ Fine-tuning is driven by two components:
 1. A recipe script (e.g., [`train.py`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/recipes/diffusion/train.py)) — the Python entry point that orchestrates the training loop: loading the model, building the dataloader, running forward/backward passes, computing the flow matching loss, checkpointing, and logging.
 2. A YAML configuration file — a text file in YAML format that specifies all settings the recipe uses: which model to fine-tune, where the data lives, optimizer hyperparameters, parallelism strategy, etc.
 1. A recipe script, for example [`train.py`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/recipes/diffusion/train.py), is the Python entry point that orchestrates the training loop: loading the model, building the data loader, running forward and backward passes, computing the flow matching loss, checkpointing, and logging.
-2. A YAML configuration file is a text file in YAML format that specifies all settings the recipe uses: which model to fine-tune, where the data lives, optimizer hyperparameters, parallelism strategy, and other settings. You customize training by editing this file rather than modifying code, allowing you to scale seamlessly from 1 to hundreds of GPUs.
+1. A recipe script, such as [`train.py`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/recipes/diffusion/train.py), orchestrates the training loop by loading the model, building the data loader, running forward and backward passes, computing the flow matching loss, checkpointing, and logging.
+2. A YAML configuration file is a text file in YAML format that specifies all settings the recipe uses: which model to fine-tune, where the data lives, optimizer hyperparameters, parallelism strategy, and other settings. You customize training by editing this file rather than modifying code, allowing you to scale seamlessly from one to hundreds of GPUs.
 
 The following annotated [`wan2_1_t2v_flow.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/finetune/wan2_1_t2v_flow.yaml) config explains each section:
 
@@ -245,7 +246,39 @@ checkpoint:
 | `flow_matching` | Yes | `adapter_type` must match the model (`simple` for Wan, `flux` for FLUX, `hunyuan` for HunyuanVideo, or `ltx2` for LTX-2.3). |
 | `fsdp` | Yes | Set `dp_size` to the number of GPUs on your node. |
 | `checkpoint` | Recommended | Set `checkpoint_dir` to a persistent path, especially in Docker. |
+| `data.validation_dataloader` | Optional | Held-out cache used for the periodic validation loss. Pair it with `step_scheduler.val_every_steps`; see [Validation Loss](#validation-loss). |
 | `wandb` | Optional | Configure to enable Weights & Biases logging. |
+
+### Validation Loss
+
+To track a held-out loss during training, add a `data.validation_dataloader` block and set
+`step_scheduler.val_every_steps`:
+
+```yaml
+step_scheduler:
+  val_every_steps: 500       # Run validation every N optimizer steps
+
+data:
+  dataloader:
+    _target_: nemo_automodel.components.datasets.diffusion.build_video_multiresolution_dataloader
+    cache_dir: PATH_TO_YOUR_DATA
+    model_type: wan
+  validation_dataloader:
+    _target_: nemo_automodel.components.datasets.diffusion.build_video_multiresolution_dataloader
+    cache_dir: PATH_TO_YOUR_VAL_DATA
+    model_type: wan
+    shuffle: false
+```
+
+The validation loader takes the same builders and fields as the training one and is sharded across
+data-parallel ranks the same way. Validation scores the held-out set with the training flow-matching
+objective in `eval()` mode under `torch.no_grad()`, and logs `val_loss` to the console and to
+Weights & Biases, on the same scale as `train_loss`.
+
+Timesteps and noise are drawn under a fixed seed, and the training RNG state is restored afterward. The curve therefore reflects the model rather than the sampling. Enabling validation does not change the training trajectory.
+
+The two keys are independent: a `validation_dataloader` without `val_every_steps` validates on
+checkpoint steps only, and `val_every_steps` without a loader logs a warning and skips validation.
 
 ## Fine-Tune the Model
 
@@ -267,7 +300,7 @@ When a single node does not provide enough GPUs or memory for your workload, you
 
 The main change is in the `fsdp` section. Set `dp_size` to the **total number of GPUs across all nodes**, and optionally increase `dp_replicate_size` for gradient replication across nodes.
 
-For example, to train on 2 nodes with 8 GPUs each (16 GPUs total):
+For example, to train on two nodes with eight GPUs each (16 GPUs total):
 
 ```yaml
 fsdp:
@@ -305,7 +338,7 @@ Use the following table to select a model for your use case:
 
 | Use Case | Model | Why Choose It |
 |----------|-------|---------------|
-| **Video generation on limited hardware** | [Wan 2.1 T2V 1.3B](#wan-21-t2v-13b) | Smallest model (1.3B params) — fast iteration, fits on a single A100 40GB |
+| **Video generation on limited hardware** | [Wan 2.1 T2V 1.3B](#wan-21-t2v-13b) | Smallest model (1.3B params): fast iteration, fits on a single A100 40 GB |
 | **High-quality image generation** | [FLUX.1-dev](#flux1-dev-text-to-image) | State-of-the-art text-to-image with 12B params and guidance-based control |
 | **High-quality video generation** | [HunyuanVideo 1.5](#hunyuanvideo-15) | Larger video model with condition-latent support for richer motion and detail |
 | **Synchronized video and audio generation** | [LTX-2.3](#ltx-23) | Jointly denoises video and audio latents with a dual-stream transformer |

--- a/docs/guides/diffusion/finetune.mdx
+++ b/docs/guides/diffusion/finetune.mdx
@@ -45,7 +45,6 @@ All models use FSDP2 for distributed training and flow matching for loss computa
 
 ## Install NeMo AutoModel
 
-Diffusion fine-tuning needs the `diffusion` extra plus `diffusion-media` (OpenCV
 Diffusion fine-tuning requires the `diffusion` and `diffusion-media` extras. The `diffusion-media` extra provides OpenCV for image and video preprocessing, and `imageio-ffmpeg` for text-to-video export:
 
 ```bash
@@ -79,7 +78,6 @@ For the full set of installation methods, see the [installation guide](/get-star
 
 ## Prepare Your Dataset
 
-Diffusion models operate in latent space — a compressed representation of visual data — rather than directly on raw images or videos. To avoid re-encoding data on every training step, the preprocessing
 Diffusion models operate in latent space (a compressed representation of visual data) rather than directly on raw images or videos. To avoid re-encoding data on every training step, the preprocessing pipeline encodes all inputs ahead of time and saves them as `.meta` or `.pt` cache files.
 
 Each cache file contains:
@@ -139,9 +137,6 @@ For the full set of arguments and input format details, see the [Diffusion Datas
 
 Fine-tuning is driven by two components:
 
-1. A recipe script (e.g., [`train.py`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/recipes/diffusion/train.py)) — the Python entry point that orchestrates the training loop: loading the model, building the dataloader, running forward/backward passes, computing the flow matching loss, checkpointing, and logging.
-2. A YAML configuration file — a text file in YAML format that specifies all settings the recipe uses: which model to fine-tune, where the data lives, optimizer hyperparameters, parallelism strategy, etc.
-1. A recipe script, for example [`train.py`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/recipes/diffusion/train.py), is the Python entry point that orchestrates the training loop: loading the model, building the data loader, running forward and backward passes, computing the flow matching loss, checkpointing, and logging.
 1. A recipe script, such as [`train.py`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/recipes/diffusion/train.py), orchestrates the training loop by loading the model, building the data loader, running forward and backward passes, computing the flow matching loss, checkpointing, and logging.
 2. A YAML configuration file is a text file in YAML format that specifies all settings the recipe uses: which model to fine-tune, where the data lives, optimizer hyperparameters, parallelism strategy, and other settings. You customize training by editing this file rather than modifying code, allowing you to scale seamlessly from one to hundreds of GPUs.
 

--- a/examples/diffusion/finetune/wan2_2_t2v_flow.yaml
+++ b/examples/diffusion/finetune/wan2_2_t2v_flow.yaml
@@ -30,8 +30,6 @@ step_scheduler:
   num_epochs: 100
   log_remote_every_steps: 2
   save_checkpoint_every_epoch: false
-  # Validation cadence; needs the data.validation_dataloader block below.
-  val_every_steps: 500
 
 data:
   dataloader:
@@ -42,16 +40,6 @@ data:
     base_resolution: [512, 512]
     dynamic_batch_size: false
     shuffle: true
-    drop_last: false
-    num_workers: 2
-  # Held-out cache for the validation loss. Shuffle off keeps the loss comparable across steps.
-  validation_dataloader:
-    _target_: nemo_automodel.components.datasets.diffusion.build_video_multiresolution_dataloader
-    cache_dir: PATH_TO_YOUR_WAN22_VAL_DATA
-    model_type: wan
-    base_resolution: [512, 512]
-    dynamic_batch_size: false
-    shuffle: false
     drop_last: false
     num_workers: 2
 

--- a/examples/diffusion/finetune/wan2_2_t2v_flow.yaml
+++ b/examples/diffusion/finetune/wan2_2_t2v_flow.yaml
@@ -30,6 +30,8 @@ step_scheduler:
   num_epochs: 100
   log_remote_every_steps: 2
   save_checkpoint_every_epoch: false
+  # Validation cadence; needs the data.validation_dataloader block below.
+  val_every_steps: 500
 
 data:
   dataloader:
@@ -40,6 +42,16 @@ data:
     base_resolution: [512, 512]
     dynamic_batch_size: false
     shuffle: true
+    drop_last: false
+    num_workers: 2
+  # Held-out cache for the validation loss. Shuffle off keeps the loss comparable across steps.
+  validation_dataloader:
+    _target_: nemo_automodel.components.datasets.diffusion.build_video_multiresolution_dataloader
+    cache_dir: PATH_TO_YOUR_WAN22_VAL_DATA
+    model_type: wan
+    base_resolution: [512, 512]
+    dynamic_batch_size: false
+    shuffle: false
     drop_last: false
     num_workers: 2
 

--- a/nemo_automodel/recipes/_typed_config.py
+++ b/nemo_automodel/recipes/_typed_config.py
@@ -560,6 +560,12 @@ class RecipeConfig:
         return self.resolve_diffusion_dataloader(node) if node is not None else None
 
     @cached_property
+    def diffusion_validation_dataloader(self) -> "DiffusionDataloaderConfig" | None:
+        """Typed diffusion validation dataloader config resolved from ``data.validation_dataloader``."""
+        node = self._raw.get("data.validation_dataloader", None)
+        return self.resolve_diffusion_dataloader(node) if node is not None else None
+
+    @cached_property
     def bagel_dataloader(self) -> "BagelDataloaderConfig" | None:
         """Typed packed-dataset and dataloader config for BAGEL recipes."""
         from nemo_automodel.components.datasets.multimodal.datasets import BagelDatasetConfig

--- a/nemo_automodel/recipes/diffusion/train.py
+++ b/nemo_automodel/recipes/diffusion/train.py
@@ -928,9 +928,11 @@ class TrainDiffusionRecipe(BaseRecipe):
     def _run_validation_epoch(self, global_step: int) -> float:
         """Score the held-out set with the training flow-matching objective.
 
-        The fixed seed makes every evaluation draw the same timesteps, noise, and CFG dropout,
-        so ``val_loss`` tracks the model rather than the sampling; ``ScopedRNG`` restores the
-        training RNG state afterwards, leaving the training trajectory unchanged.
+        Seeding by data rank mirrors training: every evaluation draws the same timesteps, noise,
+        and CFG dropout, so ``val_loss`` tracks the model rather than the sampling, while
+        data-parallel ranks stay decorrelated and context-parallel peers of one rank draw
+        identical values for their shared batch. ``ScopedRNG`` restores the training RNG state
+        afterwards, leaving the training trajectory unchanged.
 
         The forward runs under the same compute-dtype autocast as training, so a single-rank
         split-dtype config evaluates the way it trains. FP8 autocast is left out: delayed-scaling
@@ -948,7 +950,11 @@ class TrainDiffusionRecipe(BaseRecipe):
         local_loss_sum = 0.0
         local_num_batches = 0
         try:
-            with ScopedRNG(seed=self.seed, ranked=False), torch.no_grad(), self._autocast_context():
+            with (
+                ScopedRNG(seed=self.seed + self._get_dp_rank(), ranked=False),
+                torch.no_grad(),
+                self._autocast_context(),
+            ):
                 for batch in self.val_dataloader:
                     _, average_weighted_loss, _, _ = self.flow_matching_pipeline.step(
                         model=self.model,

--- a/nemo_automodel/recipes/diffusion/train.py
+++ b/nemo_automodel/recipes/diffusion/train.py
@@ -32,7 +32,7 @@ from nemo_automodel.components.distributed.utils import get_sync_ctx
 from nemo_automodel.components.flow_matching.pipeline import FlowMatchingPipeline, create_adapter
 from nemo_automodel.components.loggers.log_utils import setup_logging
 from nemo_automodel.components.loggers.wandb_utils import suppress_wandb_log_messages
-from nemo_automodel.components.training.rng import StatefulRNG, init_all_rng
+from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG, init_all_rng
 from nemo_automodel.components.training.utils import (
     clip_grad_norm,
     prepare_after_first_microbatch,
@@ -815,6 +815,34 @@ class TrainDiffusionRecipe(BaseRecipe):
         if len(self.dataloader) == 0:
             raise RuntimeError("Training dataloader is empty; cannot proceed with training")
 
+        # Optional held-out loader; same typed contract and dp sharding as the training one.
+        validation_dataloader_config = self.cfg.diffusion_validation_dataloader
+        self.val_dataloader = None
+        self.val_sampler = None
+        val_every_steps = self.cfg.get("step_scheduler.val_every_steps", None)
+        if validation_dataloader_config is not None:
+            validation_build = validation_dataloader_config.build(
+                dp_rank=self._get_dp_rank(),
+                dp_world_size=self._get_dp_group_size(),
+                batch_size=self.cfg.get("step_scheduler.local_batch_size"),
+            )
+            self.val_dataloader = validation_build.dataloader
+            self.val_sampler = validation_build.sampler
+            if len(self.val_dataloader) == 0:
+                raise RuntimeError("Validation dataloader is empty; remove data.validation_dataloader or fix its path")
+            if val_every_steps is None:
+                # is_val_step is also true on checkpoint steps, so validation is not dead here.
+                logging.warning(
+                    "[WARN] data.validation_dataloader is set without step_scheduler.val_every_steps; "
+                    "validation will only run at checkpoint steps"
+                )
+        elif val_every_steps is not None:
+            logging.warning(
+                "[WARN] step_scheduler.val_every_steps=%s is set but no data.validation_dataloader is configured; "
+                "validation is skipped",
+                val_every_steps,
+            )
+
         # Derive DP size consistent with model parallel config
         # (manual until the distributed section is standardized; DistributedSetup owns this math)
         if ddp_cfg is not None:
@@ -896,6 +924,59 @@ class TrainDiffusionRecipe(BaseRecipe):
             recipe=self._te_fp8_recipe,
             amax_reduction_group=self._te_fp8_group,
         )
+
+    def _run_validation_epoch(self, global_step: int) -> float:
+        """Score the held-out set with the training flow-matching objective.
+
+        The fixed seed makes every evaluation draw the same timesteps, noise, and CFG dropout,
+        so ``val_loss`` tracks the model rather than the sampling; ``ScopedRNG`` restores the
+        training RNG state afterwards, leaving the training trajectory unchanged.
+
+        The forward runs under the same compute-dtype autocast as training, so a single-rank
+        split-dtype config evaluates the way it trains. FP8 autocast is left out: delayed-scaling
+        amax history is training state and must not be updated from held-out batches.
+
+        Args:
+            global_step: Current optimizer step, forwarded to the flow-matching pipeline for
+                its periodic diagnostics.
+
+        Returns:
+            Mean loss over the validation batches of the data-parallel group, comparable to the
+            logged ``train_loss``.
+        """
+        self.model.eval()
+        local_loss_sum = 0.0
+        local_num_batches = 0
+        try:
+            with ScopedRNG(seed=self.seed, ranked=False), torch.no_grad(), self._autocast_context():
+                for batch in self.val_dataloader:
+                    _, average_weighted_loss, _, _ = self.flow_matching_pipeline.step(
+                        model=self.model,
+                        batch=batch,
+                        device=self.device,
+                        dtype=self.compute_dtype,
+                        global_step=global_step,
+                        collect_metrics=False,
+                        check_loss=False,
+                    )
+                    local_loss_sum += float(average_weighted_loss.detach())
+                    local_num_batches += 1
+        finally:
+            self.model.train()
+
+        # Ranks can hold a different number of batches, so reduce sum and count and divide once.
+        # CP peers all compute the same full-sequence loss, so the reduction excludes the cp axis.
+        totals = torch.tensor(
+            [local_loss_sum, float(local_num_batches)],
+            device=self._get_collective_device(),
+            dtype=torch.float64,
+        )
+        if dist.is_initialized():
+            dist.all_reduce(totals, op=dist.ReduceOp.SUM, group=self._get_dp_group())
+        global_loss_sum, global_num_batches = totals.tolist()
+        if global_num_batches == 0:
+            raise RuntimeError("Validation produced no batches; cannot compute validation loss")
+        return global_loss_sum / global_num_batches
 
     def run_train_validation_loop(self):
         logging.info("[INFO] Starting T2V training with Flow Matching")
@@ -1059,6 +1140,18 @@ class TrainDiffusionRecipe(BaseRecipe):
                                 "s/s": f"{throughput_metrics['samples_per_sec']:.1f}",
                                 "s/s/gpu": f"{throughput_metrics['samples_per_sec_per_gpu']:.2f}",
                             }
+                        )
+
+                if self.val_dataloader is not None and self.step_scheduler.is_val_step:
+                    val_loss = self._run_validation_epoch(global_step)
+                    if self.dist_env.is_main:
+                        if wandb.run is not None:
+                            wandb.log({"val_loss": val_loss}, step=global_step)
+                        logging.info(
+                            "[VAL] step=%s epoch=%s val_loss=%.6f",
+                            global_step,
+                            epoch,
+                            val_loss,
                         )
 
                 if self.step_scheduler.is_ckpt_step:

--- a/tests/unit_tests/recipes/test_diffusion_train.py
+++ b/tests/unit_tests/recipes/test_diffusion_train.py
@@ -352,6 +352,9 @@ def test_example_diffusion_yamls_coerce_through_typed_configs(yaml_path):
 
     assert cfg.optimizer is not None
 
+    if "validation_dataloader" in (raw.get("data") or {}):
+        assert cfg.diffusion_validation_dataloader is not None
+
 
 def test_recipe_config_resolves_diffusion_builder_target_to_typed_config():
     config = RecipeConfig(
@@ -376,6 +379,32 @@ def test_recipe_config_resolves_diffusion_builder_target_to_typed_config():
     assert config.cache_dir == "/tmp/cache"
     assert config.base_resolution == (512, 512)
     assert config.num_workers == 0
+
+
+def test_recipe_config_resolves_diffusion_validation_dataloader_only_when_declared():
+    raw = {
+        "data": {
+            "dataloader": {
+                "_target_": (
+                    "nemo_automodel.components.datasets.diffusion.build_text_to_image_multiresolution_dataloader"
+                ),
+                "cache_dir": "/tmp/cache",
+            }
+        }
+    }
+
+    assert RecipeConfig(ConfigNode(raw)).diffusion_validation_dataloader is None
+
+    raw["data"]["validation_dataloader"] = {
+        "_target_": "nemo_automodel.components.datasets.diffusion.build_text_to_image_multiresolution_dataloader",
+        "cache_dir": "/tmp/val-cache",
+        "shuffle": False,
+    }
+    config = RecipeConfig(ConfigNode(raw)).diffusion_validation_dataloader
+
+    assert isinstance(config, TextToImageDataloaderConfig)
+    assert config.cache_dir == "/tmp/val-cache"
+    assert config.shuffle is False
 
 
 def test_recipe_config_rejects_unknown_diffusion_dataloader_field():

--- a/tests/unit_tests/recipes/test_diffusion_train_metrics.py
+++ b/tests/unit_tests/recipes/test_diffusion_train_metrics.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call
@@ -21,6 +22,7 @@ import torch
 import torch.nn as nn
 
 from nemo_automodel.components.config.loader import ConfigNode
+from nemo_automodel.recipes._typed_config import RecipeConfig
 from nemo_automodel.recipes.diffusion import train as diffusion_train
 from nemo_automodel.recipes.diffusion.train import (
     TrainDiffusionRecipe,
@@ -218,6 +220,8 @@ def _minimal_diffusion_recipe_cfg(
     attention_backend="flash_varlen",
     optimize_hunyuan_flash_varlen_mask=True,
     fsdp=None,
+    checkpoint=None,
+    val_every_steps=None,
 ):
     cfg = {
         "model": {
@@ -237,6 +241,10 @@ def _minimal_diffusion_recipe_cfg(
     }
     if fsdp is not None:
         cfg["fsdp"] = fsdp
+    if checkpoint is not None:
+        cfg["checkpoint"] = checkpoint
+    if val_every_steps is not None:
+        cfg["step_scheduler"]["val_every_steps"] = val_every_steps
     return ConfigNode(cfg)
 
 
@@ -791,7 +799,7 @@ class _FakeValidationPipeline:
         return None, self.losses[(self.calls - 1) % len(self.losses)], None, {}
 
 
-def _make_validation_recipe(losses, num_batches=2):
+def _make_validation_recipe(losses, num_batches=2, dp_rank=0):
     recipe = object.__new__(TrainDiffusionRecipe)
     recipe.model = nn.Linear(1, 1)
     recipe.model.train()
@@ -799,9 +807,102 @@ def _make_validation_recipe(losses, num_batches=2):
     recipe.compute_dtype = torch.float32
     recipe._autocast_dtype = None
     recipe.seed = 1234
+    recipe._get_dp_rank = MagicMock(return_value=dp_rank)
     recipe.val_dataloader = [{"video_latents": torch.zeros(1, 1)} for _ in range(num_batches)]
     recipe.flow_matching_pipeline = _FakeValidationPipeline(losses)
     return recipe
+
+
+class _StopSetupAfterDataloaders(Exception):
+    """Ends ``setup()`` right after the dataloader section; the rest needs a real model."""
+
+
+def _patch_setup_dataloaders(monkeypatch, *, validation_batches=1, with_validation=True):
+    """Run ``setup()`` through the dataloader section with stub typed configs.
+
+    Returns the validation config stub so tests can assert how ``build`` was called.
+    """
+    _patch_lightweight_diffusion_recipe_setup(monkeypatch)
+    monkeypatch.setattr(
+        diffusion_train,
+        "build_diffusion_pipeline",
+        MagicMock(return_value=(SimpleNamespace(transformer=nn.Linear(1, 1)), None)),
+    )
+
+    validation_config = None
+    if with_validation:
+        validation_config = SimpleNamespace(
+            build=MagicMock(
+                return_value=SimpleNamespace(dataloader=[object()] * validation_batches, sampler="val-sampler")
+            )
+        )
+
+    def _stop(self):
+        raise _StopSetupAfterDataloaders
+
+    monkeypatch.setattr(RecipeConfig, "checkpoint", property(lambda self: SimpleNamespace(build=MagicMock())))
+    monkeypatch.setattr(
+        RecipeConfig,
+        "diffusion_dataloader",
+        property(
+            lambda self: SimpleNamespace(
+                build=MagicMock(return_value=SimpleNamespace(dataloader=[object()], sampler="train-sampler"))
+            )
+        ),
+    )
+    monkeypatch.setattr(RecipeConfig, "diffusion_validation_dataloader", property(lambda self: validation_config))
+    monkeypatch.setattr(RecipeConfig, "step_scheduler", property(_stop))
+    return validation_config
+
+
+def _setup_cfg(**kwargs):
+    return _minimal_diffusion_recipe_cfg(
+        adapter_type="simple",
+        attention_backend=None,
+        optimize_hunyuan_flash_varlen_mask=False,
+        checkpoint={"enabled": False},
+        **kwargs,
+    )
+
+
+def test_setup_shards_the_validation_dataloader_like_the_training_one(monkeypatch):
+    validation_config = _patch_setup_dataloaders(monkeypatch)
+    recipe = TrainDiffusionRecipe(_setup_cfg(val_every_steps=5))
+
+    with pytest.raises(_StopSetupAfterDataloaders):
+        recipe.setup()
+
+    # dist is not initialized in the harness, so the data-parallel group is rank 0 of 1.
+    validation_config.build.assert_called_once_with(dp_rank=0, dp_world_size=1, batch_size=1)
+    assert recipe.val_sampler == "val-sampler"
+    assert len(recipe.val_dataloader) == 1
+
+
+def test_setup_rejects_an_empty_validation_dataloader(monkeypatch):
+    _patch_setup_dataloaders(monkeypatch, validation_batches=0)
+    recipe = TrainDiffusionRecipe(_setup_cfg(val_every_steps=5))
+
+    with pytest.raises(RuntimeError, match="Validation dataloader is empty"):
+        recipe.setup()
+
+
+@pytest.mark.parametrize(
+    ("with_validation", "val_every_steps", "expected_warning"),
+    [
+        (True, None, "without step_scheduler.val_every_steps"),
+        (False, 100, "no data.validation_dataloader is configured"),
+    ],
+)
+def test_setup_warns_when_the_loader_and_the_cadence_disagree(
+    monkeypatch, caplog, with_validation, val_every_steps, expected_warning
+):
+    _patch_setup_dataloaders(monkeypatch, with_validation=with_validation)
+    recipe = TrainDiffusionRecipe(_setup_cfg(val_every_steps=val_every_steps))
+
+    with caplog.at_level(logging.WARNING), pytest.raises(_StopSetupAfterDataloaders):
+        recipe.setup()
+
+    assert expected_warning in caplog.text
 
 
 def test_run_validation_epoch_averages_batch_losses_in_eval_mode(monkeypatch):
@@ -857,6 +958,28 @@ def test_run_validation_epoch_repeats_sampling_and_leaves_training_rng_untouched
     assert train_draw == pytest.approx(expected_train_draw)
 
 
+def test_run_validation_epoch_raises_when_the_loader_yields_no_batches(monkeypatch):
+    monkeypatch.setattr(diffusion_train.dist, "is_initialized", lambda: False)
+    recipe = _make_validation_recipe([torch.tensor(1.0)], num_batches=0)
+
+    with pytest.raises(RuntimeError, match="Validation produced no batches"):
+        recipe._run_validation_epoch(global_step=0)
+
+
+def test_run_validation_epoch_decorrelates_sampling_across_dp_ranks(monkeypatch):
+    monkeypatch.setattr(diffusion_train.dist, "is_initialized", lambda: False)
+    losses = [torch.tensor(1.0), torch.tensor(3.0)]
+    # Ranks hold different shards, so drawing the same timesteps and noise everywhere would
+    # correlate the estimate; training offsets its seed by the data rank for the same reason.
+    rank0 = _make_validation_recipe(losses, dp_rank=0)
+    rank1 = _make_validation_recipe(losses, dp_rank=1)
+
+    rank0._run_validation_epoch(global_step=0)
+    rank1._run_validation_epoch(global_step=0)
+
+    assert rank0.flow_matching_pipeline.random_draws != rank1.flow_matching_pipeline.random_draws
+
+
 def test_run_validation_epoch_reduces_sum_and_count_over_dp_group(monkeypatch):
     recipe = _make_validation_recipe([torch.tensor(2.0), torch.tensor(4.0)])
     recipe._get_dp_group = MagicMock(return_value="dp-group")
@@ -888,7 +1011,9 @@ def test_run_train_validation_loop_validates_only_with_a_val_dataloader(monkeypa
     monkeypatch.setattr(diffusion_train, "prepare_after_first_microbatch", MagicMock())
     monkeypatch.setattr(diffusion_train, "clip_grad_norm", MagicMock(return_value=torch.tensor(0.25)))
     monkeypatch.setattr(diffusion_train.torch.cuda, "is_available", lambda: False)
-    monkeypatch.setattr(diffusion_train.wandb, "run", None, raising=False)
+    wandb_log = MagicMock()
+    monkeypatch.setattr(diffusion_train.wandb, "run", MagicMock(), raising=False)
+    monkeypatch.setattr(diffusion_train.wandb, "log", wandb_log, raising=False)
 
     recipe = object.__new__(TrainDiffusionRecipe)
     recipe.dist_env = SimpleNamespace(is_main=True)
@@ -928,5 +1053,7 @@ def test_run_train_validation_loop_validates_only_with_a_val_dataloader(monkeypa
 
     if with_val_dataloader:
         recipe._run_validation_epoch.assert_called_once_with(1)
+        assert call({"val_loss": 1.25}, step=1) in wandb_log.call_args_list
     else:
         recipe._run_validation_epoch.assert_not_called()
+        assert all(call_args.args[0].keys() != {"val_loss"} for call_args in wandb_log.call_args_list)

--- a/tests/unit_tests/recipes/test_diffusion_train_metrics.py
+++ b/tests/unit_tests/recipes/test_diffusion_train_metrics.py
@@ -652,11 +652,12 @@ class _FakeProgressBar:
 
 
 class _FakeStepScheduler:
-    def __init__(self, batch_group):
+    def __init__(self, batch_group, is_val_step=False):
         self.step = 0
         self.epochs = [0]
         self.dataloader = None
         self.is_ckpt_step = False
+        self.is_val_step = is_val_step
         self.log_remote_every_steps = 1
         self._batch_group = batch_group
 
@@ -700,6 +701,7 @@ def test_run_train_validation_loop_uses_hot_path_and_logs_perf_metrics(monkeypat
     recipe.sampler = SimpleNamespace(set_epoch=MagicMock())
     recipe.dataloader = [object()]
     recipe.step_scheduler = _FakeStepScheduler(batch_group)
+    recipe.val_dataloader = None
     recipe.optimizer = [
         SimpleNamespace(
             zero_grad=MagicMock(),
@@ -764,3 +766,167 @@ def test_run_train_validation_loop_uses_hot_path_and_logs_perf_metrics(monkeypat
         "s/s": "2.5",
         "s/s/gpu": "2.50",
     }
+
+
+class _FakeValidationPipeline:
+    """Flow-matching stub recording how each validation batch was executed."""
+
+    def __init__(self, losses):
+        self.losses = list(losses)
+        self.calls = 0
+        self.grad_enabled = []
+        self.model_was_training = []
+        self.random_draws = []
+        self.autocast_dtypes = []
+
+    def step(self, *, model, batch, device, dtype, global_step, collect_metrics, check_loss):
+        self.grad_enabled.append(torch.is_grad_enabled())
+        self.model_was_training.append(model.training)
+        self.autocast_dtypes.append(
+            torch.get_autocast_dtype(device.type) if torch.is_autocast_enabled(device.type) else None
+        )
+        # Flow matching draws timesteps and noise per step; record the draw to check repeatability.
+        self.random_draws.append(float(torch.rand(())))
+        self.calls += 1
+        return None, self.losses[(self.calls - 1) % len(self.losses)], None, {}
+
+
+def _make_validation_recipe(losses, num_batches=2):
+    recipe = object.__new__(TrainDiffusionRecipe)
+    recipe.model = nn.Linear(1, 1)
+    recipe.model.train()
+    recipe.device = torch.device("cpu")
+    recipe.compute_dtype = torch.float32
+    recipe._autocast_dtype = None
+    recipe.seed = 1234
+    recipe.val_dataloader = [{"video_latents": torch.zeros(1, 1)} for _ in range(num_batches)]
+    recipe.flow_matching_pipeline = _FakeValidationPipeline(losses)
+    return recipe
+
+
+def test_run_validation_epoch_averages_batch_losses_in_eval_mode(monkeypatch):
+    monkeypatch.setattr(diffusion_train.dist, "is_initialized", lambda: False)
+    recipe = _make_validation_recipe([torch.tensor(2.0), torch.tensor(4.0)])
+
+    val_loss = recipe._run_validation_epoch(global_step=7)
+
+    assert val_loss == pytest.approx(3.0)
+    assert recipe.flow_matching_pipeline.grad_enabled == [False, False]
+    assert recipe.flow_matching_pipeline.model_was_training == [False, False]
+    assert recipe.model.training is True
+
+
+def test_run_validation_epoch_runs_under_the_training_autocast(monkeypatch):
+    monkeypatch.setattr(diffusion_train.dist, "is_initialized", lambda: False)
+    recipe = _make_validation_recipe([torch.tensor(2.0)], num_batches=1)
+    # Split-dtype configs leave parameters in model_dtype when FSDP2 skips sharding; the
+    # validation forward needs the same cast the training forward gets.
+    recipe._autocast_dtype = torch.bfloat16
+
+    recipe._run_validation_epoch(global_step=0)
+
+    assert recipe.flow_matching_pipeline.autocast_dtypes == [torch.bfloat16]
+
+
+def test_run_validation_epoch_restores_train_mode_when_a_batch_fails(monkeypatch):
+    monkeypatch.setattr(diffusion_train.dist, "is_initialized", lambda: False)
+    recipe = _make_validation_recipe([torch.tensor(2.0)])
+    recipe.flow_matching_pipeline.step = MagicMock(side_effect=RuntimeError("boom"))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        recipe._run_validation_epoch(global_step=0)
+
+    assert recipe.model.training is True
+
+
+def test_run_validation_epoch_repeats_sampling_and_leaves_training_rng_untouched(monkeypatch):
+    monkeypatch.setattr(diffusion_train.dist, "is_initialized", lambda: False)
+    recipe = _make_validation_recipe([torch.tensor(1.0), torch.tensor(3.0)])
+
+    torch.manual_seed(7)
+    expected_train_draw = float(torch.rand(()))
+
+    torch.manual_seed(7)
+    recipe._run_validation_epoch(global_step=0)
+    first_draws = list(recipe.flow_matching_pipeline.random_draws)
+    train_draw = float(torch.rand(()))
+    recipe.flow_matching_pipeline.random_draws.clear()
+    recipe._run_validation_epoch(global_step=1)
+
+    assert recipe.flow_matching_pipeline.random_draws == first_draws
+    assert train_draw == pytest.approx(expected_train_draw)
+
+
+def test_run_validation_epoch_reduces_sum_and_count_over_dp_group(monkeypatch):
+    recipe = _make_validation_recipe([torch.tensor(2.0), torch.tensor(4.0)])
+    recipe._get_dp_group = MagicMock(return_value="dp-group")
+    all_reduce_calls = []
+
+    def fake_all_reduce(tensor, op=None, group=None):
+        all_reduce_calls.append((op, group, tensor.tolist()))
+        # Emulate a second data-parallel rank holding an identical shard.
+        tensor.mul_(2)
+
+    monkeypatch.setattr(diffusion_train.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(diffusion_train.dist, "get_backend", lambda: "gloo")
+    monkeypatch.setattr(diffusion_train.dist, "all_reduce", fake_all_reduce)
+
+    val_loss = recipe._run_validation_epoch(global_step=0)
+
+    assert all_reduce_calls == [(diffusion_train.dist.ReduceOp.SUM, "dp-group", [6.0, 2.0])]
+    # 12.0 summed loss over 4 summed batches: the mean is invariant to the rank count.
+    assert val_loss == pytest.approx(3.0)
+
+
+@pytest.mark.parametrize("with_val_dataloader", [True, False])
+def test_run_train_validation_loop_validates_only_with_a_val_dataloader(monkeypatch, with_val_dataloader):
+    batch_group = [{"video_latents": torch.zeros(2, 1), "text_embeddings": torch.zeros(2, 1)}]
+
+    monkeypatch.setitem(sys.modules, "tqdm", SimpleNamespace(tqdm=lambda iterable, desc: iterable))
+    monkeypatch.setattr(diffusion_train, "prepare_for_grad_accumulation", MagicMock())
+    monkeypatch.setattr(diffusion_train, "prepare_for_final_backward", MagicMock())
+    monkeypatch.setattr(diffusion_train, "prepare_after_first_microbatch", MagicMock())
+    monkeypatch.setattr(diffusion_train, "clip_grad_norm", MagicMock(return_value=torch.tensor(0.25)))
+    monkeypatch.setattr(diffusion_train.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(diffusion_train.wandb, "run", None, raising=False)
+
+    recipe = object.__new__(TrainDiffusionRecipe)
+    recipe.dist_env = SimpleNamespace(is_main=True)
+    recipe.global_batch_size = 2
+    recipe.local_batch_size = 2
+    recipe.num_nodes = 1
+    recipe.dp_size = 1
+    recipe.cp_size = 1
+    recipe.world_size = 1
+    recipe.num_epochs = 1
+    recipe.sampler = None
+    recipe.dataloader = [object()]
+    recipe.step_scheduler = _FakeStepScheduler(batch_group, is_val_step=True)
+    recipe.optimizer = [SimpleNamespace(zero_grad=MagicMock(), step=MagicMock(), param_groups=[{"lr": 0.01}])]
+    recipe.lr_scheduler = None
+    recipe.model = nn.Linear(1, 1)
+    recipe.device = torch.device("cpu")
+    recipe.compute_dtype = torch.float32
+    recipe.check_loss = False
+    recipe.clip_grad_max_norm = 0.5
+    recipe.grad_clip_foreach = False
+    recipe.defer_fsdp_grad_sync = True
+    recipe.transformer_engine_fp8 = False
+    recipe._autocast_dtype = None
+    recipe.peft_cfg = None
+    recipe._elapsed_seconds_since = MagicMock(return_value=(2.0, 10.0))
+    recipe._count_global_samples = MagicMock(return_value=2)
+    recipe._get_memory_metrics = MagicMock(return_value={"mem": 0.0, "max_memory_allocated_gb": 0.0})
+    recipe.save_checkpoint = MagicMock()
+    recipe.val_dataloader = [{"video_latents": torch.zeros(1, 1)}] if with_val_dataloader else None
+    recipe._run_validation_epoch = MagicMock(return_value=1.25)
+    recipe.flow_matching_pipeline = SimpleNamespace(
+        step=MagicMock(return_value=(None, torch.tensor(2.0, requires_grad=True), None, {}))
+    )
+
+    recipe.run_train_validation_loop()
+
+    if with_val_dataloader:
+        recipe._run_validation_epoch.assert_called_once_with(1)
+    else:
+        recipe._run_validation_epoch.assert_not_called()


### PR DESCRIPTION
# What does this PR do ?

Adds periodic validation loss to the diffusion training recipe, so checking eval loss no longer means saving a checkpoint and running the eval set through the model by hand.

# Changelog

* New optional `data.validation_dataloader` block, resolved by the same `resolve_diffusion_dataloader` as the training loader (`_typed_config.py`), so it takes the same four builders and the same field validation. One loader, matching the training side, rather than the dict of named loaders the LLM recipe has.
* The recipe builds it in `setup()` with the same dp sharding and batch size as the training loader, and raises if it comes out empty. Half-configured setups get a warning instead of silence: a loader without `val_every_steps` validates on checkpoint steps only, `val_every_steps` without a loader is skipped.
* `_run_validation_epoch` scores the held-out set with the training flow-matching objective in `eval()` under `torch.no_grad()`, restores train mode in a `finally`, and reduces `[loss_sum, batch_count]` in one all-reduce over the dp group, so the mean does not depend on how batches are spread across ranks. CP is excluded from that reduction since every peer computes the same full-sequence loss.
* The pass runs inside `ScopedRNG(seed=self.seed)`. Without it the sampled timesteps dominate the curve and validation would consume the training RNG stream, changing the run. FP8 autocast is deliberately not applied: delayed-scaling amax history is training state and should not be updated from held-out batches.
* The loop calls it on `step_scheduler.is_val_step`, before the checkpoint branch, and logs `val_loss` to the console and to W&B.
* Example config (`wan2_2_t2v_flow.yaml`) and the diffusion fine-tuning guide.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](<https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md>)
- [X] Did you write any new necessary tests?
- [X] Did you add or update any necessary documentation?

# Additional Information

* Closes NVIDIA-NeMo/Automodel#3244
* Unit tests cover the averaging in eval mode, train mode restored after a failing batch, repeatable sampling with the training RNG left untouched, the dp reduction, and that the loop validates only when a loader is configured.
* Ran it for real on 2x H200 with FSDP2 (`dp_size: 2`) against a small Wan transformer: validation fired at the configured steps and the run finished clean. Also ran the same training twice, with and without validation enabled, and the training losses and final weights come out bit-identical, which is the property the fixed seed and RNG restore are there for.
* Not exercised: `cp_size > 1`, `tp_size > 1`, multi-node, and the LoRA and FP8 paths.