### PR TITLE
fix(checkpoint): load base weights under DDP and MegatronFSDP

### DIFF
--- a/nemo_automodel/_transformers/infrastructure.py
+++ b/nemo_automodel/_transformers/infrastructure.py
@@ -593,9 +593,16 @@ def apply_model_infrastructure(
 
     checkpoint_already_loaded = False
     if load_before_shard:
-        if is_meta_device:
-            lora_a_init = getattr(peft_config, "lora_A_init", None)
-            checkpointer.initialize_model_weights(model, device, peft_init_method=lora_a_init)
+        if weights_already_loaded:
+            # HF's from_pretrained already populated the weights during model init.
+            # Still call load_base_model with load_base_model=False to
+            # handle weight tying
+            checkpointer.load_base_model(model, device, cache_dir, pretrained_model_name_or_path, load_base_model=False)
+        else:
+            # Only meta-device models need their parameter shells materialized first.
+            if is_meta_device:
+                lora_a_init = getattr(peft_config, "lora_A_init", None)
+                checkpointer.initialize_model_weights(model, device, peft_init_method=lora_a_init)
             checkpointer.load_base_model(
                 model,
                 device,
@@ -603,11 +610,6 @@ def apply_model_infrastructure(
                 pretrained_model_name_or_path,
                 load_base_model=load_base_model,
             )
-        else:
-            # Non-meta models already have weights from from_pretrained.
-            # Still call load_base_model with load_base_model=False to
-            # handle weight tying
-            checkpointer.load_base_model(model, device, cache_dir, pretrained_model_name_or_path, load_base_model=False)
         checkpoint_already_loaded = True
 
     # hold a list copy of the model state dict keys before any parallelization. To be used during checkpoint saving in safetensors format.

--- a/tests/unit_tests/_transformers/test_auto_model.py
+++ b/tests/unit_tests/_transformers/test_auto_model.py
@@ -1727,6 +1727,43 @@ class TestBuildModelRetryDepth:
             assert result is sentinel_model
             assert mock_init.call_count == 2
 
+    def test_custom_model_under_ddp_still_needs_its_checkpoint(self):
+        """A MODEL_ARCH_MAPPING model under DDP reaches infrastructure unloaded and off meta.
+
+        ``DDPManager`` is excluded from meta-device init, and custom model constructors
+        only build the architecture, so ``apply_model_infrastructure`` has to be told the
+        weights are still missing. If either flag is wrong the model enters training
+        randomly initialized and nothing is raised.
+        """
+        build_kwargs, mock_config = self._make_build_kwargs()
+        build_kwargs["is_hf_model"] = False
+        dummy_manager_cls = type("DummyManager", (), {})
+        build_kwargs["model_wrapper"] = dummy_manager_cls()
+        sentinel_model = MagicMock()
+        captured = {}
+
+        def capture(**kwargs):
+            captured.update(kwargs)
+            return sentinel_model
+
+        with (
+            patch("nemo_automodel._transformers.auto_model.DDPManager", dummy_manager_cls),
+            patch("nemo_automodel._transformers.auto_model._init_model", return_value=(True, sentinel_model)),
+            patch("nemo_automodel._transformers.auto_model.get_world_size_safe", return_value=1),
+            patch(
+                "nemo_automodel._transformers.capabilities.attach_capabilities_and_validate",
+                return_value=sentinel_model,
+            ),
+            patch("nemo_automodel._transformers.auto_model.apply_model_infrastructure", side_effect=capture),
+            patch("nemo_automodel._transformers.auto_model.get_hf_config", return_value=mock_config),
+            patch("nemo_automodel._transformers.auto_model._maybe_dequantize_fp8_for_peft", return_value=False),
+            patch("torch.cuda.current_device", return_value=0),
+        ):
+            _BaseNeMoAutoModelClass._build_model(mock_config, **build_kwargs)
+
+        assert captured["is_meta_device"] is False
+        assert captured["weights_already_loaded"] is False
+
 
 class TestNeMoAutoModelForMultimodalLM:
     """Tests for the NeMoAutoModelForMultimodalLM class and its exports."""

--- a/tests/unit_tests/_transformers/test_infrastructure.py
+++ b/tests/unit_tests/_transformers/test_infrastructure.py
@@ -569,7 +569,9 @@ class TestApplyModelInfrastructurePostShardInit:
 # =============================================================================
 
 
-def _run_apply_model_infrastructure_load_before_shard(*, peft_config=None):
+def _run_apply_model_infrastructure_load_before_shard(
+    *, peft_config=None, is_meta_device=True, weights_already_loaded=False
+):
     """Helper that invokes apply_model_infrastructure with load_before_shard=True."""
     from nemo_automodel._transformers.infrastructure import apply_model_infrastructure
 
@@ -588,12 +590,13 @@ def _run_apply_model_infrastructure_load_before_shard(*, peft_config=None):
 
         result = apply_model_infrastructure(
             model=model,
-            is_meta_device=True,
+            is_meta_device=is_meta_device,
             device=torch.device("cpu"),
             load_base_model=True,
             peft_config=peft_config,
             pretrained_model_name_or_path="test/model",
             cache_dir="/tmp/cache",
+            weights_already_loaded=weights_already_loaded,
         )
 
         return result, mock_ckpt, model
@@ -631,6 +634,76 @@ class TestLoadBeforeShardPath:
 
         _, kwargs = mock_ckpt.load_base_model.call_args
         assert "peft_init_method" not in kwargs
+
+    def test_load_before_shard_loads_checkpoint_when_init_left_weights_unloaded(self):
+        """A non-meta model whose init did not load weights must still read the checkpoint.
+
+        ``is_meta_device`` is False for every model built under DDP or MegatronFSDP,
+        including AutoModel's own implementations, whose constructor only creates the
+        architecture. Gating the read on it left those models randomly initialized.
+        """
+        _, mock_ckpt, model = _run_apply_model_infrastructure_load_before_shard(
+            is_meta_device=False, weights_already_loaded=False
+        )
+
+        mock_ckpt.load_base_model.assert_called_once_with(
+            model, torch.device("cpu"), "/tmp/cache", "test/model", load_base_model=True
+        )
+        # Nothing is on meta, so there are no parameter shells to materialize.
+        mock_ckpt.initialize_model_weights.assert_not_called()
+
+    def test_load_before_shard_skips_checkpoint_when_init_already_loaded_weights(self):
+        """HF's from_pretrained already populated the weights; only re-tie, do not re-read."""
+        _, mock_ckpt, model = _run_apply_model_infrastructure_load_before_shard(
+            is_meta_device=False, weights_already_loaded=True
+        )
+
+        mock_ckpt.load_base_model.assert_called_once_with(
+            model, torch.device("cpu"), "/tmp/cache", "test/model", load_base_model=False
+        )
+        mock_ckpt.initialize_model_weights.assert_not_called()
+
+
+def test_load_before_shard_populates_unloaded_model_from_checkpoint(tmp_path):
+    """End-to-end guard on CPU: the model must end up holding the checkpoint's values.
+
+    The mocked tests above pin the call; this one pins the outcome, using the real
+    Checkpointer and a real safetensors checkpoint whose every tensor is 0.5.
+    """
+    from transformers import LlamaConfig
+    from transformers import LlamaForCausalLM as HFLlamaForCausalLM
+
+    from nemo_automodel._transformers.infrastructure import apply_model_infrastructure
+    from nemo_automodel.components.models.llama.model import LlamaForCausalLM
+
+    config = LlamaConfig(
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        vocab_size=256,
+        max_position_embeddings=128,
+        tie_word_embeddings=False,
+    )
+    reference = HFLlamaForCausalLM(config)
+    with torch.no_grad():
+        for param in reference.parameters():
+            param.fill_(0.5)
+    reference.save_pretrained(tmp_path, safe_serialization=True)
+
+    config.torch_dtype = torch.float32
+    model = apply_model_infrastructure(
+        model=LlamaForCausalLM(config),
+        is_meta_device=False,
+        device=torch.device("cpu"),
+        load_base_model=True,
+        pretrained_model_name_or_path=str(tmp_path),
+        weights_already_loaded=False,
+    )
+
+    for name, param in model.named_parameters():
+        assert torch.equal(param.detach(), torch.full_like(param, 0.5)), f"{name} was not loaded"
 
 
 # =============================================================================


### PR DESCRIPTION
# What does this PR do ?

Loads the pretrained checkpoint for `MODEL_ARCH_MAPPING` models under `strategy: ddp` and
`strategy: megatron_fsdp`. These models previously trained from random weights, with no
error or warning.

The pre-shard load in `apply_model_infrastructure` was gated on `is_meta_device`. Its
`else` branch assumes the weights already came from `from_pretrained`, which is true only
on the HuggingFace fallback path. AutoModel's own models are built architecture-only, and
`auto_model.py:517` excludes `DDPManager` and `MegatronFSDPManager` from meta init, so the
checkpoint read was skipped. `checkpoint_already_loaded = True` then suppressed the
post-shard load. The fix branches on `weights_already_loaded`, which is already computed
in `auto_model.py` and already used at the post-shard load site.

# Changelog

### Fix

- `nemo_automodel/_transformers/infrastructure.py`
  - In the `load_before_shard` path, branch on `weights_already_loaded` instead of
    `is_meta_device` when deciding whether to read the base checkpoint.
  - `initialize_model_weights` stays gated on `is_meta_device`. Only meta models need
    their parameter shells materialized.

### Tests

- `tests/unit_tests/_transformers/test_infrastructure.py` (3 CPU tests, load decision)
  - `test_load_before_shard_loads_checkpoint_when_init_left_weights_unloaded`: reads the
    checkpoint when init left the weights unloaded. Fails without the fix.
  - `test_load_before_shard_skips_checkpoint_when_init_already_loaded_weights`: skips the
    read when `from_pretrained` already populated the weights.
  - `test_load_before_shard_populates_unloaded_model_from_checkpoint`: end to end against
    a real safetensors checkpoint, asserts every parameter holds its value. Fails without
    the fix.
- `tests/unit_tests/_transformers/test_auto_model.py` (1 CPU test, flag computation)
  - `test_custom_model_under_ddp_still_needs_its_checkpoint`: asserts `is_meta_device` and
    `weights_already_loaded` are both False for a `MODEL_ARCH_MAPPING` model under
    `DDPManager`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Not applicable. No public API,
      config key, or documented behavior changes.

# Additional Information

## Reproducing

```python
# Saves a tiny Llama checkpoint whose every weight is 0.5, loads it back through
# NeMoAutoModelForCausalLM.from_pretrained, and counts how many parameters hold that
# value. Needs a GPU: from_pretrained calls torch.cuda.current_device().
#
#   torchrun --nproc-per-node 1 repro.py ddp             # 0/21 before the fix, 21/21 after
#   torchrun --nproc-per-node 2 repro.py megatron_fsdp   # 0/12 before the fix, 12/12 after
#   torchrun --nproc-per-node 1 repro.py fsdp2           # 21/21 either way

import sys
import tempfile

import torch
from transformers import LlamaConfig, LlamaForCausalLM

from nemo_automodel import NeMoAutoModelForCausalLM
from nemo_automodel.components.distributed import DistributedSetup, initialize_distributed

config = LlamaConfig(hidden_size=64, intermediate_size=128, num_hidden_layers=2, num_attention_heads=4, vocab_size=256)
reference = LlamaForCausalLM(config)
with torch.no_grad():
    for param in reference.parameters():
        param.fill_(0.5)
checkpoint = tempfile.mkdtemp()
reference.save_pretrained(checkpoint)

strategy = sys.argv[1] if len(sys.argv) > 1 else "ddp"
dist_env = initialize_distributed("nccl")
setup = DistributedSetup.build(strategy=strategy, world_size=dist_env.world_size)
model = NeMoAutoModelForCausalLM.from_pretrained(checkpoint, distributed_setup=setup)

# Skip 0-element shards: megatron_fsdp leaves some ranks holding empty slices,
# and `.all()` on an empty tensor is vacuously True.
shards = [p.detach().to_local() if hasattr(p, "to_local") else p.detach() for p in model.parameters()]
shards = [t for t in shards if t.numel() > 0]
loaded = sum(int(t.eq(0.5).all()) for t in shards)
print(f"\n[{strategy}] {loaded}/{len(shards)} params hold the checkpoint value")
```
