### PR TITLE
test(pp): add deepseek_v4 PP and EP parity tests [2/4]

### DIFF
--- a/tests/functional_tests/parallelism/L2_Parallelism_DeepSeekV4_EP2_Parity.sh
+++ b/tests/functional_tests/parallelism/L2_Parallelism_DeepSeekV4_EP2_Parity.sh
@@ -1,0 +1,69 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+# Expert-parallel parity for the DeepSeek-V4 Flash recipe.
+#
+# Both legs run on 2 ranks with dp_size=2 and differ only in ep_size, so the
+# data sharding and FSDP wrapping are identical and the comparison isolates
+# expert parallelism. That also allows a tighter bound than the PP test, whose
+# single-rank baseline is not FSDP-wrapped.
+#
+# The proxy generates its own synthetic token sequences, so this test stages no
+# tokenizer or dataset.
+#
+# Known gap: this catches EP changing the numbers, but not EP silently never
+# being applied -- that would make both legs identical and pass. The PP test
+# closes the equivalent hole by grepping for the static-metadata log line;
+# `apply_ep` has no such line to grep.
+
+set -xeuo pipefail
+
+export PYTHONPATH=${PYTHONPATH:-}:$(pwd)
+export CUDA_VISIBLE_DEVICES="0,1"
+
+RUN_DIR=$(mktemp -d)
+cleanup() { rm -rf "$RUN_DIR"; }
+trap cleanup EXIT
+
+COMMON_ARGS=(
+    --config tests/functional_tests/parallelism/deepseek_v4_proxy.yaml
+    --step_scheduler.max_steps 6
+    --step_scheduler.global_batch_size 4
+    --step_scheduler.local_batch_size 2
+    --distributed.tp_size 1
+    --distributed.cp_size 1
+    --distributed.pp_size 1
+)
+
+# --- Reference: 2 ranks, data parallel only ---
+TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run \
+    examples/llm_finetune/finetune.py \
+    "${COMMON_ARGS[@]}" \
+    --checkpoint.checkpoint_dir "$RUN_DIR/dp2" \
+    --distributed.ep_size 1
+
+# --- Expert parallel: same 2 ranks, experts sharded ---
+TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run \
+    examples/llm_finetune/finetune.py \
+    "${COMMON_ARGS[@]}" \
+    --checkpoint.checkpoint_dir "$RUN_DIR/ep2" \
+    --distributed.ep_size 2
+
+python tests/functional_tests/parallelism/compare_parallel_parity.py \
+    "$RUN_DIR/dp2/training.jsonl" \
+    "$RUN_DIR/ep2/training.jsonl" \
+    --axis ep \
+    --loss-tol 0.02 \
+    --grad-norm-rtol 0.05

--- a/tests/functional_tests/parallelism/L2_Parallelism_DeepSeekV4_PP2_Parity.sh
+++ b/tests/functional_tests/parallelism/L2_Parallelism_DeepSeekV4_PP2_Parity.sh
@@ -13,19 +13,14 @@
 # limitations under the License.
 
 #!/bin/bash
-# Pipeline-parallel parity for the Gemma4 31B VLM recipe.
+# Pipeline-parallel parity for the DeepSeek-V4 Flash recipe.
 #
-# Runs the Gemma4 31B proxy twice with the same seed and data order -- once on a
-# single rank, once at pp_size=2 -- and asserts both follow the same loss and
-# gradient-norm trajectory. `dp_size` is 1 in both runs, so the dataloader yields
-# identical batches and any divergence is attributable to the pipeline split.
+# DeepSeek-V4 owns `get_pipeline_stage_metas`, so it carries extra tensors across
+# the stage boundary rather than just hidden states. The generic PP tests do not
+# cover that contract.
 #
-# Covers the gap from PR #2983 (commit 00f40419).
-#
-# Required CI environment:
-#   * `$TEST_DATA_DIR/hf_gemma4_e4b_2l/` -- staged Gemma4 processor (already
-#     required by L2_HF_Transformer_VLM_Gemma4_Joint_Drafter.sh).
-#   * `$HF_CACHE/mini_cord_v2/` -- the standard VLM mini dataset.
+# The proxy generates its own synthetic token sequences, so this test stages no
+# tokenizer or dataset.
 
 set -xeuo pipefail
 
