### PR TITLE
test: add functional coverage for under-tested recipes

### DIFF
--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: "10"
   test-folder:
-    description: "Name of the folder containg tests suite"
+    description: "Comma-separated names of folders containing test suites"
     required: false
   is-optional:
     description: "Failure will cancel all other tests if set to true"

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -508,6 +508,21 @@ jobs:
             timeout: 20
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
+          - test-name: L2_DLLM
+            test-folder: dllm
+            timeout: 20
+            runner: ${{ needs.pre-flight.outputs.runner_prefix }}
+            test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
+          - test-name: L2_DSpark
+            test-folder: speculative
+            timeout: 30
+            runner: ${{ needs.pre-flight.outputs.runner_prefix }}
+            test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
+          - test-name: L2_Diffusion
+            test-folder: models/qwen_image_edit
+            timeout: 30
+            runner: ${{ needs.pre-flight.outputs.runner_prefix }}
+            test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           - test-name: L2_MoE
             test-folder: moe
             timeout: 20

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -519,7 +519,7 @@ jobs:
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           - test-name: L2_Diffusion
-            test-folder: models/qwen_image_edit
+            test-folder: diffusion
             timeout: 30
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -459,8 +459,8 @@ jobs:
       matrix:
         include:
           - test-name: L2_Pretrain_and_KD
-            test-folder: llm_pretrain_and_kd
-            timeout: 20
+            test-folder: llm_pretrain_and_kd,speculative
+            timeout: 30
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           - test-name: L2_HF_DCP
@@ -508,18 +508,8 @@ jobs:
             timeout: 20
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
-          - test-name: L2_DLLM
-            test-folder: dllm
-            timeout: 20
-            runner: ${{ needs.pre-flight.outputs.runner_prefix }}
-            test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
-          - test-name: L2_DSpark
-            test-folder: speculative
-            timeout: 30
-            runner: ${{ needs.pre-flight.outputs.runner_prefix }}
-            test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           - test-name: L2_Diffusion
-            test-folder: diffusion
+            test-folder: diffusion,dllm
             timeout: 30
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}

--- a/tests/functional_tests/diffusion/test_qwen_image_edit_training_step.py
+++ b/tests/functional_tests/diffusion/test_qwen_image_edit_training_step.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real-CUDA functional coverage for Qwen image-edit flow matching."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+import torch
+
+_DIFFUSERS_AVAILABLE = importlib.util.find_spec("diffusers") is not None
+
+pytestmark = [
+    pytest.mark.skipif(not _DIFFUSERS_AVAILABLE, reason="diffusers is not installed"),
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA"),
+]
+
+
+def test_qwen_image_edit_flow_matching_updates_model() -> None:
+    """Run production input packing, flow matching, backward, and AdamW on CUDA."""
+    from diffusers import QwenImageTransformer2DModel
+
+    from nemo_automodel.components.flow_matching.pipeline import FlowMatchingPipeline
+    from nemo_automodel.components.models.qwen_image_edit.adapter import QwenImageEditAdapter
+
+    torch.manual_seed(123)
+    device = torch.device("cuda")
+    model = QwenImageTransformer2DModel(
+        patch_size=2,
+        in_channels=16,
+        out_channels=4,
+        num_layers=2,
+        attention_head_dim=8,
+        num_attention_heads=1,
+        joint_attention_dim=12,
+        axes_dims_rope=(2, 2, 4),
+        zero_cond_t=True,
+    ).to(device)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-2)
+    pipeline = FlowMatchingPipeline(
+        model_adapter=QwenImageEditAdapter(),
+        timestep_sampling="uniform",
+        flow_shift=1.0,
+        cfg_dropout_prob=0.0,
+        mix_uniform_ratio=0.0,
+        use_loss_weighting=False,
+        device=device,
+    )
+    batch = {
+        "image_latents": torch.randn((1, 4, 4, 4)),
+        "context_latents": [torch.randn((1, 4, 4, 4))],
+        "text_embeddings": torch.randn((1, 5, 12)),
+        "text_attention_mask": torch.tensor([[1, 1, 1, 1, 0]]),
+        "data_type": "image",
+    }
+
+    parameters = dict(model.named_parameters())
+    required_gradients = (
+        "transformer_blocks.0.attn.to_q.weight",
+        "transformer_blocks.0.attn.add_q_proj.weight",
+        "transformer_blocks.0.img_mlp.net.0.proj.weight",
+        "transformer_blocks.0.txt_mlp.net.0.proj.weight",
+    )
+    initial_parameter = parameters[required_gradients[0]].detach().clone()
+
+    weighted_loss, loss, loss_mask, metrics = pipeline.step(
+        model,
+        batch,
+        device=device,
+        dtype=torch.float32,
+        global_step=1,
+        collect_metrics=False,
+    )
+
+    assert weighted_loss.shape == batch["image_latents"].shape
+    assert loss_mask is None
+    assert metrics == {}
+    assert torch.isfinite(loss) and loss > 0
+
+    loss.backward()
+    for name in required_gradients:
+        gradient = parameters[name].grad
+        assert gradient is not None, f"missing gradient for {name}"
+        assert torch.isfinite(gradient).all(), f"non-finite gradient for {name}"
+    assert torch.linalg.vector_norm(parameters[required_gradients[0]].grad) > 0
+
+    optimizer.step()
+    assert not torch.equal(parameters[required_gradients[0]], initial_parameter)

