### PR TITLE
fix(checkpoint): avoid DCP collectives during initialization

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -1520,9 +1520,15 @@ class Checkpointer:
             state_dict = _load_safetensors(_adapter_path(path))
         else:
             storage_reader = _maybe_msc_reader(path, storage_reader)
-            process_group = getattr(self, "process_group", None)
-            process_group_kwargs = {"process_group": process_group} if process_group is not None else {}
-            dcp.load(state_dict, checkpoint_id=path, storage_reader=storage_reader, **process_group_kwargs)
+            if is_init_step:
+                # Initialization state dicts already contain each rank's local destinations.
+                # Avoid DCP's distributed coordinator here: it is unnecessary for this load
+                # and leaves rank 0 holding extra NCCL allocations for the rest of training.
+                load_kwargs = {"no_dist": True}
+            else:
+                process_group = getattr(self, "process_group", None)
+                load_kwargs = {"process_group": process_group} if process_group is not None else {}
+            dcp.load(state_dict, checkpoint_id=path, storage_reader=storage_reader, **load_kwargs)
         return state_dict
 
     def _do_save(

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -3564,6 +3564,33 @@ class TestDoSavePEFT:
 class TestDoLoadFullSFT:
     """Tests that _do_load correctly routes full-SFT loads for DCP and safetensors formats on cloud and local paths."""
 
+    def test_init_load_is_local_to_each_rank(self):
+        """Initialization avoids DCP coordination even when a process group exists."""
+        ckptr = _make_ckptr(is_peft=False)
+        ckptr.process_group = MagicMock(name="process_group")
+        sd = {"w": torch.zeros(4)}
+
+        with patch("nemo_automodel.components.checkpoint.checkpointing.dcp") as mock_dcp:
+            Checkpointer._do_load(ckptr, sd, LOCAL_PATH_MODEL, is_init_step=True)
+
+        _, kwargs = mock_dcp.load.call_args
+        assert kwargs["no_dist"] is True
+        assert "process_group" not in kwargs
+
+    def test_resume_load_preserves_process_group_coordination(self):
+        """Training resume continues to use the checkpointer's process group."""
+        ckptr = _make_ckptr(is_peft=False)
+        process_group = MagicMock(name="process_group")
+        ckptr.process_group = process_group
+        sd = {"w": torch.zeros(4)}
+
+        with patch("nemo_automodel.components.checkpoint.checkpointing.dcp") as mock_dcp:
+            Checkpointer._do_load(ckptr, sd, LOCAL_PATH_MODEL, is_init_step=False)
+
+        _, kwargs = mock_dcp.load.call_args
+        assert kwargs["process_group"] is process_group
+        assert "no_dist" not in kwargs
+
     def test_dcp_cloud_uses_msc_reader(self):
         """DCP + cloud: MSC reader injected when no reader provided."""
         ckptr = _make_ckptr(is_peft=False)


### PR DESCRIPTION
# What does this PR do ?

Load base-model checkpoints independently on each rank instead of invoking
PyTorch DCP's distributed coordinator during initialization.

Initialization has already materialized each rank's local tensor destinations,
so the coordinator's gather/global-plan/scatter collectives are unnecessary.
With an NCCL process group, those object collectives leave persistent non-PyTorch
GPU allocations and disproportionately charge coordinator rank 0.

Training-checkpoint resume remains distributed and continues to use the
checkpointer's process group.

# Changelog

- Pass `no_dist=True` to DCP only for `is_init_step` base-checkpoint loads.
- Preserve process-group coordination for model and optimizer resume loads.
- Add regression tests covering both branches.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] No documentation update is required; this does not change config or public API.

# Validation

- `ruff format --check` on both changed files: passed.
- `ruff check nemo_automodel/components/checkpoint/checkpointing.py`: passed.
- `pytest -q tests/unit_tests/checkpoint/test_checkpointing.py`: 202 passed, 5 skipped.
One-node, eight-H100 A/B at the first base-checkpoint DCP boundary:

| Path | Rank 0 non-PyTorch GPU memory | Ranks 1-7 | Rank skew |
| --- | ---: | ---: | ---: |
| Distributed DCP coordinator | 4.15 GiB | 1.90 GiB/rank | 2.25 GiB |
| Independent rank-local DCP | 1.47 GiB | 1.47 GiB/rank | 0 GiB |

- At setup completion, the distributed path retained 4.66 GiB on rank 0 and
  2.41 GiB on ranks 1-7. The rank-local path retained 1.98 GiB on every rank.
- The rank-local path completed a 40-step, eight-H100 training run with finite
  loss and gradient norm. Loss decreased from 7.6569 at step 0 to 0.0451 at
  step 39.

The H100 qualification used the same `_do_load` behavior as current `main`;
changes to this file between the qualification base and `a41906d6` are PEP 604
annotation-only changes.

# Additional Information

- Related to #3616 and #3619, but not duplicated by them. Those drafts reduce
  checkpoint tensor/CPU memory and route more initialization loads through DCP;
  their current heads still pass `process_group` to `_do_load` and therefore
  retain the coordinator collectives addressed here.