@@ -34,50 +29,32 @@ export CUDA_VISIBLE_DEVICES="0,1"
 
 RUN_DIR=$(mktemp -d)
 LOG_FILE="$RUN_DIR/pp2.log"
-PROXY_CKPT="$RUN_DIR/proxy"
 cleanup() { rm -rf "$RUN_DIR"; }
 trap cleanup EXIT
 
-# Build the randomly-initialized proxy checkpoint. Both runs load the same
-# weights, which is what makes the two loss trajectories comparable at all.
-python tests/functional_tests/parallelism/make_gemma4_proxy_checkpoint.py \
-    --output-dir "$PROXY_CKPT" \
-    --processor-dir $TEST_DATA_DIR/hf_gemma4_e4b_2l/
-
 COMMON_ARGS=(
-    --config tests/functional_tests/parallelism/gemma4_31b_proxy.yaml
-    --model.pretrained_model_name_or_path "$PROXY_CKPT"
-    --processor.pretrained_model_name_or_path "$PROXY_CKPT"
-    --dataset.path_or_dataset $HF_CACHE/mini_cord_v2/
-    --dataset.split train
-    --dataset.limit_dataset_samples 32
-    --validation_dataset.path_or_dataset $HF_CACHE/mini_cord_v2/
-    --validation_dataset.split validation
-    --validation_dataset.limit_dataset_samples 8
+    --config tests/functional_tests/parallelism/deepseek_v4_proxy.yaml
     --step_scheduler.max_steps 6
     --step_scheduler.global_batch_size 4
     --step_scheduler.local_batch_size 2
+    --distributed.tp_size 1
+    --distributed.cp_size 1
+    --distributed.ep_size 1
 )
 
 # --- Baseline: single rank, no parallelism ---
 TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=1 --nnodes=1 -m coverage run \
-    examples/vlm_finetune/finetune.py \
+    examples/llm_finetune/finetune.py \
     "${COMMON_ARGS[@]}" \
     --checkpoint.checkpoint_dir "$RUN_DIR/baseline" \
-    --distributed.tp_size 1 \
-    --distributed.cp_size 1 \
     --distributed.pp_size 1
 
-# --- Pipeline parallel: 2 ranks, pp_size=2 ---
+# --- Pipeline parallel: 2 ranks ---
 TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run \
-    examples/vlm_finetune/finetune.py \
+    examples/llm_finetune/finetune.py \
     "${COMMON_ARGS[@]}" \
     --checkpoint.checkpoint_dir "$RUN_DIR/pp2" \
-    --distributed.tp_size 1 \
-    --distributed.cp_size 1 \
     --distributed.pp_size 2 \
-    --distributed.pipeline.pp_schedule 1f1b \
-    --distributed.pipeline.pp_microbatch_size 1 \
     2>&1 | tee "$LOG_FILE"
 
 # Guard against the `_precompute_stage_shapes` bug from PR #2983. Assert the
@@ -92,13 +69,18 @@ if ! grep -q "Precomputed pipeline stage shapes" "$LOG_FILE"; then
     exit 1
 fi
 
-# The gradient-norm bound is looser than the loss bound because the single-rank
-# baseline runs unwrapped while the pp2 run goes through FSDP2 in bf16.
-# global_batch_size is twice local_batch_size, so each step accumulates two
-# micro-batches -- the case PR #3530 fixed.
+# Loss here is ~10.9 (random init over a 32k vocab) and both legs compute it in
+# bf16, whose ~0.4% relative resolution at that magnitude is already ~0.04
+# absolute. 0.10 sits above that floor; a tighter absolute bound would be
+# measuring bf16, not pipeline parallelism.
+#
+# Gradient norm is the sensitive half of this check and is compared relatively,
+# so it is unaffected by the loss magnitude. The bound stays loose because the
+# single-rank baseline runs unwrapped while the pp2 run goes through FSDP2's
+# bf16 mixed-precision policy.
 python tests/functional_tests/parallelism/compare_parallel_parity.py \
     "$RUN_DIR/baseline/training.jsonl" \
     "$RUN_DIR/pp2/training.jsonl" \
     --axis pp \
-    --loss-tol 0.05 \
+    --loss-tol 0.10 \
     --grad-norm-rtol 0.20

