### PR TITLE
fix(kimi_k25): map lm_head to model.language_model.lm_head

### DIFF
--- a/nemo_automodel/components/models/kimi_k25_vl/state_dict_adapter.py
+++ b/nemo_automodel/components/models/kimi_k25_vl/state_dict_adapter.py
@@ -381,8 +381,9 @@ class KimiK25VLStateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter)
                 llm_key = key.replace("language_model.model.", "model.")
                 llm_keys[llm_key] = value
             elif key.startswith("language_model.lm_head."):
-                native_key = key.replace("language_model.lm_head.", "lm_head.")
-                native_state_dict[native_key] = value
+                # The VL model's head lives at model.language_model.lm_head.*; a top-level
+                # "lm_head." key matches no parameter and strict=False leaves the head at init.
+                native_state_dict["model." + key] = value
             elif key.startswith("mm_projector."):
                 # Map HF mm_projector keys to our multi_modal_projector structure
                 # mm_projector.proj.0.* -> multi_modal_projector.linear_1.*

--- a/tests/unit_tests/models/kimi_k25_vl/test_state_dict_adapter.py
+++ b/tests/unit_tests/models/kimi_k25_vl/test_state_dict_adapter.py
@@ -303,7 +303,16 @@ class TestKimiK25VLStateDictAdapterFromHF:
 
         result = adapter.from_hf(hf_state_dict)
 
-        assert "lm_head.weight" in result
+        assert "model.language_model.lm_head.weight" in result
+        assert "lm_head.weight" not in result
+
+    def test_lm_head_round_trip(self, adapter):
+        """to_hf(from_hf(x)) returns the HF lm_head key unchanged."""
+        hf_state_dict = {"language_model.lm_head.weight": torch.randn(2, 3)}
+        native = adapter.from_hf(hf_state_dict)
+        back = adapter.to_hf(native)
+        assert "language_model.lm_head.weight" in back
+        assert torch.equal(back["language_model.lm_head.weight"].float(), native["model.language_model.lm_head.weight"].float())
 
     def test_from_hf_dtype_conversion(self, adapter):
         """Test from_hf converts tensors to target dtype."""


### PR DESCRIPTION
# What does this PR do ?

Fixes the Kimi-K2.5 state-dict adapter mapping `language_model.lm_head.*` to a top-level `lm_head.*` key that no parameter has, which left the output head at random init on every load through `NeMoAutoModelForCausalLM` / `KimiK25VLForConditionalGeneration`.

# Changelog

- `kimi_k25_vl/state_dict_adapter.py`: `from_hf` maps `language_model.lm_head.*` to `model.language_model.lm_head.*` (the model's actual FQN), using the same `"model." + key rule the adapter already applies to the other `language_model.*` keys.

Background: loading `moonshotai/Kimi-K2.5` logged `Checkpoint key mismatch ... missing=['model.language_model.lm_head.weight'] unexpected=['lm_head.weight']` and continued, because the base-model load uses `set_model_state_dict(strict=False)`. Training then runs against an uninitialised head with a plausible-looking loss curve. With this fix the warning is gone and step-0 SFT loss on chat data is 2.18 (a random head gives ~ln(163840) ≈ 12).

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
  - updated the test that asserted the buggy key; added a round-trip test
- [x] Did you add or update any necessary documentation?
  - none needed — no user-facing option changes

# Additional Information

- This seems to have been a thing ever since Kimi K2.5 support was introduced in #1132. Cc @HuiyingLi as the author of that PR.