### PR TITLE
perf(checkpoint): avoid full GC scans during MoE export

### DIFF
--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -928,10 +928,12 @@ class MoESplitExpertsStateDictMixin:
                     else:
                         w_up = checkpoint_load_destination(w.transpose(0, 1), w)
                     result.append((f"{prefix}layers.{layer_num}.{expert_segment}.{expert_id}.up_proj.weight", w_up))
+            # These split views were created during this conversion. Check only newly created Python objects before
+            # releasing unused CUDA blocks; scanning every long-lived model object for each layer makes exports slow.
             del splits
             if not inplace_ok and isinstance(tensor, torch.Tensor) and not tensor.is_meta and torch.cuda.is_available():
                 if tensor.is_cuda and not reused_checkpoint_load_views:
-                    gc.collect()
+                    gc.collect(0)
                     torch.cuda.empty_cache()
             return result
 
@@ -974,7 +976,7 @@ class MoESplitExpertsStateDictMixin:
             del splits
             if not inplace_ok and isinstance(tensor, torch.Tensor) and not tensor.is_meta and torch.cuda.is_available():
                 if tensor.is_cuda and not reused_checkpoint_load_views:
-                    gc.collect()
+                    gc.collect(0)
                     torch.cuda.empty_cache()
             return result
 

--- a/tests/unit_tests/moe/test_state_dict_mixin.py
+++ b/tests/unit_tests/moe/test_state_dict_mixin.py
@@ -894,6 +894,45 @@ class TestFromHfWMergedExperts:
 
 
 class TestConvertSingleMergedExpertToHfSplitExperts:
+    def test_allocating_cuda_conversions_use_generation_zero_collection(self):
+        mixin = MockMoEStateDictMixin(n_experts=2, inter_dim=3)
+        mixin.backend.experts = "te"
+        gate_up_tensor = Mock(spec=torch.Tensor, is_meta=False, is_cuda=True)
+        down_tensor = Mock(spec=torch.Tensor, ndim=3, shape=(2, 3, 4), is_meta=False, is_cuda=True)
+        gate_up_splits = [
+            torch.arange(24, dtype=torch.float32).reshape(4, 6) + 24 * expert_id for expert_id in range(2)
+        ]
+        down_splits = [torch.arange(12, dtype=torch.float32).reshape(3, 4) + 12 * expert_id for expert_id in range(2)]
+
+        with (
+            patch.object(mixin, "_split_experts_weights", side_effect=[gate_up_splits, down_splits]),
+            patch("torch.cuda.is_available", return_value=True),
+            patch("nemo_automodel.components.moe.state_dict_mixin.gc.collect") as collect,
+            patch("torch.cuda.empty_cache") as empty_cache,
+        ):
+            mixin._last_expert_ids = [0, 1]
+            gate_up_result = mixin._convert_single_merged_expert_to_hf_split_experts(
+                "model.layers.0.mlp.experts.gate_and_up_projs", gate_up_tensor
+            )
+            down_result = mixin._convert_single_merged_expert_to_hf_split_experts(
+                "model.layers.0.mlp.experts.down_projs", down_tensor
+            )
+
+        assert gate_up_result is not None and down_result is not None
+        assert [gc_call.args for gc_call in collect.call_args_list] == [(0,), (0,)]
+        assert empty_cache.call_count == 2
+        converted = dict(gate_up_result + down_result)
+        for expert_id, (gate_up_split, down_split) in enumerate(zip(gate_up_splits, down_splits)):
+            torch.testing.assert_close(
+                converted[f"model.layers.0.mlp.experts.{expert_id}.gate_proj.weight"], gate_up_split[:, :3].T
+            )
+            torch.testing.assert_close(
+                converted[f"model.layers.0.mlp.experts.{expert_id}.up_proj.weight"], gate_up_split[:, 3:].T
+            )
+            torch.testing.assert_close(
+                converted[f"model.layers.0.mlp.experts.{expert_id}.down_proj.weight"], down_split.T
+            )
+
     @patch("nemo_automodel.components.moe.state_dict_mixin.is_dtensor")
     def test_gate_and_up_projs_conversion(self, mock_is_dtensor):
         mock_is_dtensor.return_value = False