--- a/tests/functional_tests/parallelism/deepseek_v4_proxy.yaml
+++ b/tests/functional_tests/parallelism/deepseek_v4_proxy.yaml
@@ -31,11 +31,10 @@
 #     `fake_balanced_gate` stays off: it would swap the hash gate these layers
 #     exist to exercise for a fixed balanced one.
 #
-# The real recipe uses `attn: tilelang`, `experts: torch_mm` and
-# `dispatcher: hybridep`. This proxy uses sdpa plus the torch dispatcher, which
-# is what runs on a 2-GPU runner. `dispatcher: torch` still shards the expert
-# weights on the expert axis over the EP mesh (`apply_ep` -> `ExpertParallel`),
-# so the sharding under test is the same.
+# Backends vs the real recipe: `experts` matches it. `attn` uses sdpa rather
+# than tilelang, which JIT-compiles its kernels on every run, and `dispatcher`
+# uses torch rather than hybridep, which is not installed in the CI container.
+# Neither changes what EP shards.
 
 recipe: TrainFinetuneRecipeForNextTokenPrediction
 
@@ -93,7 +92,7 @@ model:
     linear: torch
     rms_norm: torch_fp32
     rope_fusion: false
-    experts: torch
+    experts: torch_mm
     dispatcher: torch
     enable_hf_state_dict_adapter: false
     # Recipe value. Gates the MoEFSDPSyncMixin sync deferral that the

--- a/tests/functional_tests/parallelism/deepseek_v4_proxy.yaml
+++ b/tests/functional_tests/parallelism/deepseek_v4_proxy.yaml
@@ -1,0 +1,171 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Randomly-initialized proxy for DeepSeek-V4 Flash, shaped like
+# `examples/llm_finetune/deepseek_v4/deepseek_v4_flash_hellaswag.yaml` but small
+# enough for the 2-GPU PR runners.
+#
+# Shrunk from the real config. These fields are deliberately NOT scaled down,
+# because the parallelism code branches on them:
+#
+#   * MoE (`n_routed_experts`, `n_shared_experts`, `num_experts_per_tok`)
+#     -- what expert parallelism shards. Routed and shared experts take
+#     different EP paths, so both stay present.
+#   * MLA (`q_lora_rank`, `o_lora_rank`, `head_dim` != `qk_rope_head_dim`,
+#     `num_key_value_heads` = 1) -- the attention layout FSDP wraps and the
+#     stage split has to carry. DeepSeek-V4 declares `supports_tp: False`, so
+#     there is no TP leg here.
+#   * `num_hash_layers` / hyper-connections -- carried across PP stage
+#     boundaries, which is why this model owns `get_pipeline_stage_metas`.
+#     `fake_balanced_gate` stays off: it would swap the hash gate these layers
+#     exist to exercise for a fixed balanced one.
+#
+# The real recipe uses `attn: tilelang`, `experts: torch_mm` and
+# `dispatcher: hybridep`. This proxy uses sdpa plus the torch dispatcher, which
+# is what runs on a 2-GPU runner. `dispatcher: torch` still shards the expert
+# weights on the expert axis over the EP mesh (`apply_ep` -> `ExpertParallel`),
+# so the sharding under test is the same.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 4
+  local_batch_size: 2
+  ckpt_every_steps: 1000
+  val_every_steps: 1000
+  max_steps: 6
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_config
+  config:
+    _target_: nemo_automodel.components.models.deepseek_v4.config.DeepseekV4Config
+    # Routes NeMoAutoModel to the NeMo class via MODEL_ARCH_MAPPING, not the HF one.
+    architectures: [DeepseekV4ForCausalLM]
+    vocab_size: 32000
+    hidden_size: 256
+    moe_intermediate_size: 128
+    # 6 layers over pp_size=2 puts all 3 hash-routing layers on stage 0, as
+    # the shipped 43-layer/pp_size=4 recipe does. A hash layer on a later stage
+    # gets input_ids=None and silently falls back to score-based topk, which
+    # would diverge from the single-rank baseline for reasons unrelated to PP.
+    num_hidden_layers: 6
+    num_attention_heads: 8
+    num_key_value_heads: 1
+    head_dim: 64
+    qk_rope_head_dim: 16
+    q_lora_rank: 64
+    o_lora_rank: 64
+    o_groups: 2
+    n_routed_experts: 8
+    n_shared_experts: 1
+    num_experts_per_tok: 2
+    num_hash_layers: 3
+    index_head_dim: 32
+    index_n_heads: 8
+    index_topk: 32
+    sliding_window: 64
+    max_position_embeddings: 4096
+    num_nextn_predict_layers: 0
+    use_cache: false
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: torch
+    rms_norm: torch_fp32
+    rope_fusion: false
+    experts: torch
+    dispatcher: torch
+    enable_hf_state_dict_adapter: false
+    # Recipe value. Gates the MoEFSDPSyncMixin sync deferral that the
+    # gradient-accumulation path under test runs through.
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: checkpoints/deepseek_v4_proxy/
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 1
+
+  sequence_parallel: false
+  activation_checkpointing: false
+
+  pipeline:
+    pp_schedule: 1f1b
+    pp_microbatch_size: 1
+    scale_grads_in_schedule: false
+    # DeepSeek-V4 owns a PP-aware forward (hc_mult stream expansion, MTP,
+    # hash routing). Leaving these at their `true` default lets
+    # `patch_hf_model_for_pp` replace it with the generic CausalLM forward,
+    # which is why every shipped deepseek_v4 recipe turns them off.
+    patch_inner_model: false
+    patch_causal_lm_model: false
+
+  moe:
+    reshard_after_forward: false
+    wrap_outer_model: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+# Synthetic fixed-length token sequences, so the test depends on no staged
+# tokenizer or dataset. What is under test is whether two topologies agree on
+# identical inputs, not what those inputs say. `std_len: 0` makes every sample
+# the same length, which is what lets the pipeline stages use static shapes.
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.mock.build_unpacked_dataset
+  num_sentences: 64
+  mean_len: 127
+  std_len: 0
+  vocab_size: 32000
+  max_sentence_len: 128
+  seed: 42
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.mock.build_unpacked_dataset
+  num_sentences: 8
+  mean_len: 127
+  std_len: 0
+  vocab_size: 32000
+  max_sentence_len: 128
+  seed: 7
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 1e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.95]

