### PR TITLE
perf(checkpoint): bound quantized DCP load memory

### DIFF
--- a/nemo_automodel/components/checkpoint/_backports/hf_storage.py
+++ b/nemo_automodel/components/checkpoint/_backports/hf_storage.py
@@ -276,6 +276,14 @@ class _HuggingFaceStorageReader(FsspecReader):
             super().__init__(path=path)
 
         self.key_mapping = key_mapping
+        self._metadata_cache: Metadata | None = None
+
+    def reset(self, checkpoint_id: str | os.PathLike | None = None) -> None:
+        """Reset reader state and discard metadata only when the checkpoint changes."""
+        previous_path = str(self.path)
+        super().reset(checkpoint_id)
+        if checkpoint_id is not None and str(self.path) != previous_path:
+            self._metadata_cache = None
 
     def read_data(self, plan: LoadPlan, planner: LoadPlanner) -> Future[None]:
         per_file: dict[str, list[ReadItem]] = {}
@@ -372,6 +380,11 @@ class _HuggingFaceStorageReader(FsspecReader):
         return fut
 
     def read_metadata(self) -> Metadata:
+        if self._metadata_cache is not None:
+            if getattr(self._metadata_cache, "storage_meta", None) is not None:
+                self._metadata_cache.storage_meta.load_id = self.load_id
+            return self._metadata_cache
+
         state_dict_metadata: dict[str, TensorStorageMetadata] = {}
         storage_data: dict[MetadataIndex, _HFStorageInfo] = {}
 
@@ -443,6 +456,7 @@ class _HuggingFaceStorageReader(FsspecReader):
             metadata.storage_meta = StorageMeta()
         metadata.storage_meta.load_id = self.load_id  # type: ignore[union-attr]
 
+        self._metadata_cache = metadata
         return metadata
 
 

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -1009,13 +1009,14 @@ class Checkpointer:
 
         part_loaded_model_state_dict: dict[str, torch.Tensor] | None = None
         checkpoint_load_parts: Iterator[CheckpointLoadPart] | None = None
