### PR TITLE
refactor(checkpoint): StateDictAdapter method target-module rename

### DIFF
--- a/nemo_automodel/components/checkpoint/addons.py
+++ b/nemo_automodel/components/checkpoint/addons.py
@@ -26,6 +26,7 @@ from nemo_automodel.components.checkpoint._backports.hf_utils import (
     FQN_TO_DTYPE_MAPPING_FILENAME,
     FQN_TO_FILE_INDEX_MAPPING_FILENAME,
 )
+from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
 from nemo_automodel.components.checkpoint.stateful_wrappers import ModelState
 from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin
 from nemo_automodel.shared.parameter_names import canonical_parameter_fqn
@@ -534,9 +535,10 @@ def _extract_target_modules(
     # mlp.experts.{E}.gate_proj -> block_sparse_moe.experts.{E}.w1) convert the
     # state-dict keys on save, so adapter_config.json's target_modules must get
     # the same treatment or PEFT can't resolve them against the real model.
-    map_target_module = getattr(adapter, "map_peft_target_module_to_hf", None)
-    if callable(map_target_module):
-        final_target_modules = {map_target_module(name) for name in final_target_modules}
+    # The base method defaults to the identity; legacy adapters that don't
+    # subclass StateDictAdapter (llama, qwen2/3, kimivl) skip it, as before.
+    if isinstance(adapter, StateDictAdapter):
+        final_target_modules = {adapter.map_peft_target_module_to_hf(name) for name in final_target_modules}
 
     # Under pipeline parallelism each rank only holds the local stage's layers,
     # so named_modules() above yields layer-specific target names for that stage

--- a/nemo_automodel/components/checkpoint/state_dict_adapter.py
+++ b/nemo_automodel/components/checkpoint/state_dict_adapter.py
@@ -84,3 +84,20 @@ class StateDictAdapter(ABC):
             Hugging Face state-dict keys in adapter iteration order.
         """
         return list(self.to_hf(state_dict, exclude_key_regex=r".*_extra_state.*", quantization=False))
+
+    def map_peft_target_module_to_hf(self, name: str) -> str:
+        """Translate a PEFT target-module name to the HuggingFace layout.
+
+        adapter_config.json's target_modules are collected from native module
+        names. Adapters whose ``to_hf`` renames modules (e.g. Kimi K3's
+        ``mlp.experts.{E}.gate_proj`` -> ``block_sparse_moe.experts.{E}.w1``)
+        should override this with the same renames so PEFT can resolve the
+        entries against the converted checkpoint.
+
+        Args:
+            name: A target-module name in native layout.
+
+        Returns:
+            The name in HuggingFace layout. Defaults to the name unchanged.
+        """
+        return name

--- a/tests/unit_tests/checkpoint/test_addons.py
+++ b/tests/unit_tests/checkpoint/test_addons.py
@@ -29,6 +29,7 @@ from nemo_automodel.components.checkpoint.addons import (
     _maybe_save_custom_model_code,
     _maybe_strip_quantization_config,
 )
+from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
 from nemo_automodel.components.checkpoint.stateful_wrappers import ModelState
 
 
@@ -279,6 +280,22 @@ def _make_model_with_named_modules(module_names):
     return root
 
 
+class _StubStateDictAdapter(StateDictAdapter):
+    """Minimal concrete StateDictAdapter, no renames of its own."""
+
+    def to_hf(self, state_dict, **kwargs):
+        """Identity pass-through; tensor values keep their native layouts."""
+        return state_dict
+
+    def from_hf(self, hf_state_dict, device_mesh=None, **kwargs):
+        """Identity pass-through; tensor values keep their HF layouts."""
+        return hf_state_dict
+
+    def convert_single_tensor_to_hf(self, fqn, tensor, **kwargs):
+        """Identity pass-through; ``tensor`` keeps its layout, whatever it is."""
+        return [(fqn, tensor)]
+
+
 class TestExtractTargetModules:
     """Tests for _extract_target_modules with combined-projection expansion."""
 
@@ -387,15 +404,15 @@ class TestExtractTargetModules:
         assert "layers.0.mlp.down_proj" in result
         assert all(not m.startswith("model.") for m in result)
 
-    def test_adapter_target_module_hook_applied(self):
-        """An adapter exposing map_peft_target_module_to_hf rewrites the entries.
+    def test_adapter_target_module_renames_applied(self):
+        """An adapter overriding map_peft_target_module_to_hf rewrites the entries.
 
         Adapters that rename modules between the native and checkpoint layouts
         (e.g. Kimi K3's expert projections) convert the saved keys, so the
         target_modules metadata has to follow or PEFT can't resolve it.
         """
 
-        class _RenamingAdapter:
+        class _RenamingAdapter(_StubStateDictAdapter):
             def map_peft_target_module_to_hf(self, name):
                 return name.replace(".mlp.experts.", ".block_sparse_moe.experts.")
 
@@ -410,6 +427,40 @@ class TestExtractTargetModules:
         assert "model.layers.0.block_sparse_moe.experts.0.gate_proj" in result
         assert "model.layers.0.self_attn.q_proj" in result
         assert all(".mlp.experts." not in m for m in result)
+
+    def test_adapter_without_override_keeps_target_modules_unchanged(self):
+        """Adapters that don't rename modules inherit the identity default."""
+        adapter = _StubStateDictAdapter()
+        assert adapter.map_peft_target_module_to_hf("model.layers.0.self_attn.q_proj") == (
+            "model.layers.0.self_attn.q_proj"
+        )
+
+        model = _make_model_with_named_modules(
+            [
+                "model.layers.0.mlp.experts.0.gate_proj.lora_A",
+                "model.layers.0.self_attn.q_proj.lora_A",
+            ]
+        )
+        model.state_dict_adapter = adapter
+        result = _extract_target_modules(model)
+        assert "model.layers.0.mlp.experts.0.gate_proj" in result
+        assert "model.layers.0.self_attn.q_proj" in result
+
+    def test_duck_typed_adapter_without_the_method_is_tolerated(self):
+        """Adapters that don't subclass StateDictAdapter must not crash the save.
+
+        llama, qwen2/3, and kimivl attach plain classes as state_dict_adapter,
+        and some tests attach mixin-only adapters; they have no
+        map_peft_target_module_to_hf and just keep their names.
+        """
+
+        class _BareAdapter:
+            pass
+
+        model = _make_model_with_named_modules(["model.layers.0.self_attn.q_proj.lora_A"])
+        model.state_dict_adapter = _BareAdapter()
+        result = _extract_target_modules(model)
+        assert result == ["model.layers.0.self_attn.q_proj"]
 
 
 class TestMaybeStripQuantizationConfig:


### PR DESCRIPTION
@HuiyingLi    follow up to #3435.

made the rename hook a real method on `StateDictAdapter` instead of a getattr. so now the base class has the method, it just returns the name unchanged, and kimi_k3 overrides it with its own renames.

some older adapters (llama, qwen2/3, kimivl) don't inherit from `StateDictAdapter`, so I added an isinstance check to keep their saves working like before.