--- a/tests/functional_tests/parallelism/test_parallelism.py
+++ b/tests/functional_tests/parallelism/test_parallelism.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Parallel-vs-single-rank parity tests for production recipe topologies.
+"""Parallelism parity tests for production recipe topologies.
 
 Each script runs a randomly-initialized proxy of a real recipe twice with the
-same seed and data order -- once on a single rank, once with one parallelism
-axis enabled -- and asserts both follow the same loss and gradient-norm
-trajectory. Divergence means the sharding changed the computation.
+same seed and data order, changing exactly one parallelism axis between the two
+runs, and asserts both follow the same loss and gradient-norm trajectory.
+Divergence means the sharding changed the computation.
+
+The PP and TP tests compare a parallel run against a single-rank baseline. The
+EP test compares two 2-rank runs that differ only in ``ep_size``, so the data
+sharding and FSDP wrapping match and the bound can be tighter.
 
 Covers the gap from PR #2983 (commit 00f40419).
 """
@@ -28,6 +32,8 @@ TEST_FOLDER = "parallelism"
 GEMMA4_PP2_PARITY_FILENAME = "L2_Parallelism_VLM_Gemma4_PP2_Parity.sh"
 GEMMA4_TP2_PARITY_FILENAME = "L2_Parallelism_VLM_Gemma4_TP2_Parity.sh"
 PP_GRAD_ACCUM_PARITY_FILENAME = "L2_Parallelism_PP_Grad_Accum_Parity.sh"
+DEEPSEEK_V4_PP2_PARITY_FILENAME = "L2_Parallelism_DeepSeekV4_PP2_Parity.sh"
+DEEPSEEK_V4_EP2_PARITY_FILENAME = "L2_Parallelism_DeepSeekV4_EP2_Parity.sh"
 
 
 class TestParallelismParity:
@@ -39,3 +45,9 @@ class TestParallelismParity:
 
     def test_pp_grad_accum_parity(self):
         run_test_script(TEST_FOLDER, PP_GRAD_ACCUM_PARITY_FILENAME)
+
+    def test_deepseek_v4_pp2_parity(self):
+        run_test_script(TEST_FOLDER, DEEPSEEK_V4_PP2_PARITY_FILENAME)
+
+    def test_deepseek_v4_ep2_parity(self):
+        run_test_script(TEST_FOLDER, DEEPSEEK_V4_EP2_PARITY_FILENAME)


### PR DESCRIPTION
## What