--- a/tests/functional_tests/dllm/test_sft_training_step.py
+++ b/tests/functional_tests/dllm/test_sft_training_step.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real-CUDA functional coverage for an MDLM supervised-finetuning step."""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from nemo_automodel.recipes.dllm.strategy import get_dllm_strategy
+from nemo_automodel.recipes.dllm.train_ft import DiffusionLMSFTRecipe
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+class _TinyDenoiser(nn.Module):
+    """Small bidirectional token denoiser used to exercise the production recipe."""
+
+    def __init__(self, vocab_size: int, hidden_size: int) -> None:
+        super().__init__()
+        self.embedding = nn.Embedding(vocab_size, hidden_size)
+        self.projection = nn.Linear(hidden_size, vocab_size)
+
+    def forward(self, input_ids: torch.Tensor) -> SimpleNamespace:
+        """Return per-token logits for token IDs shaped ``[batch, sequence]``."""
+        return SimpleNamespace(logits=self.projection(self.embedding(input_ids)))
+
+
+def test_mdlm_sft_step_corrupts_tokens_and_updates_model() -> None:
+    """Run corruption, denoising loss, backward, clipping, and AdamW on CUDA."""
+    torch.manual_seed(7)
+    device = torch.device("cuda")
+    model = _TinyDenoiser(vocab_size=32, hidden_size=16).to(device)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-2)
+
+    strategy = get_dllm_strategy("mdlm")
+    recipe = DiffusionLMSFTRecipe.__new__(DiffusionLMSFTRecipe)
+    recipe.cfg = {}
+    recipe.dllm_mode = "mdlm"
+    recipe.dllm_strategy = strategy
+    recipe.dllm_loss_fn = strategy.create_loss_fn({})
+    recipe.dllm_eps = 1.0
+    recipe.dllm_block_size = None
+    recipe.dllm_half_life_ratio = None
+    recipe.mask_token_id = 31
+    recipe._self_cond_base_seed = 123
+    recipe._dllm_loss_buffer = []
+    recipe._dflash_correct_per_pos_buffer = []
+    recipe._dflash_count_per_pos_buffer = []
+    recipe.model_parts = [model]
+    recipe.optimizer = [optimizer]
+    recipe.lr_scheduler = None
+    recipe.checkpointer = SimpleNamespace(maybe_wait_for_staging=lambda: None)
+    recipe.dist_env = SimpleNamespace(device=device, world_size=1)
+    recipe.distributed_config = SimpleNamespace(defer_fsdp_grad_sync=True, autocast_dtype=None)
+    recipe.device_mesh = None
+    recipe.moe_mesh = None
+    recipe.pp_enabled = False
+    recipe.te_fp8 = None
+    recipe.step_scheduler = SimpleNamespace(step=0, epoch=0, grad_acc_steps=1)
+    recipe.timestamp = time.perf_counter()
+    recipe.mfu_calculator = None
+    recipe._get_dp_group_size = lambda include_cp=False: 1
+    recipe._get_cp_group_size = lambda: 1
+    recipe._dp_allreduce = lambda value, include_cp=False: value
+
+    clean_ids = torch.tensor(
+        [[1, 2, 3, 4, 5, 6, 7, 8], [9, 10, 11, 12, 13, 14, 15, 16]],
+        dtype=torch.long,
+    )
+    batches = [
+        {"input_ids": clean_ids, "attention_mask": torch.ones_like(clean_ids), "loss_mask": torch.ones_like(clean_ids)}
+    ]
+    before = model.projection.weight.detach().clone()
+
+    metrics = recipe._run_train_optim_step(batches, max_grad_norm=1.0)
+
+    assert metrics.metrics["supervised_tokens"] == clean_ids.numel()
+    assert metrics.metrics["tokens_per_step"] == clean_ids.numel()
+    assert metrics.metrics["loss"] > 0
+    assert torch.isfinite(torch.tensor(metrics.metrics["dllm_loss"]))
+    assert torch.isfinite(torch.as_tensor(metrics.metrics["grad_norm"]))
+    assert not torch.equal(model.projection.weight, before)
+    assert torch.all(batches[0]["_noisy_input_ids"] == recipe.mask_token_id)
+    assert torch.equal(batches[0]["input_ids"], clean_ids)

--- a/tests/functional_tests/retrieval/test_bi_encoder_distillation.py
+++ b/tests/functional_tests/retrieval/test_bi_encoder_distillation.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real-CUDA functional coverage for cached-teacher bi-encoder distillation."""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from nemo_automodel.components.loss.embedding_distill import EmbeddingDistillLoss, EmbeddingMSELoss
+from nemo_automodel.components.loss.infonce import InfoNCEDistillLoss, InfoNCELoss
+from nemo_automodel.recipes.retrieval.distill_bi_encoder import EmbeddingDistillRecipe
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+class _TinyStudent(nn.Module):
+    """Embedding student with native and teacher-space representations."""
+
+    def __init__(self, vocab_size: int, hidden_size: int, teacher_size: int) -> None:
+        super().__init__()
+        self.embedding = nn.Embedding(vocab_size, hidden_size)
+        self.projection = nn.Linear(hidden_size, teacher_size)
+
+    def forward(self, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor, dict]:
+        """Pool token embeddings from tensors shaped ``[batch, sequence]``."""
+        hidden = self.embedding(batch["input_ids"])
+        mask = batch["attention_mask"].unsqueeze(-1).to(hidden.dtype)
+        pooled = (hidden * mask).sum(dim=1) / mask.sum(dim=1).clamp_min(1)
+        return F.normalize(pooled, dim=-1), self.projection(pooled), {}
+
+
+def test_cached_teacher_distillation_updates_backbone_and_projection() -> None:
+    """Run four production loss branches, backward, clipping, and AdamW on CUDA."""
+    torch.manual_seed(11)
+    device = torch.device("cuda")
+    student = _TinyStudent(vocab_size=48, hidden_size=8, teacher_size=6).to(device)
+    optimizer = torch.optim.AdamW(student.parameters(), lr=1e-2)
+
+    recipe = EmbeddingDistillRecipe.__new__(EmbeddingDistillRecipe)
+    recipe.loss_weights = {"distill": 1.0, "mse": 0.5, "score": 0.0, "intermediate": 0.0, "nce": 0.2, "nce_kd": 0.2}
+    recipe.distill_loss = EmbeddingDistillLoss()
+    recipe.mse_loss = EmbeddingMSELoss()
+    recipe.infonce_loss = InfoNCELoss(cross_device_negatives=False)
+    recipe.infonce_distill_loss = InfoNCEDistillLoss(cross_device_negatives=False)
+    recipe.use_cached_teacher = True
+    recipe.model_parts = [student]
+    recipe.optimizer = [optimizer]
+    recipe.lr_scheduler = None
+    recipe.checkpointer = SimpleNamespace(maybe_wait_for_staging=lambda: None)
+    recipe.dist_env = SimpleNamespace(device=device)
+    recipe.distributed_config = SimpleNamespace(defer_fsdp_grad_sync=True)
+    recipe.device_mesh = None
+    recipe.moe_mesh = None
+    recipe.pp_enabled = False
+    recipe.step_scheduler = SimpleNamespace(step=0, epoch=0)
+    recipe.loss_average_window = deque(maxlen=8)
+    recipe.timestamp = time.perf_counter()
+    recipe._get_dp_group_size = lambda include_cp=False: 1
+
+    batch_size, num_negatives, sequence_length = 2, 2, 4
+    batch = {
+        "q_input_ids": torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]]),
+        "q_attention_mask": torch.ones(batch_size, sequence_length, dtype=torch.long),
+        "d_input_ids": torch.tensor([[9, 10, 11, 12], [13, 14, 15, 16]]),
+        "d_attention_mask": torch.ones(batch_size, sequence_length, dtype=torch.long),
+        "n_input_ids": torch.tensor([[[17, 18, 19, 20], [21, 22, 23, 24]], [[25, 26, 27, 28], [29, 30, 31, 32]]]),
+        "n_attention_mask": torch.ones(batch_size, num_negatives, sequence_length, dtype=torch.long),
+        "n_mask": torch.tensor([[1, 1], [1, 0]], dtype=torch.long),
+        "t_q_pool": torch.randn(batch_size, 6),
+        "t_d_pool": torch.randn(batch_size, 6),
+        "t_n_pool": torch.randn(batch_size, num_negatives, 6),
+    }
+    before_backbone = student.embedding.weight.detach().clone()
+    before_projection = student.projection.weight.detach().clone()
+
+    metrics = recipe._run_train_optim_step([batch], max_grad_norm=1.0)
+
+    for key in ("loss", "loss_distill", "loss_mse", "loss_nce", "loss_nce_distill"):
+        assert torch.isfinite(torch.tensor(metrics.metrics[key]))
+    assert metrics.metrics["loss"] > 0
+    assert torch.isfinite(torch.as_tensor(metrics.metrics["grad_norm"]))
+    assert not torch.equal(student.embedding.weight, before_backbone)
+    assert not torch.equal(student.projection.weight, before_projection)

