### PR TITLE
fix(diffusion): apply compute_dtype via autocast when FSDP2 skips 

### DIFF
--- a/nemo_automodel/components/distributed/fsdp2.py
+++ b/nemo_automodel/components/distributed/fsdp2.py
@@ -35,6 +35,25 @@ from nemo_automodel.components.distributed.parallelizer import (
 logger = logging.getLogger(__name__)
 
 
+def fsdp2_sharding_enabled(device_mesh: DeviceMesh) -> bool:
+    """Report whether :meth:`FSDP2Manager.parallelize` shards the model for this mesh.
+
+    Parallelization is skipped on a single-rank world or a single-element mesh, which
+    also skips every side effect of ``fully_shard`` — most importantly the
+    ``MixedPrecisionPolicy`` cast of parameters to the compute dtype. Callers that
+    depend on that cast must check this instead of assuming FSDP2 is active.
+
+    Args:
+        device_mesh: Device mesh the ``FSDP2Manager`` was constructed with.
+
+    Returns:
+        True when ``fully_shard`` is applied, False when parallelization is skipped.
+    """
+    if get_world_size_safe() == 1 or device_mesh.size() == 1:
+        return False
+    return True
+
+
 def _patch_is_packed_sequence_for_training() -> None:
     """Eliminate CPU-GPU sync from flash attention for standard (non-packed) training.
 
@@ -123,7 +142,7 @@ class FSDP2Manager:
         Returns:
             The parallelized model.
         """
-        if get_world_size_safe() == 1 or self.device_mesh.size() == 1:
+        if not fsdp2_sharding_enabled(self.device_mesh):
             logger.info("World size or FSDP mesh size is 1, skipping parallelization.")
             if self.activation_checkpointing:
                 if is_selective_activation_checkpointing(self.activation_checkpointing):

--- a/nemo_automodel/recipes/diffusion/train.py
+++ b/nemo_automodel/recipes/diffusion/train.py
@@ -26,6 +26,7 @@ import wandb
 from torch.distributed.fsdp import CPUOffloadPolicy, MixedPrecisionPolicy
 
 from nemo_automodel._diffusers.auto_diffusion_pipeline import NeMoAutoDiffusionPipeline
+from nemo_automodel.components.distributed.fsdp2 import fsdp2_sharding_enabled
 from nemo_automodel.components.distributed.init_utils import initialize_distributed
 from nemo_automodel.components.distributed.utils import get_sync_ctx
 from nemo_automodel.components.flow_matching.pipeline import FlowMatchingPipeline, create_adapter
@@ -693,6 +694,21 @@ class TrainDiffusionRecipe(BaseRecipe):
 
         self.model = self.pipe.transformer
 
+        # FSDP2's MixedPrecisionPolicy is what casts parameters to compute_dtype, and
+        # parallelization is skipped entirely on a single-rank mesh. Autocast covers
+        # that path so split-dtype configs behave the same on 1 GPU as on many, while
+        # leaving resident parameters and their gradients in model_dtype.
+        fsdp_casts_parameters = self.device_mesh is not None and fsdp2_sharding_enabled(self.device_mesh)
+        self._autocast_dtype = None
+        if self.model_dtype != self.compute_dtype and not fsdp_casts_parameters:
+            self._autocast_dtype = self.compute_dtype
+            logging.info(
+                "[INFO] FSDP2 parameter casting inactive (single-rank mesh); running the forward pass under "
+                "torch.autocast(%s) so parameters stay in %s",
+                self._autocast_dtype,
+                self.model_dtype,
+            )
+
         self.cp_size = int((fsdp_cfg or {}).get("cp_size", 1) or 1)
         if self.cp_size > 1:
             # CP peers receive the same batch (dataloader shards by dp rank, cp
@@ -865,6 +881,12 @@ class TrainDiffusionRecipe(BaseRecipe):
         if dist.is_initialized():
             dist.barrier()
 
+    def _autocast_context(self) -> Any:
+        """Return the per-forward autocast context used when FSDP2 does not cast parameters."""
+        if self._autocast_dtype is None:
+            return nullcontext()
+        return torch.autocast(device_type=self.device.type, dtype=self._autocast_dtype)
+
     def _transformer_engine_fp8_context(self) -> Any:
         """Return the per-forward Transformer Engine FP8 context."""
         if not self.transformer_engine_fp8:
@@ -923,7 +945,7 @@ class TrainDiffusionRecipe(BaseRecipe):
                     )
                     with sync_context:
                         try:
-                            with self._transformer_engine_fp8_context():
+                            with self._autocast_context(), self._transformer_engine_fp8_context():
                                 _, average_weighted_loss, _, _ = self.flow_matching_pipeline.step(
                                     model=self.model,
                                     batch=micro_batch,

--- a/tests/unit_tests/distributed/test_parallelizer.py
+++ b/tests/unit_tests/distributed/test_parallelizer.py
@@ -2682,6 +2682,32 @@ class TestSingleGpuActivationCheckpointing:
             assert isinstance(layer.self_attn, CheckpointWrapper)
 
 
+class TestFsdp2ShardingEnabled:
+    """`fsdp2_sharding_enabled` reports whether fully_shard — and its mixed-precision casts — apply."""
+
+    def test_disabled_on_single_rank_world(self, monkeypatch):
+        import nemo_automodel.components.distributed.fsdp2 as fsdp2_mod
+
+        monkeypatch.setattr(fsdp2_mod, "get_world_size_safe", lambda: 1)
+
+        # The mesh is never inspected once the world is single-rank.
+        assert fsdp2_mod.fsdp2_sharding_enabled(MagicMock()) is False
+
+    def test_disabled_on_single_element_mesh(self, monkeypatch):
+        import nemo_automodel.components.distributed.fsdp2 as fsdp2_mod
+
+        monkeypatch.setattr(fsdp2_mod, "get_world_size_safe", lambda: 4)
+
+        assert fsdp2_mod.fsdp2_sharding_enabled(SimpleNamespace(size=lambda: 1)) is False
+
+    def test_enabled_on_multi_rank_mesh(self, monkeypatch):
+        import nemo_automodel.components.distributed.fsdp2 as fsdp2_mod
+
+        monkeypatch.setattr(fsdp2_mod, "get_world_size_safe", lambda: 4)
+
+        assert fsdp2_mod.fsdp2_sharding_enabled(SimpleNamespace(size=lambda: 4)) is True
+
+
 class TestSelectiveCheckpointSaveOps:
     """Tests for the TorchTitan-style save-op set used by selective AC."""
 

--- a/tests/unit_tests/recipes/test_diffusion_train.py
+++ b/tests/unit_tests/recipes/test_diffusion_train.py
@@ -25,6 +25,7 @@ from nemo_automodel.components.datasets.diffusion.collate_fns import TextToImage
 from nemo_automodel.components.optim.optimizer import LRSchedulerConfig, OptimizerFromFactoryConfig
 from nemo_automodel.recipes._typed_config import RecipeConfig
 from nemo_automodel.recipes.diffusion.train import (
+    TrainDiffusionRecipe,
     _build_diffusion_parallel_manager_args,
     _reject_removed_diffusion_keys,
     _resolve_model_dtypes,
@@ -89,6 +90,45 @@ def test_validate_precision_configuration_allows_matching_dtype_for_ddp_or_peft(
         ddp_cfg={"world_size": 1},
         peft_cfg=object(),
     )
+
+
+# ---------------------------------------------------------------------------
+# Split-dtype autocast fallback when FSDP2 does not shard (issue #3578)
+# ---------------------------------------------------------------------------
+
+
+def _make_recipe_with_autocast_dtype(autocast_dtype):
+    """Build a bare recipe carrying only the attributes ``_autocast_context`` reads."""
+    recipe = TrainDiffusionRecipe.__new__(TrainDiffusionRecipe)
+    recipe._autocast_dtype = autocast_dtype
+    recipe.device = torch.device("cpu")
+    return recipe
+
+
+def test_autocast_context_is_inactive_when_fsdp_casts_parameters():
+    with _make_recipe_with_autocast_dtype(None)._autocast_context():
+        assert not torch.is_autocast_enabled("cpu")
+
+
+def test_autocast_context_runs_bf16_activations_through_fp32_weights():
+    """Reproduces #3578: bf16 inputs must survive fp32 conv weights on the unsharded path.
+
+    The conv mirrors the fp32 patch embedding that raised ``Input type (c10::BFloat16)
+    and bias type (float) should be the same``. Its input is a bf16 tensor of shape
+    [batch, channels, frames, height, width], matching what the flow-matching step
+    casts latents to before the transformer forward.
+    """
+    conv = torch.nn.Conv3d(2, 2, kernel_size=1, dtype=torch.float32)
+    latents = torch.randn(1, 2, 2, 2, 2, dtype=torch.bfloat16)
+
+    with pytest.raises(RuntimeError):
+        conv(latents)
+
+    with _make_recipe_with_autocast_dtype(torch.bfloat16)._autocast_context():
+        output = conv(latents)
+
+    assert output.dtype is torch.bfloat16
+    assert conv.weight.dtype is torch.float32
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/recipes/test_diffusion_train_metrics.py
+++ b/tests/unit_tests/recipes/test_diffusion_train_metrics.py
@@ -716,6 +716,7 @@ def test_run_train_validation_loop_uses_hot_path_and_logs_perf_metrics(monkeypat
     recipe.grad_clip_foreach = False
     recipe.defer_fsdp_grad_sync = True
     recipe.transformer_engine_fp8 = False
+    recipe._autocast_dtype = None
     recipe.peft_cfg = None
     recipe._elapsed_seconds_since = MagicMock(return_value=(2.0, 10.0))
     recipe._count_global_samples = MagicMock(return_value=5)


### PR DESCRIPTION
# What does this PR do ?

Split model.torch_dtype/model.compute_dtype relies on FSDP2's MixedPrecisionPolicy to cast parameters to the compute dtype. On a single-rank world or mesh, FSDP2Manager.parallelize skips sharding, so that cast never happens: parameters stay in torch_dtype while the flow-matching step still casts its inputs to compute_dtype. The forward pass then mixes dtypes and fails with

  RuntimeError: Input type (c10::BFloat16) and bias type (float) should
  be the same

on the transformer's fp32 patch embedding. The same config works on 2+ GPUs, and five shipped diffusion example configs use this split (torch_dtype: float32 with compute_dtype: bfloat16).

Wrap the forward pass in torch.autocast on that path, following the autocast approach the retrieval and dLLM recipes already use for FSDP2Config.autocast_dtype. Resident parameters and their gradients stay in torch_dtype, so optimizer state is unchanged. Numerics are close to but not identical to the sharded path, since autocast keeps reductions such as normalization in fp32 rather than casting every parameter.

Extract the skip condition into fsdp2_sharding_enabled() so the recipe checks the same predicate FSDP2Manager acts on instead of duplicating it.

LLM/VLM recipes drop mp_policy at world size 1 the same way, but degrade silently to fp32 compute rather than failing; that is left for a separate change.

Fixes #3578



