### PR TITLE
fix(moe): forward permute fusion to HybridEP

### DIFF
--- a/nemo_automodel/components/moe/megatron/fused_a2a.py
+++ b/nemo_automodel/components/moe/megatron/fused_a2a.py
@@ -409,6 +409,7 @@ class HybridEPDispatch(torch.autograd.Function):
         num_sms_combine_api=24,
         num_permuted_tokens=None,
         pad_multiple=None,
+        permute_fusion=False,
     ):
         """Forward pass of fused dispatch of the HybridEP backend."""
         if _hybrid_ep_buffer is None:
@@ -439,10 +440,12 @@ class HybridEPDispatch(torch.autograd.Function):
             pad_multiple=pad_multiple,
             num_permuted_tokens=num_permuted_tokens,
             non_blocking=non_blocking,
+            fuse_permute_dispatch=permute_fusion,
         )
 
         ctx.handle = handle
         ctx.pad_multiple = pad_multiple
+        ctx.permute_fusion = permute_fusion
         return (
             dispatched_hidden,
             dispatched_probs,
@@ -456,23 +459,31 @@ class HybridEPDispatch(torch.autograd.Function):
         """Backward pass of fused dispatch of the HybridEP backend."""
         handle = ctx.handle
         combined_hidden, combined_probs = _hybrid_ep_buffer.combine_with_unpermute(
-            hidden=grad_x, probs=grad_probs, handle=handle, pad_multiple=ctx.pad_multiple
+            hidden=grad_x,
+            probs=grad_probs,
+            handle=handle,
+            pad_multiple=ctx.pad_multiple,
+            fuse_unpermute_combine=ctx.permute_fusion,
         )
-        return combined_hidden, None, combined_probs, None, None, None, None, None, None
+        return combined_hidden, None, combined_probs, None, None, None, None, None, None, None
 
 
 class HybridEPCombine(torch.autograd.Function):
     """Fused combine operation for permute + combine a2a + permute using the HybridEP backend."""
 
     @staticmethod
-    def forward(ctx, x, handle, num_permuted_tokens=None, pad_multiple=None):
+    def forward(ctx, x, handle, num_permuted_tokens=None, pad_multiple=None, permute_fusion=False):
         """Forward pass of fused combine of the HybridEP backend."""
         combined_hidden, _ = _hybrid_ep_buffer.combine_with_unpermute(
-            hidden=x, handle=handle, pad_multiple=pad_multiple
+            hidden=x,
+            handle=handle,
+            pad_multiple=pad_multiple,
+            fuse_unpermute_combine=permute_fusion,
         )
         ctx.handle = handle
         ctx.pad_multiple = pad_multiple
         ctx.num_permuted_tokens = num_permuted_tokens
+        ctx.permute_fusion = permute_fusion
         return combined_hidden
 
     @staticmethod
@@ -485,8 +496,9 @@ class HybridEPCombine(torch.autograd.Function):
             handle=handle,
             pad_multiple=ctx.pad_multiple,
             num_permuted_tokens=ctx.num_permuted_tokens,
+            fuse_permute_dispatch=ctx.permute_fusion,
         )
-        return dispatched_hidden, None, None, None
+        return dispatched_hidden, None, None, None, None
 
 
 if HAVE_HYBRIDEP:
@@ -501,6 +513,7 @@ if HAVE_HYBRIDEP:
         num_sms_combine_api=24,
         num_permuted_tokens=None,
         pad_multiple=None,
+        permute_fusion=False,
     ):
         """Perform fused dispatch for permute + dispatch a2a + permute using the HybridEP backend."""
         return HybridEPDispatch.apply(
@@ -513,11 +526,12 @@ if HAVE_HYBRIDEP:
             num_sms_combine_api,
             num_permuted_tokens,
             pad_multiple,
+            permute_fusion,
         )
 
-    def hybrid_ep_combine(x, handle, num_permuted_tokens=None, pad_multiple=None):
+    def hybrid_ep_combine(x, handle, num_permuted_tokens=None, pad_multiple=None, permute_fusion=False):
         """Perform fused combine for unpermute + combine a2a + unpermute using the HybridEP backend."""