--- a/tests/functional_tests/retrieval/test_hard_negative_mining.py
+++ b/tests/functional_tests/retrieval/test_hard_negative_mining.py
@@ -49,7 +49,7 @@ def test_mining_ranks_negatives_and_filters_false_negatives() -> None:
     )
 
     assert neg_indices == [[2, 3], [3, 2]]
-    np.testing.assert_allclose(neg_scores, [[0.95, 0.20], [0.95, 0.20]])
+    np.testing.assert_allclose(neg_scores, [[0.95, 0.20], [0.95, 0.20]], rtol=0.0, atol=3e-4)
     assert pos_scores[0] == pytest.approx([1.0, 1.0])
     assert pos_scores[1] == pytest.approx([1.0])
 

--- a/tests/functional_tests/retrieval/test_hard_negative_mining.py
+++ b/tests/functional_tests/retrieval/test_hard_negative_mining.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real-CUDA functional coverage for hard-negative mining."""
+
+import numpy as np
+import pytest
+import torch
+
+from nemo_automodel.recipes.retrieval.mine_hard_negatives import MineHardNegativesRecipe
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def test_mining_ranks_negatives_and_filters_false_negatives() -> None:
+    """Mine by GPU similarity while preserving duplicate-positive score order."""
+    recipe = MineHardNegativesRecipe.__new__(MineHardNegativesRecipe)
+    queries = np.asarray([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+    documents = np.asarray(
+        [
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [0.95, 0.20],
+            [0.20, 0.95],
+            [-1.0, 0.0],
+            [0.0, -1.0],
+        ],
+        dtype=np.float32,
+    )
+    positives = [[0, 0], [1]]
+
+    neg_indices, neg_scores, pos_scores = recipe._mine_hard_negatives(
+        queries,
+        documents,
+        positives,
+        batch_size=2,
+        num_negs=2,
+    )
+
+    assert neg_indices == [[2, 3], [3, 2]]
+    np.testing.assert_allclose(neg_scores, [[0.95, 0.20], [0.95, 0.20]])
+    assert pos_scores[0] == pytest.approx([1.0, 1.0])
+    assert pos_scores[1] == pytest.approx([1.0])
+
+    filtered_indices, filtered_scores, _ = recipe._mine_hard_negatives(
+        queries,
+        documents,
+        positives,
+        batch_size=1,
+        num_negs=2,
+        hard_neg_margin=0.1,
+        hard_neg_margin_type="abs",
+    )
+
+    assert 2 not in filtered_indices[0]
+    assert 3 not in filtered_indices[1]
+    assert all(score <= 0.9 for row in filtered_scores for score in row)

--- a/tests/functional_tests/speculative/test_dspark_trainer_module.py
+++ b/tests/functional_tests/speculative/test_dspark_trainer_module.py
@@ -19,6 +19,8 @@ the target wrapper, then train the draft via the trainer module -- on the actual
 component classes (not hand-rolled capture). Requires a GPU (FlexAttention).
 """
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 from transformers import AutoModelForCausalLM, Qwen3Config
@@ -35,6 +37,7 @@ from nemo_automodel.components.speculative.dspark import Qwen3DSparkModel, build
 from nemo_automodel.components.speculative.dspark.core import DSparkStepMetrics, DSparkTrainerModule
 from nemo_automodel.components.speculative.dspark.registry import build_target_layer_ids
 from nemo_automodel.components.speculative.dspark.target import HFDSparkTargetModel
