### PR TITLE
fix(ci): detect incomplete Hugging Face cache snapshots

### DIFF
--- a/tests/ci_tests/utils/hf_cache_check.py
+++ b/tests/ci_tests/utils/hf_cache_check.py
@@ -31,7 +31,9 @@ The inversion (0 = "please act") lets the caller shell reduce to::
 """
 
 import argparse
+import json
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any, Iterable
@@ -45,6 +47,8 @@ import yaml
 #   - ci.checkpoint_robustness.tokenizer_name
 #   - any future nested block using the same keys
 REPO_ID_KEYS = ("pretrained_model_name_or_path", "tokenizer_name")
+_WEIGHT_INDEX_FILENAMES = ("model.safetensors.index.json", "pytorch_model.bin.index.json")
+_SHARD_FILENAME_PATTERN = re.compile(r"^(?P<prefix>.+)-(?P<index>\d+)-of-(?P<total>\d+)\.(?P<suffix>safetensors|bin)$")
 
 
 def _walk_repo_ids(node: Any) -> Iterable[str]:
@@ -96,13 +100,59 @@ def _repo_folder(repo_id: str) -> str:
         return "models--" + repo_id.replace("/", "--")
 
 
+def _snapshot_is_complete(snapshot_dir: Path) -> bool:
+    """Return whether a cached snapshot has every discoverable weight shard."""
+    for index_filename in _WEIGHT_INDEX_FILENAMES:
+        index_path = snapshot_dir / index_filename
+        if not index_path.is_file():
+            continue
+        try:
+            weight_map = json.loads(index_path.read_text(encoding="utf-8"))["weight_map"]
+        except (OSError, ValueError, KeyError, TypeError):
+            return False
+        if not isinstance(weight_map, dict) or not weight_map:
+            return False
+        filenames = list(weight_map.values())
+        if not all(isinstance(filename, str) for filename in filenames):
+            return False
+        filenames = set(filenames)
+        return all(
+            not Path(filename).is_absolute()
+            and ".." not in Path(filename).parts
+            and (snapshot_dir / filename).is_file()
+            for filename in filenames
+        )
+
+    for path in snapshot_dir.iterdir():
+        if path.is_file() and _SHARD_FILENAME_PATTERN.match(path.name):
+            # A sharded checkpoint is not self-describing without its index.
+            # Even an apparently contiguous filename series may be stale while
+            # config files already point at a newer Hub revision.
+            return False
+
+    # Preserve the existing behavior for unsharded checkpoints and tokenizer-only repos.
+    return any(snapshot_dir.iterdir())
+
+
 def _has_snapshot(repo_dir: Path) -> bool:
-    """A cache entry is usable iff ``snapshots/<rev>/`` exists with at least one file."""
+    """Return whether the active cached snapshot has a complete weight-shard series."""
     snapshots = repo_dir / "snapshots"
     if not snapshots.is_dir():
         return False
+
+    main_ref = repo_dir / "refs" / "main"
+    if main_ref.is_file():
+        try:
+            revision = main_ref.read_text(encoding="utf-8").strip()
+        except OSError:
+            return False
+        if not revision or Path(revision).name != revision or revision in {".", ".."}:
+            return False
+        snapshot_dir = snapshots / revision
+        return snapshot_dir.is_dir() and _snapshot_is_complete(snapshot_dir)
+
     for rev in snapshots.iterdir():
-        if rev.is_dir() and any(rev.iterdir()):
+        if rev.is_dir() and _snapshot_is_complete(rev):
             return True
     return False
 

--- a/tests/unit_tests/ci_tests/test_hf_cache_check.py
+++ b/tests/unit_tests/ci_tests/test_hf_cache_check.py
@@ -117,13 +117,14 @@ def test_is_hf_repo_id(value, expected):
 # ---------------------------------------------------------------------------
 
 
-def _seed_cache(hf_home: Path, repo_id: str, with_file: bool = True) -> None:
+def _seed_cache(hf_home: Path, repo_id: str, with_file: bool = True) -> Path:
     """Create a ``$HF_HOME/hub/models--<org>--<name>/snapshots/<rev>/`` layout."""
     folder = "models--" + repo_id.replace("/", "--")
     rev_dir = hf_home / "hub" / folder / "snapshots" / "abc123"
     rev_dir.mkdir(parents=True, exist_ok=True)
     if with_file:
         (rev_dir / "config.json").write_text("{}", encoding="utf-8")
+    return rev_dir
 
 
 def test_check_cache_partitions_hits_and_misses(tmp_path):
@@ -151,6 +152,82 @@ def test_check_cache_empty_snapshot_dir_counts_as_missing(tmp_path):
         "meta-llama/Llama-3.2-1B",
         "meta-llama/Llama-3.2-3B-Instruct",
     }
+
+
+def test_check_cache_partial_shard_series_counts_as_missing(tmp_path):
+    hf_home = tmp_path / "hf_home"
+    snapshot = _seed_cache(hf_home, "Qwen/Qwen3-VL-4B-Thinking", with_file=False)
+    for index in (1, 2, 4):
+        (snapshot / f"model-{index:05d}-of-00004.safetensors").touch()
+
+    recipe = _write_recipe(tmp_path, "vlm.yaml", VLM_RECIPE)
+    cached, missing = hf_cache_check.check_cache(recipe, hf_home)
+
+    assert cached == []
+    assert missing == ["Qwen/Qwen3-VL-4B-Thinking"]
+
+
+def test_check_cache_complete_shard_series_without_index_counts_as_missing(tmp_path):
+    hf_home = tmp_path / "hf_home"
+    snapshot = _seed_cache(hf_home, "Qwen/Qwen3-VL-4B-Thinking", with_file=False)
+    for index in range(1, 5):
+        (snapshot / f"model-{index:05d}-of-00004.safetensors").touch()
+
+    recipe = _write_recipe(tmp_path, "vlm.yaml", VLM_RECIPE)
+    cached, missing = hf_cache_check.check_cache(recipe, hf_home)
+
+    assert cached == []
+    assert missing == ["Qwen/Qwen3-VL-4B-Thinking"]
+
+
+def test_check_cache_index_with_missing_shard_counts_as_missing(tmp_path):
+    hf_home = tmp_path / "hf_home"
+    snapshot = _seed_cache(hf_home, "Qwen/Qwen3-VL-4B-Thinking", with_file=False)
+    (snapshot / "model-00001-of-00002.safetensors").touch()
+    (snapshot / "model.safetensors.index.json").write_text(
+        '{"weight_map":{"layer.0":"model-00001-of-00002.safetensors","layer.1":"model-00002-of-00002.safetensors"}}',
+        encoding="utf-8",
+    )
+
+    recipe = _write_recipe(tmp_path, "vlm.yaml", VLM_RECIPE)
+    cached, missing = hf_cache_check.check_cache(recipe, hf_home)
+
+    assert cached == []
+    assert missing == ["Qwen/Qwen3-VL-4B-Thinking"]
+
+
+def test_check_cache_complete_index_counts_as_cached(tmp_path):
+    hf_home = tmp_path / "hf_home"
+    snapshot = _seed_cache(hf_home, "Qwen/Qwen3-VL-4B-Thinking", with_file=False)
+    for index in range(1, 3):
+        (snapshot / f"model-{index:05d}-of-00002.safetensors").touch()
+    (snapshot / "model.safetensors.index.json").write_text(
+        '{"weight_map":{"layer.0":"model-00001-of-00002.safetensors","layer.1":"model-00002-of-00002.safetensors"}}',
+        encoding="utf-8",
+    )
+
+    recipe = _write_recipe(tmp_path, "vlm.yaml", VLM_RECIPE)
+    cached, missing = hf_cache_check.check_cache(recipe, hf_home)
+
+    assert cached == ["Qwen/Qwen3-VL-4B-Thinking"]
+    assert missing == []
+
+
+def test_check_cache_uses_main_ref_instead_of_unreferenced_snapshot(tmp_path):
+    hf_home = tmp_path / "hf_home"
+    complete_snapshot = _seed_cache(hf_home, "Qwen/Qwen3-VL-4B-Thinking")
+    repo_dir = complete_snapshot.parents[1]
+    incomplete_snapshot = complete_snapshot.parent / "def456"
+    incomplete_snapshot.mkdir()
+    (incomplete_snapshot / "model-00001-of-00002.safetensors").touch()
+    (repo_dir / "refs").mkdir()
+    (repo_dir / "refs" / "main").write_text("def456", encoding="utf-8")
+
+    recipe = _write_recipe(tmp_path, "vlm.yaml", VLM_RECIPE)
+    cached, missing = hf_cache_check.check_cache(recipe, hf_home)
+
+    assert cached == []
+    assert missing == ["Qwen/Qwen3-VL-4B-Thinking"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this PR do ?

Detect incomplete Hugging Face weight snapshots in the CI cache preflight so partially downloaded sharded checkpoints are allowed to go online and finish downloading instead of failing later in Torch DCP with misleading missing-key errors.

# Changelog

- Validate every shard referenced by safetensors and PyTorch weight indexes.
- Detect gaps in numbered shard series when an index has not been cached yet.
- Inspect the snapshot selected by `refs/main` rather than accepting an unrelated cached revision.
- Add CPU unit coverage for partial and complete snapshots, with and without an index.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed the contributor guidelines.
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (No user-facing documentation change is needed.)

# Validation

- `uv run pytest tests/unit_tests/ci_tests/test_hf_cache_check.py -q` (23 passed)
- `uv run ruff format --check .`
- `uv run ruff check .`
- NeMo-CI original-container verification: in progress

# Additional Information

- Linear: https://linear.app/nvidia/issue/AMINT-279/missing-checkpoint-key-modelaudioencoderweight-causing-runtimeerror-on
- The EOS Inkling cache currently has an active non-empty snapshot but no `model.safetensors.index.json`; the old preflight therefore incorrectly keeps `HF_HUB_OFFLINE=1`.