-        return HybridEPCombine.apply(x, handle, num_permuted_tokens, pad_multiple)
+        return HybridEPCombine.apply(x, handle, num_permuted_tokens, pad_multiple, permute_fusion)
 
 else:
     hybrid_ep_dispatch = None

--- a/nemo_automodel/components/moe/megatron/token_dispatcher.py
+++ b/nemo_automodel/components/moe/megatron/token_dispatcher.py
@@ -453,6 +453,7 @@ class _HybridEPManager(_DispatchManager):
             num_sms_combine_api=self.moe_hybridep_num_sms,
             num_permuted_tokens=self.num_permuted_tokens,
             pad_multiple=self.pad_multiple,
+            permute_fusion=self.permute_fusion,
         )
 
         self.tokens_per_expert = tokens_per_expert
@@ -471,6 +472,7 @@ class _HybridEPManager(_DispatchManager):
             handle=self.handle,
             num_permuted_tokens=self.num_permuted_tokens,
             pad_multiple=self.pad_multiple,
+            permute_fusion=self.permute_fusion,
         )
         self.handle = None
         self.num_permuted_tokens = None

--- a/tests/unit_tests/moe/test_fused_a2a.py
+++ b/tests/unit_tests/moe/test_fused_a2a.py
@@ -12,23 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for DeepEP buffer teardown (``fused_a2a.free_buffer``)."""
+"""Unit tests for DeepEP and HybridEP autograd wiring."""
 
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
+import torch
 
 import nemo_automodel.components.moe.megatron.fused_a2a as fused_a2a
 
 
 @pytest.fixture(autouse=True)
 def _restore_buffer():
-    """Save/restore the module-global ``_buffer`` so tests don't leak state."""
+    """Save/restore module-global buffers so tests don't leak state."""
     saved = fused_a2a._buffer
+    saved_hybrid_ep = fused_a2a._hybrid_ep_buffer
     try:
         yield
     finally:
         fused_a2a._buffer = saved
+        fused_a2a._hybrid_ep_buffer = saved_hybrid_ep
 
 
 def test_free_buffer_destroys_and_clears():
@@ -60,3 +64,38 @@ def test_free_buffer_swallows_destroy_errors():
 
     boom.destroy.assert_called_once_with()
     assert fused_a2a._buffer is None
+
+
+def test_hybridep_autograd_forwards_permute_fusion_in_both_directions():
+    buffer = mock.MagicMock()
+    hidden = torch.randn(4, 8)
+    probs = torch.randn(4, 2)
+    routing_map = torch.ones(4, 2, dtype=torch.bool)
+    tokens_per_expert = torch.tensor([2, 2])
+    handle = object()
+    buffer.dispatch_with_permute.return_value = (hidden, probs, None, tokens_per_expert, handle)
+    buffer.combine_with_unpermute.return_value = (hidden, probs)
+    fused_a2a._hybrid_ep_buffer = buffer
+
+    dispatch_ctx = SimpleNamespace()
+    fused_a2a.HybridEPDispatch.forward(
+        dispatch_ctx,
+        hidden,
+        routing_map,
+        probs,
+        None,
+        2,
+        permute_fusion=True,
+    )
+    dispatch_grads = fused_a2a.HybridEPDispatch.backward(dispatch_ctx, hidden, probs, None, None, None)
+
+    combine_ctx = SimpleNamespace()
+    fused_a2a.HybridEPCombine.forward(combine_ctx, hidden, handle, permute_fusion=True)
+    combine_grads = fused_a2a.HybridEPCombine.backward(combine_ctx, hidden)
+
+    assert buffer.dispatch_with_permute.call_args_list[0].kwargs["fuse_permute_dispatch"] is True
+    assert buffer.dispatch_with_permute.call_args_list[1].kwargs["fuse_permute_dispatch"] is True
+    assert buffer.combine_with_unpermute.call_args_list[0].kwargs["fuse_unpermute_combine"] is True
+    assert buffer.combine_with_unpermute.call_args_list[1].kwargs["fuse_unpermute_combine"] is True
+    assert len(dispatch_grads) == 10
+    assert len(combine_grads) == 5

