### PR TITLE
fix(perf): recognize RTX PRO 6000 for MFU

### DIFF
--- a/nemo_automodel/_transformers/mfu.py
+++ b/nemo_automodel/_transformers/mfu.py
@@ -57,7 +57,8 @@ _DEVICE_FLOPS: dict[str, float] = {
     "910B": 354e12,
     "Ascend910": 354e12,
     "RTX 3070 Ti": 21.75e12,
-    "RTX PRO 6000": 503.8e12,
+    "RTX PRO 6000 Blackwell Max-Q Workstation Edition": 438.9e12,
+    "RTX PRO 6000 Blackwell Workstation Edition": 503.8e12,
 }
 
 _UNIT_TO_SCALE = {

--- a/nemo_automodel/_transformers/mfu.py
+++ b/nemo_automodel/_transformers/mfu.py
@@ -57,6 +57,7 @@ _DEVICE_FLOPS: dict[str, float] = {
     "910B": 354e12,
     "Ascend910": 354e12,
     "RTX 3070 Ti": 21.75e12,
+    "RTX PRO 6000": 503.8e12,
 }
 
 _UNIT_TO_SCALE = {

--- a/tests/unit_tests/utils/test_flops_utils.py
+++ b/tests/unit_tests/utils/test_flops_utils.py
@@ -318,6 +318,17 @@ def test_automfu_h100_reference_uses_dense_bf16_peak():
     assert h100_tflops == 989.0
 
 
+@pytest.mark.parametrize(
+    "device_name, expected_tflops",
+    [
+        ("NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition", 438.9),
+        ("NVIDIA RTX PRO 6000 Blackwell Workstation Edition", 503.8),
+    ],
+)
+def test_get_device_flops_distinguishes_rtx_pro_6000_variants(device_name, expected_tflops):
+    assert get_device_flops(unit="T", device_name=device_name) == expected_tflops
+
+
 def test_get_device_flops_detects_current_cuda_device(monkeypatch):
     monkeypatch.setattr(mfu_module.torch.cuda, "is_available", lambda: True)
     monkeypatch.setattr(mfu_module.torch.cuda, "current_device", lambda: 3)


### PR DESCRIPTION
# What does this PR do ?

Register the RTX PRO 6000 Workstation and Max-Q dense BF16 peak throughput values so automatic device detection reports MFU with the correct denominator for each variant.

## Problem

`AutoMFU` detects the current CUDA device to select the theoretical peak used by MFU logging. Neither RTX PRO 6000 workstation variant is currently present in the device table, so their full CUDA device names are treated as unknown. A shared `RTX PRO 6000` key is not sufficient because substring matching would assign the 503.8 TFLOP/s Workstation peak to the 438.9 TFLOP/s Max-Q variant.

[NVIDIA RTX Blackwell GPU Architecture v1.1, Table 4](https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/quadro-product-literature/pdf/NVIDIA-RTX-Blackwell-PRO-GPU-Architecture-v1_1.pdf#page=47) lists dense BF16 Tensor Core peaks of 503.8 TFLOP/s for the Workstation Edition and 438.9 TFLOP/s for the Max-Q Workstation Edition. The device table uses these dense values.

## Validation

### RTX PRO 6000 GPU smoke test

Ran the clean-main and patched MFU modules on GPU 0 of an RTX PRO 6000 Blackwell workstation. With fixed calculation inputs of 100 total TFLOPs, two GPUs, and one second:

```text
device=NVIDIA RTX PRO 6000 Blackwell Workstation Edition
before: peak_tflops=inf, mfu=0.0
after: peak_tflops=503.8, mfu=9.924573243350537
```

This smoke test exercises CUDA device-name detection and the resulting MFU denominator; it does not run a model training workload.

After narrowing the lookup key, the same physical GPU still resolves correctly:

```text
device=NVIDIA RTX PRO 6000 Blackwell Workstation Edition
peak_tflops=503.8
```

Max-Q hardware was not available. A CPU regression test covers both expected full CUDA device strings and verifies that Max-Q resolves to 438.9 while the Workstation Edition resolves to 503.8.

### Unit and style checks

```bash
uv run pytest tests/unit_tests/utils/test_flops_utils.py -q
uv run ruff check nemo_automodel/_transformers/mfu.py tests/unit_tests/utils/test_flops_utils.py
uv run ruff format --check nemo_automodel/_transformers/mfu.py tests/unit_tests/utils/test_flops_utils.py
```

# Changelog

- Add distinct RTX PRO 6000 Workstation and Max-Q entries to `_DEVICE_FLOPS`.
- Add regression coverage for both full device names.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? Added focused coverage for the two RTX PRO 6000 variants and ran a targeted GPU smoke test.
- [x] Did you add or update any necessary documentation? No repository documentation changes are needed; the NVIDIA specification is linked above.

# Additional Information

- No related issue.