+from nemo_automodel.recipes.llm.train_dspark import TrainDSparkRecipe
 
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="FlexAttention backward requires a GPU")
 
@@ -112,6 +115,95 @@ def test_trainer_module_with_target_wrapper_trains():
         losses.append(out.loss.item())
 
     assert losses[-1] < losses[0], f"loss did not decrease: {losses[0]:.4f} -> {losses[-1]:.4f}"
+
+
+def test_recipe_loop_flushes_partial_accumulation_window():
+    """Exercise the live-target recipe loop and its trailing optimizer update."""
+    device, dtype = torch.device("cuda"), torch.float32
+    target_config = Qwen3Config(
+        vocab_size=VOCAB,
+        hidden_size=HIDDEN,
+        intermediate_size=2 * HIDDEN,
+        num_hidden_layers=6,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+    )
+    target_layer_ids = build_target_layer_ids(target_config.num_hidden_layers, 3)
+    target = AutoModelForCausalLM.from_config(target_config).to(device=device, dtype=dtype).eval()
+    target.requires_grad_(False)
+    target_wrapper = HFDSparkTargetModel(target, target_layer_ids=target_layer_ids)
+    model_args = _Args(
+        num_draft_layers=2,
+        target_layer_ids=target_layer_ids,
+        block_size=4,
+        mask_token_id=7,
+        num_anchors=16,
+        markov_rank=32,
+        markov_head_type="vanilla",
+        confidence_head_alpha=1.0,
+        confidence_head_with_markov=True,
+    )
+    draft = Qwen3DSparkModel(build_draft_config(target_config, model_args)).to(device=device, dtype=dtype)
+    draft.initialize_embeddings_and_head(
+        embed_tokens=target_wrapper.get_input_embeddings(),
+        lm_head=target_wrapper.get_output_embeddings(),
+        freeze=True,
+    )
+    trainer = DSparkTrainerModule(
+        draft,
+        loss_decay_gamma=4.0,
+        ce_loss_alpha=0.1,
+        l1_loss_alpha=0.9,
+        confidence_head_alpha=1.0,
+    ).to(device)
+    optimizer = torch.optim.AdamW([parameter for parameter in trainer.parameters() if parameter.requires_grad], lr=1e-3)
+
+    torch.manual_seed(5)
+    batches = []
+    for _ in range(3):
+        input_ids = torch.randint(0, VOCAB, (1, 16))
+        batches.append(
+            {
+                "input_ids": input_ids,
+                "attention_mask": torch.ones_like(input_ids),
+                "loss_mask": torch.ones_like(input_ids, dtype=torch.uint8),
+            }
+        )
+
+    recipe = TrainDSparkRecipe.__new__(TrainDSparkRecipe)
+    recipe.trainer_module = trainer
+    recipe.target_wrapper = target_wrapper
+    recipe.train_dataloader = batches
+    recipe.val_dataloader = None
+    recipe.optimizer = optimizer
+    recipe.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lambda _: 1.0)
+    recipe.runtime = SimpleNamespace(global_step=0)
+    recipe.num_epochs = 1
+    recipe._resume_epoch = 0
+    recipe.total_optim_steps = 2
+    recipe.grad_accumulation_steps = 2
+    recipe.defer_fsdp_grad_sync = True
+    recipe.max_grad_norm = 1.0
+    recipe.block_size = 4
+    recipe.device = device
+    recipe.dist_env = SimpleNamespace(is_main=False)
+    recipe.log_every_steps = 100
+    recipe.metric_logger = None
+    recipe.wandb_run = None
+    recipe.save_checkpoint_every_epoch = False
+    recipe.ckpt_every_steps = None
+    recipe._make_progress_bar = lambda **kwargs: None
+    recipe._maybe_precompute_fp8_scales = lambda: None
+    recipe._maybe_save_step_checkpoint = lambda epoch: False
+    recipe._maybe_save_final_checkpoint = lambda completed_epochs: False
+    recipe._finalize_and_close_checkpointer = lambda: None
+
+    before = next(parameter for parameter in trainer.parameters() if parameter.requires_grad).detach().clone()
+    recipe.run_train_validation_loop()
+
+    assert recipe.runtime.global_step == 2
+    assert not torch.equal(next(parameter for parameter in trainer.parameters() if parameter.requires_grad), before)
 
 
 def test_trainer_module_trains_from_offline_cache(tmp_path):

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -17,7 +17,6 @@ set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 
 UNIT_TEST=false
 CPU=false