+        # Adapter-owned parts name their DCP destinations with exact checkpoint keys, so any generic Transformers
+        # key_mapping is redundant for this path and must not prevent the adapter from describing bounded groups.
         if (
             is_init_step
             and is_safetensors
             and should_dequantize_base_checkpoint
             and isinstance(state_dict_adapter, StateDictAdapter)
             and len(model_state.model) == 1
-            and key_mapping is None
             and not allow_checkpoint_key_subset
         ):
             candidate_state_dict = model_state.state_dict()

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -21,6 +21,7 @@ import pickle
 import threading
 import time
 import uuid
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
@@ -70,7 +71,7 @@ from nemo_automodel.components.checkpoint.conversion_mapping import (
     requires_tensor_merging,
 )
 from nemo_automodel.components.checkpoint.lifecycle import CheckpointLifecycle
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint.state_dict_adapter import CheckpointLoadPart, StateDictAdapter
 from nemo_automodel.components.checkpoint.stateful_wrappers import ModelState, OptimizerState
 from nemo_automodel.components.checkpoint.utils import (
     ensure_tied_lm_head,
@@ -787,6 +788,137 @@ class Checkpointer:
         self._do_load(state_dict, os.path.join(weights_path, "optim"))
         optimizer_state.load_state_dict(state_dict)
 
+    def _load_model_in_parts(
+        self,
+        model_state: ModelState,
+        load_parts: Iterator[CheckpointLoadPart],
+        model_state_dict: dict[str, torch.Tensor],
+        model_path: str,
+        storage_reader: StorageReader,
+    ) -> None:
+        """Load, convert, and release one checkpoint part at a time.
+
+        Args:
+            model_state: Wrapper for the model whose final parameter storage is populated.
+            load_parts: Adapter-owned sequence of checkpoint destinations and finish callbacks.
+            model_state_dict: Native model names mapped to final model tensors. Every key must be completed exactly
+                once across ``load_parts``.
+            model_path: Hugging Face safetensors checkpoint directory.
+            storage_reader: Reader already bound to ``model_path``. Its parsed metadata is reused across parts.
+
+        Raises:
+            RuntimeError: If the checkpoint is missing a requested tensor or the parts do not cover all model tensors.
+            TypeError: If the adapter yields an object other than :class:`CheckpointLoadPart`.
+            ValueError: If a part is empty or repeats checkpoint or model keys.
+        """
+        started = time.monotonic()
+        checkpoint_keys = _get_checkpoint_metadata_keys(model_path, storage_reader)
+        metadata_seconds = time.monotonic() - started
+        expected_model_keys = set(model_state_dict)
+        requested_checkpoint_keys: set[str] = set()
+        completed_model_keys: set[str] = set()
+        requested_bytes = 0
+        max_temporary_bytes = 0
+        read_seconds = 0.0
+        finish_seconds = 0.0
+        part_count = 0
+        process_group_kwargs = {"process_group": self.process_group} if self.process_group is not None else {}
+
+        for part in load_parts:
+            if not isinstance(part, CheckpointLoadPart):
+                raise TypeError(f"Checkpoint adapter yielded {type(part).__name__}, expected CheckpointLoadPart")
+            if not part.checkpoint_tensors:
+                raise ValueError("Checkpoint adapter yielded a load part with no checkpoint tensors")
+            if not part.model_keys:
+                raise ValueError("Checkpoint adapter yielded a load part with no completed model tensors")
+
+            part_checkpoint_keys = set(part.checkpoint_tensors)
+            unknown_temporary_keys = sorted(part.temporary_checkpoint_keys - part_checkpoint_keys)
+            if unknown_temporary_keys:
+                raise ValueError(
+                    f"Checkpoint adapter reported {len(unknown_temporary_keys)} temporary tensors absent from its "
+                    f"load destinations (examples={unknown_temporary_keys[:5]})"
+                )
+            duplicate_checkpoint_keys = sorted(part_checkpoint_keys & requested_checkpoint_keys)
+            if duplicate_checkpoint_keys:
+                raise ValueError(
+                    f"Checkpoint adapter requested {len(duplicate_checkpoint_keys)} tensors more than once "
+                    f"(examples={duplicate_checkpoint_keys[:5]})"
+                )
+            missing_checkpoint_keys = sorted(part_checkpoint_keys - checkpoint_keys)
+            if missing_checkpoint_keys:
+                raise RuntimeError(
+                    f"Checkpoint {model_path} is missing {len(missing_checkpoint_keys)} tensors required by load "
+                    f"part {part_count + 1} (examples={missing_checkpoint_keys[:5]})"
+                )
+
+            duplicate_model_keys = sorted(part.model_keys & completed_model_keys)
+            if duplicate_model_keys:
+                raise ValueError(
+                    f"Checkpoint adapter completed {len(duplicate_model_keys)} model tensors more than once "
+                    f"(examples={duplicate_model_keys[:5]})"
+                )
+            unexpected_model_keys = sorted(part.model_keys - expected_model_keys)
+            if unexpected_model_keys:
+                raise ValueError(
+                    f"Checkpoint adapter reported {len(unexpected_model_keys)} unknown model tensors "
+                    f"(examples={unexpected_model_keys[:5]})"
+                )
+
+            part_bytes = sum(estimate_tensor_bytes(tensor) for tensor in part.checkpoint_tensors.values())
+            requested_bytes += part_bytes
+            temporary_bytes = sum(
+                estimate_tensor_bytes(
+                    tensor.to_local() if type(tensor).__name__ == "DTensor" else tensor  # noqa: PLC2801
+                )
+                for checkpoint_key, tensor in part.checkpoint_tensors.items()
+                if checkpoint_key in part.temporary_checkpoint_keys
+            )
+            max_temporary_bytes = max(max_temporary_bytes, temporary_bytes)
+            requested_checkpoint_keys |= part_checkpoint_keys
+
+            read_started = time.monotonic()
+            # The reader already points at model_path. Omitting checkpoint_id avoids resetting it, so safetensors
+            # metadata parsed before the first part can be reused by every subsequent DCP plan.
+            dcp.load(part.checkpoint_tensors, storage_reader=storage_reader, **process_group_kwargs)
+            read_seconds += time.monotonic() - read_started
+
+            finish_started = time.monotonic()
+            part.finish()
+            finish_seconds += time.monotonic() - finish_started
+            completed_model_keys |= part.model_keys
+            part_count += 1
+            del part
+
+        if part_count == 0:
+            raise RuntimeError("Checkpoint adapter returned an empty load-part sequence")
+        missing_model_keys = sorted(expected_model_keys - completed_model_keys)
+        if missing_model_keys:
+            raise RuntimeError(
+                f"Checkpoint load parts omitted {len(missing_model_keys)} model tensors "
+                f"(examples={missing_model_keys[:5]})"
+            )
+
+        if model_state.uses_tied_lm_head and not model_state.is_peft:
+            ensure_tied_lm_head(model_state.model[0])
+
+        total_seconds = time.monotonic() - started
+        requested_gb = requested_bytes / (1 << 30)
+        max_temporary_gb = max_temporary_bytes / (1 << 30)
+        logger.info(
+            "load_model: loaded a %.2f GB checkpoint in %d parts over %.2fs "
+            "(%.2f GB/s overall | largest temporary allocation on this rank %.2f GB, metadata %.2fs, "
+            "storage read %.2fs, finish %.2fs)",
+            requested_gb,
+            part_count,
+            total_seconds,
+            requested_gb / max(total_seconds, 1e-9),
+            max_temporary_gb,
+            metadata_seconds,
+            read_seconds,
+            finish_seconds,
+        )
+
     @torch.no_grad()
     def load_model(
         self,
@@ -859,7 +991,9 @@ class Checkpointer:
         is_custom_model = _is_custom_model(model_state.model[0])
         # Models with standard HF state-dict keys need no conversion, so DCP can load their tensors directly. Custom
         # adapters may also opt in when most tensors load into model weight memory and any temporary tensors are small.
-        # Quantized initialization and other adapter conversions keep the host fallback on one device.
+        # A quantized adapter may instead describe small, self-contained groups that DCP can load and convert in
+        # sequence. Other quantized initialization keeps the existing fallback: full CPU conversion on one device,
+        # or rank-local DCP conversion for a distributed custom model.
         # World size inline (not via components.distributed) so the checkpoint component stays
         # independent per the import-linter contract.
         if torch.distributed.is_initialized():
@@ -872,9 +1006,53 @@ class Checkpointer:
             uses_standard_hf_state_dict
             or (isinstance(state_dict_adapter, StateDictAdapter) and state_dict_adapter.supports_low_memory_dcp_load)
         )
+
+        part_loaded_model_state_dict: dict[str, torch.Tensor] | None = None
+        checkpoint_load_parts: Iterator[CheckpointLoadPart] | None = None
+        if (
+            is_init_step
+            and is_safetensors
+            and should_dequantize_base_checkpoint
+            and isinstance(state_dict_adapter, StateDictAdapter)
+            and len(model_state.model) == 1
+            and key_mapping is None
+            and not allow_checkpoint_key_subset
+        ):
+            candidate_state_dict = model_state.state_dict()
+            candidate_parts = state_dict_adapter.iter_checkpoint_load_parts(
+                candidate_state_dict,
+                device_mesh=self.moe_mesh,
+            )
+            if candidate_parts is not None:
+                part_loaded_model_state_dict = candidate_state_dict
+                checkpoint_load_parts = candidate_parts
+
         safetensors_requires_full_cpu = (
-            is_safetensors and not can_use_low_memory_dcp and (not is_custom_model or world_size == 1)
+            is_safetensors
+            and not can_use_low_memory_dcp
+            and checkpoint_load_parts is None
+            and (not is_custom_model or world_size == 1)
         )
+        if checkpoint_load_parts is not None and part_loaded_model_state_dict is not None:
+            storage_reader = self._get_storage_reader(
+                model_path,
+                key_mapping=None,
+                is_init_step=True,
+                is_safetensors=True,
+            )
+            if storage_reader is None:
+                raise RuntimeError(
+                    f"No safetensors storage reader is available for part-by-part loading from {model_path}"
+                )
+            self._load_model_in_parts(
+                model_state,
+                checkpoint_load_parts,
+                part_loaded_model_state_dict,
+                model_path,
+                storage_reader,
+            )
+            return
+
         if (
             is_init_step
             and len(model_state.model) == 1

--- a/nemo_automodel/components/checkpoint/state_dict_adapter.py
+++ b/nemo_automodel/components/checkpoint/state_dict_adapter.py
@@ -14,12 +14,38 @@
 
 import re
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 
 if TYPE_CHECKING:
     from torch.distributed.device_mesh import DeviceMesh
+
+
+@dataclass
+class CheckpointLoadPart:
+    """One part of a checkpoint that is loaded and finished before the next part.
+
+    DCP fills ``checkpoint_tensors`` using their Hugging Face names and layouts. ``finish`` then converts any
+    temporary checkpoint tensors into the final model tensors named by ``model_keys`` before the loader advances to
+    the next part. Tensors that already have the model's exact dtype and layout may point directly at model storage.
+
+    Attributes:
+        checkpoint_tensors: Hugging Face checkpoint names mapped to DCP destinations. Destinations may use final model
+            storage or temporary storage owned by this part.
+        model_keys: Native model state-dict names completed after ``finish`` returns.
+        temporary_checkpoint_keys: Names in ``checkpoint_tensors`` whose destinations use temporary storage rather
+            than final model storage. The loader uses these keys to report the largest per-rank temporary allocation.
+        finish: Callback that installs temporary checkpoint tensors into final model storage. It must not save those
+            temporary tensors anywhere outside this load part.
+    """
+
+    checkpoint_tensors: dict[str, torch.Tensor]
+    model_keys: frozenset[str]
+    temporary_checkpoint_keys: frozenset[str]
+    finish: Callable[[], None]
 
 
 class StateDictAdapter(ABC):
@@ -40,6 +66,29 @@ class StateDictAdapter(ABC):
         safely below a full model copy, including when loading on one GPU.
         """
         return self._supports_low_memory_dcp_load
+
+    def iter_checkpoint_load_parts(
+        self,
+        model_state_dict: dict[str, torch.Tensor],
+        device_mesh: Optional["DeviceMesh"] = None,
+    ) -> Iterator[CheckpointLoadPart] | None:
+        """Optionally load and finish a quantized checkpoint in small parts.
+
+        Ordinary adapters do not need to implement this method. It is only for adapters that cannot let DCP write
+        checkpoint tensors directly into model storage because a dtype or layout conversion is required, but can
+        complete that conversion for one small part of the model at a time.
+
+        Args:
+            model_state_dict: Native model names mapped to the final parameter and persistent-buffer tensors that the
+                checkpoint must populate. Tensors retain their model-specific shapes, axis orders, dtypes, devices,
+                strides, distributed placements, and storage.
+            device_mesh: Optional device mesh describing distributed model storage.
+
+        Returns:
+            An iterator of dependency-complete load parts, or ``None`` when the adapter does not support this path.
+            Across all parts, ``model_keys`` must cover ``model_state_dict`` exactly once.
+        """
+        return None
 
     @abstractmethod
     def to_hf(self, state_dict: dict[str, Any], **kwargs) -> dict[str, Any]:

--- a/nemo_automodel/components/models/mistral3/model.py
+++ b/nemo_automodel/components/models/mistral3/model.py
@@ -552,7 +552,7 @@ class Ministral3ForCausalLM(HFCheckpointingMixin, Ministral3PreTrainedModel, Gen
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
         self.post_init()
         if quant_method == "fp8":
-            self.state_dict_adapter = Mistral3FP8StateDictAdapter.for_causal_lm()
+            self.state_dict_adapter = Mistral3FP8StateDictAdapter.for_causal_lm(config)
 
     def get_input_embeddings(self):
         return self.model.embed_tokens

--- a/nemo_automodel/components/models/mistral3/state_dict_adapter.py
+++ b/nemo_automodel/components/models/mistral3/state_dict_adapter.py
@@ -123,7 +123,8 @@ def _identity(k: str) -> str:
 
 _MISTRAL3P5_128B_NUM_HIDDEN_LAYERS = 88
 _CHECKPOINT_LAYERS_PER_PART = 8
-_DECODER_LAYER_KEY = re.compile(r"^(.*?\.layers\.(\d+))\.")
+_CAUSAL_LM_DECODER_LAYER_KEY = re.compile(r"^(model\.layers\.(\d+))\.")
+_VLM_DECODER_LAYER_KEY = re.compile(r"^(model\.language_model(?:\.model)?\.layers\.(\d+))\.")
 
 
 def _config_attr(config: Any | None, attr: str) -> Any:
@@ -249,13 +250,27 @@ class Mistral3FP8StateDictAdapter(StateDictAdapter):
             "model.multi_modal_projector",
             # "lm_head" already in _NON_QUANTIZED_SUFFIXES via suffix match.
         )
+        text_config = _config_attr(config, "text_config")
+        # Tied Hugging Face checkpoints omit lm_head.weight. The existing fallback paths already handle that case;
+        # grouped loading currently requires every requested checkpoint key to exist. Keep tied VLMs on the fallback
+        # until grouped loading can represent a model tensor populated through another tied destination.
+        num_hidden_layers = (
+            _config_attr(text_config, "num_hidden_layers")
+            if _config_attr(config, "tie_word_embeddings") is False
+            else None
+        )
         if _uses_identity_vlm_layout(config):
-            return cls(layout_name="vlm_full_identity", not_fp8_prefixes=not_fp8)
+            return cls(
+                layout_name="vlm_full_identity",
+                not_fp8_prefixes=not_fp8,
+                num_hidden_layers=num_hidden_layers,
+            )
         return cls(
             native_to_hf=_vlm_full_native_to_hf,
             hf_to_native=_vlm_full_hf_to_native,
             layout_name="vlm_full",
             not_fp8_prefixes=not_fp8,
+            num_hidden_layers=num_hidden_layers,
         )
 
     # --------------------------------------------------------------------- #
@@ -297,34 +312,36 @@ class Mistral3FP8StateDictAdapter(StateDictAdapter):
         model_state_dict: dict[str, torch.Tensor],
         device_mesh: "DeviceMesh" | None = None,
     ) -> Iterator[CheckpointLoadPart] | None:
-        """Load text-only Mistral3 FP8 weights in bounded decoder-layer groups.
+        """Load Mistral3 FP8 weights in bounded decoder-layer groups.
 
         Each quantized model tensor has BF16 model shape and storage. Its load part creates an FP8 destination with
         the same shape, device, strides, and distributed placements, plus the scalar BF16 ``_scale_inv`` destination
         stored by the checkpoint. After DCP fills both tensors, the part copies and scales the FP8 value directly into
-        the BF16 model tensor. Non-quantized tensors use their final model storage as the DCP destination.
+        the BF16 model tensor. Non-quantized tensors, including VLM vision and projector weights, use their final model
+        storage as the DCP destination.
 
         This path requires the complete decoder on every rank. Pipeline-parallel ranks own different layer subsets and
-        therefore retain the existing rank-local DCP path until part scheduling can be coordinated across stages. VLM
-        layouts also retain that existing path.
+        therefore retain the existing rank-local DCP path until part scheduling can be coordinated across stages. Tied
+        VLM checkpoints also retain that path because they omit the LM-head tensor expected by grouped loading.
 
         Args:
-            model_state_dict: Native text-model names mapped to final model tensors. Decoder tensors may be local
-                DTensor shards; their placements are preserved by ``torch.empty_like``.
+            model_state_dict: Native model names mapped to final parameter and persistent-buffer tensors. Each tensor
+                has arbitrary model-defined rank and shape. Decoder tensors may be local DTensor shards; their global
+                shapes, local shards, and placements are preserved by ``torch.empty_like``. Non-quantized destinations
+                alias and are populated through final model storage.
             device_mesh: Optional distributed mesh. The tensors already carry their final placements, so this value is
                 not otherwise needed.
 
         Returns:
             One direct-load part for tensors outside decoder layers plus bounded temporary-load parts for decoder
-            layers, or ``None`` for VLM layouts, partial decoders, and non-BF16 model weights.
+            layers, or ``None`` for tied VLM checkpoints, partial decoders, and non-BF16 model weights.
         """
         del device_mesh
-        if self._layout_name != "causal_lm":
-            return None
+        decoder_layer_key = _CAUSAL_LM_DECODER_LAYER_KEY if self._layout_name == "causal_lm" else _VLM_DECODER_LAYER_KEY
         present_layer_indices = {
             int(layer_match.group(2))
             for model_key in model_state_dict
-            if (layer_match := _DECODER_LAYER_KEY.match(model_key)) is not None
+            if (layer_match := decoder_layer_key.match(model_key)) is not None
         }
         if self._num_hidden_layers is None or present_layer_indices != set(range(self._num_hidden_layers)):
             return None
@@ -333,15 +350,29 @@ class Mistral3FP8StateDictAdapter(StateDictAdapter):
             for model_key, tensor in model_state_dict.items()
         ):
             return None
-        return self._iter_causal_lm_checkpoint_load_parts(model_state_dict)
+        return self._iter_checkpoint_load_parts(model_state_dict, decoder_layer_key)
 
-    def _iter_causal_lm_checkpoint_load_parts(
+    def _iter_checkpoint_load_parts(
         self,
         model_state_dict: dict[str, torch.Tensor],
+        decoder_layer_key: re.Pattern[str],
     ) -> Iterator[CheckpointLoadPart]:
+        """Build load parts for a complete causal-LM or VLM decoder.
+
+        Args:
+            model_state_dict: Native model names mapped to final tensors of arbitrary model-defined rank and shape.
+                Quantized linear weights must use BF16 final storage; non-quantized tensors remain direct DCP
+                destinations and are mutated in place during the load.
+            decoder_layer_key: Pattern that identifies decoder-layer names and captures the zero-based layer index in
+                group 2. It must exclude vision-tower layers from the bounded FP8 groups.
+
+        Returns:
+            Dependency-complete load parts. Each quantized destination has the same shape, strides, device, and DTensor
+            placements as its corresponding final model tensor but uses temporary FP8 storage.
+        """
         grouped_model_keys: dict[str, list[str]] = {}
         for model_key in model_state_dict:
-            layer_match = _DECODER_LAYER_KEY.match(model_key)
+            layer_match = decoder_layer_key.match(model_key)
             group_name = (
                 f"layers-{int(layer_match.group(2)) // _CHECKPOINT_LAYERS_PER_PART}"
                 if layer_match is not None

--- a/nemo_automodel/components/models/mistral3/state_dict_adapter.py
+++ b/nemo_automodel/components/models/mistral3/state_dict_adapter.py
@@ -38,11 +38,14 @@ Structurally modelled after
 from __future__ import annotations
 
 import logging
+import re
+from collections.abc import Iterator
+from functools import partial
 from typing import TYPE_CHECKING, Any, Callable
 
 import torch
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint.state_dict_adapter import CheckpointLoadPart, StateDictAdapter
 
 if TYPE_CHECKING:
     from torch.distributed.device_mesh import DeviceMesh
@@ -92,11 +95,35 @@ def _dequantize_from_fp8(
     return (weight_fp8.float() * scale_inv.float()).to(target_dtype)
 
 
+@torch.no_grad()
+def _dequantize_from_fp8_into(
+    target: torch.Tensor,
+    weight_fp8: torch.Tensor,
+    scale_inv: torch.Tensor,
+) -> None:
+    """Dequantize a per-tensor FP8 weight directly into its final model tensor.
+
+    ``target`` keeps its native model shape, BF16 dtype, device, strides, distributed placements, and storage.
+    ``weight_fp8`` has the same shape and distributed placements but uses the checkpoint's FP8 dtype and temporary
+    storage. ``scale_inv`` is the checkpoint's scalar BF16 inverse scale.
+    """
+    target.copy_(weight_fp8)
+    target.mul_(scale_inv.item())
+
+
+def _finish_fp8_loads(conversions: tuple[tuple[torch.Tensor, torch.Tensor, torch.Tensor], ...]) -> None:
+    """Install one load part's FP8 tensors into final model storage."""
+    for target, weight_fp8, scale_inv in conversions:
+        _dequantize_from_fp8_into(target, weight_fp8, scale_inv)
+
+
 def _identity(k: str) -> str:
     return k
 
 
 _MISTRAL3P5_128B_NUM_HIDDEN_LAYERS = 88
+_CHECKPOINT_LAYERS_PER_PART = 8
+_DECODER_LAYER_KEY = re.compile(r"^(.*?\.layers\.(\d+))\.")
 
 
 def _config_attr(config: Any | None, attr: str) -> Any:
@@ -175,14 +202,16 @@ class Mistral3FP8StateDictAdapter(StateDictAdapter):
         hf_to_native: Callable[[str], str] = _identity,
         layout_name: str = "vlm_full",
         not_fp8_prefixes: tuple[str, ...] = (),
+        num_hidden_layers: int | None = None,
     ):
         self._native_to_hf = native_to_hf
         self._hf_to_native = hf_to_native
         self._layout_name = layout_name
         self._not_fp8_prefixes = tuple(not_fp8_prefixes)
+        self._num_hidden_layers = num_hidden_layers
 
     @classmethod
-    def for_causal_lm(cls) -> "Mistral3FP8StateDictAdapter":
+    def for_causal_lm(cls, config: Any | None = None) -> "Mistral3FP8StateDictAdapter":
         """Text-only path for per-tensor FP8 Ministral3ForCausalLM checkpoints.
 
         Devstral-2 stores text-model keys in the same layout exposed by the
@@ -190,7 +219,7 @@ class Mistral3FP8StateDictAdapter(StateDictAdapter):
         while embeddings, norms, and the untied LM head remain BF16 and are
         excluded by ``_NON_QUANTIZED_SUFFIXES``.
         """
-        return cls(layout_name="causal_lm")
+        return cls(layout_name="causal_lm", num_hidden_layers=_config_attr(config, "num_hidden_layers"))
 
     @classmethod
     def for_vlm_full(cls, config: Any | None = None) -> "Mistral3FP8StateDictAdapter":
@@ -251,8 +280,6 @@ class Mistral3FP8StateDictAdapter(StateDictAdapter):
         hf: dict[str, Any] = {}
         for model_key, value in state_dict.items():
             if exclude_key_regex is not None:
-                import re
-
                 if re.match(exclude_key_regex, model_key):
                     continue
             hf_key = self._native_to_hf(model_key)
@@ -264,6 +291,87 @@ class Mistral3FP8StateDictAdapter(StateDictAdapter):
             else:
                 hf[hf_key] = value
         return hf
+
+    def iter_checkpoint_load_parts(
+        self,
+        model_state_dict: dict[str, torch.Tensor],
+        device_mesh: "DeviceMesh" | None = None,
+    ) -> Iterator[CheckpointLoadPart] | None:
+        """Load text-only Mistral3 FP8 weights in bounded decoder-layer groups.
+
+        Each quantized model tensor has BF16 model shape and storage. Its load part creates an FP8 destination with
+        the same shape, device, strides, and distributed placements, plus the scalar BF16 ``_scale_inv`` destination
+        stored by the checkpoint. After DCP fills both tensors, the part copies and scales the FP8 value directly into
+        the BF16 model tensor. Non-quantized tensors use their final model storage as the DCP destination.
+
+        This path requires the complete decoder on every rank. Pipeline-parallel ranks own different layer subsets and
+        therefore retain the existing rank-local DCP path until part scheduling can be coordinated across stages. VLM
+        layouts also retain that existing path.
+
+        Args:
+            model_state_dict: Native text-model names mapped to final model tensors. Decoder tensors may be local
+                DTensor shards; their placements are preserved by ``torch.empty_like``.
+            device_mesh: Optional distributed mesh. The tensors already carry their final placements, so this value is
+                not otherwise needed.
+
+        Returns:
+            One direct-load part for tensors outside decoder layers plus bounded temporary-load parts for decoder
+            layers, or ``None`` for VLM layouts, partial decoders, and non-BF16 model weights.
+        """
+        del device_mesh
+        if self._layout_name != "causal_lm":
+            return None
+        present_layer_indices = {
+            int(layer_match.group(2))
+            for model_key in model_state_dict
+            if (layer_match := _DECODER_LAYER_KEY.match(model_key)) is not None
+        }
+        if self._num_hidden_layers is None or present_layer_indices != set(range(self._num_hidden_layers)):
+            return None
+        if any(
+            _is_fp8_weight_key(model_key, self._not_fp8_prefixes) and tensor.dtype != torch.bfloat16
+            for model_key, tensor in model_state_dict.items()
+        ):
+            return None
+        return self._iter_causal_lm_checkpoint_load_parts(model_state_dict)
+
+    def _iter_causal_lm_checkpoint_load_parts(
+        self,
+        model_state_dict: dict[str, torch.Tensor],
+    ) -> Iterator[CheckpointLoadPart]:
+        grouped_model_keys: dict[str, list[str]] = {}
+        for model_key in model_state_dict:
+            layer_match = _DECODER_LAYER_KEY.match(model_key)
+            group_name = (
+                f"layers-{int(layer_match.group(2)) // _CHECKPOINT_LAYERS_PER_PART}"
+                if layer_match is not None
+                else "shared"
+            )
+            grouped_model_keys.setdefault(group_name, []).append(model_key)
+
+        for model_keys in grouped_model_keys.values():
+            checkpoint_tensors: dict[str, torch.Tensor] = {}
+            temporary_checkpoint_keys: set[str] = set()
+            conversions: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = []
+            for model_key in model_keys:
+                target = model_state_dict[model_key]
+                hf_key = self._native_to_hf(model_key)
+                if _is_fp8_weight_key(model_key, self._not_fp8_prefixes):
+                    weight_fp8 = torch.empty_like(target, dtype=torch.float8_e4m3fn)
+                    scale_inv = torch.empty((), dtype=torch.bfloat16)
+                    checkpoint_tensors[hf_key] = weight_fp8
+                    checkpoint_tensors[hf_key + "_scale_inv"] = scale_inv
+                    temporary_checkpoint_keys.update((hf_key, hf_key + "_scale_inv"))
+                    conversions.append((target, weight_fp8, scale_inv))
+                else:
+                    checkpoint_tensors[hf_key] = target
+
+            yield CheckpointLoadPart(
+                checkpoint_tensors=checkpoint_tensors,
+                model_keys=frozenset(model_keys),
+                temporary_checkpoint_keys=frozenset(temporary_checkpoint_keys),
+                finish=partial(_finish_fp8_loads, tuple(conversions)),
+            )
 
     # --------------------------------------------------------------------- #
     # HF → model                                                            #

--- a/nemo_automodel/components/models/mistral3/state_dict_adapter.py
+++ b/nemo_automodel/components/models/mistral3/state_dict_adapter.py
@@ -103,7 +103,7 @@ def _dequantize_from_fp8_into(
 ) -> None:
     """Dequantize a per-tensor FP8 weight directly into its final model tensor.
 
-    ``target`` keeps its native model shape, BF16 dtype, device, strides, distributed placements, and storage.
+    ``target`` keeps its native model shape, BF16 or FP32 dtype, device, strides, distributed placements, and storage.
     ``weight_fp8`` has the same shape and distributed placements but uses the checkpoint's FP8 dtype and temporary
     storage. ``scale_inv`` is the checkpoint's scalar BF16 inverse scale.
     """
@@ -314,10 +314,10 @@ class Mistral3FP8StateDictAdapter(StateDictAdapter):
     ) -> Iterator[CheckpointLoadPart] | None:
         """Load Mistral3 FP8 weights in bounded decoder-layer groups.
 
-        Each quantized model tensor has BF16 model shape and storage. Its load part creates an FP8 destination with
+        Each quantized model tensor has BF16 or FP32 model shape and storage. Its load part creates an FP8 destination with
         the same shape, device, strides, and distributed placements, plus the scalar BF16 ``_scale_inv`` destination
         stored by the checkpoint. After DCP fills both tensors, the part copies and scales the FP8 value directly into
-        the BF16 model tensor. Non-quantized tensors, including VLM vision and projector weights, use their final model
+        the final model tensor. Non-quantized tensors, including VLM vision and projector weights, use their final model
         storage as the DCP destination.
 
         This path requires the complete decoder on every rank. Pipeline-parallel ranks own different layer subsets and
@@ -334,7 +334,7 @@ class Mistral3FP8StateDictAdapter(StateDictAdapter):
 
         Returns:
             One direct-load part for tensors outside decoder layers plus bounded temporary-load parts for decoder
-            layers, or ``None`` for tied VLM checkpoints, partial decoders, and non-BF16 model weights.
+            layers, or ``None`` for tied VLM checkpoints, partial decoders, and unsupported model-weight dtypes.
         """
         del device_mesh
         decoder_layer_key = _CAUSAL_LM_DECODER_LAYER_KEY if self._layout_name == "causal_lm" else _VLM_DECODER_LAYER_KEY
@@ -346,7 +346,8 @@ class Mistral3FP8StateDictAdapter(StateDictAdapter):
         if self._num_hidden_layers is None or present_layer_indices != set(range(self._num_hidden_layers)):
             return None
         if any(
-            _is_fp8_weight_key(model_key, self._not_fp8_prefixes) and tensor.dtype != torch.bfloat16
+            _is_fp8_weight_key(model_key, self._not_fp8_prefixes)
+            and tensor.dtype not in (torch.bfloat16, torch.float32)
             for model_key, tensor in model_state_dict.items()
         ):
             return None
@@ -361,7 +362,7 @@ class Mistral3FP8StateDictAdapter(StateDictAdapter):
 
         Args:
             model_state_dict: Native model names mapped to final tensors of arbitrary model-defined rank and shape.
-                Quantized linear weights must use BF16 final storage; non-quantized tensors remain direct DCP
+                Quantized linear weights must use BF16 or FP32 final storage; non-quantized tensors remain direct DCP
                 destinations and are mutated in place during the load.
             decoder_layer_key: Pattern that identifies decoder-layer names and captures the zero-based layer index in
                 group 2. It must exclude vision-tower layers from the bounded FP8 groups.

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -34,6 +34,8 @@ from torch.nn.parallel import DistributedDataParallel
 from nemo_automodel.components.checkpoint._backports.hf_storage import (
     _DIFFUSERS_INDEX_FN,
     _extract_file_index_with_status,
+    _get_safetensors_file_metadata,
+    _HuggingFaceStorageReader,
     get_fqn_to_dtype_mapping,
     get_fqn_to_file_index_mapping,
 )
@@ -75,6 +77,7 @@ from nemo_automodel.components.checkpoint.utils import (
 )
 from nemo_automodel.components.models.gemma4_moe.state_dict_adapter import Gemma4MoEStateDictAdapter
 from nemo_automodel.components.models.llama.state_dict_adapter import LlamaStateDictAdapter
+from nemo_automodel.components.models.mistral3.state_dict_adapter import Mistral3FP8StateDictAdapter
 from nemo_automodel.components.models.qwen2.state_dict_adapter import Qwen2StateDictAdapter
 from nemo_automodel.components.models.qwen3.state_dict_adapter import Qwen3StateDictAdapter
 from nemo_automodel.components.training.rng import RNGState, StatefulRNG, init_all_rng
@@ -1847,6 +1850,7 @@ class TestLoadModelCustomModelGuard:
         model.config = SimpleNamespace(quantization_config=quantization_config)
         model.state_dict_adapter = MagicMock(spec=StateDictAdapter)
         model.state_dict_adapter.supports_low_memory_dcp_load = True
+        model.state_dict_adapter.iter_checkpoint_load_parts.return_value = None
         mock_state_dict = {"layer.weight": torch.randn(4, 4), "layer.bias": torch.randn(4)}
         mock_load_hf.return_value = mock_state_dict
 
@@ -1884,6 +1888,66 @@ class TestLoadModelCustomModelGuard:
             mock_load_hf.assert_not_called()
             mock_dcp_load.assert_called_once()
             assert "load_model:" in caplog.text
+
+    def test_mistral3_fp8_checkpoint_loads_and_finishes_bounded_layer_groups(self, tmp_path):
+        """The allocating FP8 adapter must not retain every layer's temporary destinations."""
+
+        class WeightOnly(torch.nn.Module):
+            def __init__(self, size):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.zeros(size, dtype=torch.bfloat16))
+
+        CustomModel = type("CustomModel", (torch.nn.Module,), {})
+        CustomModel.__module__ = "nemo_automodel.components.models.mistral3.model"
+        model = CustomModel()
+        model.model = torch.nn.Module()
+        model.model.embed_tokens = torch.nn.Embedding(4, 4, dtype=torch.bfloat16)
+        model.model.layers = torch.nn.ModuleList()
+        for _ in range(2):
+            layer = torch.nn.Module()
+            layer.self_attn = torch.nn.Module()
+            layer.self_attn.q_proj = torch.nn.Linear(4, 4, bias=False, dtype=torch.bfloat16)
+            model.model.layers.append(layer)
+        model.model.norm = WeightOnly(4)
+        model.lm_head = torch.nn.Linear(4, 4, bias=False, dtype=torch.bfloat16)
+        model.config = SimpleNamespace(
+            tie_word_embeddings=False,
+            num_hidden_layers=2,
+            quantization_config={"quant_method": "fp8", "weight_block_size": None},
+        )
+        model.state_dict_adapter = Mistral3FP8StateDictAdapter.for_causal_lm(model.config)
+
+        checkpoint_state = {}
+        expected_state = {}
+        for key, tensor in model.state_dict().items():
+            if ".layers." in key and key.endswith(".weight"):
+                checkpoint_state[key] = torch.full(tensor.shape, 2.0, dtype=torch.float8_e4m3fn)
+                checkpoint_state[key + "_scale_inv"] = torch.tensor(0.5, dtype=torch.bfloat16)
+                expected_state[key] = torch.ones_like(tensor)
+            else:
+                checkpoint_state[key] = torch.full_like(tensor, 3.0)
+                expected_state[key] = torch.full_like(tensor, 3.0)
+
+        model_path = tmp_path / "model"
+        model_path.mkdir()
+        save_file(checkpoint_state, model_path / "model.safetensors")
+        checkpointer = self._make_checkpointer()
+
+        with (
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._load_hf_checkpoint_preserving_dtype"
+            ) as full_cpu_load,
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing.dcp.load",
+                wraps=dcp.load,
+            ) as dcp_load,
+        ):
+            checkpointer.load_model(model, model_path=str(model_path), is_init_step=True)
+
+        full_cpu_load.assert_not_called()
+        assert dcp_load.call_count == 2  # shared tensors and one bounded decoder-layer group
+        for key, expected in expected_state.items():
+            torch.testing.assert_close(model.state_dict()[key], expected)
 
 
 class TestLoadModelCheckpointKeySubset:
@@ -2930,6 +2994,21 @@ class TestGetStorageReaderInitStep:
         # Backport reader must be constructed instead
         backport_marker.assert_called_once_with(path="/fake/path", key_mapping=None)
         assert reader is backport_marker.return_value
+
+    def test_backport_reader_parses_safetensors_metadata_once(self, tmp_path):
+        """Part-by-part loads reuse one parsed copy of the checkpoint metadata."""
+        save_file({"weight": torch.ones(2, 2)}, tmp_path / "model.safetensors")
+        reader = _HuggingFaceStorageReader(str(tmp_path))
+
+        with patch(
+            "nemo_automodel.components.checkpoint._backports.hf_storage._get_safetensors_file_metadata",
+            wraps=_get_safetensors_file_metadata,
+        ) as parse_metadata:
+            first = reader.read_metadata()
+            second = reader.read_metadata()
+
+        assert first is second
+        parse_metadata.assert_called_once()
 
     def test_non_init_step_no_keymap_uses_upstream(self):
         """For mid-training safetensors loads (is_init_step=False, no key_mapping),

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -1942,7 +1942,14 @@ class TestLoadModelCustomModelGuard:
                 wraps=dcp.load,
             ) as dcp_load,
         ):
-            checkpointer.load_model(model, model_path=str(model_path), is_init_step=True)
+            # Mistral3 VLMs also expose a generic Transformers conversion mapping. Load parts already use exact HF
+            # checkpoint names, so that redundant mapping must not disable the adapter-owned grouped path.
+            checkpointer.load_model(
+                model,
+                model_path=str(model_path),
+                is_init_step=True,
+                key_mapping={"^model": "unused.generic.mapping"},
+            )
 
         full_cpu_load.assert_not_called()
         assert dcp_load.call_count == 2  # shared tensors and one bounded decoder-layer group

--- a/tests/unit_tests/models/mistral3_vlm/test_state_dict_adapter.py
+++ b/tests/unit_tests/models/mistral3_vlm/test_state_dict_adapter.py
@@ -132,18 +132,19 @@ class TestDequantizeFromFp8:
         assert torch.equal(out, expected)
         assert not torch.equal(out, low_precision)
 
+    @pytest.mark.parametrize("target_dtype", [torch.bfloat16, torch.float32])
     @pytest.mark.parametrize("scale_value", [1e-5, 0.125, 1.0, 3.5, 1000.0])
-    def test_direct_destination_matches_existing_conversion(self, scale_value):
+    def test_direct_destination_matches_existing_conversion(self, scale_value, target_dtype):
         weight_fp8 = torch.tensor(
             [-448.0, -13.0, -0.03125, 0.0, 0.0703125, 7.5, 96.0, 448.0],
             dtype=torch.float8_e4m3fn,
         )
         scale = torch.tensor(scale_value, dtype=torch.bfloat16)
-        target = torch.empty_like(weight_fp8, dtype=torch.bfloat16)
+        target = torch.empty_like(weight_fp8, dtype=target_dtype)
 
         _dequantize_from_fp8_into(target, weight_fp8, scale)
 
-        assert torch.equal(target, _dequantize_from_fp8(weight_fp8, scale))
+        assert torch.equal(target, _dequantize_from_fp8(weight_fp8, scale, target_dtype=target_dtype))
 
 
 # --------------------------------------------------------------------------- #
@@ -197,15 +198,16 @@ class TestForCausalLmFactory:
 
         assert converted == {key: value}
 
-    def test_checkpoint_load_parts_dequantize_bounded_layer_groups_into_model_storage(self):
+    @pytest.mark.parametrize("model_dtype", [torch.bfloat16, torch.float32])
+    def test_checkpoint_load_parts_dequantize_bounded_layer_groups_into_model_storage(self, model_dtype):
         adapter = Mistral3FP8StateDictAdapter.for_causal_lm({"num_hidden_layers": 2})
         model_state = {
-            "model.embed_tokens.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
-            "model.layers.0.self_attn.q_proj.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
-            "model.layers.0.mlp.down_proj.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
-            "model.layers.1.self_attn.q_proj.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
-            "model.norm.weight": torch.zeros(2, dtype=torch.bfloat16),
-            "lm_head.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
+            "model.embed_tokens.weight": torch.zeros(2, 2, dtype=model_dtype),
+            "model.layers.0.self_attn.q_proj.weight": torch.zeros(2, 2, dtype=model_dtype),
+            "model.layers.0.mlp.down_proj.weight": torch.zeros(2, 2, dtype=model_dtype),
+            "model.layers.1.self_attn.q_proj.weight": torch.zeros(2, 2, dtype=model_dtype),
+            "model.norm.weight": torch.zeros(2, dtype=model_dtype),
+            "lm_head.weight": torch.zeros(2, 2, dtype=model_dtype),
         }
 
         load_parts = adapter.iter_checkpoint_load_parts(model_state)
@@ -236,32 +238,32 @@ class TestForCausalLmFactory:
 
         torch.testing.assert_close(
             model_state["model.layers.0.self_attn.q_proj.weight"],
-            torch.ones(2, 2, dtype=torch.bfloat16),
+            torch.ones(2, 2, dtype=model_dtype),
         )
         torch.testing.assert_close(
             model_state["model.layers.0.mlp.down_proj.weight"],
-            torch.ones(2, 2, dtype=torch.bfloat16),
+            torch.ones(2, 2, dtype=model_dtype),
         )
         torch.testing.assert_close(
             model_state["model.layers.1.self_attn.q_proj.weight"],
-            torch.ones(2, 2, dtype=torch.bfloat16),
+            torch.ones(2, 2, dtype=model_dtype),
         )
         torch.testing.assert_close(
             model_state["model.embed_tokens.weight"],
-            torch.full((2, 2), 7.0, dtype=torch.bfloat16),
+            torch.full((2, 2), 7.0, dtype=model_dtype),
         )
         torch.testing.assert_close(
             model_state["model.norm.weight"],
-            torch.full((2,), 7.0, dtype=torch.bfloat16),
+            torch.full((2,), 7.0, dtype=model_dtype),
         )
         torch.testing.assert_close(
             model_state["lm_head.weight"],
-            torch.full((2, 2), 7.0, dtype=torch.bfloat16),
+            torch.full((2, 2), 7.0, dtype=model_dtype),
         )
 
-    def test_non_bf16_model_keeps_existing_one_pass_dcp_load(self):
+    def test_unsupported_model_dtype_keeps_existing_one_pass_dcp_load(self):
         adapter = Mistral3FP8StateDictAdapter.for_causal_lm({"num_hidden_layers": 1})
-        model_state = {"model.layers.0.self_attn.q_proj.weight": torch.zeros(2, 2)}
+        model_state = {"model.layers.0.self_attn.q_proj.weight": torch.zeros(2, 2, dtype=torch.float16)}
 
         assert adapter.iter_checkpoint_load_parts(model_state) is None
 

--- a/tests/unit_tests/models/mistral3_vlm/test_state_dict_adapter.py
+++ b/tests/unit_tests/models/mistral3_vlm/test_state_dict_adapter.py
@@ -259,11 +259,6 @@ class TestForCausalLmFactory:
             torch.full((2, 2), 7.0, dtype=torch.bfloat16),
         )
 
-    def test_vlm_layout_keeps_existing_one_pass_dcp_load(self):
-        adapter = Mistral3FP8StateDictAdapter.for_vlm_full()
-
-        assert adapter.iter_checkpoint_load_parts({}) is None
-
     def test_non_bf16_model_keeps_existing_one_pass_dcp_load(self):
         adapter = Mistral3FP8StateDictAdapter.for_causal_lm({"num_hidden_layers": 1})
         model_state = {"model.layers.0.self_attn.q_proj.weight": torch.zeros(2, 2)}
@@ -281,6 +276,17 @@ class TestForCausalLmFactory:
 
 class TestForVlmFullFactory:
     """The single shipped factory wires layout name and not_fp8_prefixes."""
+
+    def test_tied_vlm_layout_keeps_existing_one_pass_dcp_load(self):
+        adapter = Mistral3FP8StateDictAdapter.for_vlm_full(
+            SimpleNamespace(
+                tie_word_embeddings=True,
+                text_config=SimpleNamespace(model_type="ministral3", num_hidden_layers=1),
+            )
+        )
+        model_state = {"model.language_model.layers.0.self_attn.q_proj.weight": torch.zeros(2, 2, dtype=torch.bfloat16)}
+
+        assert adapter.iter_checkpoint_load_parts(model_state) is None
 
     def test_layout_name(self):
         a = Mistral3FP8StateDictAdapter.for_vlm_full()
@@ -347,10 +353,99 @@ class TestForVlmFullFactory:
             assert a._hf_to_native(key) == key
 
     def test_smaller_mistral3_configs_keep_nested_body_layout(self):
-        cfg = SimpleNamespace(text_config=SimpleNamespace(model_type="ministral3", num_hidden_layers=36))
+        cfg = SimpleNamespace(
+            tie_word_embeddings=False,
+            text_config=SimpleNamespace(model_type="ministral3", num_hidden_layers=36),
+        )
         a = Mistral3FP8StateDictAdapter.for_vlm_full(cfg)
         assert a._layout_name == "vlm_full"
         assert a._native_to_hf("model.language_model.embed_tokens.weight") == "language_model.model.embed_tokens.weight"
+
+    def test_checkpoint_load_parts_dequantize_vlm_text_layers_and_direct_load_vlm_components(self):
+        config = SimpleNamespace(
+            tie_word_embeddings=False,
+            text_config=SimpleNamespace(model_type="ministral3", num_hidden_layers=2),
+        )
+        adapter = Mistral3FP8StateDictAdapter.for_vlm_full(config)
+        text_weight_key = "model.language_model.layers.0.self_attn.q_proj.weight"
+        vision_weight_key = "model.vision_tower.transformer.layers.0.attention.q_proj.weight"
+        projector_weight_key = "model.multi_modal_projector.linear_1.weight"
+        model_state = {
+            "model.language_model.embed_tokens.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
+            text_weight_key: torch.zeros(2, 2, dtype=torch.bfloat16),
+            "model.language_model.layers.1.mlp.down_proj.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
+            vision_weight_key: torch.zeros(2, 2, dtype=torch.bfloat16),
+            projector_weight_key: torch.zeros(2, 2, dtype=torch.bfloat16),
+            "lm_head.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
+        }
+
+        load_parts = adapter.iter_checkpoint_load_parts(model_state)
+        assert load_parts is not None
+        parts = list(load_parts)
+
+        assert len(parts) == 2
+        assert set().union(*(part.model_keys for part in parts)) == set(model_state)
+        shared_part = next(part for part in parts if vision_weight_key in part.model_keys)
+        assert shared_part.temporary_checkpoint_keys == frozenset()
+        assert (
+            shared_part.checkpoint_tensors["vision_tower.transformer.layers.0.attention.q_proj.weight"]
+            is model_state[vision_weight_key]
+        )
+        assert (
+            shared_part.checkpoint_tensors["multi_modal_projector.linear_1.weight"] is model_state[projector_weight_key]
+        )
+        decoder_part = next(part for part in parts if text_weight_key in part.model_keys)
+        checkpoint_text_key = "language_model.model.layers.0.self_attn.q_proj.weight"
+        assert decoder_part.checkpoint_tensors[checkpoint_text_key].dtype == torch.float8_e4m3fn
+        assert decoder_part.checkpoint_tensors[checkpoint_text_key] is not model_state[text_weight_key]
+
+        for part in parts:
+            for checkpoint_key, destination in part.checkpoint_tensors.items():
+                if checkpoint_key.endswith("_scale_inv"):
+                    destination.fill_(0.5)
+                elif destination.dtype == torch.float8_e4m3fn:
+                    destination.fill_(2.0)
+                else:
+                    destination.fill_(7.0)
+            part.finish()
+
+        torch.testing.assert_close(model_state[text_weight_key], torch.ones(2, 2, dtype=torch.bfloat16))
+        torch.testing.assert_close(model_state[vision_weight_key], torch.full((2, 2), 7.0, dtype=torch.bfloat16))
+        torch.testing.assert_close(model_state[projector_weight_key], torch.full((2, 2), 7.0, dtype=torch.bfloat16))
+
+    def test_vision_layer_indices_do_not_hide_partial_text_decoder(self):
+        config = SimpleNamespace(
+            tie_word_embeddings=False,
+            text_config=SimpleNamespace(model_type="ministral3", num_hidden_layers=2),
+        )
+        adapter = Mistral3FP8StateDictAdapter.for_vlm_full(config)
+        model_state = {
+            "model.language_model.layers.1.self_attn.q_proj.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
+            "model.vision_tower.transformer.layers.0.attention.q_proj.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
+        }
+
+        assert adapter.iter_checkpoint_load_parts(model_state) is None
+
+    def test_identity_vlm_layout_uses_bounded_decoder_groups(self):
+        config = SimpleNamespace(
+            tie_word_embeddings=False,
+            text_config=SimpleNamespace(model_type="ministral3", num_hidden_layers=88),
+        )
+        adapter = Mistral3FP8StateDictAdapter.for_vlm_full(config)
+        model_state = {
+            f"model.language_model.layers.{layer}.self_attn.q_proj.weight": torch.zeros(1, 1, dtype=torch.bfloat16)
+            for layer in range(88)
+        }
+
+        load_parts = adapter.iter_checkpoint_load_parts(model_state)
+        assert load_parts is not None
+        parts = list(load_parts)
+
+        assert len(parts) == 11
+        assert set().union(*(part.model_keys for part in parts)) == set(model_state)
+        first_key = "model.language_model.layers.0.self_attn.q_proj.weight"
+        first_part = next(part for part in parts if first_key in part.model_keys)
+        assert first_key in first_part.checkpoint_tensors
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit_tests/models/mistral3_vlm/test_state_dict_adapter.py
+++ b/tests/unit_tests/models/mistral3_vlm/test_state_dict_adapter.py
@@ -23,6 +23,7 @@ from nemo_automodel.components.models.mistral3.state_dict_adapter import (
     _NON_QUANTIZED_SUFFIXES,
     Mistral3FP8StateDictAdapter,
     _dequantize_from_fp8,
+    _dequantize_from_fp8_into,
     _is_fp8_weight_key,
 )
 
@@ -131,6 +132,19 @@ class TestDequantizeFromFp8:
         assert torch.equal(out, expected)
         assert not torch.equal(out, low_precision)
 
+    @pytest.mark.parametrize("scale_value", [1e-5, 0.125, 1.0, 3.5, 1000.0])
+    def test_direct_destination_matches_existing_conversion(self, scale_value):
+        weight_fp8 = torch.tensor(
+            [-448.0, -13.0, -0.03125, 0.0, 0.0703125, 7.5, 96.0, 448.0],
+            dtype=torch.float8_e4m3fn,
+        )
+        scale = torch.tensor(scale_value, dtype=torch.bfloat16)
+        target = torch.empty_like(weight_fp8, dtype=torch.bfloat16)
+
+        _dequantize_from_fp8_into(target, weight_fp8, scale)
+
+        assert torch.equal(target, _dequantize_from_fp8(weight_fp8, scale))
+
 
 # --------------------------------------------------------------------------- #
 # Mistral3FP8StateDictAdapter — factories and key rewrites                    #
@@ -182,6 +196,87 @@ class TestForCausalLmFactory:
         converted = adapter.to_hf({key: value}, quantization=True)
 
         assert converted == {key: value}
+
+    def test_checkpoint_load_parts_dequantize_bounded_layer_groups_into_model_storage(self):
+        adapter = Mistral3FP8StateDictAdapter.for_causal_lm({"num_hidden_layers": 2})
+        model_state = {
+            "model.embed_tokens.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
+            "model.layers.0.self_attn.q_proj.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
+            "model.layers.0.mlp.down_proj.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
+            "model.layers.1.self_attn.q_proj.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
+            "model.norm.weight": torch.zeros(2, dtype=torch.bfloat16),
+            "lm_head.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
+        }
+
+        load_parts = adapter.iter_checkpoint_load_parts(model_state)
+        assert load_parts is not None
+        parts = list(load_parts)
+
+        assert len(parts) == 2
+        assert set().union(*(part.model_keys for part in parts)) == set(model_state)
+        shared_part = next(part for part in parts if "model.embed_tokens.weight" in part.model_keys)
+        assert shared_part.temporary_checkpoint_keys == frozenset()
+        assert max(
+            sum(
+                part.checkpoint_tensors[key].numel() * part.checkpoint_tensors[key].element_size()
+                for key in part.temporary_checkpoint_keys
+            )
+            for part in parts
+            if part.temporary_checkpoint_keys
+        ) < sum(tensor.numel() * tensor.element_size() for tensor in model_state.values())
+        for part in parts:
+            for checkpoint_key, destination in part.checkpoint_tensors.items():
+                if checkpoint_key.endswith("_scale_inv"):
+                    destination.fill_(0.5)
+                elif destination.dtype == torch.float8_e4m3fn:
+                    destination.fill_(2.0)
+                else:
+                    destination.fill_(7.0)
+            part.finish()
+
+        torch.testing.assert_close(
+            model_state["model.layers.0.self_attn.q_proj.weight"],
+            torch.ones(2, 2, dtype=torch.bfloat16),
+        )
+        torch.testing.assert_close(
+            model_state["model.layers.0.mlp.down_proj.weight"],
+            torch.ones(2, 2, dtype=torch.bfloat16),
+        )
+        torch.testing.assert_close(
+            model_state["model.layers.1.self_attn.q_proj.weight"],
+            torch.ones(2, 2, dtype=torch.bfloat16),
+        )
+        torch.testing.assert_close(
+            model_state["model.embed_tokens.weight"],
+            torch.full((2, 2), 7.0, dtype=torch.bfloat16),
+        )
+        torch.testing.assert_close(
+            model_state["model.norm.weight"],
+            torch.full((2,), 7.0, dtype=torch.bfloat16),
+        )
+        torch.testing.assert_close(
+            model_state["lm_head.weight"],
+            torch.full((2, 2), 7.0, dtype=torch.bfloat16),
+        )
+
+    def test_vlm_layout_keeps_existing_one_pass_dcp_load(self):
+        adapter = Mistral3FP8StateDictAdapter.for_vlm_full()
+
+        assert adapter.iter_checkpoint_load_parts({}) is None
+
+    def test_non_bf16_model_keeps_existing_one_pass_dcp_load(self):
+        adapter = Mistral3FP8StateDictAdapter.for_causal_lm({"num_hidden_layers": 1})
+        model_state = {"model.layers.0.self_attn.q_proj.weight": torch.zeros(2, 2)}
+
+        assert adapter.iter_checkpoint_load_parts(model_state) is None
+
+    def test_partial_decoder_keeps_existing_one_pass_dcp_load(self):
+        adapter = Mistral3FP8StateDictAdapter.for_causal_lm({"num_hidden_layers": 2})
+        model_state = {
+            "model.layers.1.self_attn.q_proj.weight": torch.zeros(2, 2, dtype=torch.bfloat16),
+        }
+
+        assert adapter.iter_checkpoint_load_parts(model_state) is None
 
 
 class TestForVlmFullFactory:


### PR DESCRIPTION
## What this changes

This PR makes FP8 checkpoint conversion use a small part of the model at a time instead of keeping temporary tensors for the complete checkpoint alive at once.

Main already includes #3616, which chooses DCP according to whether dequantization is actually needed. Two expensive cases remain for Mistral3/Devstral FP8 checkpoints:

- **Distributed 123B model:** DCP reads rank-local FP8 tensors, but the adapter retains all temporary FP8 tensors until the complete read finishes. On TP=8, that peaks at 71.95 GiB of GPU memory per rank.
- **Single-GPU 24B VLM:** the safe fallback first builds and converts the complete checkpoint in CPU memory, then installs it into the model. This uses about 66.5 GiB of process memory in addition to the GPU model and makes loading much slower.

This PR adds an optional adapter hook for checkpoints that require dtype or layout conversion:

1. The adapter describes one self-contained part of the checkpoint.
2. DCP reads only that part.
3. Non-quantized tensors are written directly into model weights. FP8 tensors are converted directly into their final BF16 or FP32 model weights.
4. Temporary tensors are released before the next part is read.

Ordinary adapters do not implement the hook and keep their existing loading path.

The Mistral3 adapter groups at most eight text-decoder layers per part. It supports both the causal-LM layout and the untied full-VLM layout used by `mistralai/Devstral-Small-2-24B-Instruct-2512`. In the VLM layout, the vision encoder and multimodal projector load directly into their final model weights rather than becoming additional temporary copies.

FP32 master-weight configurations use the same bounded path. The model weights already have FP32 storage when loading begins, so each FP8 checkpoint part is converted directly into those FP32 destinations. The later FSDP mixed-precision policy can still use BF16 for compute.

## Safety boundaries

The new path is considered only when all of the following are true:

- this is the initial model load from a safetensors checkpoint;
- dequantization is actually required;
- one complete model state is being loaded, without a requested key subset; and
- the model adapter explicitly provides the load parts.

The Mistral3 implementation additionally requires a complete decoder, BF16 or FP32 final weights, and the supported per-tensor FP8 checkpoint format. Pipeline-parallel ranks that own only part of the decoder and tied VLM checkpoints keep their existing fallback. Unsupported adapters and dtypes are unchanged.

The shared loader rejects missing checkpoint tensors, repeated checkpoint requests, repeated model destinations, and incomplete model coverage instead of allowing a partial load.

## Historical measurements

These measurements predate the September 15 rebase. They compare the original implementation against its then-parent #3616; no new controlled before/after performance comparison on the rebased head is claimed. The fresh GB10 functional CI result is reported separately below.

### Devstral 123B, TP=8 + LoRA

These runs used the same official `mistralai/Devstral-2-123B-Instruct-2512` checkpoint, staged image, TP=8 + LoRA setup, and one-token forward pass.

| Code path | Slurm job | Model load | Peak allocated GPU memory/rank | Peak reserved GPU memory/rank |
|---|---:|---:|---:|---:|
| Parent #3616: retain all rank-local FP8 destinations | `16296055` | 90.08 s | 71.95 GiB | 73.35–73.36 GiB |
| Intermediate: one decoder layer per part | `16295655` | 101.50 s | 30.25 GiB | 30.37 GiB |
| This PR: up to eight decoder layers per part | `16296372` | 91.16 s | 30.44 GiB | 31.48 GiB |

The final path reduces peak allocated GPU memory by **41.51 GiB/rank (57.7%)**. Model-load time changes by **+1.08 seconds (1.2%)**, so the 123B result is a memory/OOM improvement with loading speed preserved, not a speed claim.

The final run used 12 DCP parts; its largest temporary part was 1.29 GiB/rank. It completed with 1,852 sharded parameters, trainable LoRA weights, and finite logits.

### Devstral Small 2 24B VLM, one H100

This is the full `Mistral3ForConditionalGeneration` VLM checkpoint, including its vision encoder and multimodal projector. At the time of this benchmark, the text-only SQuAD recipe used a multi-GPU CI node; the benchmark used one GPU to exercise the path that previously built the complete checkpoint in CPU memory.

Both measurements used the same checkpoint files after download. The comparison uses the fastest observed full-CPU run, making the speed comparison conservative.

| Code path | Slurm job | Model load | Peak CPU/process memory | Peak GPU memory | Peak CPU + GPU memory |
|---|---:|---:|---:|---:|---:|
| Parent #3616: full checkpoint converted on CPU first | `16301212` | 56.57 s | 66.48 GiB | 44.73 GiB | 111.21 GiB |
| This PR: DCP load and conversion in six parts | `16301550` | **14.40 s** | **5.19 GiB** | 48.87 GiB | **54.06 GiB** |

For this real single-GPU VLM case, the new path is **3.9x faster**. Peak CPU/process memory falls by **61.29 GiB**, and peak CPU + GPU memory falls by **57.15 GiB (51.4%)**. GPU memory increases by 4.14 GiB because one bounded FP8 decoder group is temporarily present alongside the BF16 model; that allocation is released before the next group.

The loader read the 24.02 GB checkpoint in 12.65 seconds, including 12.55 seconds of storage reads and 0.02 seconds of FP8 conversion. The final one-token forward produced finite logits.

CPU/process and GPU memory were sampled together on a discrete-memory H100 system. Their sum is useful for estimating total loading pressure, but it is not a direct DGX Spark unified-memory measurement.

## Rebase validation — September 15, 2026

Rebased the three bounded-FP8 commits onto main `087f3d34d791ea68cf0b61c774b7037195958bf8`. The rebased implementation head was `7da03d831181c4f0ec0b5336eea50bf0e7b74835`, with seven implementation/test files. The subsequent GB10 CI configuration commit is described below.

- Preserved main's checkpoint and Mistral fixes. Resolved test import conflicts and updated the bounded loader to use main's current metadata helper.
- **437 focused CPU tests passed, no skips**, on this exact head (Slurm `18662592`). Coverage includes checkpoint loading, adapter capabilities, native-HF weight/gradient/export parity, shared parameters, the integrated-memory reader, Mistral causal/VLM models and FP8 adapters, and the existing GPT-OSS adapter.
- Python 3.12; PyTorch 2.10.0+cu130; Transformers 5.12.1.
- Repository Ruff format/check and `git diff --check` passed. All three commits retain DCO signoffs.
- Fresh single-GB10 scoped CI passed on the subsequent recipe-config head below. The historical multi-GPU performance/parity runs were not repeated after rebase; this PR remains draft.

## GB10 release regression coverage

Current head: `4cc19dbcdc76a862f603b2e94380be713a3dcb46`.

The existing Devstral 24B LoRA recipe now selects one GB10 process in release CI. The release override runs five optimizer steps at global/local batch size 1, saves a checkpoint and validates at step 5, and uses four validation samples. The recipe is not added to nightly CI. The normal training settings remain unchanged.

- Local generation confirms the recipe is selected by release CI and absent from nightly CI. Config resolution and Ruff/whitespace checks passed.
- [Scoped GB10 pipeline 68002362](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/68002362) builds only the ARM AutoModel image from this exact pushed commit and selects only `devstral2_small_2512_squad_peft` on `dlcluster_digits`.
- **Passed:** [GB10 job 440920076](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/440920076), with its artifact confirming the exact commit above, release scope, and one GB10. Runtime: PyTorch 2.14.0a0+4fdf77b940.nv26.08, CUDA 13.4, Transformers 5.15.1.
- The real FP8 checkpoint used the bounded path: six parts, with 4.14 GiB of temporary checkpoint destinations in the largest part. All five optimizer steps completed with finite losses and gradient norms; validation loss was 0.3138 and checkpoint saving completed in approximately seven seconds.
- **Loading performance remains unresolved:** the loader reported 1523.35 s total (25m23s), including 36.10 s for metadata and 1487.07 s in DCP load calls (97.6% of the total). The effective rate over those calls was about 16.5 MiB/s. The GB10 launcher uses an S3-FUSE checkpoint cache, which is a likely contributor, but the DCP timer also includes planning, CPU staging, and device copies. This run has no same-host parent baseline or local-cache comparison, so it does not establish the cause or rule out a loading regression. The reported 0.03 s finish-callback time is not a separately synchronized GPU conversion benchmark.
- Logged CUDA allocation peaks were 46.47–48.96 GiB. They exclude total system RAM and swap, which were not recorded; this result does not establish fit on the separate 60 GB machine.
- The GPU job took 35m21s, including 26m56s in the finetune launcher. Its preceding ARM image build took 48m56s, dominated by dependency compilation (37m16s preparing four source-built packages, with MagiAttention finishing last).
- This smoke covers initial loading, LoRA training, validation, and checkpoint saving. It does not assert reload parity or a peak unified-memory limit.
- Timeout caveat: the GB10 Docker launch path does not consume the recipe's `ci.time`; that value is only passed to sbatch on the other launch path. The 35m21s job therefore did not enforce a 30-minute recipe timeout. Enforcing a bounded Docker runtime is a shared CI launcher follow-up; changing this recipe value alone would not enforce it.

## Original GPU and conversion validation

- Real Devstral 123B TP=8 + LoRA load and forward: Slurm `16296372`
- Real Devstral Small 2 24B full-VLM load and forward on one H100: Slurm `16301550`
- Exact tiny TP=2 check: Slurm `16295582`; every reconstructed parameter matched, including 16 real DTensor shards, and the forward was finite
- Focused checkpoint, Mistral3 adapter, and VLM model unit suites: passed
- BF16 and FP32 destination conversion parity and grouped-load unit coverage: passed
- Ruff format/check and `git diff --check`: passed

Addresses the Devstral FP8 loading-memory case discussed in #2114.