--- a/tests/unit_tests/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/moe/test_token_dispatcher.py
@@ -117,6 +117,45 @@ class TestIndicesToMultihot:
         assert routing_map[0, 0] and routing_map[0, 7]
 
 
+def test_hybridep_manager_forwards_permute_fusion_to_dispatch_and_combine():
+    with patch(
+        "nemo_automodel.components.moe.megatron.token_dispatcher.hybrid_ep_dispatch",
+        new=Mock(),
+    ):
+        manager = _HybridEPManager(
+            group=None,
+            num_local_experts=2,
+            num_experts=8,
+            router_topk=2,
+            permute_fusion=True,
+        )
+    manager.routing_map = torch.zeros(2, 8, dtype=torch.bool)
+    manager.token_probs = torch.zeros(2, 8, dtype=torch.float32)
+    hidden_states = torch.randn(2, 4)
+    dispatched_hidden = torch.randn(3, 4)
+    dispatched_probs = torch.randn(3)
+    tokens_per_expert = torch.tensor([1, 2])
+    handle = (object(),)
+
+    with (
+        patch(
+            "nemo_automodel.components.moe.megatron.token_dispatcher.hybrid_ep_dispatch",
+            return_value=(dispatched_hidden, dispatched_probs, None, tokens_per_expert, handle),
+        ) as dispatch,
+        patch(
+            "nemo_automodel.components.moe.megatron.token_dispatcher.hybrid_ep_combine",
+            return_value=hidden_states,
+        ) as combine,
+    ):
+        actual_dispatched = manager.dispatch(hidden_states)
+        actual_combined = manager.combine(dispatched_hidden)
+
+    torch.testing.assert_close(actual_dispatched, dispatched_hidden)
+    torch.testing.assert_close(actual_combined, hidden_states)
+    assert dispatch.call_args.kwargs["permute_fusion"] is True
+    assert combine.call_args.kwargs["permute_fusion"] is True
+
+
 @pytest.mark.parametrize("enabled", [False, True])
 def test_token_unpermutation_applies_async_setting_to_deepep_combine(enabled):
     dispatcher = object.__new__(MoEFlexTokenDispatcher)


### PR DESCRIPTION
# What does this PR do ?

Forward the existing `moe_permute_fusion` setting through AutoModel's HybridEP
dispatch/combine autograd wrappers to DeepEP's `fuse_permute_dispatch` and
`fuse_unpermute_combine` flags.

Without this propagation, enabling `moe_permute_fusion` changes the local
permute/unpermute path but silently leaves the HybridEP DeepEP path unfused.

# Changelog

- Pass `permute_fusion` from `_HybridEPManager` into HybridEP dispatch and
  combine.
- Preserve the setting on the autograd context and use the matching DeepEP
  fusion flag in backward.
- Add unit coverage for all four DeepEP dispatch/combine forward/backward calls
  and for manager-level knob propagation.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] The change is focused on the existing HybridEP permute-fusion knob.
- [x] Unit tests cover forward and backward propagation.
- [x] No documentation change is required; this fixes an existing setting.
- [x] The commit includes a DCO sign-off.

# Validation

- `ruff format --check` on all four changed files: passed.
- `ruff check` on the changed source files: passed.
- `pytest -q tests/unit_tests/moe/test_fused_a2a.py tests/unit_tests/moe/test_token_dispatcher.py`: 13 passed.
- H100 qualification with DeepEP `421443037f64e9d422814bec9341c0559749c215`:
  - 1 node / 8 GPUs: aggregate valid TGS/GPU improved from 6550.50 to
    6936.18 (+5.89%).
  - 16 nodes / 128 GPUs: aggregate valid TGS/GPU improved from 7453.16 to
    7904.66 (+6.06%); all 40/40 steps completed with finite loss and gradient
    norm.

# Additional Information

Current `main` (`bb0fe53a`) still omits this propagation and pins the same
DeepEP revision used for the H100 qualification. The relevant HybridEP code
path has no behavioral change between the qualification baseline and current
`main`.