-TEST_DIR="tests/"
 TEST_NAME=""
 ADDITIONAL_ARGS=""
 SHARD_ID=""
@@ -50,14 +49,22 @@ else
 fi
 
 if [[ "$UNIT_TEST" == "true" ]]; then
-    export TEST_DIR="tests/unit_tests"
+    TEST_DIRS=("tests/unit_tests")
 else
-    export TEST_DIR="tests/functional_tests/$TEST_NAME"
+    IFS=',' read -r -a TEST_FOLDERS <<< "$TEST_NAME"
+    TEST_DIRS=()
+    for TEST_FOLDER in "${TEST_FOLDERS[@]}"; do
+        if [[ -z "$TEST_FOLDER" ]]; then
+            echo "Functional test folder names must not be empty" >&2
+            exit 2
+        fi
+        TEST_DIRS+=("tests/functional_tests/$TEST_FOLDER")
+    done
 fi
 
 # Install opt-in media extras (kept out of the default media-free image) per folder.
-case "$TEST_NAME" in
-    hf_transformer_vlm) MEDIA_EXTRA="vlm-media" ;;
+case ",$TEST_NAME," in
+    *,hf_transformer_vlm,*) MEDIA_EXTRA="vlm-media" ;;
     *) MEDIA_EXTRA="" ;;
 esac
 if [[ -n "$MEDIA_EXTRA" ]]; then
