### PR TITLE
perf(checkpoint): bound GPT-OSS MXFP4 loading

### DIFF
--- a/nemo_automodel/components/models/gpt_oss/state_dict_adapter.py
+++ b/nemo_automodel/components/models/gpt_oss/state_dict_adapter.py
@@ -16,12 +16,14 @@ import gc
 import math
 import re
 from collections import defaultdict
+from collections.abc import Iterator
+from functools import partial
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 from transformers import GptOssConfig
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint.state_dict_adapter import CheckpointLoadPart, StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe.config import MoEConfig
 
@@ -46,6 +48,34 @@ FP4_VALUES = [
     -4.0,
     -6.0,
 ]
+
+_DECODER_LAYER_KEY = re.compile(r"^model\.layers\.(\d+)\.")
+_MXFP4_EXPERT_SUFFIXES = (
+    "mlp.experts.gate_and_up_projs",
+    "mlp.experts.down_projs",
+)
+
+
+@torch.no_grad()
+def _finish_mxfp4_loads(
+    adapter: "GPTOSSStateDictAdapter",
+    conversions: tuple[tuple[torch.Tensor, torch.Tensor, torch.Tensor], ...],
+) -> None:
+    """Install one decoder layer's packed MXFP4 expert tensors into model storage.
+
+    Args:
+        adapter: GPT-OSS adapter that decodes the checkpoint's MXFP4 representation.
+        conversions: Tuples of ``(target, blocks, scales)``. Each ``target`` is a final BF16 or FP32 model tensor with
+            layout ``[experts, input_features, output_features]``. ``blocks`` is a temporary uint8 checkpoint tensor
+            with layout ``[experts, output_features, input_features / 32, 16]``; each byte holds two FP4 values.
+            ``scales`` is its temporary uint8 exponent tensor with layout
+            ``[experts, output_features, input_features / 32]``. This function mutates each target in place and does
+            not retain the temporary tensors.
+    """
+    for target, blocks, scales in conversions:
+        converted = adapter._convert_moe_packed_tensors(blocks, scales, dtype=target.dtype)
+        target.copy_(converted)
+        del converted
 
 
 class GPTOSSStateDictAdapter(StateDictAdapter):
@@ -87,6 +117,152 @@ class GPTOSSStateDictAdapter(StateDictAdapter):
             if new_key != key:
                 state_dict[new_key] = state_dict.pop(key)
         return state_dict
