### PR TITLE
feat(vlm): add CP vision shape floor

### DIFF
--- a/docs/guides/cp-vision-frame-sharding.mdx
+++ b/docs/guides/cp-vision-frame-sharding.mdx
@@ -42,6 +42,7 @@ distributed:
         mesh_dims: [cp]
         min_tokens: 2048
         min_frames: 32
+        min_local_patch_rows: 96
         cost_alpha: auto
 ```
 
@@ -71,6 +72,7 @@ The following table describes the vision frame sharding fields:
 | `mesh_dims` | `[cp]` | Selects the device-mesh dimensions used to distribute frames. Only `[cp]` is currently supported. |
 | `min_tokens` | `2048` | Minimum number of merged visual tokens that can activate sharding. Set it to `0` to always satisfy the token threshold. |
 | `min_frames` | `32` | Minimum number of independent image or video-frame units that can activate sharding even below `min_tokens`. Set it to `0` to always satisfy the frame threshold. |
+| `min_local_patch_rows` | `96` | Minimum pre-merge patch rows processed by each sharded rank that owns real frames. Smaller shards append whole, same-shaped zero frames and discard their outputs before the gather. Because this counts patch rows, it accounts for both frame count and resolution. Set it to `0` to disable local padding. |
 | `cost_alpha` | `auto` | Controls how frame cost is estimated for load balancing. `auto` uses the vision hidden size and is the recommended setting. A nonnegative integer overrides the inferred value. Setting it to `0` uses a purely quadratic attention-cost estimate. |
 
 Vision frame sharding uses the replicated path only when both the merged visual-token count is below
@@ -102,6 +104,12 @@ gradients for vision-tower weights that are replicated across TP ranks.
 If a batch contains fewer frames than CP ranks, the implementation adds minimal dummy
 frames so every rank participates in the vision forward and collectives. The corresponding
 embeddings are discarded and contribute no gradient.
+
+After partitioning, a rank with fewer than `min_local_patch_rows` pre-merge patch rows
+appends enough whole zero frames of the same resolution to reach the configured floor.
+Their outputs are removed before the differentiable gather, so the padding changes only
+the local vision-kernel shape and contributes no token or gradient to training. Ranks that
+own only a rank-fill dummy remain at the minimal shape.
 
 ## Check Your Workload
 

--- a/docs/guides/cp-vision-frame-sharding.mdx
+++ b/docs/guides/cp-vision-frame-sharding.mdx
@@ -105,11 +105,23 @@ If a batch contains fewer frames than CP ranks, the implementation adds minimal 
 frames so every rank participates in the vision forward and collectives. The corresponding
 embeddings are discarded and contribute no gradient.
 
-After partitioning, a rank with fewer than `min_local_patch_rows` pre-merge patch rows
-appends enough whole zero frames of the same resolution to reach the configured floor.
-Their outputs are removed before the differentiable gather, so the padding changes only
-the local vision-kernel shape and contributes no token or gradient to training. Ranks that
-own only a rank-fill dummy remain at the minimal shape.
+Frame sharding without local padding is mathematically valid. However, enabling frame
+sharding can make each rank's reduced-precision ViT input much smaller than the input used
+when frame sharding is disabled and the full vision tower is replicated. Tiny local shapes
+can select different kernel tiling and accumulation orders, increasing numerical variation
+relative to that replicated baseline. The default `min_local_patch_rows=96` is a
+conservative kernel-shape floor intended to improve this sharded-versus-replicated parity.
+
+A rank below the floor appends enough whole zero frames of the same resolution to reach it.
+Their outputs are removed before the differentiable gather, so they contribute no model
+token or gradient; they only change the local vision-kernel shape. Ranks that own only a
+rank-fill dummy remain minimal.
+
+This padding is a minor parity aid, not a correctness requirement, a bitwise-equivalence
+guarantee, or a throughput optimization. It adds some vision work and may be unnecessary
+for workloads whose unpadded sharded training already matches the frame-sharding-disabled
+baseline closely. Set `min_local_patch_rows: 0` after workload-specific convergence
+validation when avoiding that extra work is preferred.
 
 ## Check Your Workload
 

--- a/nemo_automodel/components/distributed/cp_vision_frame_shard.py
+++ b/nemo_automodel/components/distributed/cp_vision_frame_shard.py
@@ -93,6 +93,11 @@ class CpVisionFrameShardingConfig:
         min_frames: Minimum number of independent image/frame units that can select
             sharding even below ``min_tokens``. Long videos reduce per-frame spatial
             resolution, so merged-token count alone underestimates their ViT work.
+        min_local_patch_rows: Minimum number of pre-merge patch rows processed by each
+            rank that owns real frames. Smaller local shards append whole, same-shaped
+            zero frames before the vision forward and remove their outputs before the
+            gather. This avoids unstable reduced-precision kernels for tiny ViT shapes.
+            Set to ``0`` to disable local padding.
         cost_alpha: Non-negative linear term in the partition cost
             ``p * (p + cost_alpha)``. ``"auto"`` infers ``3 * vision_hidden_size``
             and falls back to ``0`` when the width is unavailable. ``None`` remains
@@ -103,6 +108,7 @@ class CpVisionFrameShardingConfig:
     mesh_dims: tuple[Literal["cp"]] = ("cp",)
     min_tokens: int = 2048
     min_frames: int = 32
+    min_local_patch_rows: int = 96
     cost_alpha: int | Literal["auto"] | None = "auto"
 
     def __post_init__(self) -> None:
@@ -118,6 +124,12 @@ class CpVisionFrameShardingConfig:
             raise ValueError(f"{config_path}.min_tokens must be a non-negative integer")
         if isinstance(self.min_frames, bool) or not isinstance(self.min_frames, int) or self.min_frames < 0:
             raise ValueError(f"{config_path}.min_frames must be a non-negative integer")
+        if (
+            isinstance(self.min_local_patch_rows, bool)
+            or not isinstance(self.min_local_patch_rows, int)
+            or self.min_local_patch_rows < 0
+        ):
+            raise ValueError(f"{config_path}.min_local_patch_rows must be a non-negative integer")
         if self.cost_alpha not in (None, "auto") and (
             isinstance(self.cost_alpha, bool) or not isinstance(self.cost_alpha, int) or self.cost_alpha < 0
         ):
@@ -536,6 +548,18 @@ def _all_gather_var_tokens(
     return torch.cat(blocks, dim=0)
 
 
+def _padding_frames_for_min_patch_rows(
+    local_patch_rows: int,
+    frame_patch_rows: int,
+    min_patch_rows: int,
+) -> int:
+    """Return the whole same-shaped frames needed to reach a local patch-row floor."""
+    if min_patch_rows <= local_patch_rows or frame_patch_rows <= 0:
+        return 0
+    missing_rows = min_patch_rows - local_patch_rows
+    return (missing_rows + frame_patch_rows - 1) // frame_patch_rows
+
+
 def _raise_if_any_rank_failed(
     local_ok: bool,
     group: dist.ProcessGroup,
@@ -757,6 +781,34 @@ def maybe_distribute_visual(
             local_rows[-1][0] += 1
         else:
             local_rows.append([1, h, w, f_entry[i]])
+
+    # Very small reduced-precision ViT shards can select materially different GEMM
+    # kernels. Keep ranks that own real frames above a resolution-aware patch-row floor
+    # by appending whole, same-shaped zero frames. Ranks that own only a global rank-fill
+    # dummy stay minimal. The synthetic outputs are validated and sliced below before
+    # they enter the differentiable gather, so they cannot reach the loss or vision grads.
+    numeric_pad_frames = 0
+    numeric_pad_patch_rows = 0
+    local_real_start = min(cuts[rank], n_units)
+    local_real_end = min(cuts[rank + 1], n_units)
+    if scope.config.min_local_patch_rows > 0 and local_real_end > local_real_start:
+        pad_h, pad_w = f_hw[local_real_end - 1]
+        frame_patch_rows = pad_h * pad_w
+        numeric_pad_frames = _padding_frames_for_min_patch_rows(
+            int(local_pixel.shape[0]),
+            frame_patch_rows,
+            scope.config.min_local_patch_rows,
+        )
+        if numeric_pad_frames:
+            numeric_pad_patch_rows = numeric_pad_frames * frame_patch_rows
+            local_pixel = torch.cat(
+                [
+                    local_pixel,
+                    local_pixel.new_zeros(numeric_pad_patch_rows, local_pixel.shape[1]),
+                ],
+                dim=0,
+            )
+            local_rows.append([numeric_pad_frames, pad_h, pad_w, -1])
     local_grid = torch.tensor(
         [[c, h, w] for c, h, w, _ in local_rows],
         dtype=grid_host.dtype,
@@ -771,14 +823,21 @@ def maybe_distribute_visual(
     # rank makes EVERY rank raise -- a bare per-rank ``raise`` here would hang the group,
     # since the failing rank would raise while peers block in the all-gather below.
     expected_local_tokens = token_counts[rank]
+    numeric_pad_tokens = numeric_pad_patch_rows // sms_sq
+    expected_visual_tokens = expected_local_tokens + numeric_pad_tokens
     actual_local_tokens = local_out.pooler_output.shape[0]
     _raise_if_any_rank_failed(
-        actual_local_tokens == expected_local_tokens,
+        actual_local_tokens == expected_visual_tokens,
         group,
         local_out.pooler_output.device,
         f"cp_vision_frame_shard: rank {rank} produced {actual_local_tokens} visual tokens for its "
-        f"frame slice, expected {expected_local_tokens}.",
+        f"frame slice, expected {expected_visual_tokens} including {numeric_pad_tokens} local "
+        "padding tokens.",
     )
+
+    # Local numerical padding is not part of the gather contract. Removing it here gives
+    # every synthetic output zero upstream gradient and keeps token_counts unchanged.
+    local_out.pooler_output = local_out.pooler_output[:expected_local_tokens]
 
     # Gather all per-rank blocks (real + any dummy) in rank order, then slice to the real
     # token count: dummy frames live on the last `n_pad` ranks, so their tokens are the
@@ -793,7 +852,7 @@ def maybe_distribute_visual(
     if deepstack is not None:
         # Same consensus contract as the pooler check above: a per-rank ``raise`` before the
         # deepstack all-gathers would deadlock, so agree across the group first.
-        bad_k = next((k for k, d in enumerate(deepstack) if d.shape[0] != expected_local_tokens), None)
+        bad_k = next((k for k, d in enumerate(deepstack) if d.shape[0] != expected_visual_tokens), None)
         _raise_if_any_rank_failed(
             bad_k is None,
             group,
@@ -802,9 +861,11 @@ def maybe_distribute_visual(
             if bad_k is None
             else (
                 f"cp_vision_frame_shard: rank {rank} deepstack feature {bad_k} has "
-                f"{deepstack[bad_k].shape[0]} visual tokens, expected {expected_local_tokens}."
+                f"{deepstack[bad_k].shape[0]} visual tokens, expected {expected_visual_tokens} "
+                f"including {numeric_pad_tokens} local padding tokens."
             ),
         )
+        deepstack = [d[:expected_local_tokens] for d in deepstack]
         local_out.deepstack_features = [
             _all_gather_var_tokens(d, group, world, token_counts)[:n_real_tokens] for d in deepstack
         ]

--- a/nemo_automodel/components/distributed/cp_vision_frame_shard.py
+++ b/nemo_automodel/components/distributed/cp_vision_frame_shard.py
@@ -93,11 +93,11 @@ class CpVisionFrameShardingConfig:
         min_frames: Minimum number of independent image/frame units that can select
             sharding even below ``min_tokens``. Long videos reduce per-frame spatial
             resolution, so merged-token count alone underestimates their ViT work.
-        min_local_patch_rows: Minimum number of pre-merge patch rows processed by each
-            rank that owns real frames. Smaller local shards append whole, same-shaped
-            zero frames before the vision forward and remove their outputs before the
-            gather. This avoids unstable reduced-precision kernels for tiny ViT shapes.
-            Set to ``0`` to disable local padding.
+        min_local_patch_rows: Optional minimum number of pre-merge patch rows processed
+            by each rank that owns real frames. Smaller local shards append whole,
+            same-shaped zero frames before the vision forward and remove their outputs
+            before the gather. This can reduce shape-dependent numerical variation from
+            tiny reduced-precision ViT kernels. ``0`` disables local padding.
         cost_alpha: Non-negative linear term in the partition cost
             ``p * (p + cost_alpha)``. ``"auto"`` infers ``3 * vision_hidden_size``
             and falls back to ``0`` when the width is unavailable. ``None`` remains

--- a/tests/unit_tests/distributed/test_cp_vision_frame_shard.py
+++ b/tests/unit_tests/distributed/test_cp_vision_frame_shard.py
@@ -69,6 +69,18 @@ class _RecordingStubVisual(_StubVisual):
         self.patch_rows = []
 
     def forward(self, pixel_values, grid_thw=None, return_dict=True):
+        """Record the local patch-row count and delegate to the stub vision tower.
+
+        Args:
+            pixel_values: Tensor of shape [patch_rows, patch_dim].
+            grid_thw: Optional tensor of shape [entries, 3] containing ``(time, height, width)`` rows.
+            return_dict: Whether to return the vision output as a structured object.
+
+        Returns:
+            Vision output whose ``pooler_output`` tensor has shape [tokens, hidden],
+            ``last_hidden_state`` tensor has shape [patch_rows, hidden], and optional
+            ``deepstack_features`` tensors each have shape [tokens, hidden].
+        """
         self.patch_rows.append(int(pixel_values.shape[0]))
         return super().forward(pixel_values, grid_thw=grid_thw, return_dict=return_dict)
 

--- a/tests/unit_tests/distributed/test_cp_vision_frame_shard.py
+++ b/tests/unit_tests/distributed/test_cp_vision_frame_shard.py
@@ -63,6 +63,16 @@ class _StubVisual(torch.nn.Module):
         return out
 
 
+class _RecordingStubVisual(_StubVisual):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.patch_rows = []
+
+    def forward(self, pixel_values, grid_thw=None, return_dict=True):
+        self.patch_rows.append(int(pixel_values.shape[0]))
+        return super().forward(pixel_values, grid_thw=grid_thw, return_dict=return_dict)
+
+
 class _RecorderVisual(torch.nn.Module):
     """Parameter-free stub that records its call args and returns a fixed output.
 
@@ -90,11 +100,12 @@ def _pixels(grid, in_dim=8, seed=0):
     return torch.randn(total_patches, in_dim, generator=g)
 
 
-def _policy(*, enabled=True, min_tokens=0, min_frames=32, cost_alpha="auto"):
+def _policy(*, enabled=True, min_tokens=0, min_frames=32, min_local_patch_rows=0, cost_alpha="auto"):
     return vs.CpVisionFrameShardingConfig(
         enabled=enabled,
         min_tokens=min_tokens,
         min_frames=min_frames,
+        min_local_patch_rows=min_local_patch_rows,
         cost_alpha=cost_alpha,
     )
 
@@ -243,6 +254,31 @@ def test_cost_alpha_override_and_unknown_model_fallback():
     for invalid_alpha in (-1, True, "AUTO", "not-auto"):
         with pytest.raises(ValueError, match="cost_alpha"):
             vs.CpVisionFrameShardingConfig(cost_alpha=invalid_alpha)
+
+
+def test_min_local_patch_rows_default_override_and_validation():
+    assert vs.CpVisionFrameShardingConfig().min_local_patch_rows == 96
+    assert vs.CpVisionFrameShardingConfig(min_local_patch_rows=0).min_local_patch_rows == 0
+
+    for invalid_floor in (-1, True, 1.5, "96"):
+        with pytest.raises(ValueError, match="min_local_patch_rows"):
+            vs.CpVisionFrameShardingConfig(min_local_patch_rows=invalid_floor)
+
+
+@pytest.mark.parametrize(
+    ("local_rows", "frame_rows", "floor", "expected"),
+    [
+        (4, 4, 96, 23),
+        (8, 4, 96, 22),
+        (92, 4, 96, 1),
+        (96, 4, 96, 0),
+        (100, 4, 96, 0),
+        (4, 0, 96, 0),
+        (4, 4, 0, 0),
+    ],
+)
+def test_padding_frames_for_min_patch_rows(local_rows, frame_rows, floor, expected):
+    assert vs._padding_frames_for_min_patch_rows(local_rows, frame_rows, floor) == expected
 
 
 def test_partition_cost_alpha_flattens_mixed_frame_sizes():
@@ -464,6 +500,7 @@ def _simulate_maybe_distribute(
     ``test_pad_backward_through_real_code_matches_replicate``."""
     import torch.distributed as dist
 
+    resolved_policy = policy or _policy()
     sms = visual.spatial_merge_size
     sms_sq = sms**2
     # frame-level units (mirror maybe_distribute_visual): expand (t,h,w) -> t x (h*w patches)
@@ -492,7 +529,21 @@ def _simulate_maybe_distribute(
         padded = []
         for r in range(world):
             lp = pixel[pix_bounds[cuts[r]] : pix_bounds[cuts[r + 1]]]
-            t = field_getter(visual(lp))  # stub ignores grid; output depends only on pixel rows
+            local_real_start = min(cuts[r], n_units)
+            local_real_end = min(cuts[r + 1], n_units)
+            if resolved_policy.min_local_patch_rows > 0 and local_real_end > local_real_start:
+                frame_patch_rows = f_patches[local_real_end - 1]
+                pad_frames = vs._padding_frames_for_min_patch_rows(
+                    int(lp.shape[0]),
+                    frame_patch_rows,
+                    resolved_policy.min_local_patch_rows,
+                )
+                if pad_frames:
+                    lp = torch.cat(
+                        [lp, lp.new_zeros(pad_frames * frame_patch_rows, lp.shape[1])],
+                        dim=0,
+                    )
+            t = field_getter(visual(lp))[: token_counts[r]]
             if t.shape[0] < max_tok:
                 t = torch.cat([t, t.new_zeros(max_tok - t.shape[0], t.shape[-1])], 0)
             padded.append(t.detach())
@@ -530,7 +581,7 @@ def _simulate_maybe_distribute(
 
     tok = vs.set_cp_vision_group(
         object(),
-        config=policy or _policy(),
+        config=resolved_policy,
         spans_only_cp=spans_only_cp,
     )  # any non-None group activates the path
     try:
@@ -569,6 +620,84 @@ def test_maybe_distribute_gathers_deepstack(monkeypatch, world):
     for got, exp in zip(out.deepstack_features, rep.deepstack_features):
         assert got.shape == exp.shape
         assert torch.allclose(got, exp, atol=1e-6)
+
+
+def test_min_local_patch_rows_preserves_forward_and_deepstack(monkeypatch):
+    grid = _grid([(8, 2, 2)])
+    pixel = _pixels(grid, seed=23)
+    visual = _RecordingStubVisual(with_deepstack=True)
+    replicated = visual(pixel, grid)
+
+    out = _simulate_maybe_distribute(
+        visual,
+        pixel,
+        grid,
+        world=4,
+        rank=0,
+        monkeypatch=monkeypatch,
+        policy=_policy(min_local_patch_rows=24),
+    )
+
+    assert visual.patch_rows[-1] == 24
+    assert torch.equal(out.pooler_output, replicated.pooler_output)
+    assert out.deepstack_features is not None
+    for got, expected in zip(out.deepstack_features, replicated.deepstack_features):
+        assert torch.equal(got, expected)
+
+
+def test_min_local_patch_rows_does_not_grow_dummy_only_rank(monkeypatch):
+    grid = _grid([(1, 2, 2)])
+    pixel = _pixels(grid, seed=29)
+    visual = _RecordingStubVisual()
+    replicated = visual(pixel, grid).pooler_output
+
+    out = _simulate_maybe_distribute(
+        visual,
+        pixel,
+        grid,
+        world=4,
+        rank=1,
+        monkeypatch=monkeypatch,
+        policy=_policy(min_local_patch_rows=96),
+    )
+
+    assert visual.patch_rows[-1] == 4
+    assert torch.equal(out.pooler_output, replicated)
+
+
+def test_min_local_patch_rows_backward_matches_replicate(monkeypatch):
+    torch.manual_seed(31)
+    grid = _grid([(8, 2, 2)])
+    pixel = _pixels(grid, seed=29)
+    visual = _StubVisual(bias=True)
+    replicated = visual(pixel, grid).pooler_output
+    target = torch.randn_like(replicated)
+
+    visual.zero_grad(set_to_none=True)
+    (visual(pixel, grid).pooler_output * target).sum().backward()
+    expected_weight_grad = visual.proj.weight.grad.clone()
+    expected_bias_grad = visual.proj.bias.grad.clone()
+
+    weight_grads, bias_grads = [], []
+    for rank in range(4):
+        visual.zero_grad(set_to_none=True)
+        out = _simulate_maybe_distribute(
+            visual,
+            pixel,
+            grid,
+            world=4,
+            rank=rank,
+            monkeypatch=monkeypatch,
+            grad=True,
+            policy=_policy(min_local_patch_rows=24),
+        )
+        assert torch.equal(out.pooler_output, replicated)
+        (out.pooler_output * target).sum().backward()
+        weight_grads.append(visual.proj.weight.grad.clone())
+        bias_grads.append(visual.proj.bias.grad.clone())
+
+    assert torch.allclose(torch.stack(weight_grads).sum(0), expected_weight_grad, atol=1e-6)
+    assert torch.allclose(torch.stack(bias_grads).sum(0), expected_bias_grad, atol=1e-6)
 
 
 @pytest.mark.parametrize("world", [2, 4])

--- a/tests/unit_tests/distributed/test_cp_vision_frame_shard_gloo.py
+++ b/tests/unit_tests/distributed/test_cp_vision_frame_shard_gloo.py
@@ -135,6 +135,7 @@ def _sharded_forward_backward(
     targets: list[torch.Tensor],
     rank: int,
     world_size: int,
+    min_local_patch_rows: int = 0,
 ):
     """Drive ``maybe_distribute_visual`` with real collectives and backprop this rank's shard.
 
@@ -147,7 +148,11 @@ def _sharded_forward_backward(
     from nemo_automodel.components.distributed import cp_vision_frame_shard as vs
 
     visual.zero_grad(set_to_none=True)
-    config = vs.CpVisionFrameShardingConfig(enabled=True, min_tokens=0)
+    config = vs.CpVisionFrameShardingConfig(
+        enabled=True,
+        min_tokens=0,
+        min_local_patch_rows=min_local_patch_rows,
+    )
     token = vs.set_cp_vision_group(dist.group.WORLD, config=config)
     try:
         out = vs.maybe_distribute_visual(visual, pixel, grid)
@@ -221,6 +226,43 @@ def _pad_path_worker(rank: int, world_size: int, port: int) -> None:
             # would mean the dummy frame leaked gradient into the shared vision params.
             assert torch.count_nonzero(gb) == 0
             assert torch.count_nonzero(gw) == 0
+        dist.all_reduce(gw, op=dist.ReduceOp.SUM)
+        dist.all_reduce(gb, op=dist.ReduceOp.SUM)
+        torch.testing.assert_close(gw, gw_ref, atol=1e-6, rtol=1e-6)
+        torch.testing.assert_close(gb, gb_ref, atol=1e-6, rtol=1e-6)
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _local_patch_floor_worker(rank: int, world_size: int, port: int) -> None:
+    """Local patch-row floor: padded ViT work is removed before real collectives."""
+    try:
+        _init_gloo(rank, world_size, port)
+        torch.set_num_threads(1)
+        torch.manual_seed(0)
+        visual = _GlooVisual(n_deepstack=2)
+        grid = torch.tensor([[8, 2, 2]], dtype=torch.long)
+        gen = torch.Generator().manual_seed(7)
+        pixel = torch.randn(int(grid.prod(dim=-1).sum()), 8, generator=gen)
+
+        rep_pooler, rep_deepstack, targets, (gw_ref, gb_ref) = _replicated_reference(visual, pixel, grid)
+
+        out = _sharded_forward_backward(
+            visual,
+            pixel,
+            grid,
+            targets,
+            rank,
+            world_size,
+            min_local_patch_rows=32,
+        )
+        torch.testing.assert_close(out.pooler_output, rep_pooler, atol=1e-6, rtol=1e-6)
+        for got, exp in zip(out.deepstack_features, rep_deepstack):
+            torch.testing.assert_close(got, exp, atol=1e-6, rtol=1e-6)
+
+        gw = visual.proj.weight.grad.clone()
+        gb = visual.proj.bias.grad.clone()
         dist.all_reduce(gw, op=dist.ReduceOp.SUM)
         dist.all_reduce(gb, op=dist.ReduceOp.SUM)
         torch.testing.assert_close(gw, gw_ref, atol=1e-6, rtol=1e-6)
@@ -351,3 +393,8 @@ def test_cp_vision_frame_shard_two_rank_gloo_real_qwen3_5_tower_forward_parity()
 @pytest.mark.skipif(not dist.is_available(), reason="torch.distributed is not available")
 def test_cp_vision_frame_shard_two_rank_gloo_pad_path_parity():
     mp.spawn(_pad_path_worker, args=(2, _free_port()), nprocs=2, join=True)
+
+
+@pytest.mark.skipif(not dist.is_available(), reason="torch.distributed is not available")
+def test_cp_vision_frame_shard_two_rank_gloo_local_patch_floor_parity():
+    mp.spawn(_local_patch_floor_worker, args=(2, _free_port()), nprocs=2, join=True)

--- a/tests/unit_tests/recipes/test_dist_utils.py
+++ b/tests/unit_tests/recipes/test_dist_utils.py
@@ -150,6 +150,7 @@ class TestParsing:
                         "enabled": True,
                         "mesh_dims": ["cp"],
                         "min_tokens": 0,
+                        "min_local_patch_rows": 128,
                         "cost_alpha": 0,
                     }
                 }
@@ -163,6 +164,7 @@ class TestParsing:
             enabled=True,
             mesh_dims=("cp",),
             min_tokens=0,
+            min_local_patch_rows=128,
             cost_alpha=0,
         )
         assert cfg["multimodal"]["vision"]["frame_sharding"]["mesh_dims"] == ["cp"]


### PR DESCRIPTION
## Summary

* add a `min_local_patch_rows` policy for CP vision frame sharding, defaulting to 96 pre-merge patch rows
* append whole, same-shaped zero frames only on sharded ranks with real visual work, then validate and remove their outputs before the differentiable gather
* cover forward, DeepStack, backward, dummy-only ranks, real two-rank collectives, YAML parsing, and user documentation

This does not enable vision frame sharding globally. The floor applies only after the existing frame-sharding policy is enabled and selects the sharded path. Set `min_local_patch_rows: 0` to retain the previous unpadded local shapes.

This is deliberately a minor parity aid. It does not fix a demonstrated mathematical-correctness bug, and many workloads may not need it. The default favors closer parity with the frame-sharding-disabled replicated baseline when local BF16 shards become tiny; users can disable it after workload-specific convergence validation.

## Motivation

At high CP, a long video's low-resolution frames can leave each rank with a very small ViT input even when the global visual workload is substantial. The unpadded computation remains mathematically valid, but reduced-precision kernels can use different tiling and accumulation orders for these tiny local shapes and drift farther from the larger replicated reference.

The floor is a conservative numerical-parity guard, not a claim that padding itself improves throughput. It is resolution-aware: it counts pre-merge patch rows (`h * w` per frame), not a fixed number of frames. Synthetic frames use a real local frame's shape, and their pooled and DeepStack outputs are sliced before `token_counts` and the all-gather contract. They therefore cannot become model tokens or contribute vision gradients. Ranks that own only an existing rank-fill dummy remain minimal. Padding adds ViT work, but the default gives users a safer initial sharded-versus-replicated parity posture; `0` remains available when unpadded convergence has been validated.

## Validation

* Qwen3.5-MoE 35B, 32 H100, CP4/EP8, diverse 1,024-row image/video/text corpus, 20-step ABBA comparison: loss correlation 0.999952, candidate loss log-RMS 0.00253 (limit 0.02956), candidate gradient log-RMS 0.01043 (limit 0.13976), and 0.285% final-five signed loss regression.
* No padding-specific TPS improvement is claimed. Padding trades some of frame sharding's maximum efficiency for closer numerical parity with the replicated shape.
* Exact-source two-H100 Qwen3.5 NCCL smoke, real local rows 16 -> processed rows 96:
  * FP32: zero output drift; summed vision-gradient normalized RMS 4.89e-8.
  * BF16: zero output drift; summed vision-gradient normalized RMS 0.00262, cosine 0.9999965.
* `66 passed`: focused simulated-rank unit suite.
* `5 passed`: real two-rank gloo forward/backward suite, including real Qwen3.5 and the new local-floor path.
* `95 passed`: distributed-config and Qwen CP recipe integration suites.
* Ruff check and format check pass for all touched Python files; `git diff --check` passes.
* [GitHub PR CI](<https://github.com/NVIDIA-NeMo/Automodel/actions/runs/32262354847>) on `aad23d6388c7f5e7757c858f60fd7654851ec225`: 78 checks passed, 6 expected skips, and no failures, including CPU/GPU L0 and context-parallel L2 coverage.
* [Scoped VLM release CI](<https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/63499086>): `qwen3_5_4b_cp2_vision_frame_shard` passed all 50 finetuning steps on one EOS node; Slurm completed with exit code 0. The run set `--model.num_nextn_predict_layers 0` because Qwen3.5-4B checkpoint MTP is unsupported with CP, isolating the supported vision frame-sharding path.

Tracking: NVIDIA-NeMo/Automodel#2985, [AMINT-281](https://linear.app/nvidia/issue/AMINT-281/internal-groot-vlm-performance-profiler-and-scaling-efficiency)

Related to NVIDIA-NeMo/Automodel#2985.