### PR TITLE
fix: EP collective deadlock with variable-length token counts (LoRA flavor)

### DIFF
--- a/nemo_automodel/components/_peft/lora_experts.py
+++ b/nemo_automodel/components/_peft/lora_experts.py
@@ -15,13 +15,16 @@
 import math
 
 import torch
+import torch.distributed as dist
+import torch.distributed.nn.functional as dist_nn_f
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.distributed.tensor import DTensor, Partial, Shard
+from torch.distributed.tensor import DTensor
 
 from nemo_automodel.components.moe.experts import (
     GroupedExperts,
     GroupedExpertsDeepEP,
+    _AllGatherConcatVarlenFn,
     _apply_bias,
     _permute_tokens_for_grouped_mm,
 )
@@ -180,15 +183,33 @@ class GroupedExpertsLoRA(GroupedExperts):
         lora_down_A = _to_grouped_mm_operand(self.lora_down_A, compute_dtype)
         lora_down_B = _to_grouped_mm_operand(self.lora_down_B, compute_dtype)
 
+        local_num_tokens = x.size(0)
         if ep_size > 1:
-            x = DTensor.from_local(x, device_mesh=ep_mesh, placements=[Shard(0)]).full_tensor(
-                grad_placements=[Partial()]
-            )
-            weights = DTensor.from_local(weights.float(), device_mesh=ep_mesh, placements=[Shard(0)]).full_tensor(
-                grad_placements=[Partial()]
-            )
-            indices = DTensor.from_local(indices, device_mesh=ep_mesh, placements=[Shard(0)]).full_tensor()
-            token_mask = DTensor.from_local(token_mask, device_mesh=ep_mesh, placements=[Shard(0)]).full_tensor()
+            # Variable-length EP gather, mirroring GroupedExperts.forward.
+            # DTensor.from_local(..., Shard(0)).full_tensor() assumes identical local shapes on
+            # every EP rank; with ragged (unpacked / unpadded) batches each rank infers a different
+            # global shape and the all_gather never completes. Exchange lengths, pad, gather, narrow.
+            ep_group = ep_mesh.get_group()
+            local_len_t = torch.tensor([local_num_tokens], device=x.device, dtype=torch.int64)
+            gathered_len_t = [torch.zeros_like(local_len_t) for _ in range(ep_size)]
+            dist.all_gather(gathered_len_t, local_len_t, group=ep_group)
+            gathered_lens = [int(t.item()) for t in gathered_len_t]
+            max_len = max(gathered_lens)
+
+            def _gather_var(t: torch.Tensor, *, differentiable: bool) -> torch.Tensor:
+                if differentiable:
+                    return _AllGatherConcatVarlenFn.apply(t, ep_group, gathered_lens, max_len)
+                if max_len > t.size(0):
+                    pad = torch.zeros((max_len - t.size(0),) + tuple(t.shape[1:]), dtype=t.dtype, device=t.device)
+                    t = torch.cat([t, pad], dim=0)
+                gathered = [torch.empty_like(t) for _ in range(ep_size)]
+                dist.all_gather(gathered, t, group=ep_group)
+                return torch.cat([g[:n] for g, n in zip(gathered, gathered_lens)], dim=0)
+
+            x = _gather_var(x, differentiable=True)
+            weights = _gather_var(weights.float(), differentiable=True)
+            indices = _gather_var(indices, differentiable=False)
+            token_mask = _gather_var(token_mask, differentiable=False)
 
         n_local_experts = self.n_routed_experts // ep_size
         experts_start_idx = ep_rank * n_local_experts
@@ -231,8 +252,12 @@ class GroupedExpertsLoRA(GroupedExperts):
             )
 
         if ep_size > 1:
-            y = DTensor.from_local(y, device_mesh=ep_mesh, placements=[Partial()])
-            y = y.redistribute(placements=[Shard(0)]).to_local()
+            # Ragged-aware combine, mirroring GroupedExperts.forward:
+            # redistribute(Shard(0)) would split the gathered output into equal chunks.
+            y.add_(x.sum(dtype=torch.float32) * 0.0)  # keep the differentiable gather attached
+            y = dist_nn_f.all_reduce(y, op=dist.ReduceOp.SUM, group=ep_group)
+            start = sum(gathered_lens[:ep_rank])
+            y = y.narrow(0, start, local_num_tokens).contiguous()
 
         return y.to(input_dtype)
 
@@ -486,7 +511,7 @@ class GroupedExpertsDeepEPLoRA(GroupedExpertsDeepEP):
         token_mask: torch.Tensor,
         weights: torch.Tensor,
         indices: torch.Tensor,
-    ):
+    ) -> torch.Tensor:
         """Forward pass for GroupedExpertsDeepEPLoRA with LoRA injection.
 
         Mirrors GroupedExpertsDeepEP.forward but injects LoRA computations

--- a/tests/functional_tests/moe/test_experts_ep_router_grad.py
+++ b/tests/functional_tests/moe/test_experts_ep_router_grad.py
@@ -12,19 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Scheduled two-rank CPU regression for router gradients through the EP all-gather.
+"""Scheduled two-rank regressions for gradients through the EP all-gather.
 
 ``GroupedExperts.forward`` all-gathers the per-token routing probabilities across
 the expert-parallel group before dispatching tokens to local experts. Routing
 probabilities participate in the main-loss gradient, so the gather must be
 autograd-safe: a plain ``dist.all_gather`` detaches every gathered tensor and
 silently leaves the router trainable only through auxiliary losses.
