### PR TITLE
perf(checkpoint): reduce allocating grouped MoE load overhead

### DIFF
--- a/examples/vlm_finetune/gemma4/gemma4_26b_a4b_moe.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_26b_a4b_moe.yaml
@@ -119,8 +119,8 @@ freeze_config:
 ci:
   recipe_owner: athitten
   nodes: 1
-  # Full robustness takes about 50 minutes.
-  time: "01:15:00"
+  # Full robustness measured 32 minutes; keep 13 minutes for filesystem variance.
+  time: "00:45:00"
   # Keep failures blocking; residual MoE drift is tracked by AM-707/AM-719.
   checkpoint_robustness:
     # The shared robustness batch of 2 exceeds this 26B MoE recipe's memory

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -830,12 +830,10 @@ class Checkpointer:
         # fall behind other ranks' async allocations.
         is_safetensors = _is_safetensors_checkpoint(model_path)
         is_custom_model = _is_custom_model(model_state.model[0])
-        # Custom adapters traditionally took the frugal full-state path here because converting
-        # grouped experts into load destinations could materialize a second on-device copy and OOM.
-        # Adapters whose model-sized destinations alias final model storage can now opt into the standard DCP path
-        # below, which writes checkpoint tensors directly through those views. A bounded adapter may also retain
-        # small auxiliary destinations that it consumes in-place after the read. Keep the CPU path for other
-        # non-aliasing adapters and quantized initialization, whose conversion allocates model-sized tensors.
+        # Custom models traditionally loaded the complete checkpoint on the host because model-specific conversion
+        # could otherwise create a second full copy on the GPU. Use DCP when the adapter can place large checkpoint
+        # values directly in model weight memory. An adapter such as Gemma4 may also use a small temporary value that
+        # it applies after the read. Other custom adapters and quantized initialization keep the host fallback.
         # World size inline (not via components.distributed) so the checkpoint component stays
         # independent per the import-linter contract.
         if torch.distributed.is_initialized():
@@ -843,16 +841,16 @@ class Checkpointer:
         else:
             world_size = int(os.environ.get("WORLD_SIZE", "1"))
         state_dict_adapter = getattr(_unwrap_ddp_model(model_state.model[0]), "state_dict_adapter", None)