+
+    def _model_to_hf_key(self, model_key: str) -> str:
+        """Map one native GPT-OSS tensor name to its Hugging Face name."""
+        for pattern, replacement in self.internal_to_hf_map.items():
+            if model_key.endswith(pattern):
+                return model_key[: -len(pattern)] + replacement
+        return model_key
+
+    def iter_checkpoint_load_parts(
+        self,
+        model_state_dict: dict[str, torch.Tensor],
+        device_mesh: Optional["DeviceMesh"] = None,
+    ) -> Iterator[CheckpointLoadPart] | None:
+        """Load a single-GPU GPT-OSS MXFP4 checkpoint one decoder layer at a time.
+
+        Ordinary checkpoint tensors load directly into their final model tensors. Each decoder-layer part allocates
+        only that layer's packed uint8 expert blocks and scales. After DCP fills them, the part decodes one projection
+        at a time into the existing BF16 or FP32 model tensor and releases the packed values before advancing. Backend
+        bookkeeping entries ending in ``_extra_state`` are not checkpoint tensors and keep their initialized values.
+
+        This path intentionally requires a complete, non-distributed decoder. Distributed GPT-OSS loading already
+        uses rank-local DCP tensors, while some distributed expert backends expose state-dict tensors that do not own
+        the final parameter storage.
+
+        Args:
+            model_state_dict: Native names mapped to final model tensors. Expert projection tensors must have layout
+                ``[experts, input_features, output_features]``, use BF16 or FP32, and own ordinary single-device
+                storage. Other tensors retain arbitrary model-defined shapes, dtypes, devices, strides, and storage.
+            device_mesh: Optional distributed mesh. A non-``None`` mesh disables this single-device path.
+
+        Returns:
+            One direct-load part for ordinary tensors followed by one bounded temporary-load part per decoder layer,
+            or ``None`` when the model is distributed, the decoder is partial, or an expert tensor has an unsupported
+            layout or dtype.
+        """
+        if device_mesh is not None:
+            return None
+        if torch.distributed.is_initialized() and torch.distributed.get_world_size() != 1:
+            return None
+
+        num_hidden_layers = getattr(self.config, "num_hidden_layers", None)
+        if not isinstance(num_hidden_layers, int) or num_hidden_layers <= 0:
+            return None
+        present_layer_indices = {
+            int(layer_match.group(1))
+            for model_key in model_state_dict
+            if (layer_match := _DECODER_LAYER_KEY.match(model_key)) is not None
+        }
+        if present_layer_indices != set(range(num_hidden_layers)):
+            return None
+
+        expert_model_keys_by_layer: dict[int, list[str]] = defaultdict(list)
+        for model_key, target in model_state_dict.items():
+            if not model_key.endswith(_MXFP4_EXPERT_SUFFIXES):
+                continue
+            layer_match = _DECODER_LAYER_KEY.match(model_key)
+            if layer_match is None:
+                return None
+            if (
+                not isinstance(target, torch.Tensor)
+                or isinstance(target, torch.distributed.tensor.DTensor)
+                or target.dtype not in (torch.bfloat16, torch.float32)
+                or target.ndim != 3
+                or target.shape[1] % 32 != 0
+            ):
+                return None
+            expert_model_keys_by_layer[int(layer_match.group(1))].append(model_key)
+
+        if set(expert_model_keys_by_layer) != set(range(num_hidden_layers)):
+            return None
+        expected_expert_suffixes = set(_MXFP4_EXPERT_SUFFIXES)
+        for model_keys in expert_model_keys_by_layer.values():
+            found_expert_suffixes = {
+                suffix for model_key in model_keys for suffix in _MXFP4_EXPERT_SUFFIXES if model_key.endswith(suffix)
+            }
+            if found_expert_suffixes != expected_expert_suffixes:
+                return None
+        return self._iter_checkpoint_load_parts(model_state_dict, expert_model_keys_by_layer)
+
+    def _iter_checkpoint_load_parts(
+        self,
+        model_state_dict: dict[str, torch.Tensor],
+        expert_model_keys_by_layer: dict[int, list[str]],
+    ) -> Iterator[CheckpointLoadPart]:
+        """Build lazy direct and per-layer MXFP4 load parts.
+
+        Args:
+            model_state_dict: Native names mapped to final single-device tensors. Expert tensors have layout
+                ``[experts, input_features, output_features]`` and BF16 or FP32 dtype. All direct destinations are
+                mutated in place by DCP.
+            expert_model_keys_by_layer: Complete decoder-layer indices mapped to the two native expert projection
+                names owned by each layer.
+
+        Yields:
+            A direct-load part followed by one part per decoder layer. Each layer part owns uint8 ``blocks`` tensors
+            with layout ``[experts, output_features, input_features / 32, 16]`` and matching ``scales`` tensors with
+            layout ``[experts, output_features, input_features / 32]`` until its finish callback returns.
+        """
+        expert_model_keys = {
+            model_key for layer_model_keys in expert_model_keys_by_layer.values() for model_key in layer_model_keys
+        }
+        direct_model_keys = [model_key for model_key in model_state_dict if model_key not in expert_model_keys]
+        yield CheckpointLoadPart(
+            checkpoint_tensors={
+                self._model_to_hf_key(model_key): model_state_dict[model_key]
+                for model_key in direct_model_keys
+                if not model_key.endswith("_extra_state")
+            },
+            model_keys=frozenset(direct_model_keys),
+            temporary_checkpoint_keys=frozenset(),
+            finish=lambda: None,
+        )
+
+        for layer_idx in range(len(expert_model_keys_by_layer)):
+            model_keys = expert_model_keys_by_layer[layer_idx]
+            checkpoint_tensors: dict[str, torch.Tensor] = {}
+            temporary_checkpoint_keys: set[str] = set()
+            conversions: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = []
+            for model_key in model_keys:
+                target = model_state_dict[model_key]
+                hf_key = self._model_to_hf_key(model_key)
+                n_experts, input_features, output_features = target.shape
+                blocks = torch.empty(
+                    (n_experts, output_features, input_features // 32, 16),
+                    dtype=torch.uint8,
+                    device=target.device,
+                )
+                scales = torch.empty(
+                    (n_experts, output_features, input_features // 32),
+                    dtype=torch.uint8,
+                    device=target.device,
+                )
+                blocks_key = f"{hf_key}_blocks"
+                scales_key = f"{hf_key}_scales"
+                checkpoint_tensors[blocks_key] = blocks
+                checkpoint_tensors[scales_key] = scales
+                temporary_checkpoint_keys.update((blocks_key, scales_key))
+                conversions.append((target, blocks, scales))
+
+            yield CheckpointLoadPart(
+                checkpoint_tensors=checkpoint_tensors,
+                model_keys=frozenset(model_keys),
+                temporary_checkpoint_keys=frozenset(temporary_checkpoint_keys),
+                finish=partial(_finish_mxfp4_loads, self, tuple(conversions)),
+            )
+            del checkpoint_tensors, temporary_checkpoint_keys, conversions, blocks, scales
 
     def _dequantize_block_scale_tensors(self, state_dict: dict[str, Any]) -> dict[str, Any]:
         layer_name_to_quantized_weights = defaultdict(dict)
@@ -248,11 +424,7 @@ class GPTOSSStateDictAdapter(StateDictAdapter):
         quantization = kwargs.get("quantization", False)
         exclude_key_regex = kwargs.get("exclude_key_regex", None)
 
-        hf_fqn = fqn
-        for pattern, replacement in self.internal_to_hf_map.items():
-            if fqn.endswith(pattern):
-                hf_fqn = fqn[: -len(pattern)] + replacement
-                break
+        hf_fqn = self._model_to_hf_key(fqn)
 
         if exclude_key_regex:
             if re.match(exclude_key_regex, hf_fqn):

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -76,6 +76,7 @@ from nemo_automodel.components.checkpoint.utils import (
     materialize_missing_tied_lm_head,
 )
 from nemo_automodel.components.models.gemma4_moe.state_dict_adapter import Gemma4MoEStateDictAdapter
+from nemo_automodel.components.models.gpt_oss.state_dict_adapter import GPTOSSStateDictAdapter
 from nemo_automodel.components.models.llama.state_dict_adapter import LlamaStateDictAdapter
 from nemo_automodel.components.models.mistral3.state_dict_adapter import Mistral3FP8StateDictAdapter
 from nemo_automodel.components.models.qwen2.state_dict_adapter import Qwen2StateDictAdapter
@@ -1955,6 +1956,79 @@ class TestLoadModelCustomModelGuard:
         assert dcp_load.call_count == 2  # shared tensors and one bounded decoder-layer group
         for key, expected in expected_state.items():
             torch.testing.assert_close(model.state_dict()[key], expected)
+
+    def test_gpt_oss_mxfp4_checkpoint_loads_without_full_cpu_state(self, tmp_path):
+        """The one-GPU GPT-OSS path must decode packed experts into persistent model tensors."""
+
+        class LinearWithExtraState(torch.nn.Linear):
+            def get_extra_state(self) -> torch.Tensor:
+                """Return backend bookkeeping that is not present in the HF checkpoint."""
+                return torch.empty(0, dtype=torch.uint8)
+
+        CustomModel = type("CustomModel", (torch.nn.Module,), {})
+        CustomModel.__module__ = "nemo_automodel.components.models.gpt_oss.model"
+        model = CustomModel()
+        model.model = torch.nn.Module()
+        model.model.embed_tokens = torch.nn.Embedding(4, 4, dtype=torch.bfloat16)
+        model.model.layers = torch.nn.ModuleList()
+        layer = torch.nn.Module()
+        layer.self_attn = torch.nn.Module()
+        layer.self_attn.q_proj = LinearWithExtraState(4, 4, bias=False, dtype=torch.bfloat16)
+        layer.mlp = torch.nn.Module()
+        layer.mlp.gate = torch.nn.Linear(4, 2, bias=False, dtype=torch.bfloat16)
+        layer.mlp.experts = torch.nn.Module()
+        layer.mlp.experts.gate_and_up_projs = torch.nn.Parameter(torch.zeros(1, 32, 64, dtype=torch.bfloat16))
+        layer.mlp.experts.down_projs = torch.nn.Parameter(torch.zeros(1, 32, 64, dtype=torch.bfloat16))
+        model.model.layers.append(layer)
+        model.config = SimpleNamespace(
+            tie_word_embeddings=False,
+            num_hidden_layers=1,
+            quantization_config={"quant_method": "mxfp4"},
+        )
+        model.state_dict_adapter = GPTOSSStateDictAdapter(
+            config=model.config,
+            moe_config=SimpleNamespace(),
+            backend=SimpleNamespace(attn="flex"),
+        )
+
+        checkpoint_state = {}
+        for model_key, target in model.state_dict().items():
+            if model_key.endswith("_extra_state"):
+                continue
+            hf_key = model.state_dict_adapter._model_to_hf_key(model_key)
+            if model_key.endswith(("gate_and_up_projs", "down_projs")):
+                n_experts, input_features, output_features = target.shape
+                checkpoint_state[f"{hf_key}_blocks"] = torch.full(
+                    (n_experts, output_features, input_features // 32, 16), 0x12, dtype=torch.uint8
+                )
+                checkpoint_state[f"{hf_key}_scales"] = torch.full(
+                    (n_experts, output_features, input_features // 32), 127, dtype=torch.uint8
+                )
+            else:
+                checkpoint_state[hf_key] = torch.full_like(target, 3)
+
+        model_path = tmp_path / "model"
+        model_path.mkdir()
+        save_file(checkpoint_state, model_path / "model.safetensors")
+        checkpointer = self._make_checkpointer()
+
+        with (
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._load_hf_checkpoint_preserving_dtype"
+            ) as full_cpu_load,
+            patch("nemo_automodel.components.checkpoint.checkpointing.dcp.load", wraps=dcp.load) as dcp_load,
+        ):
+            checkpointer.load_model(model, model_path=str(model_path), is_init_step=True)
+
+        full_cpu_load.assert_not_called()
+        assert dcp_load.call_count == 2  # direct tensors and one MXFP4 decoder-layer group
+        expected_expert = torch.tensor([1.0, 0.5] * 16, dtype=torch.bfloat16).view(1, 32, 1).expand(1, 32, 64)
+        loaded_state = model.state_dict()
+        torch.testing.assert_close(loaded_state["model.layers.0.mlp.experts.gate_and_up_projs"], expected_expert)
+        torch.testing.assert_close(loaded_state["model.layers.0.mlp.experts.down_projs"], expected_expert)
+        torch.testing.assert_close(
+            loaded_state["model.layers.0.mlp.gate.weight"], torch.full((2, 4), 3, dtype=torch.bfloat16)
+        )
 
 
 class TestLoadModelCheckpointKeySubset:

--- a/tests/unit_tests/models/gpt_oss/test_gptoss_state_dict_adapter.py
+++ b/tests/unit_tests/models/gpt_oss/test_gptoss_state_dict_adapter.py
@@ -457,6 +457,113 @@ class TestGPTOSSStateDictAdapter:
         assert "model.layers.0.mlp.router.weight" in out
 
 
+class TestBoundedMXFP4CheckpointLoad:
+    def _make_adapter(self, num_hidden_layers=2):
+        config = Mock(spec=GptOssConfig)
+        config.num_hidden_layers = num_hidden_layers
+        backend = Mock(spec=BackendConfig)
+        backend.attn = "flex"
+        return GPTOSSStateDictAdapter(config=config, moe_config=Mock(spec=MoEConfig), backend=backend)
+
+    def _make_model_state(self, dtype=torch.bfloat16, num_hidden_layers=2):
+        state = {
+            "model.embed_tokens.weight": torch.zeros(4, 4, dtype=dtype),
+            "model.layers.0.self_attn.q_proj._extra_state": torch.empty(0, dtype=torch.uint8),
+        }
+        for layer_idx in range(num_hidden_layers):
+            prefix = f"model.layers.{layer_idx}"
+            state[f"{prefix}.self_attn.q_proj.weight"] = torch.zeros(4, 4, dtype=dtype)
+            state[f"{prefix}.mlp.gate.weight"] = torch.zeros(2, 4, dtype=dtype)
+            state[f"{prefix}.mlp.experts.gate_and_up_projs"] = torch.zeros(1, 32, 64, dtype=dtype)
+            state[f"{prefix}.mlp.experts.down_projs"] = torch.zeros(1, 32, 64, dtype=dtype)
+        return state
+
+    def test_loads_direct_tensors_and_decodes_one_layer_at_a_time(self):
+        adapter = self._make_adapter()
+        model_state = self._make_model_state()
+
+        parts = adapter.iter_checkpoint_load_parts(model_state)
+        assert parts is not None
+
+        direct_part = next(parts)
+        assert direct_part.temporary_checkpoint_keys == frozenset()
+        assert "model.layers.0.mlp.router.weight" in direct_part.checkpoint_tensors
+        assert "model.layers.0.mlp.gate.weight" not in direct_part.checkpoint_tensors
+        assert "model.layers.0.self_attn.q_proj._extra_state" not in direct_part.checkpoint_tensors
+        assert "model.layers.0.self_attn.q_proj._extra_state" in direct_part.model_keys
+        for destination in direct_part.checkpoint_tensors.values():
+            destination.fill_(7)
+        direct_part.finish()
+
+        completed_model_keys = set(direct_part.model_keys)
+        for layer_idx in range(2):
+            layer_part = next(parts)
+            completed_model_keys.update(layer_part.model_keys)
+            assert layer_part.model_keys == frozenset(
+                {
+                    f"model.layers.{layer_idx}.mlp.experts.gate_and_up_projs",
+                    f"model.layers.{layer_idx}.mlp.experts.down_projs",
+                }
+            )
+            assert layer_part.temporary_checkpoint_keys == frozenset(layer_part.checkpoint_tensors)
+            assert len(layer_part.checkpoint_tensors) == 4
+
+            packed_byte = 0x12 if layer_idx == 0 else 0x43
+            scale = 127 if layer_idx == 0 else 128
+            for checkpoint_key, destination in layer_part.checkpoint_tensors.items():
+                destination.fill_(scale if checkpoint_key.endswith("_scales") else packed_byte)
+            layer_part.finish()
+
+        assert next(parts, None) is None
+        assert completed_model_keys == set(model_state)
+        assert torch.count_nonzero(model_state["model.embed_tokens.weight"] != 7) == 0
+        assert torch.count_nonzero(model_state["model.layers.1.mlp.gate.weight"] != 7) == 0
+
+        layer0_expected = torch.tensor([1.0, 0.5] * 16, dtype=torch.bfloat16).view(1, 32, 1).expand(1, 32, 64)
+        layer1_expected = torch.tensor([3.0, 4.0] * 16, dtype=torch.bfloat16).view(1, 32, 1).expand(1, 32, 64)
+        for projection in ("gate_and_up_projs", "down_projs"):
+            torch.testing.assert_close(model_state[f"model.layers.0.mlp.experts.{projection}"], layer0_expected)
+            torch.testing.assert_close(model_state[f"model.layers.1.mlp.experts.{projection}"], layer1_expected)
+
+    def test_supports_fp32_model_weights(self):
+        adapter = self._make_adapter(num_hidden_layers=1)
+        model_state = self._make_model_state(dtype=torch.float32, num_hidden_layers=1)
+
+        parts = adapter.iter_checkpoint_load_parts(model_state)
+        assert parts is not None
+        next(parts)
+        expert_part = next(parts)
+        for checkpoint_key, destination in expert_part.checkpoint_tensors.items():
+            destination.fill_(127 if checkpoint_key.endswith("_scales") else 0x12)
+        expert_part.finish()
+
+        expected = torch.tensor([1.0, 0.5] * 16).view(1, 32, 1).expand(1, 32, 64)
+        torch.testing.assert_close(model_state["model.layers.0.mlp.experts.gate_and_up_projs"], expected)
+        assert model_state["model.layers.0.mlp.experts.gate_and_up_projs"].dtype == torch.float32
+
+    def test_returns_none_for_partial_decoder(self):
+        adapter = self._make_adapter(num_hidden_layers=2)
+        model_state = self._make_model_state(num_hidden_layers=1)
+
+        assert adapter.iter_checkpoint_load_parts(model_state) is None
+
+    def test_returns_none_for_unsupported_expert_dtype(self):
+        adapter = self._make_adapter(num_hidden_layers=1)
+        model_state = self._make_model_state(dtype=torch.float16, num_hidden_layers=1)
+
+        assert adapter.iter_checkpoint_load_parts(model_state) is None
+
+    def test_returns_none_for_distributed_load(self):
+        adapter = self._make_adapter(num_hidden_layers=1)
+        model_state = self._make_model_state(num_hidden_layers=1)
+
+        with (
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_world_size", return_value=2),
+        ):
+            assert adapter.iter_checkpoint_load_parts(model_state) is None
+
+
 class TestConvertMoePackedTensors:
     def _make_adapter(self):
         backend = Mock(spec=BackendConfig)


### PR DESCRIPTION
## What this changes

GPT-OSS MXFP4 checkpoints currently take the full-CPU fallback on one GPU:

1. Read the complete compressed checkpoint into CPU memory.
2. Convert all expert weights to BF16 on CPU.
3. Copy the complete BF16 model into GPU weight memory.

This PR removes that fallback for the maintained GPT-OSS adapter on one GPU:

- Ordinary tensors load directly into their final model weight memory.
- DCP reads one decoder layer's compressed MXFP4 expert tensors at a time.
- That layer is converted on GPU and copied into its final model weights.
- The compressed tensors are released before the next layer is read.
- Backend-only `_extra_state` entries remain initialized because they are not stored in Hugging Face checkpoints.

The result is 25 load parts: one part for ordinary tensors and one part for each of the 24 decoder layers. The largest
compressed temporary allocation is 0.39 GB. Final expert weights may be BF16 or FP32.

This uses the bounded-load interface merged into main in #3619. It does not add another checkpoint framework or
change distributed GPT-OSS loading. Partial decoders, distributed expert tensors, and unsupported model dtypes keep
their existing path.

## Why

`gpt_oss_20b_single_gpu_peft.yaml` is an active one-GPU recipe targeting DGX Spark. Loading a complete BF16 CPU model
before filling the GPU model is especially expensive on a system where CPU and GPU allocations share physical memory.
It is also slow because MXFP4 conversion runs on CPU.

## Validation

Validated on `23af0035138c61a8c9235276edb1203c1d4f3bb9`:

- [PR CI passed](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/35048169740), including CPU and both GPU unit-test shards.
- [GPT-OSS 20B LoRA release test passed on one GB10](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/441701266): 50 training steps, validation, and checkpoint saving. Loading used 25 parts with a largest compressed temporary allocation of 0.39 GiB.
- 313 focused checkpoint/GPT-OSS tests passed, including BF16/FP32 loading and the CUDA-visible, uninitialized-process-group regression. Ruff formatting, lint, and whitespace checks passed.

## Performance evidence

Earlier H100 comparison using a cached local checkpoint (before the rebase, Slurm job `16311724`):

| Metric | Parent | Bounded loading |
|---|---:|---:|
| Model load | 35.21 s | 7.46 s |
| Peak process RSS | 50.14 GiB | 3.49 GiB |
| Simultaneous RSS + CUDA allocation | 89.10 GiB | 45.66 GiB |

The conservative first branch run was 4.7× faster, with matching parameter norms and a finite forward pass. These are historical H100 measurements; the GB10 run above validates the current commit.
