### PR TITLE
fix(deps): align pyproject DeepEP pin with the container build

### DIFF
--- a/docker/common/uv-pytorch.lock
+++ b/docker/common/uv-pytorch.lock
@@ -115,7 +115,7 @@ overrides = [
 
 [[manifest.dependency-metadata]]
 name = "deep-ep"
-version = "1.2.1+7febc6e"
+version = "1.2.1+4214430"
 requires-dist = ["torch", "packaging", "ninja"]
 
 [[manifest.dependency-metadata]]
@@ -1660,8 +1660,8 @@ wheels = [
 
 [[package]]
 name = "deep-ep"
-version = "1.2.1+7febc6e"
-source = { git = "https://github.com/deepseek-ai/DeepEP.git?rev=7febc6e25660af0f54d95dd781ecdcd62265ecca#7febc6e25660af0f54d95dd781ecdcd62265ecca" }
+version = "1.2.1+4214430"
+source = { git = "https://github.com/deepseek-ai/DeepEP.git?rev=42144303752422ade37f24bca9e2dde12df70e09#42144303752422ade37f24bca9e2dde12df70e09" }
 dependencies = [
     { name = "ninja" },
     { name = "packaging" },
@@ -4264,7 +4264,7 @@ requires-dist = [
     { name = "databricks-sql-connector", marker = "extra == 'delta-databricks'", specifier = ">=4.4.0" },
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "decord", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin' and extra == 'vlm-media'" },
-    { name = "deep-ep", marker = "extra == 'moe'", git = "https://github.com/deepseek-ai/DeepEP.git?rev=7febc6e25660af0f54d95dd781ecdcd62265ecca" },
+    { name = "deep-ep", marker = "extra == 'moe'", git = "https://github.com/deepseek-ai/DeepEP.git?rev=42144303752422ade37f24bca9e2dde12df70e09" },
     { name = "deltalake", marker = "extra == 'delta-databricks'", specifier = ">=1.0.0" },
     { name = "diffusers", marker = "extra == 'diffusion'", specifier = ">=0.39.0" },
     { name = "ffpa-attn", marker = "extra == 'ffpa'", specifier = ">=0.2.2" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,7 +300,7 @@ prerelease = "allow"
 
 [tool.uv.sources]
 megatron-fsdp = { git = "https://github.com/yuhezhang-ai/Megatron-LM.git", rev = "455389c480af6b3acdca74c7830c68b3274eb083", subdirectory = "megatron/core/distributed/fsdp/src" }
-deep_ep = { git = "https://github.com/deepseek-ai/DeepEP.git", rev = "7febc6e25660af0f54d95dd781ecdcd62265ecca" }
+deep_ep = { git = "https://github.com/deepseek-ai/DeepEP.git", rev = "42144303752422ade37f24bca9e2dde12df70e09" }
 cut-cross-entropy = { git = "https://github.com/apple/ml-cross-entropy.git", rev = "87a86aba72cfd2f0d8abecaf81c13c4528ea07d8" }
 magi_attention = { git = "https://github.com/SandAI-org/MagiAttention.git", rev = "d7ea8afd44c790b65fab68a04a6a0fdd5adbf182" }
 liger-kernel = { git = "https://github.com/linkedin/Liger-Kernel.git", rev = "1f1a4b8d6a6c3c1ddb3573a46480c41cef25bde6" }
@@ -359,7 +359,7 @@ nv_grouped_gemm = ["setuptools"]
 [[tool.uv.dependency-metadata]]
 name = "deep_ep"
 # This version has to match the version in the commit/rev/tag used
-version = "v1.2.1+7febc6e"
+version = "v1.2.1+4214430"
 requires-dist = ["torch", "packaging", "ninja"]
 
 [[tool.uv.dependency-metadata]]

--- a/tests/unit_tests/test_deepep_pin_consistency.py
+++ b/tests/unit_tests/test_deepep_pin_consistency.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DeepEP is pinned twice: once for the container build and once for uv/pip installs.
+
+`docker/Dockerfile` builds DeepEP from source at `ARG DEEPEP_COMMIT`, which is what every
+CI job and every published image actually runs. `pyproject.toml` pins the same dependency
+under `[tool.uv.sources]` for anyone installing `nemo_automodel[moe]` outside the container.
+Nothing links the two, so bumping one and forgetting the other silently ships a different
+DeepEP to users than the one the tests validated. These tests fail on that drift.
+"""
+
+import re
+from pathlib import Path
+
+try:
+    import tomllib  # ty: ignore[unresolved-import]
+except ModuleNotFoundError:
+    import tomli as tomllib  # ty: ignore[unresolved-import]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+DOCKERFILE_PATH = REPO_ROOT / "docker" / "Dockerfile"
+
+_FULL_SHA = r"[0-9a-f]{40}"
+_DOCKERFILE_ARG = re.compile(rf"^ARG\s+DEEPEP_COMMIT=({_FULL_SHA})\s*$", re.MULTILINE)
+# `git rev-parse --short` never abbreviates below 7 characters.
+_MIN_ABBREV_LEN = 7
+
+
+def _load_pyproject() -> dict:
+    with PYPROJECT_PATH.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def _pyproject_deepep_rev() -> str:
+    """The commit `uv`/`pip` resolve `deep_ep` from, per `[tool.uv.sources]`."""
+    sources = _load_pyproject()["tool"]["uv"]["sources"]
+    assert "deep_ep" in sources, f"[tool.uv.sources] in {PYPROJECT_PATH.name} no longer declares `deep_ep`"
+
+    rev = sources["deep_ep"]["rev"]
+    assert re.fullmatch(_FULL_SHA, rev), (
+        f"[tool.uv.sources] deep_ep.rev must be a full 40-character commit SHA so it can be compared "
+        f"against DEEPEP_COMMIT in docker/Dockerfile, got {rev!r}"
+    )
+    return rev
+
+
+def _pyproject_deepep_declared_version() -> str:
+    """The hand-written `[[tool.uv.dependency-metadata]]` version used to skip a build during resolution."""
+    entries = _load_pyproject()["tool"]["uv"]["dependency-metadata"]
+    matches = [entry for entry in entries if entry["name"] == "deep_ep"]
+    assert len(matches) == 1, (
+        f"expected exactly one [[tool.uv.dependency-metadata]] entry named `deep_ep` in "
+        f"{PYPROJECT_PATH.name}, found {len(matches)}"
+    )
+    return matches[0]["version"]
+
+
+def _dockerfile_deepep_commit() -> str:
+    """The commit the container builds DeepEP from, per `ARG DEEPEP_COMMIT`."""
+    matches = _DOCKERFILE_ARG.findall(DOCKERFILE_PATH.read_text())
+    assert len(matches) == 1, (
+        f"expected exactly one `ARG DEEPEP_COMMIT=<40-char sha>` line in docker/Dockerfile, "
+        f"found {len(matches)}; this test cannot tell which pin is authoritative otherwise"
+    )
+    return matches[0]
+
+
+def test_pyproject_deepep_rev_matches_dockerfile_commit():
+    """The uv/pip pin and the container build must resolve to the same DeepEP commit."""
+    pyproject_rev = _pyproject_deepep_rev()
+    dockerfile_commit = _dockerfile_deepep_commit()
+
+    assert pyproject_rev == dockerfile_commit, (
+        "DeepEP pin drift: the container and the uv/pip install path would ship different DeepEP builds.\n"
+        f"  pyproject.toml  [tool.uv.sources] deep_ep.rev = {pyproject_rev}\n"
+        f"  docker/Dockerfile           ARG DEEPEP_COMMIT = {dockerfile_commit}\n"
+        "Bump whichever is stale, then refresh both lock files (see CONTRIBUTING.md) so "
+        "`uv.lock` and `docker/common/uv-pytorch.lock` agree."
+    )
+
+
+def test_deepep_dependency_metadata_version_matches_pinned_rev():
+    """The declared `1.2.1+<short-sha>` local version must name the commit that is actually pinned.
+
+    `uv` trusts this string instead of building DeepEP during resolution; if it names a different
+    commit than `deep_ep.rev`, the lock file records a version that the built wheel never produces.
+    """
+    rev = _pyproject_deepep_rev()
+    declared = _pyproject_deepep_declared_version()
+
+    assert "+" in declared, (
+        f"[[tool.uv.dependency-metadata]] deep_ep.version must carry a `+<short-sha>` local segment "
+        f"identifying the pinned commit, got {declared!r}"
+    )
+    short_sha = declared.rsplit("+", 1)[1]
+
+    assert len(short_sha) >= _MIN_ABBREV_LEN and rev.startswith(short_sha), (
+        "DeepEP declared version does not match the pinned commit.\n"
+        f"  [tool.uv.sources]            deep_ep.rev = {rev}\n"
+        f"  [[tool.uv.dependency-metadata]]  version = {declared}\n"
+        f"`deep_ep` builds as `1.2.1+$(git rev-parse --short HEAD)`, so the local segment must be "
+        f"an abbreviation of the pinned rev (expected `+{rev[:_MIN_ABBREV_LEN]}`, got `+{short_sha}`)."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ overrides = [
 
 [[manifest.dependency-metadata]]
 name = "deep-ep"
-version = "1.2.1+7febc6e"
+version = "1.2.1+4214430"
 requires-dist = ["torch", "packaging", "ninja"]
 
 [[manifest.dependency-metadata]]
@@ -1626,8 +1626,8 @@ wheels = [
 
 [[package]]
 name = "deep-ep"
-version = "1.2.1+7febc6e"
-source = { git = "https://github.com/deepseek-ai/DeepEP.git?rev=7febc6e25660af0f54d95dd781ecdcd62265ecca#7febc6e25660af0f54d95dd781ecdcd62265ecca" }
+version = "1.2.1+4214430"
+source = { git = "https://github.com/deepseek-ai/DeepEP.git?rev=42144303752422ade37f24bca9e2dde12df70e09#42144303752422ade37f24bca9e2dde12df70e09" }
 dependencies = [
     { name = "ninja" },
     { name = "packaging" },
@@ -4259,7 +4259,7 @@ requires-dist = [
     { name = "databricks-sql-connector", marker = "extra == 'delta-databricks'", specifier = ">=4.4.0" },
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "decord", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin' and extra == 'vlm-media'" },
-    { name = "deep-ep", marker = "extra == 'moe'", git = "https://github.com/deepseek-ai/DeepEP.git?rev=7febc6e25660af0f54d95dd781ecdcd62265ecca" },
+    { name = "deep-ep", marker = "extra == 'moe'", git = "https://github.com/deepseek-ai/DeepEP.git?rev=42144303752422ade37f24bca9e2dde12df70e09" },
     { name = "deltalake", marker = "extra == 'delta-databricks'", specifier = ">=1.0.0" },
     { name = "diffusers", marker = "extra == 'diffusion'", specifier = ">=0.39.0" },
     { name = "ffpa-attn", marker = "extra == 'ffpa'", specifier = ">=0.2.2" },


### PR DESCRIPTION
## What

`deep_ep` is pinned in two independent places, and nothing keeps them in sync:

| Pin | Commit | DeepEP PR | Date |
|---|---|---|---|
| `docker/Dockerfile` — `ARG DEEPEP_COMMIT` | `42144303` | [#638](https://github.com/deepseek-ai/DeepEP/pull/638) | 2026-05-20 |
| `pyproject.toml` — `[tool.uv.sources] deep_ep.rev` | `7febc6e2` | [#580](https://github.com/deepseek-ai/DeepEP/pull/580) | 2026-02-09 |

The Dockerfile pin was bumped to pick up DeepEP #638 (pads `max_num_of_tokens_per_rank` to the
combine-kernel chunk size, fixing the HybridEP JIT `static_assert`), but the uv source was never
moved with it — so the uv/pip install path has been three months behind the container since May.

`42144303` is a linear descendant of `7febc6e2`, so this is a pure forward bump.

## Why it went unnoticed

The `moe` extra is not part of `all`, and the container builds with `--extra all`. So the image gets
DeepEP *only* from the Dockerfile source build, and CI never exercised the stale `pyproject.toml` pin.
The people who hit it are the ones installing outside the container:

```
uv sync --extra moe
pip install nemo_automodel[moe]
```

They got a DeepEP three months older than the one every MoE recipe was actually validated against.

## Changes

- `pyproject.toml`: `deep_ep.rev` → `42144303752422ade37f24bca9e2dde12df70e09`.
- `pyproject.toml`: `[[tool.uv.dependency-metadata]]` version → `v1.2.1+4214430`. DeepEP's `setup.py`
  builds as `'1.2.1' + '+' + $(git rev-parse --short HEAD)`; uv trusts this declared string instead of
  building the package during resolution, so it has to name the commit that is actually pinned. The
  in-file comment already said as much (*"This version has to match the version in the commit/rev/tag used"*)
  but nothing enforced it. Verified: `git rev-parse --short 42144303…` → `4214430`.
- `uv.lock` and `docker/common/uv-pytorch.lock`: refreshed for the new rev.
- New `tests/unit_tests/test_deepep_pin_consistency.py` (see below).

## The test

`tests/unit_tests/test_deepep_pin_consistency.py` — two checks, no network, no GPU:

1. `test_pyproject_deepep_rev_matches_dockerfile_commit` — parses `[tool.uv.sources] deep_ep.rev` out of
   `pyproject.toml` and `ARG DEEPEP_COMMIT=<40-char sha>` out of `docker/Dockerfile`, and fails if they
   differ. The failure message prints both pins and points at the lock-refresh flow.
2. `test_deepep_dependency_metadata_version_matches_pinned_rev` — fails when the declared
   `1.2.1+<short-sha>` local version stops being an abbreviation of the pinned rev, i.e. when someone
   bumps the rev and forgets the metadata block.

Both guard against a *half-applied* bump in either direction. The helpers also assert their own
preconditions (exactly one `ARG DEEPEP_COMMIT` line, a full 40-char sha, exactly one `deep_ep`
dependency-metadata entry) so the test fails loudly rather than silently passing if the files are
restructured.

## Verification

- Mutation-tested the new test against three drift scenarios — it fails on all three and passes on the fixed tree:
  - pre-fix state (`pyproject` stale, Dockerfile current) → **fails** (this is the bug this PR fixes)
  - Dockerfile bumped, `pyproject` left behind → **fails**
  - rev bumped in both, declared version forgotten → **fails**
- `uv lock --check` passes for `uv.lock`.
- `uv lock --check` passes for `docker/common/uv-pytorch.lock` after running
  `bash docker/common/update_pyproject_pytorch.sh`, matching what the *Generate Uv lock* workflow does.
- Lock diffs are scoped to the four `deep-ep` lines per file — regenerating wholesale with a newer uv
  than CI's 0.8.22 churned ~430 unrelated marker lines, so the lock edits were applied surgically to
  match what CI's uv version produces.
- `ruff check` / `ruff format --check` clean on the new file.

## Note (not in this PR)

Four `skills/*/skill-card.md` files record `v1.2.1+7febc6e (source: pyproject.toml)` under
"Skill Version(s)". Those are published release-card snapshots with eval results attached to a specific
run, so I left them alone rather than rewriting a released artifact — flagging it in case they should be
refreshed separately.