### PR DESCRIPTION
## What this PR changes

Grouped-MoE native-to-Hugging-Face conversion cleans up temporary expert views after both gate/up and down
projections. The allocating CUDA path currently runs a full Python heap scan for every projection. This PR limits
those scans to newly created objects with `gc.collect(0)`, while retaining `torch.cuda.empty_cache()`.

This is intentionally a small follow-up to NVIDIA-NeMo/Automodel#3580. It does not change checkpoint routing,
loading, tensor layouts, or serialization. The affected path is used while preparing TE and other allocating grouped
expert layouts for save/export; allocating quantized conversions can also use the same cleanup sites.

Part of NVIDIA-NeMo/Automodel#3576.

## Performance

### Complete sharded model checkpoint save

A matched local A/B measured a complete synchronous sharded model-weight save with Qwen3-30B-A3B, Transformer
Engine grouped experts, DeepEP, EP8, and 8 H100 80GB GPUs. The timer includes model state collection,
native-to-HF conversion, metadata/planning, the full DCP safetensors write, and the final rank wait. Model loading,
optimizer state, and optional consolidated HF export are excluded. Two alternating pairs ran on the same node
(Slurm job `16310166`).

| Run | #3580 head | This PR | Reduction |
| --- | ---: | ---: | ---: |
| Pair 1, median across ranks | 30.334 s | **8.368 s** | **72.4% / 3.62x** |
| Pair 2, median across ranks | 31.480 s | **8.587 s** | **72.7% / 3.67x** |

Every run wrote 61,069,868,639 bytes in 12 files, including 8 safetensors shards. File counts and total output
size matched between the base and this PR. Peak CUDA allocation was also unchanged at 13.952607 GiB per rank.
The DCP write itself remained about 7.75-8.19 seconds; the end-to-end improvement comes from removing roughly
22 seconds of full-heap GC during conversion.

### Isolated native-to-HF preparation

A matched local A/B used Qwen3-30B-A3B, Transformer Engine grouped experts, DeepEP, EP8, and 8 H100 80GB GPUs.
It timed the real native-to-HF conversion and contiguous-view preparation performed before a checkpoint save. Two
alternating pairs ran on the same node (Slurm job `16308055`).

| Run | #3580 head | This PR | Reduction |
| --- | ---: | ---: | ---: |
| Pair 1, median across ranks | 21.419 s | **0.01643 s** | **~1300x** |
| Pair 2, median across ranks | 21.928 s | **0.01646 s** | **~1330x** |

The old path made 96 full-heap scans per rank and spent 21.38-21.89 seconds in GC. The new path made the same 96
generation-zero scans in about 0.00038 seconds. Peak CUDA allocation was unchanged at 13.858858 GiB per rank.

Both sides produced 2,739 HF keys per rank, including 2,304 expert keys. Rank-local expert fingerprints and CUDA
peaks matched in both A/B pairs.

## Validation

- Added a focused regression test for both gate/up and down conversions. It verifies generation-zero collection,
  CUDA cache cleanup, output keys, values, and ordering.
- MoE conversion class: **6 passed**.
- MoE mixin CPU suite: **52 passed, 4 GPU-only skipped, 1 pre-existing Gloo test deselected** because the local
  sandbox cannot resolve its loopback address.
- Qwen3-30B-A3B TE EP8 complete sharded model-save A/B: job `16310166` completed successfully; every run wrote
  the same number of files and bytes.
- Qwen3-30B-A3B TE EP8 save-preparation A/B: job `16308055` completed successfully.
- Ruff format/check and `git diff --check` pass.

Depends on NVIDIA-NeMo/Automodel#3580.