@@ -68,7 +75,7 @@ coverage run \
     -m pytest \
     --durations 32 \
     --durations-min=0 \
-    $TEST_DIR \
+    "${TEST_DIRS[@]}" \
     -o log_cli=true \
     -o log_cli_level=INFO \
     -vs -m "not pleasefixme" --tb=short -rA \


### PR DESCRIPTION
## Summary

- add real-CUDA MDLM SFT coverage for corruption, denoising loss, backward, clipping, and optimizer update
- add real-CUDA retrieval coverage for hard-negative ranking/margin filtering and cached-teacher bi-encoder distillation
- extend the tiny-Qwen DSpark functional suite through the production recipe loop, including a trailing partial accumulation window
- add a focused real-CUDA Qwen Image Edit flow-matching training step covering production input packing, loss, backward, and AdamW update
- run dLLM with Diffusion and fold DSpark into the existing Pretrain/KD job, avoiding two additional container startups

## Why

The PR #3521 coverage artifacts showed that these recipe paths had little or no functional coverage. A line-set comparison against that PR's combined unit+functional report gives this conservative gain from the new focused recipe tests:

| Recipe module | Newly executed lines |
| --- | ---: |
| `recipes/dllm/train_ft.py` | 79 |
| `recipes/retrieval/distill_bi_encoder.py` | 73 |
| `recipes/llm/train_dspark.py` | 52 |
| `recipes/retrieval/mine_hard_negatives.py` | 43 |
| **Total** | **247** |

This excludes additional coverage from the broader DSpark component suite and the dedicated Qwen Image Edit flow-matching test.

The first CI run showed the standalone Diffusion and dLLM jobs taking 50s and 58s, while DSpark and Pretrain/KD took 7m16s and 15m45s. Combining those compatible suites keeps the longer group within a 30-minute timeout and reduces the net new L2 jobs from three to one.

## Impact

- adds one standard L2 matrix entry and expands the existing Pretrain/KD group; both stay within the two-GPU runner limit
- teaches the shared test runner to accept comma-separated functional-test folders
- adds no production-code changes
- makes failures externally meaningful: model parameters must update, gradients/losses must remain finite, mining ranks and filters exact candidates, and DSpark must flush the final accumulation window
- keeps unrelated Qwen Image Edit distributed-checkpoint coverage out of this coverage-focused PR

## Checks

- `ruff check` and `ruff format --check` on all changed Python tests
- workflow YAML parse and `git diff --check`
- combined `diffusion,dllm` invocation through `tests/run_test.sh` in Docker: 2 passed
- focused CUDA retrieval and diffusion repair tests: 2 passed
- focused CUDA recipe tests: 3 passed
- DSpark existing suite: 5 passed, 1 environment-gated skip
- DSpark recipe-loop test: 1 passed
- focused coverage run: 247 newly executed lines across the four target recipe modules versus the prior combined report
- first hosted CI run: Diffusion, dLLM, DSpark, Pretrain/KD, and both Retrieval variants passed