-        supports_memory_bounded_checkpoint_load = (
+        can_load_without_full_copy = (
             isinstance(state_dict_adapter, StateDictAdapter)
             and (
                 state_dict_adapter.supports_write_through_checkpoint_load
-                or state_dict_adapter.supports_bounded_checkpoint_load
+                or state_dict_adapter.supports_checkpoint_load_without_full_copy
             )
             and not self.config.dequantize_base_checkpoint
         )
         single_device_custom_safetensors = (
-            is_safetensors and is_custom_model and world_size == 1 and not supports_memory_bounded_checkpoint_load
+            is_safetensors and is_custom_model and world_size == 1 and not can_load_without_full_copy
         )
         if (
             is_init_step
@@ -936,7 +934,7 @@ class Checkpointer:
             # Only base-checkpoint initialization needs FP8 scale destinations.
             quantization=bool(is_init_step and self.config.dequantize_base_checkpoint),
             device_mesh=self.moe_mesh,
-            load_into_empty_destinations=True,
+            for_checkpoint_load=True,
         )
         destinations_ready = time.monotonic()
         requested_bytes = sum(

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -932,6 +932,7 @@ class Checkpointer:
             # Only base-checkpoint initialization needs FP8 scale destinations.
             quantization=bool(is_init_step and self.config.dequantize_base_checkpoint),
             device_mesh=self.moe_mesh,
+            load_into_empty_destinations=True,
         )
         destinations_ready = time.monotonic()
         requested_bytes = sum(

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -832,9 +832,10 @@ class Checkpointer:
         is_custom_model = _is_custom_model(model_state.model[0])
         # Custom adapters traditionally took the frugal full-state path here because converting
         # grouped experts into load destinations could materialize a second on-device copy and OOM.
-        # Adapters whose destinations all alias final model storage can now opt into the standard
-        # DCP path below, which writes checkpoint tensors directly through those views. Keep the CPU
-        # path for non-aliasing backends and quantized initialization, whose conversion allocates.
+        # Adapters whose model-sized destinations alias final model storage can now opt into the standard DCP path
+        # below, which writes checkpoint tensors directly through those views. A bounded adapter may also retain
+        # small auxiliary destinations that it consumes in-place after the read. Keep the CPU path for other
+        # non-aliasing adapters and quantized initialization, whose conversion allocates model-sized tensors.
         # World size inline (not via components.distributed) so the checkpoint component stays
         # independent per the import-linter contract.
         if torch.distributed.is_initialized():
@@ -842,13 +843,16 @@ class Checkpointer:
         else:
             world_size = int(os.environ.get("WORLD_SIZE", "1"))
         state_dict_adapter = getattr(_unwrap_ddp_model(model_state.model[0]), "state_dict_adapter", None)
-        supports_write_through_checkpoint_load = (
+        supports_memory_bounded_checkpoint_load = (
             isinstance(state_dict_adapter, StateDictAdapter)
-            and state_dict_adapter.supports_write_through_checkpoint_load
+            and (
+                state_dict_adapter.supports_write_through_checkpoint_load
+                or state_dict_adapter.supports_bounded_checkpoint_load
+            )
             and not self.config.dequantize_base_checkpoint
         )
         single_device_custom_safetensors = (
-            is_safetensors and is_custom_model and world_size == 1 and not supports_write_through_checkpoint_load
+            is_safetensors and is_custom_model and world_size == 1 and not supports_memory_bounded_checkpoint_load
         )
         if (
             is_init_step

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -832,7 +832,7 @@ class Checkpointer:
         is_custom_model = _is_custom_model(model_state.model[0])
         # Custom models traditionally loaded the complete checkpoint on the host because model-specific conversion
         # could otherwise create a second full copy on the GPU. Use DCP when the adapter can place large checkpoint
-        # values directly in model weight memory. An adapter such as Gemma4 may also use a small temporary value that
+        # tensors directly in model weight memory. An adapter such as Gemma4 may also use a small temporary tensor that
         # it applies after the read. Other custom adapters and quantized initialization keep the host fallback.
         # World size inline (not via components.distributed) so the checkpoint component stays
         # independent per the import-linter contract.

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -868,6 +868,7 @@ class Checkpointer:
                 )
             else:
                 state_dict_from_disk = {}
+            t_adapt = time.monotonic()
 
             # Apply key_mapping (e.g. _checkpoint_conversion_mapping) so that
             # HF checkpoint keys are renamed to match the model's parameter FQNs.
@@ -896,13 +897,14 @@ class Checkpointer:
             t_end = time.monotonic()
 
             disk_s = t_disk - t0
-            dist_s = t_end - t_disk
+            adapt_s = t_adapt - t_disk
+            install_s = t_end - t_adapt
             total_s = t_end - t0
             gb = total_bytes / (1 << 30)
             logging.info(
                 f"load_model: {gb:.2f} GB loaded in {total_s:.2f}s "
                 f"({gb / total_s:.2f} GB/s overall | "
-                f"disk read {disk_s:.2f}s, distribute {dist_s:.2f}s)"
+                f"disk read {disk_s:.2f}s, adapt {adapt_s:.2f}s, install {install_s:.2f}s)"
             )
             del state_dict_from_disk
             gc.collect()

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -1351,7 +1351,7 @@ class Checkpointer:
                     _maybe_rename_index_for_diffusers(consolidated_dir)
                 if is_rank_0():
                     logger.info("Successfully exported consolidated HF safetensors to %s.", consolidated_dir)
-            except BaseException as e:  # noqa: B036 - re-raised on the main thread in async_wait
+            except BaseException as e:  # Re-raised on the main thread in async_wait.
                 self._consolidation_error = e
 
         self._consolidation_thread = threading.Thread(

--- a/nemo_automodel/components/checkpoint/state_dict_adapter.py
+++ b/nemo_automodel/components/checkpoint/state_dict_adapter.py
@@ -27,30 +27,25 @@ class StateDictAdapter(ABC):
     """
 
     _supports_write_through_checkpoint_load: bool = False
-    _supports_bounded_checkpoint_load: bool = False
+    _supports_checkpoint_load_without_full_copy: bool = False
 
     @property
     def supports_write_through_checkpoint_load(self) -> bool:
-        """Whether all checkpoint-load destinations write through to final model storage.
+        """Whether every checkpoint value is loaded directly into final model weight memory.
 
-        Adapters should set ``_supports_write_through_checkpoint_load`` only when every tensor produced by
-        ``to_hf`` for base-checkpoint loading is either the original model tensor or a view that writes through
-        to it. The checkpoint loader uses this guarantee to avoid materializing a converted full state dict on
-        the host.
+        Enable this only when writing every tensor returned by ``to_hf`` for base-checkpoint loading updates the
+        model itself. This lets the loader skip a complete CPU copy of the checkpoint.
         """
         return self._supports_write_through_checkpoint_load
 
     @property
-    def supports_bounded_checkpoint_load(self) -> bool:
-        """Whether single-device checkpoint loading avoids a full converted state dict.
+    def supports_checkpoint_load_without_full_copy(self) -> bool:
+        """Whether DCP can load this adapter without another full set of model weights.
 
-        Adapters should set ``_supports_bounded_checkpoint_load`` only when every model-sized destination produced by
-        ``to_hf(..., load_into_empty_destinations=True)`` writes through to final model storage. Any allocating
-        destinations must be bounded auxiliary tensors, and ``from_hf`` must complete their conversion without
-        allocating another model-sized tensor. This is weaker than ``supports_write_through_checkpoint_load`` because
-        bounded auxiliary destinations do not need to alias model storage.
+        Large checkpoint values must be loaded into the model's existing weight memory. Small temporary values are
+        allowed; for example, Gemma4 loads a scale vector and applies it to an already-loaded model weight.
         """
-        return self._supports_bounded_checkpoint_load
+        return self._supports_checkpoint_load_without_full_copy
 
     @abstractmethod
     def to_hf(self, state_dict: dict[str, Any], **kwargs) -> dict[str, Any]:

--- a/nemo_automodel/components/checkpoint/state_dict_adapter.py
+++ b/nemo_automodel/components/checkpoint/state_dict_adapter.py
@@ -27,6 +27,7 @@ class StateDictAdapter(ABC):
     """
 
     _supports_write_through_checkpoint_load: bool = False
+    _supports_bounded_checkpoint_load: bool = False
 
     @property
     def supports_write_through_checkpoint_load(self) -> bool:
@@ -38,6 +39,18 @@ class StateDictAdapter(ABC):
         the host.
         """
         return self._supports_write_through_checkpoint_load
+
+    @property
+    def supports_bounded_checkpoint_load(self) -> bool:
+        """Whether single-device checkpoint loading avoids a full converted state dict.
+
+        Adapters should set ``_supports_bounded_checkpoint_load`` only when every model-sized destination produced by
+        ``to_hf(..., load_into_empty_destinations=True)`` writes through to final model storage. Any allocating
+        destinations must be bounded auxiliary tensors, and ``from_hf`` must complete their conversion without
+        allocating another model-sized tensor. This is weaker than ``supports_write_through_checkpoint_load`` because
+        bounded auxiliary destinations do not need to alias model storage.
+        """
+        return self._supports_bounded_checkpoint_load
 
     @abstractmethod
     def to_hf(self, state_dict: dict[str, Any], **kwargs) -> dict[str, Any]:

--- a/nemo_automodel/components/checkpoint/state_dict_adapter.py
+++ b/nemo_automodel/components/checkpoint/state_dict_adapter.py
@@ -31,7 +31,7 @@ class StateDictAdapter(ABC):
 
     @property
     def supports_write_through_checkpoint_load(self) -> bool:
-        """Whether every checkpoint value is loaded directly into final model weight memory.
+        """Whether every checkpoint tensor is loaded directly into the model's existing weight memory.
 
         Enable this only when writing every tensor returned by ``to_hf`` for base-checkpoint loading updates the
         model itself. This lets the loader skip a complete CPU copy of the checkpoint.
@@ -42,8 +42,9 @@ class StateDictAdapter(ABC):
     def supports_checkpoint_load_without_full_copy(self) -> bool:
         """Whether DCP can load this adapter without another full set of model weights.
 
-        Large checkpoint values must be loaded into the model's existing weight memory. Small temporary values are
-        allowed; for example, Gemma4 loads a scale vector and applies it to an already-loaded model weight.
+        Large checkpoint tensors must be loaded into the model's existing weight memory. Small temporary tensors are
+        allowed when they can be applied and discarded without making a model-sized copy. For example, Gemma4 loads
+        a scale tensor and applies it to already-loaded expert weights.
         """
         return self._supports_checkpoint_load_without_full_copy
 

--- a/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
@@ -59,6 +59,8 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
       4. Expert-parallel sharding when a device mesh is provided
     """
 
+    _supports_bounded_checkpoint_load = True
+
     def __init__(
         self,
         config: Any,
@@ -71,6 +73,7 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
         self.backend = backend
         self.dtype = dtype
         self._uses_model_prefix = True
+        self._load_destinations_alias_model = False
 
     # ------------------------------------------------------------------
     # HF -> NeMo
@@ -81,6 +84,24 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
         device_mesh: Optional[DeviceMesh] = None,
         **kwargs,
     ) -> dict[str, Any]:
+        """Convert Hugging Face Gemma4 weights into native model layout.
+
+        Args:
+            hf_state_dict: Hugging Face state mapping. Expert gate/up tensors have shape
+                ``[experts, 2 * expert_hidden, hidden]`` and down tensors have shape
+                ``[experts, hidden, expert_hidden]``. When prepared by ``to_hf`` for a bounded checkpoint load,
+                those tensors are transposed views of final model storage and are mutated in place.
+            device_mesh: Optional expert-parallel mesh. Distributed conversion slices the global expert axis and may
+                shard the native feature axis according to the mesh.
+            **kwargs: Additional adapter-interface arguments.
+
+        Returns:
+            Native state mapping. Expert gate/up tensors have shape ``[local_experts, hidden, 2 * expert_hidden]``
+            and down tensors have shape ``[local_experts, expert_hidden, hidden]``. Bounded-load outputs alias final
+            model storage; materialized conversion outputs own their storage.
+        """
+        load_destinations_alias_model = self._load_destinations_alias_model and device_mesh is None
+        self._load_destinations_alias_model = False
         self._uses_model_prefix = any(key.startswith("model.") for key in hf_state_dict)
         model_prefix = "model." if self._uses_model_prefix else ""
 
@@ -125,7 +146,7 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
             state_dict[key] = value
 
         # Process collected expert weights per layer
-        _REQUIRED_EXPERT_KEYS = {"gate_up_proj", "down_proj"}
+        _REQUIRED_EXPERT_KEYS = {"gate_up_proj", "down_proj", "per_expert_scale"}
         for layer_path, tensors in expert_buffers.items():
             missing = _REQUIRED_EXPERT_KEYS - tensors.keys()
             if missing:
@@ -139,15 +160,22 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
             per_expert_scale = tensors["per_expert_scale"]  # [E]
 
             # Transpose gate_up_proj from HF [E, 2*inter, hidden] to NeMo [E, hidden, 2*inter]
-            gate_and_up = gate_up_proj.transpose(-2, -1)  # [E, hidden, 2*inter]
+            if load_destinations_alias_model:
+                # DCP loaded the checkpoint through transposed views of final model storage. Gate/up only needs its
+                # native view restored; down additionally absorbs the small per-expert scale destination in place.
+                gate_and_up_local = gate_up_proj.transpose(-2, -1)
+                down_proj.mul_(per_expert_scale[:, None, None])
+                down_local = down_proj.transpose(-2, -1)
+            else:
+                gate_and_up = gate_up_proj.transpose(-2, -1)  # [E, hidden, 2*inter]
 
-            # Transpose down_proj from HF [E, hidden, inter] to NeMo [E, inter, hidden]
-            # and absorb per_expert_scale
-            down = down_proj.transpose(-2, -1) * per_expert_scale[:, None, None]  # [E, inter, hidden]
+                # Transpose down_proj from HF [E, hidden, inter] to NeMo [E, inter, hidden]
+                # and absorb per_expert_scale
+                down = down_proj.transpose(-2, -1) * per_expert_scale[:, None, None]  # [E, inter, hidden]
 
-            # Slice for EP
-            gate_and_up_local = gate_and_up[start_expert:end_expert].to(self.dtype)
-            down_local = down[start_expert:end_expert].to(self.dtype)
+                # Slice for EP
+                gate_and_up_local = gate_and_up[start_expert:end_expert].to(self.dtype)
+                down_local = down[start_expert:end_expert].to(self.dtype)
 
             # Slice for EP_SHARD across the feature dimension before wrapping as DTensor.
             if device_mesh is not None and "ep_shard" in device_mesh.mesh_dim_names:
@@ -185,10 +213,39 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
         quantization: bool = False,
         **kwargs,
     ) -> dict[str, Any]:
+        """Convert native Gemma4 weights to Hugging Face keys and layouts.
+
+        Args:
+            state_dict: Native state mapping. Expert gate/up tensors have shape
+                ``[local_experts, hidden, 2 * expert_hidden]`` and down tensors have shape
+                ``[local_experts, expert_hidden, hidden]``.
+            exclude_key_regex: Optional pattern selecting keys to omit.
+            quantization: Whether checkpoint initialization requires a precision conversion. Quantized loads do not
+                use aliasing destinations.
+            **kwargs: Adapter-interface arguments. ``device_mesh`` describes expert sharding.
+                ``load_into_empty_destinations=True`` requests memory-bounded single-device load destinations.
+
+        Returns:
+            Hugging Face state mapping. Expert gate/up tensors have shape
+            ``[experts, 2 * expert_hidden, hidden]`` and down tensors have shape
+            ``[experts, hidden, expert_hidden]``. For a bounded load, model-sized outputs are transposed views of
+            final model storage and each ``per_expert_scale`` output is an independently owned ``[experts]`` tensor.
+        """
         self._uses_model_prefix = any(key.startswith("model.") for key in state_dict)
         prefix = "model." if self._uses_model_prefix else ""
         device_mesh: Optional[DeviceMesh] = kwargs.get("device_mesh")
         n_experts = self.moe_config.n_routed_experts
+        load_into_model_storage = (
+            bool(kwargs.get("load_into_empty_destinations", False))
+            and not quantization
+            and device_mesh is None
+            and all(
+                isinstance(tensor, torch.Tensor) and not tensor.is_meta and not state_dict_utils.is_dtensor(tensor)
+                for fqn, tensor in state_dict.items()
+                if ".moe.experts." in fqn
+            )
+        )
+        self._load_destinations_alias_model = load_into_model_storage
 
         hf_state_dict: dict[str, Any] = {}
 
@@ -205,20 +262,31 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
             # --- Expert: gate_and_up_projs -> experts.gate_up_proj ---
             if ".moe.experts.gate_and_up_projs" in fqn:
                 layer_num = re.search(r"layers\.(\d+)", fqn).group(1)
-                global_tensor = self._gather_expert_tensor(tensor, device_mesh, n_experts)
                 layer_prefix = f"{prefix}language_model.layers.{layer_num}"
-                # Transpose from NeMo [E, hidden, 2*inter] to HF [E, 2*inter, hidden]
-                hf_state_dict[f"{layer_prefix}.experts.gate_up_proj"] = global_tensor.transpose(-2, -1).contiguous()
+                if load_into_model_storage:
+                    # DCP writes the HF [E, 2*inter, hidden] checkpoint directly through this transposed view into
+                    # the native [E, hidden, 2*inter] parameter storage.
+                    hf_state_dict[f"{layer_prefix}.experts.gate_up_proj"] = tensor.transpose(-2, -1)
+                else:
+                    global_tensor = self._gather_expert_tensor(tensor, device_mesh, n_experts)
+                    hf_state_dict[f"{layer_prefix}.experts.gate_up_proj"] = global_tensor.transpose(-2, -1).contiguous()
                 continue
 
             # --- Expert: down_projs -> experts.down_proj + router.per_expert_scale ---
             if ".moe.experts.down_projs" in fqn:
                 layer_num = re.search(r"layers\.(\d+)", fqn).group(1)
-                global_tensor = self._gather_expert_tensor(tensor, device_mesh, n_experts)
                 layer_prefix = f"{prefix}language_model.layers.{layer_num}"
-                # Transpose from NeMo [E, inter, hidden] to HF [E, hidden, inter]
-                hf_state_dict[f"{layer_prefix}.experts.down_proj"] = global_tensor.transpose(-2, -1).contiguous()
-                hf_state_dict[f"{layer_prefix}.router.per_expert_scale"] = torch.ones(n_experts, dtype=self.dtype)
+                if load_into_model_storage:
+                    # The raw HF down weight first lands in final native storage through a transposed view. from_hf
+                    # then multiplies that storage in place by this bounded auxiliary scale vector.
+                    hf_state_dict[f"{layer_prefix}.experts.down_proj"] = tensor.transpose(-2, -1)
+                    hf_state_dict[f"{layer_prefix}.router.per_expert_scale"] = torch.empty(
+                        n_experts, dtype=self.dtype, device=tensor.device
+                    )
+                else:
+                    global_tensor = self._gather_expert_tensor(tensor, device_mesh, n_experts)
+                    hf_state_dict[f"{layer_prefix}.experts.down_proj"] = global_tensor.transpose(-2, -1).contiguous()
+                    hf_state_dict[f"{layer_prefix}.router.per_expert_scale"] = torch.ones(n_experts, dtype=self.dtype)
                 continue
 
             # --- Pass-through ---

--- a/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
@@ -61,7 +61,7 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
       4. Expert-parallel sharding when a device mesh is provided
     """
 
-    _supports_bounded_checkpoint_load = True
+    _supports_checkpoint_load_without_full_copy = True
 
     def __init__(
         self,
@@ -75,7 +75,7 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
         self.backend = backend
         self.dtype = dtype
         self._uses_model_prefix = True
-        self._load_destinations_alias_model = False
+        self._loading_into_model_weights = False
 
     # ------------------------------------------------------------------
     # HF -> NeMo
@@ -91,20 +91,20 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
         Args:
             hf_state_dict: Hugging Face state mapping. Expert gate/up tensors have shape
                 ``[experts, 2 * expert_hidden, hidden]`` and down tensors have shape
-                ``[experts, hidden, expert_hidden]``. When prepared by ``to_hf`` for a bounded checkpoint load,
-                those tensors are transposed views of final model storage and are mutated in place.
+                ``[experts, hidden, expert_hidden]``. During a direct checkpoint load, those tensors use the model's
+                existing weight memory with the last two dimensions transposed.
             device_mesh: Optional expert-parallel mesh. Distributed conversion slices the global expert axis and may
                 shard the native feature axis according to the mesh.
             **kwargs: Additional adapter-interface arguments.
 
         Returns:
             Native state mapping. Expert gate/up tensors have shape ``[local_experts, hidden, 2 * expert_hidden]``
-            and down tensors have shape ``[local_experts, expert_hidden, hidden]``. Sharded bounded-load outputs are
-            DTensors with global expert shape and ``Shard(0)`` on the ``ep`` mesh; their local tensors alias final
-            model storage. Materialized conversion outputs own their storage.
+            and down tensors have shape ``[local_experts, expert_hidden, hidden]``. For a direct sharded load, outputs
+            are DTensors with global expert shape and ``Shard(0)`` on the ``ep`` mesh; each local tensor uses the
+            corresponding model weight memory. Normal conversion outputs use newly allocated memory.
         """
-        load_destinations_alias_model = self._load_destinations_alias_model
-        self._load_destinations_alias_model = False
+        loading_into_model_weights = self._loading_into_model_weights
+        self._loading_into_model_weights = False
         self._uses_model_prefix = any(key.startswith("model.") for key in hf_state_dict)
         model_prefix = "model." if self._uses_model_prefix else ""
 
@@ -163,7 +163,7 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
             per_expert_scale = tensors["per_expert_scale"]  # [E]
 
             # Transpose gate_up_proj from HF [E, 2*inter, hidden] to NeMo [E, hidden, 2*inter]
-            if load_destinations_alias_model and state_dict_utils.is_dtensor(gate_up_proj):
+            if loading_into_model_weights and state_dict_utils.is_dtensor(gate_up_proj):
                 if not state_dict_utils.is_dtensor(down_proj) or not state_dict_utils.is_dtensor(per_expert_scale):
                     raise RuntimeError(
                         f"Inconsistent sharded load destinations for {layer_path}: gate/up, down, and scale must "
@@ -178,15 +178,14 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
                         f"Sharded down projection for {layer_path} has {down_local_tensor.shape[0]} local experts, "
                         f"but its scale destination has {scale_local_tensor.shape[0]}."
                     )
-                # Checkpoint destinations are detached state-dict views owned exclusively by this load. The raw HF
-                # down tensor already occupies final native storage, so absorb its local scales without allocating a
-                # second expert tensor or communicating across the EP mesh.
+                # The loaded down tensor already uses the model's weight memory. Apply its local expert scales to that
+                # memory directly, without creating another expert tensor or communicating across the EP mesh.
                 with torch.no_grad():
                     down_local_tensor.mul_(scale_local_tensor[:, None, None])
                 down_local = down_proj.transpose(-2, -1)
-            elif load_destinations_alias_model:
-                # DCP loaded the checkpoint through transposed views of final model storage. Gate/up only needs its
-                # native view restored; down additionally absorbs the small per-expert scale destination in place.
+            elif loading_into_model_weights:
+                # DCP loaded these checkpoint tensors into the model's weight memory. Restore the native dimension
+                # order, then apply the small per-expert scale values to the loaded down weights.
                 gate_and_up_local = gate_up_proj.transpose(-2, -1)
                 down_proj.mul_(per_expert_scale[:, None, None])
                 down_local = down_proj.transpose(-2, -1)
@@ -201,10 +200,10 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
                 gate_and_up_local = gate_and_up[start_expert:end_expert].to(self.dtype)
                 down_local = down[start_expert:end_expert].to(self.dtype)
 
-            if load_destinations_alias_model and state_dict_utils.is_dtensor(gate_and_up_local):
-                # The HF-layout load DTensors and these transposed native views both alias the original model
-                # parameters. Their Shard(0) placement already selects this rank's experts, so slicing or wrapping
-                # again would corrupt the global offsets DCP used for the read.
+            if loading_into_model_weights and state_dict_utils.is_dtensor(gate_and_up_local):
+                # These transposed DTensors still use the original model weight memory. Their Shard(0) placement
+                # already selects this rank's experts, so slicing or wrapping again would corrupt the global offsets
+                # DCP used for the read.
                 prefix = f"{model_prefix}language_model.{layer_path}"
                 state_dict[f"{prefix}.moe.experts.gate_and_up_projs"] = gate_and_up_local
                 state_dict[f"{prefix}.moe.experts.down_projs"] = down_local
@@ -254,23 +253,23 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
                 ``[local_experts, expert_hidden, hidden]``.
             exclude_key_regex: Optional pattern selecting keys to omit.
             quantization: Whether checkpoint initialization requires a precision conversion. Quantized loads do not
-                use aliasing destinations.
+                load directly into the model's existing weight memory.
             **kwargs: Adapter-interface arguments. ``device_mesh`` describes expert sharding.
-                ``load_into_empty_destinations=True`` requests memory-bounded load destinations.
+                ``for_checkpoint_load=True`` requests destinations for DCP to load.
 
         Returns:
             Hugging Face state mapping. Expert gate/up tensors have shape
-            ``[experts, 2 * expert_hidden, hidden]`` and down tensors have shape
-            ``[experts, hidden, expert_hidden]``. For a bounded load, model-sized outputs are transposed views of
-            final model storage. EP outputs retain ``Shard(0)`` on the global experts axis and each rank owns a local
-            ``per_expert_scale`` slice; unsharded scale outputs are independently owned ``[experts]`` tensors.
+            ``[experts, 2 * expert_hidden, hidden]`` and down tensors have shape ``[experts, hidden, expert_hidden]``.
+            During a direct load, model-sized outputs use the existing model weight memory with transposed dimensions.
+            EP outputs retain ``Shard(0)`` on the global experts axis, and each rank creates only its small local
+            ``per_expert_scale`` slice.
         """
         self._uses_model_prefix = any(key.startswith("model.") for key in state_dict)
         prefix = "model." if self._uses_model_prefix else ""
         device_mesh: Optional[DeviceMesh] = kwargs.get("device_mesh")
         n_experts = self.moe_config.n_routed_experts
         expert_tensors = [tensor for fqn, tensor in state_dict.items() if ".moe.experts." in fqn]
-        single_device_destinations_alias = (
+        single_device_can_load_into_model = (
             device_mesh is None
             and bool(expert_tensors)
             and all(
@@ -278,17 +277,17 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
                 for tensor in expert_tensors
             )
         )
-        ep_destinations_alias = (
+        ep_can_load_into_model = (
             device_mesh is not None
             and bool(expert_tensors)
             and all(self._supports_ep_load_destination(tensor, n_experts) for tensor in expert_tensors)
         )
         load_into_model_storage = (
-            bool(kwargs.get("load_into_empty_destinations", False))
+            bool(kwargs.get("for_checkpoint_load", False))
             and not quantization
-            and (single_device_destinations_alias or ep_destinations_alias)
+            and (single_device_can_load_into_model or ep_can_load_into_model)
         )
-        self._load_destinations_alias_model = load_into_model_storage
+        self._loading_into_model_weights = load_into_model_storage
 
         hf_state_dict: dict[str, Any] = {}
 
@@ -307,8 +306,8 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
                 layer_num = re.search(r"layers\.(\d+)", fqn).group(1)
                 layer_prefix = f"{prefix}language_model.layers.{layer_num}"
                 if load_into_model_storage:
-                    # DCP writes the HF [E, 2*inter, hidden] checkpoint directly through this transposed view into
-                    # the native [E, hidden, 2*inter] parameter storage.
+                    # This transposed tensor uses the native [E, hidden, 2*inter] model weight memory, so loading the
+                    # HF [E, 2*inter, hidden] checkpoint into it updates the model directly.
                     hf_state_dict[f"{layer_prefix}.experts.gate_up_proj"] = tensor.transpose(-2, -1)
                 else:
                     global_tensor = self._gather_expert_tensor(tensor, device_mesh, n_experts)
@@ -320,8 +319,8 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
                 layer_num = re.search(r"layers\.(\d+)", fqn).group(1)
                 layer_prefix = f"{prefix}language_model.layers.{layer_num}"
                 if load_into_model_storage:
-                    # The raw HF down weight first lands in final native storage through a transposed view. from_hf
-                    # then multiplies that storage in place by this bounded auxiliary scale vector.
+                    # Load the raw HF down weight into the model's existing memory. ``from_hf`` then applies the small
+                    # per-expert scale values to those loaded weights without creating another full-sized tensor.
                     hf_state_dict[f"{layer_prefix}.experts.down_proj"] = tensor.transpose(-2, -1)
                     if state_dict_utils.is_dtensor(tensor):
                         local_tensor = tensor.to_local()

--- a/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
@@ -42,6 +42,8 @@ from typing import Any, Optional
 import torch
 import torch.distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.placement_types import Replicate, Shard
 
 from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
@@ -97,10 +99,11 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
 
         Returns:
             Native state mapping. Expert gate/up tensors have shape ``[local_experts, hidden, 2 * expert_hidden]``
-            and down tensors have shape ``[local_experts, expert_hidden, hidden]``. Bounded-load outputs alias final
-            model storage; materialized conversion outputs own their storage.
+            and down tensors have shape ``[local_experts, expert_hidden, hidden]``. Sharded bounded-load outputs are
+            DTensors with global expert shape and ``Shard(0)`` on the ``ep`` mesh; their local tensors alias final
+            model storage. Materialized conversion outputs own their storage.
         """
-        load_destinations_alias_model = self._load_destinations_alias_model and device_mesh is None
+        load_destinations_alias_model = self._load_destinations_alias_model
         self._load_destinations_alias_model = False
         self._uses_model_prefix = any(key.startswith("model.") for key in hf_state_dict)
         model_prefix = "model." if self._uses_model_prefix else ""
@@ -160,7 +163,28 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
             per_expert_scale = tensors["per_expert_scale"]  # [E]
 
             # Transpose gate_up_proj from HF [E, 2*inter, hidden] to NeMo [E, hidden, 2*inter]
-            if load_destinations_alias_model:
+            if load_destinations_alias_model and state_dict_utils.is_dtensor(gate_up_proj):
+                if not state_dict_utils.is_dtensor(down_proj) or not state_dict_utils.is_dtensor(per_expert_scale):
+                    raise RuntimeError(
+                        f"Inconsistent sharded load destinations for {layer_path}: gate/up, down, and scale must "
+                        "all be DTensors."
+                    )
+
+                gate_and_up_local = gate_up_proj.transpose(-2, -1)
+                down_local_tensor = down_proj.to_local()
+                scale_local_tensor = per_expert_scale.to_local()
+                if down_local_tensor.shape[0] != scale_local_tensor.shape[0]:
+                    raise RuntimeError(
+                        f"Sharded down projection for {layer_path} has {down_local_tensor.shape[0]} local experts, "
+                        f"but its scale destination has {scale_local_tensor.shape[0]}."
+                    )
+                # Checkpoint destinations are detached state-dict views owned exclusively by this load. The raw HF
+                # down tensor already occupies final native storage, so absorb its local scales without allocating a
+                # second expert tensor or communicating across the EP mesh.
+                with torch.no_grad():
+                    down_local_tensor.mul_(scale_local_tensor[:, None, None])
+                down_local = down_proj.transpose(-2, -1)
+            elif load_destinations_alias_model:
                 # DCP loaded the checkpoint through transposed views of final model storage. Gate/up only needs its
                 # native view restored; down additionally absorbs the small per-expert scale destination in place.
                 gate_and_up_local = gate_up_proj.transpose(-2, -1)
@@ -176,6 +200,15 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
                 # Slice for EP
                 gate_and_up_local = gate_and_up[start_expert:end_expert].to(self.dtype)
                 down_local = down[start_expert:end_expert].to(self.dtype)
+
+            if load_destinations_alias_model and state_dict_utils.is_dtensor(gate_and_up_local):
+                # The HF-layout load DTensors and these transposed native views both alias the original model
+                # parameters. Their Shard(0) placement already selects this rank's experts, so slicing or wrapping
+                # again would corrupt the global offsets DCP used for the read.
+                prefix = f"{model_prefix}language_model.{layer_path}"
+                state_dict[f"{prefix}.moe.experts.gate_and_up_projs"] = gate_and_up_local
+                state_dict[f"{prefix}.moe.experts.down_projs"] = down_local
+                continue
 
             # Slice for EP_SHARD across the feature dimension before wrapping as DTensor.
             if device_mesh is not None and "ep_shard" in device_mesh.mesh_dim_names:
@@ -223,27 +256,37 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
             quantization: Whether checkpoint initialization requires a precision conversion. Quantized loads do not
                 use aliasing destinations.
             **kwargs: Adapter-interface arguments. ``device_mesh`` describes expert sharding.
-                ``load_into_empty_destinations=True`` requests memory-bounded single-device load destinations.
+                ``load_into_empty_destinations=True`` requests memory-bounded load destinations.
 
         Returns:
             Hugging Face state mapping. Expert gate/up tensors have shape
             ``[experts, 2 * expert_hidden, hidden]`` and down tensors have shape
             ``[experts, hidden, expert_hidden]``. For a bounded load, model-sized outputs are transposed views of
-            final model storage and each ``per_expert_scale`` output is an independently owned ``[experts]`` tensor.
+            final model storage. EP outputs retain ``Shard(0)`` on the global experts axis and each rank owns a local
+            ``per_expert_scale`` slice; unsharded scale outputs are independently owned ``[experts]`` tensors.
         """
         self._uses_model_prefix = any(key.startswith("model.") for key in state_dict)
         prefix = "model." if self._uses_model_prefix else ""
         device_mesh: Optional[DeviceMesh] = kwargs.get("device_mesh")
         n_experts = self.moe_config.n_routed_experts
+        expert_tensors = [tensor for fqn, tensor in state_dict.items() if ".moe.experts." in fqn]
+        single_device_destinations_alias = (
+            device_mesh is None
+            and bool(expert_tensors)
+            and all(
+                isinstance(tensor, torch.Tensor) and not tensor.is_meta and not state_dict_utils.is_dtensor(tensor)
+                for tensor in expert_tensors
+            )
+        )
+        ep_destinations_alias = (
+            device_mesh is not None
+            and bool(expert_tensors)
+            and all(self._supports_ep_load_destination(tensor, n_experts) for tensor in expert_tensors)
+        )
         load_into_model_storage = (
             bool(kwargs.get("load_into_empty_destinations", False))
             and not quantization
-            and device_mesh is None
-            and all(
-                isinstance(tensor, torch.Tensor) and not tensor.is_meta and not state_dict_utils.is_dtensor(tensor)
-                for fqn, tensor in state_dict.items()
-                if ".moe.experts." in fqn
-            )
+            and (single_device_destinations_alias or ep_destinations_alias)
         )
         self._load_destinations_alias_model = load_into_model_storage
 
@@ -280,9 +323,20 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
                     # The raw HF down weight first lands in final native storage through a transposed view. from_hf
                     # then multiplies that storage in place by this bounded auxiliary scale vector.
                     hf_state_dict[f"{layer_prefix}.experts.down_proj"] = tensor.transpose(-2, -1)
-                    hf_state_dict[f"{layer_prefix}.router.per_expert_scale"] = torch.empty(
-                        n_experts, dtype=self.dtype, device=tensor.device
-                    )
+                    if state_dict_utils.is_dtensor(tensor):
+                        local_tensor = tensor.to_local()
+                        local_scale = torch.empty(local_tensor.shape[0], dtype=self.dtype, device=local_tensor.device)
+                        hf_state_dict[f"{layer_prefix}.router.per_expert_scale"] = DTensor.from_local(
+                            local_scale,
+                            tensor.device_mesh,
+                            tensor.placements,
+                            shape=torch.Size([n_experts]),
+                            stride=(1,),
+                        )
+                    else:
+                        hf_state_dict[f"{layer_prefix}.router.per_expert_scale"] = torch.empty(
+                            n_experts, dtype=self.dtype, device=tensor.device
+                        )
                 else:
                     global_tensor = self._gather_expert_tensor(tensor, device_mesh, n_experts)
                     hf_state_dict[f"{layer_prefix}.experts.down_proj"] = global_tensor.transpose(-2, -1).contiguous()
@@ -296,6 +350,38 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
             hf_state_dict = {k: v for k, v in hf_state_dict.items() if not re.match(exclude_key_regex, k)}
 
         return hf_state_dict
+
+    @staticmethod
+    def _supports_ep_load_destination(tensor: Any, n_experts: int) -> bool:
+        """Return whether a grouped expert DTensor can receive its HF checkpoint slice in place.
+
+        Args:
+            tensor: Native expert DTensor with global shape ``[experts, ...]`` and local shape
+                ``[local_experts, ...]``. The ``ep`` mesh dimension must use ``Shard(0)``; every other mesh dimension
+                must replicate the tensor. Inner-axis expert sharding is intentionally unsupported by this path.
+            n_experts: Total number of routed experts in the checkpoint.
+
+        Returns:
+            ``True`` when transposing the final local tensor preserves an HF-layout ``Shard(0)`` destination that
+            DCP can fill without gathering global experts.
+        """
+        if (
+            not state_dict_utils.is_dtensor(tensor)
+            or tensor.is_meta
+            or tensor.shape[0] != n_experts
+            or "ep" not in tensor.device_mesh.mesh_dim_names
+        ):
+            return False
+
+        return all(
+            (
+                isinstance(placement, Shard)
+                and placement.dim == 0
+                and tensor.device_mesh.mesh_dim_names[mesh_dim] == "ep"
+            )
+            or (isinstance(placement, Replicate) and tensor.device_mesh.mesh_dim_names[mesh_dim] != "ep")
+            for mesh_dim, placement in enumerate(tensor.placements)
+        )
 
     def get_hf_state_dict_keys(self, state_dict: dict[str, Any]) -> list[str]:
         """Return converted keys without gathering real expert weights.

--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -598,12 +598,23 @@ class MoESplitExpertsStateDictMixin:
             Creates gate_and_up_projs [n_experts, dim, inter_dim] and transposed down_projs tensors.
 
         Args:
+            hf_state_dict: State mapping consumed by this method. Per-expert gate and up tensors have shape
+                [expert_hidden, hidden], while down tensors have shape [hidden, expert_hidden]. DTensor values
+                use the same global layouts and are localized before merging.
+            device_mesh: Optional device mesh whose expert-parallel dimension selects the local experts. The
+                returned grouped expert tensors use the placements created by ``create_dtensor_from_local``.
             reset_view_loaded_keys: Clear the in-place (strided-view) loaded-key record at the
                 start of this call. A single ``from_hf`` may invoke this method more than once
                 (e.g. backbone then MTP merge); the later call(s) pass ``False`` so the view-loaded
                 keys accumulate across one logical load. Resetting here (rather than in the loader)
                 keeps the whole view-key lifecycle inside the adapter and ensures each load starts
                 clean (no leak from a prior load such as an init-time partial load).
+
+        Returns:
+            Native state mapping. Gated input projections have shape
+            [local_experts, hidden, 2 * expert_hidden], non-gated input projections have shape
+            [local_experts, hidden, expert_hidden], and down projections have shape
+            [local_experts, expert_hidden, hidden].
         """
         if reset_view_loaded_keys:
             self._view_loaded_native_keys = set()
@@ -696,7 +707,7 @@ class MoESplitExpertsStateDictMixin:
 
                     if all_complete:
                         expert_ids = sorted(expert_weights_by_layer[layer_num][native_key].keys())
-                        tensors = []
+                        expert_parts = []
                         for expert_id in expert_ids:
                             expert_data = expert_weights_by_layer[layer_num][native_key][expert_id]
 
@@ -709,29 +720,26 @@ class MoESplitExpertsStateDictMixin:
                                     up_weight = up_weight.to_local()
                                 gate_t = gate_weight.transpose(0, 1)
                                 up_t = up_weight.transpose(0, 1)
-                                tensors.append(torch.cat([gate_t, up_t], dim=-1))
+                                expert_parts.append((gate_t, up_t))
                             else:
                                 up_weight = expert_data
                                 if is_dtensor(up_weight):
                                     up_weight = up_weight.to_local()
-                                tensors.append(up_weight.transpose(0, 1))
+                                expert_parts.append((up_weight.transpose(0, 1),))
 
-                        stacked = torch.stack(tensors, dim=0).to(self.dtype)
-                        state_dict[native_key] = create_dtensor_from_local(stacked, device_mesh, rank)
+                        merged = self._direct_fill_grouped_expert_tensor(expert_parts)
+                        state_dict[native_key] = create_dtensor_from_local(merged, device_mesh, rank)
+                        merged_on_cuda = merged.is_cuda
 
-                        # Aggressively release intermediates so the per-layer
-                        # transient does not pile on top of the model's
-                        # already-materialized GPU DTensors. Without this,
-                        # ``tensors``/``stacked`` and the per-expert dict
-                        # entries hang around until Python's refcount GC
-                        # eventually runs — too late under tight GPU budgets
-                        # (e.g. a large MoE on 2 nodes / 8 GPUs).
-                        del tensors, stacked
+                        # Release the per-expert sources before processing the next projection or layer so they
+                        # do not accumulate alongside the grouped output. Only trim the CUDA allocator when the
+                        # merge itself used CUDA storage; the single-device fallback merges on the host.
+                        del expert_parts, merged
                         del expert_weights_by_layer[layer_num][native_key]
                         if not expert_weights_by_layer[layer_num]:
                             del expert_weights_by_layer[layer_num]
-                        gc.collect()
-                        if torch.cuda.is_available():
+                        gc.collect(0)
+                        if merged_on_cuda:
                             torch.cuda.empty_cache()
 
                 else:  # down_proj
@@ -740,7 +748,7 @@ class MoESplitExpertsStateDictMixin:
                     if len(expert_weights_by_layer[layer_num][native_key]) == expected_experts_per_rank:
                         expert_ids = sorted(expert_weights_by_layer[layer_num][native_key].keys())
 
-                        ordered = []
+                        expert_parts = []
                         for expert_id in expert_ids:
                             down_weight = expert_weights_by_layer[layer_num][native_key][expert_id]  # [dim, inter_dim]
 
@@ -749,20 +757,19 @@ class MoESplitExpertsStateDictMixin:
                                 down_weight = down_weight.to_local()
 
                             down_t = down_weight.transpose(0, 1)  # [inter_dim, dim]
-                            ordered.append(down_t)
+                            expert_parts.append((down_t,))
 
-                        stacked = torch.stack(ordered, dim=0)
-                        stacked = stacked.to(self.dtype)
-
-                        state_dict[native_key] = create_dtensor_from_local(stacked, device_mesh, rank)
+                        merged = self._direct_fill_grouped_expert_tensor(expert_parts)
+                        state_dict[native_key] = create_dtensor_from_local(merged, device_mesh, rank)
+                        merged_on_cuda = merged.is_cuda
 
                         # See gate/up branch above for the cleanup rationale.
-                        del ordered, stacked
+                        del expert_parts, merged
                         del expert_weights_by_layer[layer_num][native_key]
                         if not expert_weights_by_layer[layer_num]:
                             del expert_weights_by_layer[layer_num]
-                        gc.collect()
-                        if torch.cuda.is_available():
+                        gc.collect(0)
+                        if merged_on_cuda:
                             torch.cuda.empty_cache()
 
             else:
@@ -787,6 +794,63 @@ class MoESplitExpertsStateDictMixin:
         state_dict = self._convert_paramwrapper_to_native(state_dict)
 
         return state_dict
+
+    def _direct_fill_grouped_expert_tensor(self, expert_parts: list[tuple[torch.Tensor, ...]]) -> torch.Tensor:
+        """Fill one grouped expert tensor without concatenation or stacking temporaries.
+
+        Args:
+            expert_parts: One tuple per local expert. Each tensor has shape [..., columns_part], with arbitrary
+                shared leading dimensions. Parts within each tuple are concatenated logically along the last
+                axis, and tuple order defines the expert axis order. All parts must have matching shapes and
+                devices across experts.
+
+        Returns:
+            Fresh contiguous tensor of shape [local_experts, ..., combined_columns], where combined_columns is
+            the sum of the first expert's columns_part dimensions. The result uses ``self.dtype`` and the first
+            part's device and does not alias an input tensor.
+
+        Raises:
+            ValueError: If there are no expert parts or their shapes or devices are inconsistent.
+        """
+        if not expert_parts or not expert_parts[0]:
+            raise ValueError("At least one expert projection tensor is required")
+
+        expected_shapes = tuple(tuple(part.shape) for part in expert_parts[0])
+        expected_device = expert_parts[0][0].device
+        leading_shape = expected_shapes[0][:-1]
+        if any(shape[:-1] != leading_shape for shape in expected_shapes):
+            raise ValueError(f"Expert 0 projection parts have inconsistent leading shapes: {expected_shapes}")
+
+        combined_columns = sum(shape[-1] for shape in expected_shapes)
+        for expert_index, parts in enumerate(expert_parts):
+            actual_shapes = tuple(tuple(part.shape) for part in parts)
+            if actual_shapes != expected_shapes:
+                raise ValueError(
+                    f"Expert {expert_index} projection shapes {actual_shapes} do not match {expected_shapes}"
+                )
+
+            for part in parts:
+                if part.device != expected_device:
+                    raise ValueError(
+                        f"Expert {expert_index} projection device {part.device} does not match {expected_device}"
+                    )
+
+        grouped = torch.empty(
+            (len(expert_parts), *leading_shape, combined_columns),
+            dtype=self.dtype,
+            device=expected_device,
+        )
+        if len(expected_shapes) == 1:
+            torch.stack(
+                [parts[0] for parts in expert_parts],
+                dim=0,
+                out=grouped,
+            )
+        else:
+            for expert_index, parts in enumerate(expert_parts):
+                torch.cat(parts, dim=-1, out=grouped[expert_index])
+
+        return grouped
 
     def _convert_single_merged_expert_to_hf_split_experts(
         self,

--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -884,8 +884,8 @@ class MoESplitExpertsStateDictMixin:
             prefix_override: When provided, replaces ``self._hf_prefix`` in
                 emitted HF keys. Used to route conversions through namespaces
                 outside the main backbone, e.g. ``"mtp."`` for the MTP head.
-            load_into_empty_destinations: Allocate contiguous destination tensors without copying source values
-                when the result cannot alias final model storage and DCP will fully overwrite it. This mode is only
+            load_into_empty_destinations: Reuse a contiguous checkpoint-layout view when possible. Otherwise, allocate
+                a blank contiguous tensor for DCP to overwrite instead of copying the source values. This mode is only
                 valid for checkpoint loading; save conversion must preserve tensor values.
             **kwargs: Absorbed for forward-compatibility with base callers
                 that forward arbitrary state-dict kwargs (e.g. ``exclude_key_regex``).
@@ -903,7 +903,8 @@ class MoESplitExpertsStateDictMixin:
         # model (experts stay at random init -> garbage loss). So fp8 loads must take the
         # rebuild path: never mark these keys in-place-loaded when ``quantization`` is set.
         quantization = kwargs.get("quantization", False)
-        used_empty_load_destinations = False
+        created_blank_load_destinations = False
+        reused_contiguous_load_destinations = False
 
         # GroupedExpertsTE (backend.experts == "te") exposes both virtual grouped tensors as
         # torch.stack copies, so neither can be loaded through in-place views. GroupedExpertsMoK
@@ -920,6 +921,23 @@ class MoESplitExpertsStateDictMixin:
             is_dtensor,
             validate_dtensor_expert_sharding,
         )
+
+        def checkpoint_load_destination(view: torch.Tensor, source: torch.Tensor) -> torch.Tensor:
+            """Return storage that DCP can overwrite without copying initialized values."""
+            nonlocal created_blank_load_destinations, reused_contiguous_load_destinations
+
+            if not load_into_empty_destinations or quantization or is_dtensor(source):
+                return view.contiguous()
+
+            # TE stacks its per-expert parameters and then transposes the grouped tensor. Transposing an individual
+            # expert back to checkpoint layout produces a contiguous view of that temporary stack. Reuse that view:
+            # DCP will overwrite it, and allocating another blank tensor would double the destination memory.
+            if view.is_contiguous():
+                reused_contiguous_load_destinations = True
+                return view
+
+            created_blank_load_destinations = True
+            return torch.empty_like(view, memory_format=torch.contiguous_format)
 
         if f".{expert_segment}.gate_and_up_projs" in fqn and fqn.endswith(".gate_and_up_projs"):
             layer_num = re.search(r"layers\.(\d+)", fqn).group(1)
@@ -950,30 +968,22 @@ class MoESplitExpertsStateDictMixin:
                     else:
                         w_gate_view = w[:, :inter_dim].transpose(0, 1)
                         w_up_view = w[:, inter_dim:].transpose(0, 1)
-                        if load_into_empty_destinations and not quantization and not is_dtensor(w):
-                            w_gate = torch.empty_like(w_gate_view, memory_format=torch.contiguous_format)
-                            w_up = torch.empty_like(w_up_view, memory_format=torch.contiguous_format)
-                            used_empty_load_destinations = True
-                        else:
-                            w_gate = w_gate_view.contiguous()
-                            w_up = w_up_view.contiguous()
+                        w_gate = checkpoint_load_destination(w_gate_view, w)
+                        w_up = checkpoint_load_destination(w_up_view, w)
                     result.append((f"{prefix}layers.{layer_num}.{expert_segment}.{expert_id}.gate_proj.weight", w_gate))
                     result.append((f"{prefix}layers.{layer_num}.{expert_segment}.{expert_id}.up_proj.weight", w_up))
                 else:
                     # Non-gated: only up_proj (tensor is [dim, inter_dim], not [dim, 2*inter_dim])
                     if inplace_ok:
                         w_up = w.transpose(0, 1)
-                    elif load_into_empty_destinations and not quantization and not is_dtensor(w):
-                        w_up = torch.empty_like(w.transpose(0, 1), memory_format=torch.contiguous_format)
-                        used_empty_load_destinations = True
                     else:
-                        w_up = w.transpose(0, 1).contiguous()
+                        w_up = checkpoint_load_destination(w.transpose(0, 1), w)
                     result.append((f"{prefix}layers.{layer_num}.{expert_segment}.{expert_id}.up_proj.weight", w_up))
             del splits
             if not inplace_ok and isinstance(tensor, torch.Tensor) and not tensor.is_meta and torch.cuda.is_available():
-                if used_empty_load_destinations:
+                if created_blank_load_destinations:
                     gc.collect(0)
-                elif tensor.is_cuda:
+                elif tensor.is_cuda and not reused_contiguous_load_destinations:
                     gc.collect()
                     torch.cuda.empty_cache()
             return result
@@ -1005,11 +1015,8 @@ class MoESplitExpertsStateDictMixin:
                 expert_id = self._last_expert_ids[i]
                 if inplace_ok:
                     w_down = w.transpose(0, 1)
-                elif load_into_empty_destinations and not quantization and not is_dtensor(w):
-                    w_down = torch.empty_like(w.transpose(0, 1), memory_format=torch.contiguous_format)
-                    used_empty_load_destinations = True
                 else:
-                    w_down = w.transpose(0, 1).contiguous()
+                    w_down = checkpoint_load_destination(w.transpose(0, 1), w)
                 result.append(
                     (
                         f"{prefix}layers.{layer_num}.{expert_segment}.{expert_id}.down_proj.weight",
@@ -1019,9 +1026,9 @@ class MoESplitExpertsStateDictMixin:
             # See gate_and_up branch above for the cleanup rationale.
             del splits
             if not inplace_ok and isinstance(tensor, torch.Tensor) and not tensor.is_meta and torch.cuda.is_available():
-                if used_empty_load_destinations:
+                if created_blank_load_destinations:
                     gc.collect(0)
-                elif tensor.is_cuda:
+                elif tensor.is_cuda and not reused_contiguous_load_destinations:
                     gc.collect()
                     torch.cuda.empty_cache()
             return result

--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -51,17 +51,16 @@ class MoESplitExpertsStateDictMixin:
 
     @property
     def supports_write_through_checkpoint_load(self) -> bool:
-        """Whether non-expert and grouped-expert destinations both alias model storage."""
-        experts_alias = self.moe_config is None or self._supports_write_through_expert_checkpoint_load
-        return self._supports_write_through_checkpoint_load and experts_alias
+        """Whether every checkpoint value, including experts, loads directly into model weights."""
+        experts_load_directly = self.moe_config is None or self._supports_write_through_expert_checkpoint_load
+        return self._supports_write_through_checkpoint_load and experts_load_directly
 
     @property
     def _supports_write_through_expert_checkpoint_load(self) -> bool:
-        """Whether all grouped expert destinations alias final model storage.
+        """Whether grouped expert checkpoint values load directly into model weight memory.
 
-        This only describes the shared expert conversion. Concrete adapters
-        must separately verify that their non-expert conversions also alias
-        model storage before opting into a write-through full-checkpoint load.
+        This covers only the shared expert conversion. A concrete adapter must also verify that all non-expert
+        checkpoint values load directly before it enables the full-checkpoint fast path.
         """
         return self.backend.experts != "te" and self.backend.dispatcher != "mok"
 
@@ -796,56 +795,27 @@ class MoESplitExpertsStateDictMixin:
         return state_dict
 
     def _direct_fill_grouped_expert_tensor(self, expert_parts: list[tuple[torch.Tensor, ...]]) -> torch.Tensor:
-        """Fill one grouped expert tensor without concatenation or stacking temporaries.
+        """Merge experts directly into one final grouped tensor.
 
         Args:
-            expert_parts: One tuple per local expert. Each tensor has shape [..., columns_part], with arbitrary
-                shared leading dimensions. Parts within each tuple are concatenated logically along the last
-                axis, and tuple order defines the expert axis order. All parts must have matching shapes and
-                devices across experts.
+            expert_parts: Projection tensors for each local expert. Multiple tensors in a tuple are joined along
+                the last dimension.
 
         Returns:
-            Fresh contiguous tensor of shape [local_experts, ..., combined_columns], where combined_columns is
-            the sum of the first expert's columns_part dimensions. The result uses ``self.dtype`` and the first
-            part's device and does not alias an input tensor.
-
-        Raises:
-            ValueError: If there are no expert parts or their shapes or devices are inconsistent.
+            One contiguous grouped tensor in ``self.dtype``.
         """
         if not expert_parts or not expert_parts[0]:
             raise ValueError("At least one expert projection tensor is required")
 
-        expected_shapes = tuple(tuple(part.shape) for part in expert_parts[0])
-        expected_device = expert_parts[0][0].device
-        leading_shape = expected_shapes[0][:-1]
-        if any(shape[:-1] != leading_shape for shape in expected_shapes):
-            raise ValueError(f"Expert 0 projection parts have inconsistent leading shapes: {expected_shapes}")
-
-        combined_columns = sum(shape[-1] for shape in expected_shapes)
-        for expert_index, parts in enumerate(expert_parts):
-            actual_shapes = tuple(tuple(part.shape) for part in parts)
-            if actual_shapes != expected_shapes:
-                raise ValueError(
-                    f"Expert {expert_index} projection shapes {actual_shapes} do not match {expected_shapes}"
-                )
-
-            for part in parts:
-                if part.device != expected_device:
-                    raise ValueError(
-                        f"Expert {expert_index} projection device {part.device} does not match {expected_device}"
-                    )
-
+        first_expert = expert_parts[0]
+        leading_shape = first_expert[0].shape[:-1]
         grouped = torch.empty(
-            (len(expert_parts), *leading_shape, combined_columns),
+            (len(expert_parts), *leading_shape, sum(part.shape[-1] for part in first_expert)),
             dtype=self.dtype,
-            device=expected_device,
+            device=first_expert[0].device,
         )
-        if len(expected_shapes) == 1:
-            torch.stack(
-                [parts[0] for parts in expert_parts],
-                dim=0,
-                out=grouped,
-            )
+        if len(first_expert) == 1:
+            torch.stack([parts[0] for parts in expert_parts], dim=0, out=grouped)
         else:
             for expert_index, parts in enumerate(expert_parts):
                 torch.cat(parts, dim=-1, out=grouped[expert_index])
@@ -858,25 +828,14 @@ class MoESplitExpertsStateDictMixin:
         tensor: torch.Tensor,
         *,
         prefix_override: str | None = None,
-        load_into_empty_destinations: bool = False,
+        for_checkpoint_load: bool = False,
         **kwargs,
     ) -> list[tuple[str, torch.Tensor]]:
-        """Convert a single merged expert tensor from native format to split HuggingFace format.
+        """Convert one grouped expert tensor to Hugging Face's per-expert layout.
 
-        When ``tensor`` is a model DTensor with a plain (non-DTensor) local
-        split — i.e. ``ep_shard == 1`` — the per-expert outputs are returned
-        as **non-contiguous strided views** into the local storage of the
-        model's grouped DTensor instead of newly-allocated contiguous copies.
-        DCP's ``target.copy_(source)`` then writes safetensors data directly
-        through the views into the model's storage, and
-        ``_from_hf_w_merged_experts`` skips the rebuild for the corresponding
-        native key (tracked in ``_inplace_loaded_native_keys``). For loads of
-        large MoE checkpoints this avoids tens of GB of per-expert
-        scratch on top of the already-materialized model.
-
-        Save callers must materialize the views before serializing —
-        ``safetensors.torch.save`` rejects non-contiguous tensors. See
-        ``_materialize_to_hf_views_for_save`` in ``checkpointing.py``.
+        During checkpoint loading, DCP can write into contiguous or non-contiguous views. A view into model weight
+        memory updates the model directly. A view into temporary TE or MoK grouped storage is rebuilt into the model
+        by ``from_hf`` after the read. Save/export conversion still creates contiguous tensors for serialization.
 
         Args:
             fqn: Fully qualified name of the tensor in native format.
@@ -884,9 +843,8 @@ class MoESplitExpertsStateDictMixin:
             prefix_override: When provided, replaces ``self._hf_prefix`` in
                 emitted HF keys. Used to route conversions through namespaces
                 outside the main backbone, e.g. ``"mtp."`` for the MTP head.
-            load_into_empty_destinations: Reuse a contiguous checkpoint-layout view when possible. Otherwise, allocate
-                a blank contiguous tensor for DCP to overwrite instead of copying the source values. This mode is only
-                valid for checkpoint loading; save conversion must preserve tensor values.
+            for_checkpoint_load: Return views that DCP will completely overwrite. Save/export callers leave this
+                disabled so converted tensors preserve their current values in contiguous storage.
             **kwargs: Absorbed for forward-compatibility with base callers
                 that forward arbitrary state-dict kwargs (e.g. ``exclude_key_regex``).
 
@@ -897,25 +855,23 @@ class MoESplitExpertsStateDictMixin:
         inter_dim = self.moe_config.moe_inter_dim
         prefix = prefix_override if prefix_override is not None else self._hf_prefix
         expert_segment = self._expert_path_segment
-        # When quantizing, the adapter casts each split with ``value.to(float8_e4m3fn)``,
-        # which ALLOCATES a new tensor that no longer aliases the model's grouped storage.
-        # An in-place DCP ``copy_`` into that throwaway buffer would silently never reach the
-        # model (experts stay at random init -> garbage loss). So fp8 loads must take the
-        # rebuild path: never mark these keys in-place-loaded when ``quantization`` is set.
+        # Quantization casts each split with ``value.to(float8_e4m3fn)``, creating storage separate from the model's
+        # grouped weights. DCP must not treat that cast as model weight memory, or the model would keep its random
+        # expert values. Quantized loads therefore rebuild the grouped expert tensor after the read.
         quantization = kwargs.get("quantization", False)
-        created_blank_load_destinations = False
-        reused_contiguous_load_destinations = False
+        reused_checkpoint_load_views = False
 
         # GroupedExpertsTE (backend.experts == "te") exposes both virtual grouped tensors as
         # torch.stack copies, so neither can be loaded through in-place views. GroupedExpertsMoK
-        # keeps separate contiguous gate/up parameters and exposes gate_and_up_projs through a
-        # torch.cat copy; its down_projs is still an aliasing transpose view. Treat the two native
-        # keys independently so MoK rebuilds gate/up during from_hf without giving up the
-        # zero-copy down-projection load.
+        # keeps separate contiguous gate/up parameters and exposes gate_and_up_projs through a torch.cat copy. Its
+        # down_projs transpose still uses the model's weight memory. Treat the two native tensors independently so
+        # MoK rebuilds gate/up after the read while DCP loads down directly into the model.
         backend = getattr(self, "backend", None)
-        grouped_storage_aliases = getattr(backend, "experts", None) != "te"
-        gate_up_storage_aliases = grouped_storage_aliases and getattr(backend, "dispatcher", None) != "mok"
-        down_storage_aliases = grouped_storage_aliases
+        grouped_storage_is_model_weight = getattr(backend, "experts", None) != "te"
+        gate_up_storage_is_model_weight = (
+            grouped_storage_is_model_weight and getattr(backend, "dispatcher", None) != "mok"
+        )
+        down_storage_is_model_weight = grouped_storage_is_model_weight
 
         from nemo_automodel.components.moe.state_dict_utils import (
             is_dtensor,
@@ -923,21 +879,14 @@ class MoESplitExpertsStateDictMixin:
         )
 
         def checkpoint_load_destination(view: torch.Tensor, source: torch.Tensor) -> torch.Tensor:
-            """Return storage that DCP can overwrite without copying initialized values."""
-            nonlocal created_blank_load_destinations, reused_contiguous_load_destinations
+            """Return the checkpoint-layout view that DCP will fill."""
+            nonlocal reused_checkpoint_load_views
 
-            if not load_into_empty_destinations or quantization or is_dtensor(source):
-                return view.contiguous()
-
-            # TE stacks its per-expert parameters and then transposes the grouped tensor. Transposing an individual
-            # expert back to checkpoint layout produces a contiguous view of that temporary stack. Reuse that view:
-            # DCP will overwrite it, and allocating another blank tensor would double the destination memory.
-            if view.is_contiguous():
-                reused_contiguous_load_destinations = True
+            if for_checkpoint_load and not quantization and not is_dtensor(source):
+                reused_checkpoint_load_views = True
                 return view
 
-            created_blank_load_destinations = True
-            return torch.empty_like(view, memory_format=torch.contiguous_format)
+            return view.contiguous()
 
         if f".{expert_segment}.gate_and_up_projs" in fqn and fqn.endswith(".gate_and_up_projs"):
             layer_num = re.search(r"layers\.(\d+)", fqn).group(1)
@@ -952,7 +901,7 @@ class MoESplitExpertsStateDictMixin:
                 and len(splits) > 0
                 and not is_dtensor(splits[0])
                 and not quantization
-                and gate_up_storage_aliases
+                and gate_up_storage_is_model_weight
             )
             if inplace_ok:
                 self._register_inplace_loaded_key(fqn, prefix_override)
@@ -981,9 +930,7 @@ class MoESplitExpertsStateDictMixin:
                     result.append((f"{prefix}layers.{layer_num}.{expert_segment}.{expert_id}.up_proj.weight", w_up))
             del splits
             if not inplace_ok and isinstance(tensor, torch.Tensor) and not tensor.is_meta and torch.cuda.is_available():
-                if created_blank_load_destinations:
-                    gc.collect(0)
-                elif tensor.is_cuda and not reused_contiguous_load_destinations:
+                if tensor.is_cuda and not reused_checkpoint_load_views:
                     gc.collect()
                     torch.cuda.empty_cache()
             return result
@@ -1005,7 +952,7 @@ class MoESplitExpertsStateDictMixin:
                 and len(splits) > 0
                 and not is_dtensor(splits[0])
                 and not quantization
-                and down_storage_aliases
+                and down_storage_is_model_weight
             )
             if inplace_ok:
                 self._register_inplace_loaded_key(fqn, prefix_override)
@@ -1026,9 +973,7 @@ class MoESplitExpertsStateDictMixin:
             # See gate_and_up branch above for the cleanup rationale.
             del splits
             if not inplace_ok and isinstance(tensor, torch.Tensor) and not tensor.is_meta and torch.cuda.is_available():
-                if created_blank_load_destinations:
-                    gc.collect(0)
-                elif tensor.is_cuda and not reused_contiguous_load_destinations:
+                if tensor.is_cuda and not reused_checkpoint_load_views:
                     gc.collect()
                     torch.cuda.empty_cache()
             return result

--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -858,6 +858,7 @@ class MoESplitExpertsStateDictMixin:
         tensor: torch.Tensor,
         *,
         prefix_override: str | None = None,
+        load_into_empty_destinations: bool = False,
         **kwargs,
     ) -> list[tuple[str, torch.Tensor]]:
         """Convert a single merged expert tensor from native format to split HuggingFace format.
@@ -883,6 +884,9 @@ class MoESplitExpertsStateDictMixin:
             prefix_override: When provided, replaces ``self._hf_prefix`` in
                 emitted HF keys. Used to route conversions through namespaces
                 outside the main backbone, e.g. ``"mtp."`` for the MTP head.
+            load_into_empty_destinations: Allocate contiguous destination tensors without copying source values
+                when the result cannot alias final model storage and DCP will fully overwrite it. This mode is only
+                valid for checkpoint loading; save conversion must preserve tensor values.
             **kwargs: Absorbed for forward-compatibility with base callers
                 that forward arbitrary state-dict kwargs (e.g. ``exclude_key_regex``).
 
@@ -899,6 +903,7 @@ class MoESplitExpertsStateDictMixin:
         # model (experts stay at random init -> garbage loss). So fp8 loads must take the
         # rebuild path: never mark these keys in-place-loaded when ``quantization`` is set.
         quantization = kwargs.get("quantization", False)
+        used_empty_load_destinations = False
 
         # GroupedExpertsTE (backend.experts == "te") exposes both virtual grouped tensors as
         # torch.stack copies, so neither can be loaded through in-place views. GroupedExpertsMoK
@@ -943,21 +948,34 @@ class MoESplitExpertsStateDictMixin:
                         w_gate = w[:, :inter_dim].transpose(0, 1)
                         w_up = w[:, inter_dim:].transpose(0, 1)
                     else:
-                        w_gate = w[:, :inter_dim].transpose(0, 1).contiguous()
-                        w_up = w[:, inter_dim:].transpose(0, 1).contiguous()
+                        w_gate_view = w[:, :inter_dim].transpose(0, 1)
+                        w_up_view = w[:, inter_dim:].transpose(0, 1)
+                        if load_into_empty_destinations and not quantization and not is_dtensor(w):
+                            w_gate = torch.empty_like(w_gate_view, memory_format=torch.contiguous_format)
+                            w_up = torch.empty_like(w_up_view, memory_format=torch.contiguous_format)
+                            used_empty_load_destinations = True
+                        else:
+                            w_gate = w_gate_view.contiguous()
+                            w_up = w_up_view.contiguous()
                     result.append((f"{prefix}layers.{layer_num}.{expert_segment}.{expert_id}.gate_proj.weight", w_gate))
                     result.append((f"{prefix}layers.{layer_num}.{expert_segment}.{expert_id}.up_proj.weight", w_up))
                 else:
                     # Non-gated: only up_proj (tensor is [dim, inter_dim], not [dim, 2*inter_dim])
                     if inplace_ok:
                         w_up = w.transpose(0, 1)
+                    elif load_into_empty_destinations and not quantization and not is_dtensor(w):
+                        w_up = torch.empty_like(w.transpose(0, 1), memory_format=torch.contiguous_format)
+                        used_empty_load_destinations = True
                     else:
                         w_up = w.transpose(0, 1).contiguous()
                     result.append((f"{prefix}layers.{layer_num}.{expert_segment}.{expert_id}.up_proj.weight", w_up))
             del splits
             if not inplace_ok and isinstance(tensor, torch.Tensor) and not tensor.is_meta and torch.cuda.is_available():
-                gc.collect()
-                torch.cuda.empty_cache()
+                if used_empty_load_destinations:
+                    gc.collect(0)
+                elif tensor.is_cuda:
+                    gc.collect()
+                    torch.cuda.empty_cache()
             return result
 
         elif (
@@ -987,6 +1005,9 @@ class MoESplitExpertsStateDictMixin:
                 expert_id = self._last_expert_ids[i]
                 if inplace_ok:
                     w_down = w.transpose(0, 1)
+                elif load_into_empty_destinations and not quantization and not is_dtensor(w):
+                    w_down = torch.empty_like(w.transpose(0, 1), memory_format=torch.contiguous_format)
+                    used_empty_load_destinations = True
                 else:
                     w_down = w.transpose(0, 1).contiguous()
                 result.append(
@@ -998,8 +1019,11 @@ class MoESplitExpertsStateDictMixin:
             # See gate_and_up branch above for the cleanup rationale.
             del splits
             if not inplace_ok and isinstance(tensor, torch.Tensor) and not tensor.is_meta and torch.cuda.is_available():
-                gc.collect()
-                torch.cuda.empty_cache()
+                if used_empty_load_destinations:
+                    gc.collect(0)
+                elif tensor.is_cuda:
+                    gc.collect()
+                    torch.cuda.empty_cache()
             return result
 
         # MoE expert LoRA keys: convert to HF-PEFT-compatible format.

--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -51,16 +51,16 @@ class MoESplitExpertsStateDictMixin:
 
     @property
     def supports_write_through_checkpoint_load(self) -> bool:
-        """Whether every checkpoint value, including experts, loads directly into model weights."""
+        """Whether every checkpoint tensor, including expert tensors, loads directly into model weights."""
         experts_load_directly = self.moe_config is None or self._supports_write_through_expert_checkpoint_load
         return self._supports_write_through_checkpoint_load and experts_load_directly
 
     @property
     def _supports_write_through_expert_checkpoint_load(self) -> bool:
-        """Whether grouped expert checkpoint values load directly into model weight memory.
+        """Whether grouped expert checkpoint tensors load directly into model weight memory.
 
         This covers only the shared expert conversion. A concrete adapter must also verify that all non-expert
-        checkpoint values load directly before it enables the full-checkpoint fast path.
+        checkpoint tensors load directly before it enables the full-checkpoint fast path.
         """
         return self.backend.experts != "te" and self.backend.dispatcher != "mok"
 

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -1361,7 +1361,7 @@ def test_load_model_uses_state_dict_adapter_from_ddp_module(tmp_path):
     torch.testing.assert_close(encoder.model.weight, checkpoint_weight)
 
 
-def test_single_device_gemma4_bounded_load_writes_through_transposed_destinations(tmp_path):
+def test_single_device_gemma4_loads_into_model_weights_without_full_copy(tmp_path):
     """A real HF storage reader loads and scales Gemma4 experts without a materialized fallback."""
 
     class Experts(torch.nn.Module):
@@ -1472,7 +1472,7 @@ def test_load_model_only_requests_quantized_adapter_keys_for_base_checkpoint(
         checkpointer.load_model(model, model_path=str(tmp_path / "model"), is_init_step=is_init_step)
 
     assert adapter.to_hf.call_args.kwargs["quantization"] is expected_quantization
-    assert adapter.to_hf.call_args.kwargs["load_into_empty_destinations"] is True
+    assert adapter.to_hf.call_args.kwargs["for_checkpoint_load"] is True
 
 
 def test_training_checkpoint_resume_ignores_base_fp8_metadata(tmp_path):
@@ -1696,9 +1696,9 @@ class TestLoadModelCustomModelGuard:
     @patch("nemo_automodel.components.checkpoint.checkpointing._is_safetensors_checkpoint", return_value=True)
     @patch("nemo_automodel.components.checkpoint.checkpointing._load_hf_checkpoint_preserving_dtype")
     @patch("nemo_automodel.components.checkpoint.checkpointing._load_full_state_dict_into_model")
-    @pytest.mark.parametrize("load_capability", ["write_through", "bounded"])
+    @pytest.mark.parametrize("load_capability", ["write_through", "without_full_copy"])
     @pytest.mark.parametrize("dequantize_base_checkpoint", [False, True])
-    def test_single_device_memory_bounded_adapter_routes_by_quantization(
+    def test_single_device_adapter_without_full_copy_routes_by_quantization(
         self,
         mock_load_full,
         mock_load_hf,
@@ -1707,14 +1707,14 @@ class TestLoadModelCustomModelGuard:
         dequantize_base_checkpoint,
         load_capability,
     ):
-        """Quantized conversion stays materialized for every memory-bounded adapter capability."""
+        """Quantized conversion keeps the full CPU fallback for both direct-load capabilities."""
         CustomModel = type("CustomModel", (torch.nn.Module,), {})
         CustomModel.__module__ = "nemo_automodel.components.models.nemotron_v3.model"
         model = CustomModel()
         model.layer = torch.nn.Linear(4, 4)
         model.state_dict_adapter = MagicMock(spec=StateDictAdapter)
         model.state_dict_adapter.supports_write_through_checkpoint_load = load_capability == "write_through"
-        model.state_dict_adapter.supports_bounded_checkpoint_load = load_capability == "bounded"
+        model.state_dict_adapter.supports_checkpoint_load_without_full_copy = load_capability == "without_full_copy"
         mock_state_dict = {"layer.weight": torch.randn(4, 4), "layer.bias": torch.randn(4)}
         mock_load_hf.return_value = mock_state_dict
 

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -1577,7 +1577,7 @@ class TestLoadModelCustomModelGuard:
     @patch("nemo_automodel.components.checkpoint.checkpointing._is_safetensors_checkpoint", return_value=True)
     @patch("nemo_automodel.components.checkpoint.checkpointing._load_hf_checkpoint_preserving_dtype")
     @patch("nemo_automodel.components.checkpoint.checkpointing._load_full_state_dict_into_model")
-    def test_single_device_custom_model_uses_fast_path(self, mock_load_full, mock_load_hf, mock_is_st):
+    def test_single_device_custom_model_uses_fast_path(self, mock_load_full, mock_load_hf, mock_is_st, caplog):
         """A custom model without a write-through guarantee uses the full-state path.
 
         The fast path applies the state_dict_adapter from_hf conversion on CPU (via
@@ -1594,6 +1594,7 @@ class TestLoadModelCustomModelGuard:
         assert _is_custom_model(model) is True
 
         mock_load_hf.return_value = {"layer.weight": torch.randn(4, 4), "layer.bias": torch.randn(4)}
+        caplog.set_level(logging.INFO)
 
         with (
             patch("os.path.exists", return_value=True),
@@ -1607,6 +1608,9 @@ class TestLoadModelCustomModelGuard:
         # Single-device custom model takes the frugal fast path, not DCP.
         mock_load_full.assert_called_once()
         mock_dcp_load.assert_not_called()
+        assert "disk read" in caplog.text
+        assert "adapt" in caplog.text
+        assert "install" in caplog.text
 
     @patch("nemo_automodel.components.checkpoint.checkpointing._is_safetensors_checkpoint", return_value=True)
     @patch("nemo_automodel.components.checkpoint.checkpointing._load_hf_checkpoint_preserving_dtype")

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -73,6 +73,7 @@ from nemo_automodel.components.checkpoint.utils import (
     has_local_tied_lm_head,
     materialize_missing_tied_lm_head,
 )
+from nemo_automodel.components.models.gemma4_moe.state_dict_adapter import Gemma4MoEStateDictAdapter
 from nemo_automodel.components.training.rng import RNGState, StatefulRNG, init_all_rng
 
 CLOUD_PATH_MODEL = "msc://bucket/step-100/model"
@@ -1360,6 +1361,85 @@ def test_load_model_uses_state_dict_adapter_from_ddp_module(tmp_path):
     torch.testing.assert_close(encoder.model.weight, checkpoint_weight)
 
 
+def test_single_device_gemma4_bounded_load_writes_through_transposed_destinations(tmp_path):
+    """A real HF storage reader loads and scales Gemma4 experts without a materialized fallback."""
+
+    class Experts(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.gate_and_up_projs = torch.nn.Parameter(torch.zeros(2, 3, 8))
+            self.down_projs = torch.nn.Parameter(torch.zeros(2, 4, 3))
+
+    class Moe(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.experts = Experts()
+
+    class Layer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.moe = Moe()
+
+    class LanguageModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = torch.nn.ModuleDict({"0": Layer()})
+
+    class InnerModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.language_model = LanguageModel()
+
+    class Gemma4Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = InnerModel()
+            self.state_dict_adapter = Gemma4MoEStateDictAdapter(
+                config=SimpleNamespace(),
+                moe_config=SimpleNamespace(n_routed_experts=2),
+                backend=SimpleNamespace(),
+                dtype=torch.float32,
+            )
+
+    Gemma4Model.__module__ = "nemo_automodel.components.models.gemma4_moe.model"
+    model = Gemma4Model()
+    checkpoint_gate = torch.arange(48, dtype=torch.float32).reshape(2, 8, 3)
+    checkpoint_down = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+    checkpoint_scale = torch.tensor([2.0, 3.0])
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    save_file(
+        {
+            "model.language_model.layers.0.experts.gate_up_proj": checkpoint_gate,
+            "model.language_model.layers.0.experts.down_proj": checkpoint_down,
+            "model.language_model.layers.0.router.per_expert_scale": checkpoint_scale,
+        },
+        model_path / "model.safetensors",
+    )
+    config = CheckpointingConfig(
+        enabled=True,
+        checkpoint_dir=str(tmp_path),
+        model_save_format="safetensors",
+        model_cache_dir=str(tmp_path / "cache"),
+        model_repo_id="test/gemma4",
+        save_consolidated=False,
+        is_peft=False,
+    )
+    with patch("torch.distributed.is_initialized", return_value=False):
+        checkpointer = Checkpointer(config, dp_rank=0, tp_rank=0, pp_rank=0, moe_mesh=None)
+
+    checkpointer.load_model(model, model_path=str(model_path), is_init_step=True)
+
+    torch.testing.assert_close(
+        model.model.language_model.layers["0"].moe.experts.gate_and_up_projs,
+        checkpoint_gate.transpose(-2, -1),
+    )
+    torch.testing.assert_close(
+        model.model.language_model.layers["0"].moe.experts.down_projs,
+        checkpoint_down.transpose(-2, -1) * checkpoint_scale[:, None, None],
+    )
+
+
 @pytest.mark.parametrize(("is_init_step", "expected_quantization"), [(True, True), (False, False)])
 def test_load_model_only_requests_quantized_adapter_keys_for_base_checkpoint(
     tmp_path, is_init_step, expected_quantization
@@ -1616,17 +1696,25 @@ class TestLoadModelCustomModelGuard:
     @patch("nemo_automodel.components.checkpoint.checkpointing._is_safetensors_checkpoint", return_value=True)
     @patch("nemo_automodel.components.checkpoint.checkpointing._load_hf_checkpoint_preserving_dtype")
     @patch("nemo_automodel.components.checkpoint.checkpointing._load_full_state_dict_into_model")
+    @pytest.mark.parametrize("load_capability", ["write_through", "bounded"])
     @pytest.mark.parametrize("dequantize_base_checkpoint", [False, True])
-    def test_single_device_write_through_adapter_routes_by_quantization(
-        self, mock_load_full, mock_load_hf, mock_is_st, caplog, dequantize_base_checkpoint
+    def test_single_device_memory_bounded_adapter_routes_by_quantization(
+        self,
+        mock_load_full,
+        mock_load_hf,
+        mock_is_st,
+        caplog,
+        dequantize_base_checkpoint,
+        load_capability,
     ):
-        """Quantized conversion stays materialized even for a write-through adapter."""
+        """Quantized conversion stays materialized for every memory-bounded adapter capability."""
         CustomModel = type("CustomModel", (torch.nn.Module,), {})
         CustomModel.__module__ = "nemo_automodel.components.models.nemotron_v3.model"
         model = CustomModel()
         model.layer = torch.nn.Linear(4, 4)
         model.state_dict_adapter = MagicMock(spec=StateDictAdapter)
-        model.state_dict_adapter.supports_write_through_checkpoint_load = True
+        model.state_dict_adapter.supports_write_through_checkpoint_load = load_capability == "write_through"
+        model.state_dict_adapter.supports_bounded_checkpoint_load = load_capability == "bounded"
         mock_state_dict = {"layer.weight": torch.randn(4, 4), "layer.bias": torch.randn(4)}
         mock_load_hf.return_value = mock_state_dict
 

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -1392,6 +1392,7 @@ def test_load_model_only_requests_quantized_adapter_keys_for_base_checkpoint(
         checkpointer.load_model(model, model_path=str(tmp_path / "model"), is_init_step=is_init_step)
 
     assert adapter.to_hf.call_args.kwargs["quantization"] is expected_quantization
+    assert adapter.to_hf.call_args.kwargs["load_into_empty_destinations"] is True
 
 
 def test_training_checkpoint_resume_ignores_base_fp8_metadata(tmp_path):

--- a/tests/unit_tests/checkpoint/test_state_dict_adapter_capabilities.py
+++ b/tests/unit_tests/checkpoint/test_state_dict_adapter_capabilities.py
@@ -173,11 +173,11 @@ def test_materializing_grouped_expert_adapters_keep_frugal_load(adapter_type):
     assert adapter.supports_write_through_checkpoint_load is False
 
 
-def test_gemma4_moe_adapter_uses_bounded_auxiliary_destinations():
+def test_gemma4_moe_adapter_loads_without_a_full_checkpoint_copy():
     adapter = object.__new__(Gemma4MoEStateDictAdapter)
 
     assert adapter.supports_write_through_checkpoint_load is False
-    assert adapter.supports_bounded_checkpoint_load is True
+    assert adapter.supports_checkpoint_load_without_full_copy is True
 
 
 def test_dense_grouped_adapter_does_not_require_an_expert_backend():

--- a/tests/unit_tests/checkpoint/test_state_dict_adapter_capabilities.py
+++ b/tests/unit_tests/checkpoint/test_state_dict_adapter_capabilities.py
@@ -173,10 +173,11 @@ def test_materializing_grouped_expert_adapters_keep_frugal_load(adapter_type):
     assert adapter.supports_write_through_checkpoint_load is False
 
 
-def test_materializing_gemma4_moe_adapter_keeps_frugal_load():
+def test_gemma4_moe_adapter_uses_bounded_auxiliary_destinations():
     adapter = object.__new__(Gemma4MoEStateDictAdapter)
 
     assert adapter.supports_write_through_checkpoint_load is False
+    assert adapter.supports_bounded_checkpoint_load is True
 
 
 def test_dense_grouped_adapter_does_not_require_an_expert_backend():

--- a/tests/unit_tests/models/gemma4/test_gemma4_bounded_checkpoint_load.py
+++ b/tests/unit_tests/models/gemma4/test_gemma4_bounded_checkpoint_load.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from nemo_automodel.components.models.gemma4_moe.state_dict_adapter import Gemma4MoEStateDictAdapter
+
+N_EXPERTS = 4
+HIDDEN = 64
+EXPERT_INTER = 32
+
+
+@pytest.fixture
+def adapter() -> Gemma4MoEStateDictAdapter:
+    return Gemma4MoEStateDictAdapter(
+        config=SimpleNamespace(),
+        moe_config=SimpleNamespace(n_routed_experts=N_EXPERTS),
+        backend=SimpleNamespace(),
+        dtype=torch.float32,
+    )
+
+
+def test_large_destinations_alias_model_storage_and_scale_is_bounded(adapter: Gemma4MoEStateDictAdapter) -> None:
+    gate_and_up = torch.zeros(N_EXPERTS, HIDDEN, 2 * EXPERT_INTER)
+    down = torch.zeros(N_EXPERTS, EXPERT_INTER, HIDDEN)
+    state_dict = {
+        "model.language_model.layers.0.moe.experts.gate_and_up_projs": gate_and_up,
+        "model.language_model.layers.0.moe.experts.down_projs": down,
+    }
+
+    destinations = adapter.to_hf(state_dict, load_into_empty_destinations=True)
+
+    gate_destination = destinations["model.language_model.layers.0.experts.gate_up_proj"]
+    down_destination = destinations["model.language_model.layers.0.experts.down_proj"]
+    scale_destination = destinations["model.language_model.layers.0.router.per_expert_scale"]
+    assert gate_destination.untyped_storage().data_ptr() == gate_and_up.untyped_storage().data_ptr()
+    assert down_destination.untyped_storage().data_ptr() == down.untyped_storage().data_ptr()
+    assert scale_destination.untyped_storage().data_ptr() not in {
+        gate_and_up.untyped_storage().data_ptr(),
+        down.untyped_storage().data_ptr(),
+    }
+    assert scale_destination.shape == (N_EXPERTS,)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_from_hf_finalizes_aliased_destinations_in_place(
+    adapter: Gemma4MoEStateDictAdapter, dtype: torch.dtype
+) -> None:
+    adapter.dtype = dtype
+    expected_gate_hf = torch.randn(N_EXPERTS, 2 * EXPERT_INTER, HIDDEN, dtype=dtype)
+    expected_down_hf = torch.randn(N_EXPERTS, HIDDEN, EXPERT_INTER, dtype=dtype)
+    expected_scale = torch.arange(1, N_EXPERTS + 1, dtype=dtype)
+    reference = adapter.from_hf(
+        {
+            "model.language_model.layers.0.experts.gate_up_proj": expected_gate_hf.clone(),
+            "model.language_model.layers.0.experts.down_proj": expected_down_hf.clone(),
+            "model.language_model.layers.0.router.per_expert_scale": expected_scale.clone(),
+        }
+    )
+    gate_and_up = torch.zeros(N_EXPERTS, HIDDEN, 2 * EXPERT_INTER, dtype=dtype)
+    down = torch.zeros(N_EXPERTS, EXPERT_INTER, HIDDEN, dtype=dtype)
+    state_dict = {
+        "model.language_model.layers.0.moe.experts.gate_and_up_projs": gate_and_up,
+        "model.language_model.layers.0.moe.experts.down_projs": down,
+    }
+    destinations = adapter.to_hf(state_dict, load_into_empty_destinations=True)
+    destinations["model.language_model.layers.0.experts.gate_up_proj"].copy_(expected_gate_hf)
+    destinations["model.language_model.layers.0.experts.down_proj"].copy_(expected_down_hf)
+    destinations["model.language_model.layers.0.router.per_expert_scale"].copy_(expected_scale)
+
+    converted = adapter.from_hf(destinations)
+
+    converted_gate = converted["model.language_model.layers.0.moe.experts.gate_and_up_projs"]
+    converted_down = converted["model.language_model.layers.0.moe.experts.down_projs"]
+    assert converted_gate.untyped_storage().data_ptr() == gate_and_up.untyped_storage().data_ptr()
+    assert converted_down.untyped_storage().data_ptr() == down.untyped_storage().data_ptr()
+    torch.testing.assert_close(
+        converted_gate,
+        reference["model.language_model.layers.0.moe.experts.gate_and_up_projs"],
+    )
+    torch.testing.assert_close(
+        converted_down,
+        reference["model.language_model.layers.0.moe.experts.down_projs"],
+    )
+
+
+def test_export_destinations_remain_independent_contiguous_tensors(adapter: Gemma4MoEStateDictAdapter) -> None:
+    gate_and_up = torch.zeros(N_EXPERTS, HIDDEN, 2 * EXPERT_INTER)
+    down = torch.zeros(N_EXPERTS, EXPERT_INTER, HIDDEN)
+
+    exported = adapter.to_hf(
+        {
+            "model.language_model.layers.0.moe.experts.gate_and_up_projs": gate_and_up,
+            "model.language_model.layers.0.moe.experts.down_projs": down,
+        }
+    )
+
+    exported_gate = exported["model.language_model.layers.0.experts.gate_up_proj"]
+    exported_down = exported["model.language_model.layers.0.experts.down_proj"]
+    assert exported_gate.is_contiguous()
+    assert exported_down.is_contiguous()
+    assert exported_gate.untyped_storage().data_ptr() != gate_and_up.untyped_storage().data_ptr()
+    assert exported_down.untyped_storage().data_ptr() != down.untyped_storage().data_ptr()

--- a/tests/unit_tests/models/gemma4/test_gemma4_bounded_checkpoint_load.py
+++ b/tests/unit_tests/models/gemma4/test_gemma4_bounded_checkpoint_load.py
@@ -12,11 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+from datetime import timedelta
 from types import SimpleNamespace
 
 import pytest
 import torch
+import torch.distributed as dist
+import torch.distributed.checkpoint as dcp
+import torch.multiprocessing as mp
+from safetensors.torch import save_file
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import DTensor, Shard
 
+from nemo_automodel.components.checkpoint._backports.hf_storage import _HuggingFaceStorageReader
 from nemo_automodel.components.models.gemma4_moe.state_dict_adapter import Gemma4MoEStateDictAdapter
 
 N_EXPERTS = 4
@@ -31,6 +40,120 @@ def adapter() -> Gemma4MoEStateDictAdapter:
         moe_config=SimpleNamespace(n_routed_experts=N_EXPERTS),
         backend=SimpleNamespace(),
         dtype=torch.float32,
+    )
+
+
+def _run_ep_sharded_bounded_load(rank: int, world_size: int, init_file: str, model_path: str) -> None:
+    """Load this rank's HF grouped-expert slice through DTensor views of native storage."""
+    os.environ["GLOO_SOCKET_IFNAME"] = "lo"
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        mesh = init_device_mesh("cpu", (world_size,), mesh_dim_names=("ep",))
+        adapter = Gemma4MoEStateDictAdapter(
+            config=SimpleNamespace(),
+            moe_config=SimpleNamespace(n_routed_experts=N_EXPERTS),
+            backend=SimpleNamespace(),
+            dtype=torch.float32,
+        )
+        local_experts = N_EXPERTS // world_size
+        gate_local = torch.full((local_experts, HIDDEN, 2 * EXPERT_INTER), -1.0)
+        down_local = torch.full((local_experts, EXPERT_INTER, HIDDEN), -1.0)
+        gate = DTensor.from_local(gate_local, mesh, [Shard(0)])
+        down = DTensor.from_local(down_local, mesh, [Shard(0)])
+        native_state = {
+            "model.language_model.layers.0.moe.experts.gate_and_up_projs": gate,
+            "model.language_model.layers.0.moe.experts.down_projs": down,
+        }
+
+        destinations = adapter.to_hf(
+            native_state,
+            device_mesh=mesh,
+            load_into_empty_destinations=True,
+        )
+        gate_destination = destinations["model.language_model.layers.0.experts.gate_up_proj"]
+        down_destination = destinations["model.language_model.layers.0.experts.down_proj"]
+        scale_destination = destinations["model.language_model.layers.0.router.per_expert_scale"]
+        assert isinstance(gate_destination, DTensor)
+        assert isinstance(down_destination, DTensor)
+        assert isinstance(scale_destination, DTensor)
+        assert gate_destination.shape == (N_EXPERTS, 2 * EXPERT_INTER, HIDDEN)
+        assert down_destination.shape == (N_EXPERTS, HIDDEN, EXPERT_INTER)
+        assert scale_destination.shape == (N_EXPERTS,)
+        assert gate_destination.to_local().untyped_storage().data_ptr() == gate_local.untyped_storage().data_ptr()
+        assert down_destination.to_local().untyped_storage().data_ptr() == down_local.untyped_storage().data_ptr()
+        gate_chunk = gate_destination.__create_chunk_list__()[0]
+        assert gate_chunk.offsets == torch.Size([rank * local_experts, 0, 0])
+        assert gate_chunk.sizes == torch.Size([local_experts, 2 * EXPERT_INTER, HIDDEN])
+
+        dcp.load(
+            destinations,
+            checkpoint_id=model_path,
+            storage_reader=_HuggingFaceStorageReader(model_path),
+        )
+        converted = adapter.from_hf(destinations, device_mesh=mesh)
+
+        start_expert = rank * local_experts
+        end_expert = start_expert + local_experts
+        checkpoint_gate = torch.arange(
+            N_EXPERTS * 2 * EXPERT_INTER * HIDDEN,
+            dtype=torch.float32,
+        ).reshape(N_EXPERTS, 2 * EXPERT_INTER, HIDDEN)
+        checkpoint_down = torch.arange(
+            N_EXPERTS * HIDDEN * EXPERT_INTER,
+            dtype=torch.float32,
+        ).reshape(N_EXPERTS, HIDDEN, EXPERT_INTER)
+        checkpoint_scale = torch.arange(1, N_EXPERTS + 1, dtype=torch.float32)
+        loaded_gate = converted["model.language_model.layers.0.moe.experts.gate_and_up_projs"]
+        loaded_down = converted["model.language_model.layers.0.moe.experts.down_projs"]
+        torch.testing.assert_close(
+            loaded_gate.to_local(),
+            checkpoint_gate[start_expert:end_expert].transpose(-2, -1),
+        )
+        torch.testing.assert_close(
+            loaded_down.to_local(),
+            checkpoint_down[start_expert:end_expert].transpose(-2, -1)
+            * checkpoint_scale[start_expert:end_expert, None, None],
+        )
+        assert loaded_gate.to_local().untyped_storage().data_ptr() == gate_local.untyped_storage().data_ptr()
+        assert loaded_down.to_local().untyped_storage().data_ptr() == down_local.untyped_storage().data_ptr()
+    finally:
+        dist.destroy_process_group()
+
+
+def test_ep_load_reads_only_local_grouped_experts_into_final_storage(tmp_path) -> None:
+    """Two EP ranks load disjoint grouped-expert slices without global materialization."""
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    checkpoint_gate = torch.arange(
+        N_EXPERTS * 2 * EXPERT_INTER * HIDDEN,
+        dtype=torch.float32,
+    ).reshape(N_EXPERTS, 2 * EXPERT_INTER, HIDDEN)
+    checkpoint_down = torch.arange(
+        N_EXPERTS * HIDDEN * EXPERT_INTER,
+        dtype=torch.float32,
+    ).reshape(N_EXPERTS, HIDDEN, EXPERT_INTER)
+    save_file(
+        {
+            "model.language_model.layers.0.experts.gate_up_proj": checkpoint_gate,
+            "model.language_model.layers.0.experts.down_proj": checkpoint_down,
+            "model.language_model.layers.0.router.per_expert_scale": torch.arange(
+                1, N_EXPERTS + 1, dtype=torch.float32
+            ),
+        },
+        model_path / "model.safetensors",
+    )
+
+    mp.spawn(
+        _run_ep_sharded_bounded_load,
+        args=(2, str(tmp_path / "dist_init"), str(model_path)),
+        nprocs=2,
+        join=True,
     )
 
 

--- a/tests/unit_tests/models/gemma4/test_gemma4_checkpoint_load_without_full_copy.py
+++ b/tests/unit_tests/models/gemma4/test_gemma4_checkpoint_load_without_full_copy.py
@@ -43,8 +43,8 @@ def adapter() -> Gemma4MoEStateDictAdapter:
     )
 
 
-def _run_ep_sharded_bounded_load(rank: int, world_size: int, init_file: str, model_path: str) -> None:
-    """Load this rank's HF grouped-expert slice through DTensor views of native storage."""
+def _run_ep_sharded_load_without_full_copy(rank: int, world_size: int, init_file: str, model_path: str) -> None:
+    """Load this rank's expert weights directly into its part of the model's weight memory."""
     os.environ["GLOO_SOCKET_IFNAME"] = "lo"
     dist.init_process_group(
         "gloo",
@@ -74,7 +74,7 @@ def _run_ep_sharded_bounded_load(rank: int, world_size: int, init_file: str, mod
         destinations = adapter.to_hf(
             native_state,
             device_mesh=mesh,
-            load_into_empty_destinations=True,
+            for_checkpoint_load=True,
         )
         gate_destination = destinations["model.language_model.layers.0.experts.gate_up_proj"]
         down_destination = destinations["model.language_model.layers.0.experts.down_proj"]
@@ -150,14 +150,16 @@ def test_ep_load_reads_only_local_grouped_experts_into_final_storage(tmp_path) -
     )
 
     mp.spawn(
-        _run_ep_sharded_bounded_load,
+        _run_ep_sharded_load_without_full_copy,
         args=(2, str(tmp_path / "dist_init"), str(model_path)),
         nprocs=2,
         join=True,
     )
 
 
-def test_large_destinations_alias_model_storage_and_scale_is_bounded(adapter: Gemma4MoEStateDictAdapter) -> None:
+def test_large_destinations_use_model_weight_memory_and_scale_stays_small(
+    adapter: Gemma4MoEStateDictAdapter,
+) -> None:
     gate_and_up = torch.zeros(N_EXPERTS, HIDDEN, 2 * EXPERT_INTER)
     down = torch.zeros(N_EXPERTS, EXPERT_INTER, HIDDEN)
     state_dict = {
@@ -165,7 +167,7 @@ def test_large_destinations_alias_model_storage_and_scale_is_bounded(adapter: Ge
         "model.language_model.layers.0.moe.experts.down_projs": down,
     }
 
-    destinations = adapter.to_hf(state_dict, load_into_empty_destinations=True)
+    destinations = adapter.to_hf(state_dict, for_checkpoint_load=True)
 
     gate_destination = destinations["model.language_model.layers.0.experts.gate_up_proj"]
     down_destination = destinations["model.language_model.layers.0.experts.down_proj"]
@@ -180,9 +182,7 @@ def test_large_destinations_alias_model_storage_and_scale_is_bounded(adapter: Ge
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
-def test_from_hf_finalizes_aliased_destinations_in_place(
-    adapter: Gemma4MoEStateDictAdapter, dtype: torch.dtype
-) -> None:
+def test_from_hf_applies_scales_to_loaded_model_weights(adapter: Gemma4MoEStateDictAdapter, dtype: torch.dtype) -> None:
     adapter.dtype = dtype
     expected_gate_hf = torch.randn(N_EXPERTS, 2 * EXPERT_INTER, HIDDEN, dtype=dtype)
     expected_down_hf = torch.randn(N_EXPERTS, HIDDEN, EXPERT_INTER, dtype=dtype)
@@ -200,7 +200,7 @@ def test_from_hf_finalizes_aliased_destinations_in_place(
         "model.language_model.layers.0.moe.experts.gate_and_up_projs": gate_and_up,
         "model.language_model.layers.0.moe.experts.down_projs": down,
     }
-    destinations = adapter.to_hf(state_dict, load_into_empty_destinations=True)
+    destinations = adapter.to_hf(state_dict, for_checkpoint_load=True)
     destinations["model.language_model.layers.0.experts.gate_up_proj"].copy_(expected_gate_hf)
     destinations["model.language_model.layers.0.experts.down_proj"].copy_(expected_down_hf)
     destinations["model.language_model.layers.0.router.per_expert_scale"].copy_(expected_scale)

--- a/tests/unit_tests/moe/test_state_dict_mixin.py
+++ b/tests/unit_tests/moe/test_state_dict_mixin.py
@@ -1137,10 +1137,89 @@ class TestInplaceLoadViews:
         )
 
         assert result is not None
+        converted = dict(result)
         for _, v in result:
             assert v.is_contiguous(), "experts=='te' must emit contiguous copies, not in-place views"
+        for expert_id in range(2):
+            torch.testing.assert_close(
+                converted[f"model.layers.0.mlp.experts.{expert_id}.gate_proj.weight"],
+                local_storage[expert_id, :, :512].T,
+            )
+            torch.testing.assert_close(
+                converted[f"model.layers.0.mlp.experts.{expert_id}.up_proj.weight"],
+                local_storage[expert_id, :, 512:].T,
+            )
         assert not hasattr(mixin, "_inplace_loaded_native_keys") or (
             "model.layers.0.mlp.experts.gate_and_up_projs" not in (mixin._inplace_loaded_native_keys or set())
+        )
+
+    def test_te_load_destinations_do_not_copy_initialized_gate_and_up_values(self):
+        mixin = MockMoEStateDictMixin(n_experts=2, inter_dim=3)
+        mixin.backend.experts = "te"
+        initialized = torch.arange(2 * 4 * 6, dtype=torch.float32).reshape(2, 4, 6)
+
+        def sentinel_empty_like(tensor, **kwargs):
+            return torch.full_like(tensor, -17.0, **kwargs)
+
+        with (
+            patch("nemo_automodel.components.moe.state_dict_utils.is_dtensor", return_value=False),
+            patch("torch.empty_like", side_effect=sentinel_empty_like) as mock_empty_like,
+        ):
+            result = mixin._convert_single_merged_expert_to_hf_split_experts(
+                "model.layers.0.mlp.experts.gate_and_up_projs",
+                initialized,
+                load_into_empty_destinations=True,
+            )
+
+        assert result is not None and len(result) == 4
+        assert mock_empty_like.call_count == 4
+        for _, destination in result:
+            assert destination.is_contiguous()
+            torch.testing.assert_close(destination, torch.full_like(destination, -17.0))
+
+    def test_empty_te_destinations_round_trip_checkpoint_values(self):
+        mixin = MockMoEStateDictMixin(n_experts=2, inter_dim=3)
+        mixin.backend.experts = "te"
+        initialized_gate_up = torch.full((2, 4, 6), 99.0)
+        initialized_down = torch.full((2, 3, 4), 99.0)
+
+        with patch("nemo_automodel.components.moe.state_dict_utils.is_dtensor", return_value=False):
+            destinations = dict(
+                mixin._convert_single_merged_expert_to_hf_split_experts(
+                    "model.layers.0.mlp.experts.gate_and_up_projs",
+                    initialized_gate_up,
+                    load_into_empty_destinations=True,
+                )
+            )
+            destinations.update(
+                mixin._convert_single_merged_expert_to_hf_split_experts(
+                    "model.layers.0.mlp.experts.down_projs",
+                    initialized_down,
+                    load_into_empty_destinations=True,
+                )
+            )
+
+        expected_gate_up = torch.empty_like(initialized_gate_up)
+        expected_down = torch.empty_like(initialized_down)
+        for expert_id in range(2):
+            gate = torch.full((3, 4), 10.0 + expert_id)
+            up = torch.full((3, 4), 20.0 + expert_id)
+            down = torch.full((4, 3), 30.0 + expert_id)
+            destinations[f"model.layers.0.mlp.experts.{expert_id}.gate_proj.weight"].copy_(gate)
+            destinations[f"model.layers.0.mlp.experts.{expert_id}.up_proj.weight"].copy_(up)
+            destinations[f"model.layers.0.mlp.experts.{expert_id}.down_proj.weight"].copy_(down)
+            expected_gate_up[expert_id] = torch.cat((gate.T, up.T), dim=-1)
+            expected_down[expert_id] = down.T
+
+        restored = mixin._from_hf_w_merged_experts(destinations)
+
+        torch.testing.assert_close(
+            restored["model.layers.0.mlp.experts.gate_and_up_projs"],
+            expected_gate_up,
+        )
+        torch.testing.assert_close(
+            restored["model.layers.0.mlp.experts.down_projs"],
+            expected_down,
         )
 
     def test_inplace_load_skips_when_backend_experts_is_te_down_projs(self):

--- a/tests/unit_tests/moe/test_state_dict_mixin.py
+++ b/tests/unit_tests/moe/test_state_dict_mixin.py
@@ -44,8 +44,15 @@ class MockBackend:
 
 
 class MockMoEStateDictMixin(MoESplitExpertsStateDictMixin):
-    def __init__(self, n_experts=8, inter_dim=512, dtype=torch.float32, uses_model_prefix=True):
-        self.moe_config = MockMoEConfig(n_experts, inter_dim)
+    def __init__(
+        self,
+        n_experts=8,
+        inter_dim=512,
+        dtype=torch.float32,
+        uses_model_prefix=True,
+        expert_activation="swiglu",
+    ):
+        self.moe_config = MockMoEConfig(n_experts, inter_dim, expert_activation)
         self.config = MockConfig()
         self.backend = MockBackend()
         self.dtype = dtype
@@ -530,6 +537,110 @@ class TestToHfWSplitExperts:
 
 
 class TestFromHfWMergedExperts:
+    def test_direct_fill_gated_experts_preserves_values_dtype_and_layout(self):
+        mixin = MockMoEStateDictMixin(n_experts=2, inter_dim=2, dtype=torch.bfloat16)
+        hf_state_dict = {}
+        for expert_id, gate_start, up_start in ((0, 0, 10), (1, 20, 30)):
+            gate_weight = torch.arange(gate_start, gate_start + 6, dtype=torch.float32).reshape(3, 2).T
+            up_weight = torch.arange(up_start, up_start + 6, dtype=torch.float32).reshape(3, 2).T
+            assert not gate_weight.is_contiguous()
+            assert not up_weight.is_contiguous()
+            hf_state_dict[f"model.layers.0.mlp.experts.{expert_id}.gate_proj.weight"] = gate_weight
+            hf_state_dict[f"model.layers.0.mlp.experts.{expert_id}.up_proj.weight"] = up_weight
+
+        with (
+            patch.object(mixin, "_validate_expert_availability"),
+            patch("nemo_automodel.components.moe.state_dict_mixin.gc.collect") as collect,
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.empty_cache") as empty_cache,
+        ):
+            result = mixin._from_hf_w_merged_experts(hf_state_dict)
+
+        grouped = result["model.layers.0.mlp.experts.gate_and_up_projs"]
+        expected = torch.tensor(
+            [
+                [[0, 1, 10, 11], [2, 3, 12, 13], [4, 5, 14, 15]],
+                [[20, 21, 30, 31], [22, 23, 32, 33], [24, 25, 34, 35]],
+            ],
+            dtype=torch.bfloat16,
+        )
+        torch.testing.assert_close(grouped, expected, rtol=0, atol=0)
+        assert grouped.dtype == torch.bfloat16
+        assert grouped.is_contiguous()
+        collect.assert_called_once_with(0)
+        empty_cache.assert_not_called()
+
+    def test_direct_fill_non_gated_and_down_experts_preserves_values(self):
+        mixin = MockMoEStateDictMixin(
+            n_experts=2,
+            inter_dim=2,
+            dtype=torch.float32,
+            expert_activation="relu2",
+        )
+        hf_state_dict = {}
+        for expert_id, up_start, down_start in ((0, 0, 10), (1, 20, 30)):
+            hf_state_dict[f"model.layers.0.mlp.experts.{expert_id}.up_proj.weight"] = (
+                torch.arange(up_start, up_start + 6, dtype=torch.float64).reshape(3, 2).T
+            )
+            hf_state_dict[f"model.layers.0.mlp.experts.{expert_id}.down_proj.weight"] = (
+                torch.arange(down_start, down_start + 6, dtype=torch.float64).reshape(2, 3).T
+            )
+
+        with patch.object(mixin, "_validate_expert_availability"):
+            result = mixin._from_hf_w_merged_experts(hf_state_dict)
+
+        up = result["model.layers.0.mlp.experts.gate_and_up_projs"]
+        down = result["model.layers.0.mlp.experts.down_projs"]
+        expected_up = torch.tensor(
+            [
+                [[0, 1], [2, 3], [4, 5]],
+                [[20, 21], [22, 23], [24, 25]],
+            ],
+            dtype=torch.float32,
+        )
+        expected_down = torch.tensor(
+            [
+                [[10, 11, 12], [13, 14, 15]],
+                [[30, 31, 32], [33, 34, 35]],
+            ],
+            dtype=torch.float32,
+        )
+        torch.testing.assert_close(up, expected_up, rtol=0, atol=0)
+        torch.testing.assert_close(down, expected_down, rtol=0, atol=0)
+        assert up.is_contiguous()
+        assert down.is_contiguous()
+
+    def test_direct_fill_rejects_inconsistent_expert_shapes(self):
+        mixin = MockMoEStateDictMixin(dtype=torch.float32)
+        expert_parts = [
+            (torch.zeros(3, 2), torch.zeros(3, 2)),
+            (torch.zeros(3, 2), torch.zeros(3, 3)),
+        ]
+
+        with pytest.raises(ValueError, match="Expert 1 projection shapes"):
+            mixin._direct_fill_grouped_expert_tensor(expert_parts)
+
+    def test_direct_fill_merge_kernels_write_into_final_storage(self):
+        mixin = MockMoEStateDictMixin(dtype=torch.float32)
+        gated_parts = [
+            (torch.zeros(3, 2), torch.ones(3, 2)),
+            (torch.full((3, 2), 2.0), torch.full((3, 2), 3.0)),
+        ]
+
+        with patch("torch.cat", wraps=torch.cat) as cat:
+            grouped = mixin._direct_fill_grouped_expert_tensor(gated_parts)
+
+        grouped_ptr = grouped.untyped_storage().data_ptr()
+        assert cat.call_count == 2
+        assert all(call.kwargs["out"].untyped_storage().data_ptr() == grouped_ptr for call in cat.call_args_list)
+
+        single_parts = [(torch.zeros(3, 2),), (torch.ones(3, 2),)]
+        with patch("torch.stack", wraps=torch.stack) as stack:
+            grouped = mixin._direct_fill_grouped_expert_tensor(single_parts)
+
+        assert stack.call_count == 1
+        assert stack.call_args.kwargs["out"] is grouped
+
     @patch("nemo_automodel.components.moe.state_dict_mixin.create_dtensor_from_local")
     @patch("nemo_automodel.components.moe.state_dict_mixin.should_load_expert_for_rank")
     def test_basic_conversion(self, mock_should_load, mock_create_dtensor):

--- a/tests/unit_tests/moe/test_state_dict_mixin.py
+++ b/tests/unit_tests/moe/test_state_dict_mixin.py
@@ -641,6 +641,27 @@ class TestFromHfWMergedExperts:
         assert stack.call_count == 1
         assert stack.call_args.kwargs["out"] is grouped
 
+    @skip_if_no_gpu
+    @pytest.mark.run_only_on("GPU")
+    @pytest.mark.torch_memory_limit(cuda_mb=40)
+    def test_direct_fill_cuda_peak_is_inputs_plus_one_output(self):
+        """Catch reintroducing per-expert concatenation buffers before the final stack."""
+        mixin = MockMoEStateDictMixin(n_experts=8, inter_dim=512, dtype=torch.bfloat16)
+        # Inputs occupy 16 MiB and the grouped output occupies 16 MiB. The old cat-then-stack implementation retained
+        # another 16 MiB of per-expert concatenations and therefore exceeded this 40 MiB budget.
+        expert_parts = [
+            (
+                torch.empty((1024, 512), dtype=torch.bfloat16, device="cuda"),
+                torch.empty((1024, 512), dtype=torch.bfloat16, device="cuda"),
+            )
+            for _ in range(8)
+        ]
+
+        grouped = mixin._direct_fill_grouped_expert_tensor(expert_parts)
+
+        assert grouped.shape == (8, 1024, 1024)
+        assert grouped.is_contiguous()
+
     @patch("nemo_automodel.components.moe.state_dict_mixin.create_dtensor_from_local")
     @patch("nemo_automodel.components.moe.state_dict_mixin.should_load_expert_for_rank")
     def test_basic_conversion(self, mock_should_load, mock_create_dtensor):
@@ -1153,7 +1174,7 @@ class TestInplaceLoadViews:
             "model.layers.0.mlp.experts.gate_and_up_projs" not in (mixin._inplace_loaded_native_keys or set())
         )
 
-    def test_te_load_destinations_do_not_copy_initialized_gate_and_up_values(self):
+    def test_noncontiguous_load_destinations_use_blank_buffers(self):
         mixin = MockMoEStateDictMixin(n_experts=2, inter_dim=3)
         mixin.backend.experts = "te"
         initialized = torch.arange(2 * 4 * 6, dtype=torch.float32).reshape(2, 4, 6)
@@ -1176,6 +1197,78 @@ class TestInplaceLoadViews:
         for _, destination in result:
             assert destination.is_contiguous()
             torch.testing.assert_close(destination, torch.full_like(destination, -17.0))
+
+    def test_te_checkpoint_layout_views_are_reused(self):
+        mixin = MockMoEStateDictMixin(n_experts=2, inter_dim=3)
+        mixin.backend.experts = "te"
+        gate_up_storage = torch.arange(2 * 6 * 4, dtype=torch.float32).reshape(2, 6, 4)
+        down_storage = torch.arange(2 * 4 * 3, dtype=torch.float32).reshape(2, 4, 3)
+
+        # GroupedExpertsTE exposes stack(per_expert_weights).transpose(-1, -2).
+        # The adapter transposes each expert back, yielding contiguous checkpoint-layout views.
+        virtual_gate_up = gate_up_storage.transpose(-1, -2)
+        virtual_down = down_storage.transpose(-1, -2)
+
+        with (
+            patch("nemo_automodel.components.moe.state_dict_utils.is_dtensor", return_value=False),
+            patch("torch.empty_like") as empty_like,
+        ):
+            destinations = dict(
+                mixin._convert_single_merged_expert_to_hf_split_experts(
+                    "model.layers.0.mlp.experts.gate_and_up_projs",
+                    virtual_gate_up,
+                    load_into_empty_destinations=True,
+                )
+            )
+            destinations.update(
+                mixin._convert_single_merged_expert_to_hf_split_experts(
+                    "model.layers.0.mlp.experts.down_projs",
+                    virtual_down,
+                    load_into_empty_destinations=True,
+                )
+            )
+
+        empty_like.assert_not_called()
+        for expert_id in range(2):
+            gate = destinations[f"model.layers.0.mlp.experts.{expert_id}.gate_proj.weight"]
+            up = destinations[f"model.layers.0.mlp.experts.{expert_id}.up_proj.weight"]
+            down = destinations[f"model.layers.0.mlp.experts.{expert_id}.down_proj.weight"]
+            assert gate.is_contiguous() and up.is_contiguous() and down.is_contiguous()
+            assert gate.untyped_storage().data_ptr() == gate_up_storage.untyped_storage().data_ptr()
+            assert up.untyped_storage().data_ptr() == gate_up_storage.untyped_storage().data_ptr()
+            assert down.untyped_storage().data_ptr() == down_storage.untyped_storage().data_ptr()
+            torch.testing.assert_close(gate, gate_up_storage[expert_id, :3])
+            torch.testing.assert_close(up, gate_up_storage[expert_id, 3:])
+            torch.testing.assert_close(down, down_storage[expert_id])
+
+    @skip_if_no_gpu
+    @pytest.mark.run_only_on("GPU")
+    @pytest.mark.torch_memory_limit(cuda_mb=70)
+    def test_te_checkpoint_layout_cuda_peak_stays_within_one_buffer(self):
+        """Catch allocating a second model-sized destination for TE checkpoint views."""
+        mixin = MockMoEStateDictMixin(n_experts=8, inter_dim=1024, dtype=torch.bfloat16)
+        mixin.backend.experts = "te"
+        # The TE stack is 64 MiB. Reusing its checkpoint-layout views fits this 70 MiB budget; allocating blank
+        # destinations of the same total size would double live allocation to 128 MiB.
+        gate_up_storage = torch.empty((8, 2048, 2048), dtype=torch.bfloat16, device="cuda")
+        virtual_gate_up = gate_up_storage.transpose(-1, -2)
+
+        with (
+            patch("nemo_automodel.components.moe.state_dict_utils.is_dtensor", return_value=False),
+            patch("nemo_automodel.components.moe.state_dict_mixin.gc.collect") as collect,
+            patch("torch.cuda.empty_cache") as empty_cache,
+        ):
+            destinations = mixin._convert_single_merged_expert_to_hf_split_experts(
+                "model.layers.0.mlp.experts.gate_and_up_projs",
+                virtual_gate_up,
+                load_into_empty_destinations=True,
+            )
+
+        assert destinations is not None and len(destinations) == 16
+        source_ptr = gate_up_storage.untyped_storage().data_ptr()
+        assert all(value.untyped_storage().data_ptr() == source_ptr for _, value in destinations)
+        collect.assert_not_called()
+        empty_cache.assert_not_called()
 
     def test_empty_te_destinations_round_trip_checkpoint_values(self):
         mixin = MockMoEStateDictMixin(n_experts=2, inter_dim=3)

--- a/tests/unit_tests/moe/test_state_dict_mixin.py
+++ b/tests/unit_tests/moe/test_state_dict_mixin.py
@@ -610,16 +610,6 @@ class TestFromHfWMergedExperts:
         assert up.is_contiguous()
         assert down.is_contiguous()
 
-    def test_direct_fill_rejects_inconsistent_expert_shapes(self):
-        mixin = MockMoEStateDictMixin(dtype=torch.float32)
-        expert_parts = [
-            (torch.zeros(3, 2), torch.zeros(3, 2)),
-            (torch.zeros(3, 2), torch.zeros(3, 3)),
-        ]
-
-        with pytest.raises(ValueError, match="Expert 1 projection shapes"):
-            mixin._direct_fill_grouped_expert_tensor(expert_parts)
-
     def test_direct_fill_merge_kernels_write_into_final_storage(self):
         mixin = MockMoEStateDictMixin(dtype=torch.float32)
         gated_parts = [
@@ -1174,29 +1164,24 @@ class TestInplaceLoadViews:
             "model.layers.0.mlp.experts.gate_and_up_projs" not in (mixin._inplace_loaded_native_keys or set())
         )
 
-    def test_noncontiguous_load_destinations_use_blank_buffers(self):
+    def test_mok_noncontiguous_checkpoint_views_are_reused(self):
         mixin = MockMoEStateDictMixin(n_experts=2, inter_dim=3)
-        mixin.backend.experts = "te"
+        mixin.backend.experts = "gmm"
+        mixin.backend.dispatcher = "mok"
         initialized = torch.arange(2 * 4 * 6, dtype=torch.float32).reshape(2, 4, 6)
 
-        def sentinel_empty_like(tensor, **kwargs):
-            return torch.full_like(tensor, -17.0, **kwargs)
-
-        with (
-            patch("nemo_automodel.components.moe.state_dict_utils.is_dtensor", return_value=False),
-            patch("torch.empty_like", side_effect=sentinel_empty_like) as mock_empty_like,
-        ):
+        with patch("nemo_automodel.components.moe.state_dict_utils.is_dtensor", return_value=False):
             result = mixin._convert_single_merged_expert_to_hf_split_experts(
                 "model.layers.0.mlp.experts.gate_and_up_projs",
                 initialized,
-                load_into_empty_destinations=True,
+                for_checkpoint_load=True,
             )
 
         assert result is not None and len(result) == 4
-        assert mock_empty_like.call_count == 4
+        source_ptr = initialized.untyped_storage().data_ptr()
         for _, destination in result:
-            assert destination.is_contiguous()
-            torch.testing.assert_close(destination, torch.full_like(destination, -17.0))
+            assert not destination.is_contiguous()
+            assert destination.untyped_storage().data_ptr() == source_ptr
 
     def test_te_checkpoint_layout_views_are_reused(self):
         mixin = MockMoEStateDictMixin(n_experts=2, inter_dim=3)
@@ -1217,14 +1202,14 @@ class TestInplaceLoadViews:
                 mixin._convert_single_merged_expert_to_hf_split_experts(
                     "model.layers.0.mlp.experts.gate_and_up_projs",
                     virtual_gate_up,
-                    load_into_empty_destinations=True,
+                    for_checkpoint_load=True,
                 )
             )
             destinations.update(
                 mixin._convert_single_merged_expert_to_hf_split_experts(
                     "model.layers.0.mlp.experts.down_projs",
                     virtual_down,
-                    load_into_empty_destinations=True,
+                    for_checkpoint_load=True,
                 )
             )
 
@@ -1261,7 +1246,7 @@ class TestInplaceLoadViews:
             destinations = mixin._convert_single_merged_expert_to_hf_split_experts(
                 "model.layers.0.mlp.experts.gate_and_up_projs",
                 virtual_gate_up,
-                load_into_empty_destinations=True,
+                for_checkpoint_load=True,
             )
 
         assert destinations is not None and len(destinations) == 16
@@ -1270,7 +1255,7 @@ class TestInplaceLoadViews:
         collect.assert_not_called()
         empty_cache.assert_not_called()
 
-    def test_empty_te_destinations_round_trip_checkpoint_values(self):
+    def test_temporary_checkpoint_views_round_trip_loaded_values(self):
         mixin = MockMoEStateDictMixin(n_experts=2, inter_dim=3)
         mixin.backend.experts = "te"
         initialized_gate_up = torch.full((2, 4, 6), 99.0)
@@ -1281,14 +1266,14 @@ class TestInplaceLoadViews:
                 mixin._convert_single_merged_expert_to_hf_split_experts(
                     "model.layers.0.mlp.experts.gate_and_up_projs",
                     initialized_gate_up,
-                    load_into_empty_destinations=True,
+                    for_checkpoint_load=True,
                 )
             )
             destinations.update(
                 mixin._convert_single_merged_expert_to_hf_split_experts(
                     "model.layers.0.mlp.experts.down_projs",
                     initialized_down,
-                    load_into_empty_destinations=True,
+                    for_checkpoint_load=True,
                 )
             )
 


### PR DESCRIPTION
## What this PR changes

This PR improves three grouped-MoE checkpoint paths left after NVIDIA-NeMo/Automodel#3574:

1. **MoE reconstruction:** write each expert directly into the final grouped tensor instead of building one tensor per expert and stacking them afterward. Use generation-0 garbage collection instead of repeatedly scanning the full Python heap.
2. **Transformer Engine and MoK destinations:** return the checkpoint-layout view that DCP should fill. TE's views are contiguous; some MoK views are not, but DCP supports both. This avoids allocating a second set of expert tensors and avoids full GC or `torch.cuda.empty_cache()` while those views remain in use.
3. **Gemma4 grouped checkpoints:** load expert tensors through transposed views of the model weights. With expert parallelism, each rank reads only its own experts instead of materializing all experts on every rank.

The loader also reports destination preparation, storage read, adapter conversion, and model installation separately.

This PR optimizes the existing load pipeline. General sequential checkpoint streaming remains follow-up work in NVIDIA-NeMo/Automodel#3576.

## Why the model paths differ

Qwen TE and Gemma4 both transform expert weights, but their checkpoint layouts are different:

* **Qwen TE:** the HF checkpoint has separate keys for each expert. TE exposes a temporary grouped stack. The adapter turns that stack back into per-expert HF tensors before DCP reads them, then combines the loaded values into TE parameters.
* **Gemma4:** the HF checkpoint already stores all 128 experts in two grouped tensors per layer. The model stores transposed grouped tensors and also absorbs a small per-expert scale into the down projection.

For Gemma4 EP8, the old path expanded every rank's 16 experts into full 128-expert CPU tensors, read the full grouped checkpoint, and then sliced back to 16 experts. The new path gives DCP transposed, expert-sharded views of the model weights, so each rank reads only its own 16-expert slice. The small scale vector is applied in place after the read.

## Performance

### Gemma4 26B EP8

Both runs use the same 8×H100 `gemma4_26b_a4b_moe_peft` release recipe.

<!-- linear:table-colwidths:200,200,200,200 -->
| Load phase | Before this optimization | Current | Reduction |
| -- | -- | -- | -- |
| Destination preparation | 165.90 s | **0.07 s** | **99.96%** |
| Checkpoint storage read | 275.96 s | **26.41 s** | **90.4%** |
| Adapter conversion | 9.37 s | **0.01 s** | **99.9%** |
| Model installation | 0.13 s | 0.12 s | — |
| **Total model load** | **451.36 s** | **26.60 s** | **94.1% / 17.0x** |

* Before: [job 405235261](<https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/405235261>)
* Current: [job 405305252](<https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/405305252>), [pipeline 63712014](<https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/63712014>)

A matched local 8-H100 A/B measured 190.44 s before versus 24.46 s on the first optimized read and 13.87 s warm. Per-rank peak process RSS fell from 86.85 GiB to 7.41 GiB. Rank-by-rank expert probes matched, every rank owned 16 experts, and no meta parameters remained.

For single-device Gemma4, matched warm runs reduced peak process RSS from 64.30 GiB to 47.62 GiB (16.68 GiB / 25.9%). Model-load time itself was approximately neutral; EP is the large speed improvement.

### Qwen3 30B TE: corrected speed and memory explanation

The earlier explanation was incomplete. TE creates its virtual grouped tensor with `torch.stack(...).transpose(...)`. After the adapter slices and transposes an expert back to HF layout, that tensor is already contiguous. Therefore the old `.contiguous()` call reused the TE stack; it did not allocate a copy.

The large destination-setup speedup comes from avoiding repeated full `gc.collect()` calls. Full GC took roughly 19–23 seconds across the 46 expert projections. Generation-0 collection or no collection takes less than one second. `torch.cuda.empty_cache()` was not responsible for the old path's lower peak.

The initially proposed blank destinations were fast but always allocated a second set of expert tensors. The final implementation instead reuses TE's already-contiguous checkpoint views:

<!-- linear:table-colwidths:160,160,160,160,160 -->
| Code state | Load-only elapsed | Final CUDA allocation / rank | Peak CUDA allocation / rank | What it shows |
| -- | -- | -- | -- | -- |
| Before this PR: `cat` then `stack` | 59.25 s | 7.109 GiB | 14.093 GiB | Original reconstruction and full GC |
| Direct fill + `from_hf` generation-0 GC | 35.43 s | 7.109 GiB | **13.999 GiB** | Direct fill saves 96 MiB/rank; cleanup provides most of the time gain |
| Rejected blank TE destinations | 15.21 s | 7.109 GiB | 20.609 GiB | Fast setup, but duplicates 6.61 GiB/rank |
| **Current: reuse TE views** | **20.36 s** | 7.109 GiB | **13.999 GiB** | Keeps the fast setup without the memory regression |

The first three rows are the matched EP8 job `16206220`. The final row is job `16219024`, using the same cached Qwen3-30B checkpoint, EP8 topology, staged image, and load-only harness. Storage timing varies with filesystem state, so CUDA peak is the controlled comparison. In the final run, the loader's own phase timer reported 18.26 s total: 0.40 s destination setup, 17.42 s storage read, 0.31 s adapter conversion, and 0.13 s installation.

All four states completed with zero meta parameters and matching rank-local expert fingerprints. The current path reduces the rejected implementation's peak by 6.610 GiB/rank (32.1%) and returns exactly to the direct-fill peak.

### Nemotron Nano V3 single-device fallback

Matched one-GPU runs used the same 58.82 GB checkpoint, recipe, image, and one-step workload.

<!-- linear:table-colwidths:200,200,200,200 -->
| Load phase | Before this PR | Current | Reduction |
| -- | -- | -- | -- |
| Adapter conversion | 246.81 s | **146.69 s** | **40.6%** |
| Total model load | 265.78 s | **162.65 s** | **38.8%** |

The time reduction comes from replacing 46 full Python-heap scans—two expert projections across 23 MoE layers—with generation-0 collection. Direct fill separately removes one final-size reconstruction scratch buffer. The run completed successfully with the same finite first-step metrics as the parent. This older job did not record a clean load-only CUDA peak; that measurement is tracked with the sequential-loading follow-up.

## Correctness boundaries

* **Pretraining from config is unchanged.** Without a checkpoint, `load_model()` is not called and model initialization remains unchanged.
* **Checkpoint views are load-only.** DCP fully overwrites the returned views. Save/export conversion still creates contiguous tensors that preserve their current values.
* **No model-sized blank destinations are created.** DCP can fill contiguous and non-contiguous views, so both TE and MoK reuse their existing checkpoint-layout storage.
* **Partial loads preserve initialization.** Missing allowed keys are removed before DCP runs, and incomplete expert groups fail validation.
* **Quantized conversion is unchanged.** Quantized paths keep value-preserving conversion and the existing rebuild behavior.
* **Gemma4 EP direct load is topology-gated.** It requires materialized expert DTensors sharded only on the expert axis across EP. Unsupported sharding and quantized conversion use the existing fallback.

## Validation

* New TE storage test proves checkpoint-layout outputs reuse TE's temporary stack without allocating a second buffer.
* New MoK storage test proves its non-contiguous checkpoint-layout outputs reuse the existing grouped storage.
* New CUDA allocator regression test limits TE destination construction to 70 MiB for a 64 MiB stack; the rejected blank path would require 128 MiB.
* New CUDA allocator regression test limits direct fill to 40 MiB for 16 MiB of inputs plus one 16 MiB output; the old per-expert concatenations would raise the peak to 48 MiB.
* Focused GPU tests: **2 passed** in Slurm job `16219024`.
* MoE mixin CPU suite: **51 passed, 4 GPU-only skipped, 1 unrelated Gloo test deselected**.
* Qwen3 30B TE load-only EP8: job `16219024`, peak 13.999 GiB/rank, zero meta parameters, matching expert fingerprints.
* Qwen3 30B MoE checkpoint robustness: [pipeline 63370169](<https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/63370169>).
* Gemma4 26B EP 50-step run: [job 405305252](<https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/405305252>).
* Gemma4 full checkpoint robustness: [job 405377241](<https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/405377241>), [pipeline 63721419](<https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/63721419>) — base run plus all four save/reload phases passed.
* Ruff format/check and `git diff --check` pass.

Builds on NVIDIA-NeMo/Automodel#3574. Part of NVIDIA-NeMo/Automodel#3576.