+
+The NCCL LoRA variant also covers unequal per-rank token counts and checks its
+sharded adapter gradients against a single-process fp32 reference.
 """
 
 from __future__ import annotations
 
 import os
 import socket
+from datetime import timedelta
 
 import pytest
 import torch
@@ -34,6 +38,7 @@ import torch.nn as nn
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import Shard, distribute_tensor
 
+from nemo_automodel.components._peft.lora_experts import GroupedExpertsLoRA
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.experts import GroupedExperts
 
@@ -43,6 +48,13 @@ _DIM = 16
 _MOE_INTER_DIM = 32
 # Uneven per-rank token counts exercise the variable-length gather path.
 _TOKENS_PER_RANK = (3, 2)
+_LORA_DIM = 4
+_LORA_PARAM_NAMES = (
+    "lora_gate_and_up_A",
+    "lora_gate_and_up_B",
+    "lora_down_A",
+    "lora_down_B",
+)
 
 
 def _free_port() -> int:
@@ -95,6 +107,54 @@ def _build_experts(config: MoEConfig) -> GroupedExperts:
     return experts
 
 
+def _build_lora_experts(config: MoEConfig) -> GroupedExpertsLoRA:
+    """Build experts with deterministic, nonzero LoRA weights."""
+    experts = GroupedExpertsLoRA(_build_experts(config), lora_dim=_LORA_DIM, alpha=8)
+    generator = torch.Generator().manual_seed(9876)
+    with torch.no_grad():
+        for name in _LORA_PARAM_NAMES:
+            param = getattr(experts, name)
+            param.copy_(torch.randn(param.shape, generator=generator, dtype=param.dtype) * 0.05)
+    return experts
+
+
+def _lora_inputs() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return deterministic inputs and a nonuniform upstream gradient."""
+    generator = torch.Generator().manual_seed(2468)
+    num_tokens = sum(_TOKENS_PER_RANK)
+    x = torch.randn(num_tokens, _DIM, generator=generator)
+    weights = torch.rand(num_tokens, _TOP_K, generator=generator)
+    weights = weights / weights.sum(dim=-1, keepdim=True)
+    indices = torch.tensor([[0, 1], [2, 3], [0, 2], [1, 3], [3, 0]])
+    token_mask = torch.ones(num_tokens, dtype=torch.bool)
+    output_grad = torch.randn(num_tokens, _DIM, generator=generator)
+    return x, weights, indices, token_mask, output_grad
+
+
+def _lora_reference_forward_backward(
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, dict[str, torch.Tensor]]:
+    """Run the single-process fp32 LoRA forward/backward reference."""
+    experts = _build_lora_experts(_tiny_moe_config()).to(device)
+    x, weights, indices, token_mask, output_grad = _lora_inputs()
+    x, weights, indices, token_mask, output_grad = (
+        tensor.to(device) for tensor in (x, weights, indices, token_mask, output_grad)
+    )
+    weights = weights.clone().requires_grad_(True)
+    y = experts(x, token_mask, weights, indices)
+    y.backward(output_grad)
+
+    assert weights.grad is not None
+    lora_grads = {}
+    for name in _LORA_PARAM_NAMES:
+        grad = getattr(experts, name).grad
+        assert grad is not None
+        assert torch.isfinite(grad).all()
+        assert torch.count_nonzero(grad) > 0
+        lora_grads[name] = grad.detach()
+    return y.detach(), weights.grad.detach(), lora_grads
+
+
 def _reference_forward_backward() -> tuple[torch.Tensor, torch.Tensor]:
     """Single-process (ep_size=1) forward/backward as ground truth."""
     experts = _build_experts(_tiny_moe_config())
@@ -142,8 +202,79 @@ def _ep_router_grad_worker(rank: int, world_size: int, port: int) -> None:
             dist.destroy_process_group()
 
 
