### PR TITLE
test(ci): report Jensen-Shannon checkpoint parity metrics

### DIFF
--- a/examples/vlm_finetune/mistral4/mistral4_medpix.yaml
+++ b/examples/vlm_finetune/mistral4/mistral4_medpix.yaml
@@ -124,9 +124,10 @@ ci:
   checkpoint_robustness:
     # PP=4 with pp_microbatch_size=1 requires at least four pipeline microbatches.
     step_scheduler.local_batch_size: 4
-    # The original source and AutoModel reload pass standard. Only the PP4/EP8
-    # post-training HF reload has measured long-context BF16 drift.
+    # Independent-process AutoModel and HF reloads show measured long-context
+    # BF16 drift for this PP4/EP8 routed-MoE topology; source parity stays standard.
     parity_tolerance_profile_overrides:
+      automodel_reload: relaxed
       hf_reload: relaxed
     hf_device_map_auto: true
     # Transformers' load-time dequantization leaves Mistral4 expert weights in

--- a/tests/ci_tests/README.md
+++ b/tests/ci_tests/README.md
@@ -151,11 +151,12 @@ harness fails with an actionable error instead of repeating content if a request
 document. Pipeline-parallel runs resize their stage activation buffers to the configured parity length; reduce the
 length only when a model has a documented memory limit.
 
-Every comparison reports mean, p95, and max per-token `KL(reference || candidate)`; whole-tensor cosine similarity;
-and mean/max absolute logit difference. The full record is printed as `CHECKPOINT_PARITY_METRICS <json>` and saved
-under `<checkpoint_dir>/.checkpoint_robustness/parity_metrics/`. Named profiles gate mean KL, p95 KL, and cosine
-similarity. Max KL and absolute logit differences remain diagnostics, allowing a single extreme token to remain
-visible without making the default gate as unstable as max KL.
+Every comparison reports mean, p95, and max per-token `KL(reference || candidate)`; mean, p95, and max per-token
+Jensen-Shannon divergence (natural log, bounded by `ln(2)`); whole-tensor cosine similarity; and mean/max absolute
+logit difference. The full record is printed as `CHECKPOINT_PARITY_METRICS <json>` and saved under
+`<checkpoint_dir>/.checkpoint_robustness/parity_metrics/`. Named profiles gate mean KL, p95 KL, and cosine similarity.
+JSD, max KL, and absolute logit differences remain diagnostics, allowing their usefulness to be evaluated without
+changing pass/fail policy.
 
 Each vanilla-HF reference is forwarded twice through the same loaded model. The resulting `hf_source_self_repeat`
 or `hf_export_self_repeat` record is informational and distinguishes cross-framework drift from an unstable reference.