| File | What it does |
|---|---|
| `L2_Parallelism_DeepSeekV4_PP2_Parity.sh` | Trains a tiny DeepSeek-V4 twice — once on 1 GPU, once split over 2 GPUs with pipeline parallelism — and fails if the loss or gradient-norm curves drift apart. |
| `L2_Parallelism_DeepSeekV4_EP2_Parity.sh` | Same for expert parallelism: 2 GPUs both times, once with all 8 experts on every rank, once with 4 per rank. |
| `deepseek_v4_proxy.yaml` | A shrunk `deepseek_v4_flash_hellaswag.yaml` (6 layers, ~20M params) keeping every field the parallelism code branches on. |

Also raises the gemma4 PP2 test's `global_batch_size` 2 → 4 so it accumulates two micro-batches.

## Why

#2983 broke every pipeline-parallel recipe while GitHub CI stayed green, because no test ran a real recipe topology twice and compared the numbers. #3529 covered gemma4. DeepSeek-V4 is the next one that matters: it owns `get_pipeline_stage_metas`, so it carries hyper-connection streams across the stage boundary rather than just hidden states, and it is the main expert-parallel recipe.

Loss on its own is a weak detector; gradient norm is the sensitive one. Both tests assert on it, and the comparison script fails if a log has no `grad_norm`.

## No new CI assets

The proxy generates its own fixed-length synthetic token sequences (`llm.mock.build_unpacked_dataset`, `std_len: 0`) — no tokenizer, no dataset to stage. Same pattern as `baichuan_2_7b_mock_fp8.yaml`.

## Three things the proxy has to copy from the shipped recipe

Each was found by running the test, not by reading it:

1. **`patch_inner_model` / `patch_causal_lm_model: false`** — as in every shipped deepseek recipe. At their `true` default, `patch_hf_model_for_pp` replaces DeepSeek-V4's own PP-aware `forward` with the generic CausalLM one, which skips the `[B,S,dim] → [B,S,hc_mult,dim]` expansion and dies in `DeepseekV4HyperConnection`.
2. **6 layers, not 4** — with 4 over `pp_size=2` a hash-routing layer lands on stage 1, gets `input_ids=None`, and takes its score-based-topk fallback, routing differently from the baseline. The shipped 43-layer/pp4 recipe keeps all 3 hash layers on stage 0.
3. **No `fake_balanced_gate`** — `model.py:181` only installs the hash gate when it is off, so it disabled the routing `num_hash_layers: 3` is there to exercise.

## Measured

| Test | Bounds | Worst observed |
|---|---|---|
| PP2 | loss 0.10, grad-norm rtol 0.20 | 0.064, 0.19% |
| EP2 | loss 0.02, grad-norm rtol 0.05 | 0.0006, 0.064% |

PP's loss bound is 0.10 because at a loss of ~10.9 in bf16 the representable resolution is already ~0.04. EP is 50x tighter because both its legs are 2-rank and FSDP-wrapped identically — which is also the control proving the PP gap is the wrapped/unwrapped asymmetry, not pipeline parallelism.

CI cost: `L2_Parallelism` goes ~4m42s → ~9min against a 40-minute timeout, and finishes ~8 minutes before the critical-path job. No change to total pipeline wall-time.

## Backends

`experts: torch_mm` matches the shipped recipe. Two differ:

- `attn` is `sdpa`, not `tilelang` — tilelang JIT-compiles its kernels on every run (~1min for this suite), and the parity numbers are identical either way.
- `dispatcher` is `torch`, not `hybridep` — hybridep is not installed in the CI container, and at `world_size == 1` the deepep/hybridep path falls back to `GroupedExperts` (`layers.py:771`), so the PP test's single-rank baseline would run a different expert implementation than its pp2 leg.

Neither changes what EP shards: `apply_ep` → `ExpertParallel` distributes the expert weights on the expert axis in every case.

## Also

Both PP scripts now assert positively that `"Precomputed pipeline stage shapes"` appears. The pre-existing negative grep cannot catch `_precompute_stage_shapes` being skipped outright, since the fallback line disappears with it — the exact function #2983 broke.

**Known gap:** the EP test catches EP changing the numbers, but not EP silently never being applied — that would make both legs identical and pass. PP closes the equivalent hole via the log line; `apply_ep` has none to grep. Documented in the script header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