+def _lora_ep_ragged_worker(rank: int, world_size: int, port: int) -> None:
+    try:
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = str(port)
+        os.environ["RANK"] = str(rank)
+        os.environ["LOCAL_RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        torch.cuda.set_device(rank)
+        device = torch.device("cuda", rank)
+        dist.init_process_group("nccl", rank=rank, world_size=world_size, timeout=timedelta(seconds=60))
+
+        y_ref, weights_grad_ref, lora_grads_ref = _lora_reference_forward_backward(device)
+
+        ep_mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("ep",))
+        experts = _build_lora_experts(_tiny_moe_config()).to(device)
+        for name, param in list(experts.named_parameters(recurse=False)):
+            dist_param = nn.Parameter(distribute_tensor(param.detach(), ep_mesh, [Shard(0)]))
+            dist_param.requires_grad = param.requires_grad
+            experts.register_parameter(name, dist_param)
+
+        x, weights, indices, token_mask, output_grad = _lora_inputs()
+        x, weights, indices, token_mask, output_grad = (
+            tensor.to(device) for tensor in (x, weights, indices, token_mask, output_grad)
+        )
+        token_start = sum(_TOKENS_PER_RANK[:rank])
+        token_end = token_start + _TOKENS_PER_RANK[rank]
+        local_weights = weights[token_start:token_end].clone().requires_grad_(True)
+
+        y_local = experts(
+            x[token_start:token_end],
+            token_mask[token_start:token_end],
+            local_weights,
+            indices[token_start:token_end],
+        )
+        assert torch.isfinite(y_local).all()
+        torch.testing.assert_close(y_local, y_ref[token_start:token_end], rtol=1e-4, atol=1e-5)
+
+        y_local.backward(output_grad[token_start:token_end])
+
+        assert local_weights.grad is not None
+        assert torch.isfinite(local_weights.grad).all()
+        torch.testing.assert_close(local_weights.grad, weights_grad_ref[token_start:token_end], rtol=1e-4, atol=1e-5)
+
+        n_local_experts = _N_EXPERTS // world_size
+        expert_start = rank * n_local_experts
+        expert_end = expert_start + n_local_experts
+        for name in _LORA_PARAM_NAMES:
+            grad = getattr(experts, name).grad
+            assert grad is not None
+            local_grad = grad.to_local()
+            assert torch.isfinite(local_grad).all()
+            torch.testing.assert_close(
+                local_grad,
+                lora_grads_ref[name][expert_start:expert_end],
+                rtol=1e-4,
+                atol=1e-5,
+            )
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
 @pytest.mark.skipif(not dist.is_available(), reason="torch.distributed is not available")
 def test_ep_all_gather_propagates_router_weight_gradients():
     mp.spawn(
         _ep_router_grad_worker, args=(len(_TOKENS_PER_RANK), _free_port()), nprocs=len(_TOKENS_PER_RANK), join=True
     )
+
+
+@pytest.mark.skipif(
+    not dist.is_nccl_available() or torch.cuda.device_count() < len(_TOKENS_PER_RANK),
+    reason="requires two CUDA devices and NCCL",
+)
+def test_lora_ep_ragged_forward_backward_matches_reference():
+    world_size = len(_TOKENS_PER_RANK)
+    mp.spawn(_lora_ep_ragged_worker, args=(world_size, _free_port()), nprocs=world_size, join=True)


### PR DESCRIPTION
# What does this PR do?

Fixes NCCL communication deadlocks when using Expert Parallelism when training LoRAs.

Port of #1365's fix (8f2b685) to lora_experts.py, and this subclass.

# Changelog

See #1365; this is a port of it.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
  - No, but empirically without this patch, training Kimi K2.5 on a 2 x 8xB200 cluster using a ragged dataset would hang forever with CPUs pinned.
- [x] Did you add or update any necessary documentation?
  - The documentation from #1365 stands.

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to #1365.

See the below block for Claude Fable's analysis.

<details>
**Symptom:** Expert-parallel LoRA training with unpacked, unpadded batches (`packed_sequence_size: 0`, `padding: false`, `local_batch_size: 1`) hangs forever on the first MoE layer of the first forward. Every rank sits in the same `all_gather_into_tensor` (native stack: `ProcessGroupNCCL::allgather_into_tensor_coalesced` issued from `lora_experts.py:184` via `DTensor.full_tensor()`), ~200 W per GPU, no error, no timeout until the NCCL heartbeat. Reproduced on 1×8 and 2×8 nodes, `experts: torch` and `torch_mm`, with and without activation checkpointing / dynamo.

**Root cause:** the LoRA forward gathers tokens across the EP mesh with
```python
x = DTensor.from_local(x, device_mesh=ep_mesh, placements=[Shard(0)]).full_tensor(grad_placements=[Partial()])
```
`from_local(..., Shard(0))` does not exchange sizes — it assumes every rank's local tensor has the same shape and infers the global shape as `local × ep_size`. With ragged per-rank token counts (e.g. 68 / 401 / 1607 tokens across ranks), each rank issues a differently sized all-gather, which NCCL cannot detect; it waits forever. The non-LoRA parent `GroupedExperts.forward` handles this correctly (exchanges lengths, pads, `_AllGatherConcatVarlenFn`, then all-reduce + narrow to combine). The subclass docstring says it "mirrors GroupedExperts.forward" but uses the naive DTensor gather. It only works when batches are packed or padded — which every shipped recipe does, so the bug is invisible in-tree.

**Repro:** any MoE LoRA config with `ep_size > 1`, `packed_sequence_size: 0`, `padding: false`, `local_batch_size: 1`, on a dataset with variable-length samples (we used `HuggingFaceH4/no_robots` with Kimi-K2.5; a 2-layer slice of the checkpoint reproduces it in under 2 minutes on one node). Log a `x.shape[0]` per rank before the gather to see the mismatch.
</details>