@@ -214,7 +215,7 @@ parity_threshold_overrides:
 ```
 
 Supported metric names are `mean_kl`, `p95_kl`, and `cosine_similarity`. Numeric overrides are exceptional calibration
-escape hatches, not additional profiles. Max KL remains diagnostic and cannot be overridden.
+escape hatches, not additional profiles. JSD and max KL remain diagnostic and cannot be overridden.
 
 Legacy positive `check_*` controls, generic numeric cosine fields, and max-KL threshold fields are no longer accepted.
 All live recipes use default-on phases, semantic `skip_*` controls, and named profiles. The optional structured

--- a/tests/ci_tests/README.md
+++ b/tests/ci_tests/README.md
@@ -156,7 +156,8 @@ Jensen-Shannon divergence (natural log, bounded by `ln(2)`); whole-tensor cosine
 logit difference. The full record is printed as `CHECKPOINT_PARITY_METRICS <json>` and saved under
 `<checkpoint_dir>/.checkpoint_robustness/parity_metrics/`. Named profiles gate mean KL, p95 KL, and cosine similarity.
 JSD, max KL, and absolute logit differences remain diagnostics, allowing their usefulness to be evaluated without
-changing pass/fail policy.
+changing pass/fail policy. Record schema version 2 adds `mean_jsd`, `p95_jsd`, and `max_jsd` under `metrics`; existing
+version 1 fields retain their meaning.
 
 Each vanilla-HF reference is forwarded twice through the same loaded model. The resulting `hf_source_self_repeat`
 or `hf_export_self_repeat` record is informational and distinguishes cross-framework drift from an unstable reference.

--- a/tests/ci_tests/scripts/config_templates/ci_config.yaml
+++ b/tests/ci_tests/scripts/config_templates/ci_config.yaml
@@ -125,8 +125,8 @@ fixture_keys:
     - hf_reload_timeout_seconds
     - hf_source_post_load_dequantize
     # Full-logit parity defaults to 2048 tokens from the repository's fixed
-    # long-form document. Named profiles gate mean and p95 KL; all metrics are
-    # emitted for calibration.
+    # long-form document. Named profiles gate mean and p95 KL; KL, JSD, cosine,
+    # and absolute-difference metrics are emitted for calibration.
     - parity_sequence_length
     - parity_tolerance_profile
     # Optional source_load, automodel_reload, hf_reload, or cross_tp profile

--- a/tests/ci_tests/scripts/config_templates/ci_config.yaml
+++ b/tests/ci_tests/scripts/config_templates/ci_config.yaml
@@ -125,8 +125,8 @@ fixture_keys:
     - hf_reload_timeout_seconds
     - hf_source_post_load_dequantize
     # Full-logit parity defaults to 2048 tokens from the repository's fixed
-    # long-form document. Named profiles gate mean and p95 KL; KL, JSD, cosine,
-    # and absolute-difference metrics are emitted for calibration.
+    # long-form document. Named profiles gate mean KL, p95 KL, and cosine.
+    # Max KL, JSD, and absolute-difference metrics are report-only.
     - parity_sequence_length
     - parity_tolerance_profile
     # Optional source_load, automodel_reload, hf_reload, or cross_tp profile

--- a/tests/functional_tests/checkpoint_robustness/parity_metrics.py
+++ b/tests/functional_tests/checkpoint_robustness/parity_metrics.py
@@ -37,6 +37,9 @@ class _ParityMetrics:
     mean_kl: float
     p95_kl: float
     max_kl: float
+    mean_jsd: float
+    p95_jsd: float
+    max_jsd: float
     cosine_similarity: float
     mean_absolute_logit_difference: float
     max_absolute_logit_difference: float
@@ -139,6 +142,7 @@ def _compute_parity_metrics(
         raise ValueError("Cannot compare empty logit tensors")
 
     kl_chunks: list[torch.Tensor] = []
+    jsd_chunks: list[torch.Tensor] = []
     absolute_difference_sum = 0.0
     max_absolute_difference = 0.0
     dot_product = 0.0
@@ -160,6 +164,14 @@ def _compute_parity_metrics(
         token_kl = (reference_probs * (reference_log_probs - candidate_log_probs)).sum(dim=-1)
         kl_chunks.append(token_kl.cpu())
 
+        mixture_log_probs = torch.logaddexp(reference_log_probs, candidate_log_probs) - math.log(2.0)
+        candidate_probs = candidate_log_probs.exp()
+        token_jsd = 0.5 * (
+            (reference_probs * (reference_log_probs - mixture_log_probs)).sum(dim=-1)
+            + (candidate_probs * (candidate_log_probs - mixture_log_probs)).sum(dim=-1)
+        )
+        jsd_chunks.append(token_jsd.clamp(min=0.0, max=math.log(2.0)).cpu())
+
         absolute_difference = (reference_chunk - candidate_chunk).abs()
         absolute_difference_sum += absolute_difference.sum(dtype=torch.float64).item()
         max_absolute_difference = max(max_absolute_difference, absolute_difference.max().item())
@@ -170,6 +182,9 @@ def _compute_parity_metrics(
     per_token_kl = torch.cat(kl_chunks)
     if not bool(torch.isfinite(per_token_kl).all()):
         raise ValueError("KL divergence contains non-finite values")
+    per_token_jsd = torch.cat(jsd_chunks)
+    if not bool(torch.isfinite(per_token_jsd).all()):
+        raise ValueError("Jensen-Shannon divergence contains non-finite values")
 
     norm_product = math.sqrt(reference_squared_norm * candidate_squared_norm)
     if norm_product == 0.0:
@@ -183,6 +198,9 @@ def _compute_parity_metrics(
         mean_kl=per_token_kl.mean().item(),
         p95_kl=torch.quantile(per_token_kl, 0.95).item(),
         max_kl=per_token_kl.max().item(),
+        mean_jsd=per_token_jsd.mean().item(),
+        p95_jsd=torch.quantile(per_token_jsd, 0.95).item(),
+        max_jsd=per_token_jsd.max().item(),
         cosine_similarity=cosine_similarity,
         mean_absolute_logit_difference=absolute_difference_sum / reference_logits.numel(),
         max_absolute_logit_difference=max_absolute_difference,

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -528,7 +528,7 @@ def _compare_logits(
     active_failures = _parity_failures(metrics, active_profile_thresholds)
     threshold_mode = "profile_with_numeric_overrides" if uses_threshold_overrides else "profile"
     payload = {
-        "schema_version": 1,
+        "schema_version": 2,
         "parity_document_sha256": _PARITY_DOCUMENT_SHA256,
         "phase": policy.phase,
         "comparison": policy.comparison,

--- a/tests/unit_tests/ci_tests/test_checkpoint_parity_metrics.py
+++ b/tests/unit_tests/ci_tests/test_checkpoint_parity_metrics.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -38,6 +40,9 @@ def test_identical_logits_have_zero_divergence_and_unit_cosine():
     assert metrics.mean_kl == pytest.approx(0.0, abs=1e-8)
     assert metrics.p95_kl == pytest.approx(0.0, abs=1e-8)
     assert metrics.max_kl == pytest.approx(0.0, abs=1e-8)
+    assert metrics.mean_jsd == pytest.approx(0.0, abs=5e-8)
+    assert metrics.p95_jsd == pytest.approx(0.0, abs=5e-8)
+    assert metrics.max_jsd == pytest.approx(0.0, abs=5e-8)
     assert metrics.cosine_similarity == pytest.approx(1.0)
     assert metrics.mean_absolute_logit_difference == 0.0
     assert metrics.max_absolute_logit_difference == 0.0
@@ -49,13 +54,22 @@ def test_full_logit_metrics_match_direct_reference_computation():
     reference_flat = reference.reshape(-1, 3).float()
     candidate_flat = candidate.reshape(-1, 3).float()
     reference_log_probs = F.log_softmax(reference_flat, dim=-1)
-    expected_kl = (reference_log_probs.exp() * (reference_log_probs - F.log_softmax(candidate_flat, dim=-1))).sum(-1)
+    candidate_log_probs = F.log_softmax(candidate_flat, dim=-1)
+    expected_kl = (reference_log_probs.exp() * (reference_log_probs - candidate_log_probs)).sum(-1)
+    mixture_log_probs = torch.logaddexp(reference_log_probs, candidate_log_probs) - math.log(2.0)
+    expected_jsd = 0.5 * (
+        (reference_log_probs.exp() * (reference_log_probs - mixture_log_probs)).sum(-1)
+        + (candidate_log_probs.exp() * (candidate_log_probs - mixture_log_probs)).sum(-1)
+    )
 
     metrics = _compute_parity_metrics(reference, candidate, chunk_tokens=1)
 
     assert metrics.mean_kl == pytest.approx(expected_kl.mean().item(), rel=1e-6, abs=1e-8)
     assert metrics.p95_kl == pytest.approx(torch.quantile(expected_kl, 0.95).item(), rel=1e-6, abs=1e-8)
     assert metrics.max_kl == pytest.approx(expected_kl.max().item(), rel=1e-6, abs=1e-8)
+    assert metrics.mean_jsd == pytest.approx(expected_jsd.mean().item(), rel=1e-6, abs=1e-8)
+    assert metrics.p95_jsd == pytest.approx(torch.quantile(expected_jsd, 0.95).item(), rel=1e-6, abs=1e-8)
+    assert metrics.max_jsd == pytest.approx(expected_jsd.max().item(), rel=1e-6, abs=1e-8)
     assert metrics.cosine_similarity == pytest.approx(
         F.cosine_similarity(reference.flatten(), candidate.flatten(), dim=0).item(), rel=1e-6
     )
@@ -74,6 +88,23 @@ def test_p95_is_stable_against_a_single_token_outlier_while_max_remains_diagnost
     assert metrics.mean_kl > 0.0
     assert metrics.p95_kl == pytest.approx(0.0, abs=1e-8)
     assert metrics.max_kl > 1.0
+    assert metrics.mean_jsd > 0.0
+    assert metrics.p95_jsd == pytest.approx(0.0, abs=1e-8)
+    assert metrics.max_jsd > 0.0
+
+
+def test_jsd_is_symmetric_and_bounded_while_kl_remains_directional():
+    reference = torch.tensor([[[math.log(0.9), math.log(0.1)]]])
+    candidate = torch.tensor([[[math.log(0.5), math.log(0.5)]]])
+
+    forward = _compute_parity_metrics(reference, candidate)
+    reverse = _compute_parity_metrics(candidate, reference)
+
+    assert forward.mean_kl != pytest.approx(reverse.mean_kl)
+    assert forward.mean_jsd == pytest.approx(reverse.mean_jsd, rel=1e-6, abs=1e-8)
+    assert forward.p95_jsd == pytest.approx(reverse.p95_jsd, rel=1e-6, abs=1e-8)
+    assert forward.max_jsd == pytest.approx(reverse.max_jsd, rel=1e-6, abs=1e-8)
+    assert 0.0 <= forward.max_jsd <= math.log(2.0)
 
 
 def test_metric_results_do_not_depend_on_chunk_size():
@@ -219,6 +250,7 @@ def test_structured_threshold_overrides_accept_partial_gates_for_every_compariso
     [
         ({"unknown": {"mean_kl": 0.01}}, "Unknown parity_threshold_overrides comparisons"),
         ({"source_load": {"max_kl": 0.01}}, "Unknown parity_threshold_overrides.source_load metrics"),
+        ({"source_load": {"mean_jsd": 0.01}}, "Unknown parity_threshold_overrides.source_load metrics"),
         ({"hf_reload": {"mean_kl": "0.01"}}, "hf_reload.mean_kl must be numeric"),
         ({"cross_tp": {"cosine_similarity": 2.0}}, "cosine_similarity threshold override"),
     ],

--- a/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
+++ b/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
@@ -1407,7 +1407,7 @@ def test_compare_logits_persists_machine_readable_metrics(tmp_path):
 
     assert failure is None
     payload = json.loads((tmp_path / "parity_metrics/phase_2_automodel_model_reload.json").read_text())
-    assert payload["schema_version"] == 1
+    assert payload["schema_version"] == 2
     assert payload["parity_document_sha256"] == _PARITY_DOCUMENT_SHA256
     assert payload["threshold_mode"] == "profile"
     assert payload["passed"] is True
@@ -1417,6 +1417,9 @@ def test_compare_logits_persists_machine_readable_metrics(tmp_path):
     assert payload["candidate_logits"] == {"dtype": "torch.float32", "shape": [1, 2, 2]}
     assert payload["metrics"]["token_count"] == 2
     assert payload["metrics"]["mean_kl"] == pytest.approx(0.0, abs=1e-8)
+    assert payload["metrics"]["mean_jsd"] == pytest.approx(0.0, abs=5e-8)
+    assert payload["metrics"]["p95_jsd"] == pytest.approx(0.0, abs=5e-8)
+    assert payload["metrics"]["max_jsd"] == pytest.approx(0.0, abs=5e-8)
 
 
 def test_compare_logits_marks_skipped_gate_as_informational(tmp_path):

--- a/tests/unit_tests/ci_tests/test_config_resolver.py
+++ b/tests/unit_tests/ci_tests/test_config_resolver.py
@@ -553,7 +553,10 @@ def test_vlm_checkpoint_robustness_recipes_resolve(tmp_path, recipe_path):
     if "/mistral4/" in recipe_path:
         assert robustness["hf_source_post_load_dequantize"] is True
         assert "parity_tolerance_profile" not in robustness
-        assert robustness["parity_tolerance_profile_overrides"] == {"hf_reload": "relaxed"}
+        assert robustness["parity_tolerance_profile_overrides"] == {
+            "automodel_reload": "relaxed",
+            "hf_reload": "relaxed",
+        }
         for key in (
             "kl_threshold",
             "source_load_kl_threshold",


### PR DESCRIPTION
# What does this PR do ?

Stacked on #3567, report Jensen-Shannon divergence alongside the existing checkpoint-parity metrics so we can compare KL and JSD on real long-context model runs before choosing any JSD gate.

# Changelog

- Report mean, p95, and max JSD for every full-logit checkpoint-parity comparison.
- Keep JSD report-only; existing mean-KL, p95-KL, and cosine gates are unchanged.
- Bump the structured metric record to schema version 2 and document the new fields.
- Use phase-specific relaxed reload profiles for Mistral4's measured PP4/EP8 routed-MoE cross-process variance while retaining standard source-load parity.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Validation

- Focused checkpoint-parity/config unit tests and Ruff checks pass.
- Scoped data was collected on the fixed 2,048-token document. KL is directional: source load reports
  `KL(HF source || AutoModel)`, while export reload reports `KL(trained AutoModel || exported HF)`. JSD is symmetric,
  uses natural logarithms, and is bounded by `ln(2) = 0.6931`.

| Model / topology | Comparison (reference -> candidate) | Policy | KL mean / p95 / max | JSD mean / p95 / max | Cosine | Result |
|---|---|---|---:|---:|---:|---|
| Qwen3 MoE 30B / EP8 | HF source -> AutoModel | standard | 0.00260 / 0.00949 / 0.271 | 0.000653 / 0.00239 / 0.0790 | 0.998172 | pass |
| Qwen3 MoE 30B / EP8 | trained AutoModel -> HF export | standard | 0.00151 / 0.00505 / 0.155 | 0.000377 / 0.00125 / 0.0370 | 0.999202 | pass |
| ERNIE 4.5 21B-A3B / EP8 | HF source -> AutoModel | standard | 0.000957 / 0.00374 / 0.0785 | 0.000239 / 0.000943 / 0.0190 | 0.999666 | pass |
| ERNIE 4.5 21B-A3B / EP8 | trained AutoModel -> HF export | standard | 0.000938 / 0.00334 / 0.112 | 0.000239 / 0.000834 / 0.0356 | 0.999742 | pass |
| GPT-OSS 20B / EP8 | HF source -> AutoModel | standard | 0.00481 / 0.0168 / 0.555 | 0.00118 / 0.00419 / 0.146 | 0.999437 | pass |
| GPT-OSS 20B / EP8 | trained AutoModel -> HF export | standard | 0.00144 / 0.00514 / 0.326 | 0.000345 / 0.00128 / 0.0587 | 0.999853 | pass |
| Qwen3-VL MoE 30B / EP8 | HF source -> AutoModel | standard | 0.00208 / 0.00795 / 0.246 | 0.000519 / 0.00197 / 0.0655 | 0.998698 | pass |
| Qwen3-VL MoE 30B / EP8 | trained AutoModel -> HF export | standard | 0.00151 / 0.00525 / 0.113 | 0.000376 / 0.00129 / 0.0260 | 0.999303 | pass |
| Mistral4 / PP4 x EP8 | HF source -> AutoModel | standard | 0.00299 / 0.0107 / 0.645 | 0.000703 / 0.00269 / 0.0829 | 0.998259 | pass |
| Mistral4 / PP4 x EP8 | trained AutoModel -> HF export | relaxed | 0.0203 / 0.0725 / 1.79 | 0.00483 / 0.0181 / 0.277 | 0.992132 | pass |
| GLM 4.7 Flash / EP8 | HF source -> AutoModel | standard | 0.291 / 0.658 / 30.3 | 0.0262 / 0.127 / 0.693 | 0.974748 | **fail** |
| GLM 4.7 Flash / EP8 | trained AutoModel -> HF export | standard | 0.0568 / 0.0425 / 18.7 | 0.00552 / 0.0103 / 0.693 | 0.998179 | **fail** |
| Gemma4 26B-A4B / EP8 | HF source -> AutoModel | standard, informational | 11.8 / 19.4 / 28.7 | 0.625 / 0.693 / 0.693 | 0.459719 | outside profile; HF-source repeat is also unstable |
| Gemma4 26B-A4B / EP8 | trained AutoModel -> HF export | standard, informational | 0.0702 / 0.292 / 5.34 | 0.0144 / 0.0644 / 0.571 | 0.988101 | outside profile |

## Metric-selection conclusion

The measured rows show a metric-sensitivity difference, not a correctness classifier. Mistral4's accepted relaxed
reload drift has mean/p95 KL `0.0203 / 0.0725`; GLM has `0.0568 / 0.0425`. GLM's mean KL is 2.8x larger even
though its p95 is lower because fewer than 5% of its tokens form an extreme directional-KL tail. JSD compresses that
tail: GLM's mean JSD (`0.00552`) is only 14% above Mistral4 (`0.00483`), while GLM's p95 JSD (`0.0103`) is lower
than Mistral4 (`0.0181`). This demonstrates KL's greater sensitivity to rare, severe probability differences; it does
not by itself establish which result is a correctness bug.

Follow-up GLM diagnosis changes how its failed row should be interpreted:

- All 9,491 tensors shared by the source checkpoint and a zero-step AutoModel HF export are bit-for-bit identical.
- HF and AutoModel are each exactly repeatable at a fixed 2,048-token shape.
- 160 tokens (7.8%) with route differences in at least 21 MoE layers contribute 84% of total source-load KL.
- Tokens with at most five routed-layer differences form a much smaller numerical-drift floor around mean KL `0.018`.
  Replacing only the catastrophic tail with that floor predicts mean KL `0.0486`, close to the trained-export result
  `0.0568`.
- Source correction biases contain many quantized near ties. Training changes that router state, consistent with fewer
  sustained route bifurcations after export.

The GLM output divergence is therefore real and deterministic, but it is not evidence of checkpoint load/export
corruption. Small cross-kernel numerical differences are amplified by near-tied MoE routing over a long sequence.
Independent GLM model-semantics discrepancies still warrant focused fixes, but controlled variants show that those
fixes alone do not remove the long-sequence routed tail.

Neither KL nor JSD can distinguish checkpoint corruption, wrong model math, and sensitive numerical routing without
state, component, and router diagnostics. Directional KL assigns more weight to rare severe probability changes; JSD
is symmetric and bounded, making its scale easier to interpret while saturating the most divergent tokens. Mean and
p95 aggregation determine how much of either distribution becomes gating evidence, while cosine guards overall logit
geometry.

For this PR, JSD therefore remains report-only. The existing mean/p95 KL and cosine gates remain unchanged, and max
JSD is not introduced as a universal gate. A follow-up harness change can retain the fixed 2,048-token forward for
diagnostics while using a shorter blocking cross-framework prefix for route-sensitive models and optionally reporting
top-k boundary margins and sustained router bifurcations.

Repeatability remains useful for separating nondeterminism from deterministic cross-implementation divergence, but it
does not identify the root cause by itself. Gemma4's original HF source is unstable (self-repeat KL
`11.1 / 19.1 / 28.0` and JSD `0.621 / 0.693 / 0.693`), whereas GLM's fixed-shape self-repeats are exact.

Scoped pipelines: [Qwen3 MoE](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/63944522),
[Mistral4](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/63944761),
[LLM cohort](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/63948106), and
[VLM cohort](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/63948136).
The phase-specific Mistral4 profile confirmation is queued in
[NeMo-CI 63966458](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/63966458).

# Additional Information

- Base PR: #3567
- This PR intentionally does not introduce JSD thresholds; the collected distribution data will inform that decision.
