### PR TITLE
feat(dllm): add context parallelism for DiffusionGemma

### DIFF
--- a/examples/dllm_sft/dflash_sft.yaml
+++ b/examples/dllm_sft/dflash_sft.yaml
@@ -65,7 +65,7 @@ distributed:
   sequence_parallel: false
   activation_checkpointing: false
   mp_policy:
-    param_dtype: bfloat16
+    param_dtype: float32
     reduce_dtype: float32
     output_dtype: float32
   autocast_dtype: bfloat16

--- a/examples/dllm_sft/dflash_sft.yaml
+++ b/examples/dllm_sft/dflash_sft.yaml
@@ -49,7 +49,7 @@ model:
   _target_: transformers.AutoModel.from_pretrained
   pretrained_model_name_or_path: z-lab/Qwen3-4B-DFlash-b16
   trust_remote_code: true
-  dtype: bfloat16
+  dtype: float32
 
 checkpoint:
   enabled: true

--- a/examples/dllm_sft/diffusion_gemma_lora.yaml
+++ b/examples/dllm_sft/diffusion_gemma_lora.yaml
@@ -51,7 +51,7 @@ wandb:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: google/diffusiongemma-26B-A4B-it
-  torch_dtype: float32        # fp32 master weights; compute is bf16 via mp_policy
+  torch_dtype: float32        # fp32 master weights; compute is bf16 via autocast
   canvas_length: 256
   self_conditioning: true
   freeze_router: true
@@ -100,8 +100,8 @@ distributed:
   ep_size: 8
   sequence_parallel: false
   activation_checkpointing: true
-  mp_policy:                  # mixed precision: fp32 master + bf16 compute
-    param_dtype: bfloat16
+  mp_policy:                  # mixed precision: fp32 master + bf16 autocast compute
+    param_dtype: float32
     reduce_dtype: float32
     output_dtype: float32
   autocast_dtype: bfloat16

--- a/examples/dllm_sft/diffusion_gemma_sft.yaml
+++ b/examples/dllm_sft/diffusion_gemma_sft.yaml
@@ -54,7 +54,7 @@ wandb:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: google/diffusiongemma-26B-A4B-it
-  torch_dtype: float32        # fp32 master weights; compute is bf16 via mp_policy
+  torch_dtype: float32        # fp32 master weights; compute is bf16 via autocast
   canvas_length: 256
   self_conditioning: true
   freeze_router: true
@@ -86,8 +86,8 @@ distributed:
   ep_size: 8
   sequence_parallel: false
   activation_checkpointing: true
-  mp_policy:                  # mixed precision: fp32 master + bf16 compute
-    param_dtype: bfloat16
+  mp_policy:                  # mixed precision: fp32 master + bf16 autocast compute
+    param_dtype: float32
     reduce_dtype: float32
     output_dtype: float32
   autocast_dtype: bfloat16

--- a/examples/dllm_sft/diffusion_gemma_te_cp_100k.yaml
+++ b/examples/dllm_sft/diffusion_gemma_te_cp_100k.yaml
@@ -49,7 +49,7 @@ distributed:
   sequence_parallel: false
   activation_checkpointing: true
   mp_policy:
-    param_dtype: bfloat16
+    param_dtype: float32
     reduce_dtype: float32
     output_dtype: float32
   autocast_dtype: bfloat16

--- a/examples/dllm_sft/diffusion_gemma_te_cp_100k.yaml
+++ b/examples/dllm_sft/diffusion_gemma_te_cp_100k.yaml
@@ -1,0 +1,115 @@
+# Two-node (16 GPU) DiffusionGemma SFT proof at a genuine 100K-token context.
+#
+# Prepare four streamed FineWeb-Edu passkey samples:
+#   python examples/dllm_sft/prep_diffusion_gemma_long_context.py \
+#     --target-tokens 100000 --num-samples 4
+#
+# Launch on two 8-GPU nodes with torchrun. CP=16 is the entire multi-node world.
+
+recipe: DiffusionGemmaSFTRecipe
+seed: 42
+
+step_scheduler:
+  global_batch_size: 1
+  local_batch_size: 1
+  log_remote_every_steps: 1
+  ckpt_every_steps: 100000
+  val_every_steps: 100000
+  max_steps: 2
+  num_epochs: 1
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: google/diffusiongemma-26B-A4B-it
+  torch_dtype: float32
+  canvas_length: 256
+  self_conditioning: true
+  freeze_router: true
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: te
+    linear: torch
+    rms_norm: torch_fp32
+    experts: torch_mm
+    dispatcher: torch
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 16
+  pp_size: 1
+  ep_size: 1
+  sequence_parallel: false
+  activation_checkpointing: true
+  mp_policy:
+    param_dtype: bfloat16
+    reduce_dtype: float32
+    output_dtype: float32
+  autocast_dtype: bfloat16
+  offload_policy: null
+  moe:
+    reshard_after_forward: false
+
+dllm:
+  mode: block_diffusion
+  block_size: 256
+  vocab_size: 262144
+  eps: 0.001
+  pad_block_size: 256
+  pad_seq_len_divisible: 256
+  encoder_loss_weight: 1.0
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.95, 0.99]
+  eps: 1.0e-8
+  lr: 1.5e-4
+  weight_decay: 1.0e-4
+
+clip_grad_norm:
+  max_norm: 1.0
+
+lr_scheduler:
+  lr_warmup_steps: 1
+  init_lr: 0.0
+  lr_decay_style: cosine
+  min_lr: 1.5e-5
+
+checkpoint:
+  enabled: false
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.chat_dataset.ChatDataset
+  path_or_dataset_id: diffusion_gemma_long_100k.jsonl
+  split: train
+  shuffle_seed: 42
+  seq_length: 100096
+  truncation: true
+  unshifted: true
+  mask_history: true
+  chat_template: examples/dllm_sft/diffusion_gemma_chat_template.jinja
+  tokenizer:
+    pretrained_model_name_or_path: google/diffusiongemma-26B-A4B-it
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: true
+
+wandb:
+  enable: false
+
+ci:
+  recipe_owner: akoumpa
+  nodes: 2
+  time: "02:00:00"

--- a/examples/dllm_sft/llada2_lora.yaml
+++ b/examples/dllm_sft/llada2_lora.yaml
@@ -97,7 +97,7 @@ distributed:
   sequence_parallel: false
   activation_checkpointing: false
   mp_policy:
-    param_dtype: bfloat16
+    param_dtype: float32
     reduce_dtype: float32
     output_dtype: float32
   autocast_dtype: bfloat16

--- a/examples/dllm_sft/llada2_lora.yaml
+++ b/examples/dllm_sft/llada2_lora.yaml
@@ -66,7 +66,7 @@ wandb:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: inclusionAI/LLaDA2.1-mini
-  torch_dtype: bfloat16
+  torch_dtype: float32
   trust_remote_code: true
 
 checkpoint:

--- a/examples/dllm_sft/llada2_sft.yaml
+++ b/examples/dllm_sft/llada2_sft.yaml
@@ -55,7 +55,7 @@ wandb:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: inclusionAI/LLaDA2.1-mini
-  torch_dtype: bfloat16
+  torch_dtype: float32
   trust_remote_code: true
 
 checkpoint:

--- a/examples/dllm_sft/llada2_sft.yaml
+++ b/examples/dllm_sft/llada2_sft.yaml
@@ -72,7 +72,7 @@ distributed:
   sequence_parallel: false
   activation_checkpointing: false
   mp_policy:
-    param_dtype: bfloat16
+    param_dtype: float32
     reduce_dtype: float32
     output_dtype: float32
   autocast_dtype: bfloat16

--- a/examples/dllm_sft/llada_lora.yaml
+++ b/examples/dllm_sft/llada_lora.yaml
@@ -78,7 +78,7 @@ distributed:
   sequence_parallel: false
   activation_checkpointing: false
   mp_policy:
-    param_dtype: bfloat16
+    param_dtype: float32
     reduce_dtype: float32
     output_dtype: float32
   autocast_dtype: bfloat16

--- a/examples/dllm_sft/llada_scdd.yaml
+++ b/examples/dllm_sft/llada_scdd.yaml
@@ -76,7 +76,7 @@ wandb:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: GSAI-ML/LLaDA-8B-Base
-  torch_dtype: float32     # fp32 master weights; compute stays bf16 via mp_policy
+  torch_dtype: float32     # fp32 master weights; compute stays bf16 via autocast
   trust_remote_code: true
 
 checkpoint:
@@ -94,7 +94,7 @@ distributed:
   sequence_parallel: false
   activation_checkpointing: true   # 8B full FT; trade compute for memory
   mp_policy:
-    param_dtype: bfloat16
+    param_dtype: float32
     reduce_dtype: float32
     output_dtype: float32
   autocast_dtype: bfloat16

--- a/examples/dllm_sft/llada_sft.yaml
+++ b/examples/dllm_sft/llada_sft.yaml
@@ -54,7 +54,7 @@ distributed:
   sequence_parallel: false
   activation_checkpointing: false
   mp_policy:
-    param_dtype: bfloat16
+    param_dtype: float32
     reduce_dtype: float32
     output_dtype: float32
   autocast_dtype: bfloat16

--- a/examples/dllm_sft/nemotron_labs_diffusion_lora.yaml
+++ b/examples/dllm_sft/nemotron_labs_diffusion_lora.yaml
@@ -82,7 +82,7 @@ distributed:
   sequence_parallel: false
   activation_checkpointing: true
   mp_policy:
-    param_dtype: bfloat16
+    param_dtype: float32
     reduce_dtype: float32
     output_dtype: float32
   autocast_dtype: bfloat16

--- a/examples/dllm_sft/nemotron_labs_diffusion_sft.yaml
+++ b/examples/dllm_sft/nemotron_labs_diffusion_sft.yaml
@@ -59,7 +59,7 @@ distributed:
   sequence_parallel: false
   activation_checkpointing: true
   mp_policy:
-    param_dtype: bfloat16
+    param_dtype: float32
     reduce_dtype: float32
     output_dtype: float32
   autocast_dtype: bfloat16

--- a/examples/dllm_sft/nemotron_nano30b_dflash.yaml
+++ b/examples/dllm_sft/nemotron_nano30b_dflash.yaml
@@ -72,7 +72,7 @@ distributed:
   sequence_parallel: false
   activation_checkpointing: false
   mp_policy:
-    param_dtype: bfloat16
+    param_dtype: float32
     reduce_dtype: float32
     output_dtype: float32
   autocast_dtype: bfloat16

--- a/examples/dllm_sft/nemotron_nano30b_dflash.yaml
+++ b/examples/dllm_sft/nemotron_nano30b_dflash.yaml
@@ -56,7 +56,7 @@ model:
   _target_: transformers.AutoModel.from_pretrained
   pretrained_model_name_or_path: checkpoints/nemotron-nano-30b-dflash-b16/init
   trust_remote_code: true
-  dtype: bfloat16
+  dtype: float32
 
 checkpoint:
   enabled: true

--- a/examples/dllm_sft/prep_diffusion_gemma_long_context.py
+++ b/examples/dllm_sft/prep_diffusion_gemma_long_context.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Build a tiny, real-text 100K--256K DiffusionGemma SFT dataset.
+
+The source text is streamed from FineWeb-Edu, so only enough documents for the
+requested examples are downloaded. Each example is a single-turn passkey task:
+the long document is context, while the supervised response stays one short
+DiffusionGemma canvas.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from datasets import load_dataset
+from transformers import AutoTokenizer
+
+
+def _render_length(tokenizer, user: str, answer: str) -> int:
+    messages = [{"role": "user", "content": user}, {"role": "assistant", "content": answer}]
+    return len(tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=False))
+
+
+def main() -> None:
+    """Stream FineWeb-Edu and write exact-length passkey chat examples."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="diffusion_gemma_long_100k.jsonl")
+    parser.add_argument("--target-tokens", type=int, default=100_000, choices=(100_000, 131_072, 256_000))
+    parser.add_argument("--num-samples", type=int, default=4)
+    parser.add_argument("--model", default="google/diffusiongemma-26B-A4B-it")
+    args = parser.parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    documents = iter(load_dataset("HuggingFaceFW/fineweb-edu", "sample-10BT", split="train", streaming=True))
+
+    with open(args.output, "w", encoding="utf-8") as output:
+        for sample_idx in range(args.num_samples):
+            passkey = f"DG-LONG-{sample_idx:04d}-7391"
+            prefix = (
+                f"Remember this passkey: {passkey}. Read the document below. "
+                "At the end, return only the passkey.\n\nDOCUMENT START\n"
+            )
+            suffix = "\nDOCUMENT END\nReturn only the passkey."
+            answer = passkey
+
+            corpus_tokens: list[int] = []
+            # Collect with margin for the chat template and instructions.
+            while len(corpus_tokens) < args.target_tokens:
+                text = next(documents)["text"]
+                corpus_tokens.extend(tokenizer.encode(text + "\n\n", add_special_tokens=False))
+
+            lo, hi = 0, min(len(corpus_tokens), args.target_tokens)
+            best_user, best_length = "", 0
+            while lo <= hi:
+                mid = (lo + hi) // 2
+                corpus = tokenizer.decode(corpus_tokens[:mid], skip_special_tokens=True)
+                user = prefix + corpus + suffix
+                length = _render_length(tokenizer, user, answer)
+                if length <= args.target_tokens:
+                    best_user, best_length = user, length
+                    lo = mid + 1
+                else:
+                    hi = mid - 1
+
+            row = {
+                "messages": [
+                    {"role": "user", "content": best_user},
+                    {"role": "assistant", "content": answer},
+                ],
+                "source": "HuggingFaceFW/fineweb-edu/sample-10BT",
+                "rendered_tokens": best_length,
+            }
+            output.write(json.dumps(row, ensure_ascii=False) + "\n")
+            print(f"sample={sample_idx} rendered_tokens={best_length} passkey={passkey}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dllm_sft/qwen3_4b_dflash.yaml
+++ b/examples/dllm_sft/qwen3_4b_dflash.yaml
@@ -50,7 +50,7 @@ model:
   _target_: transformers.AutoModel.from_pretrained
   pretrained_model_name_or_path: z-lab/Qwen3-4B-DFlash-b16
   trust_remote_code: true
-  dtype: bfloat16
+  dtype: float32
 
 checkpoint:
   enabled: true

--- a/examples/dllm_sft/qwen3_4b_dflash.yaml
+++ b/examples/dllm_sft/qwen3_4b_dflash.yaml
@@ -66,7 +66,7 @@ distributed:
   sequence_parallel: false
   activation_checkpointing: false
   mp_policy:
-    param_dtype: bfloat16
+    param_dtype: float32
     reduce_dtype: float32
     output_dtype: float32
   autocast_dtype: bfloat16

--- a/examples/dllm_sft/qwen3_8b_idlm.yaml
+++ b/examples/dllm_sft/qwen3_8b_idlm.yaml
@@ -53,7 +53,7 @@ model:
   _target_: transformers.AutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen3-8B
   trust_remote_code: true
-  dtype: bfloat16
+  dtype: float32
   # I-DLM feeds a custom [x_t | x_0] block-diffusion mask; sdpa honours it.
   # Use flex_attention to avoid materialising the dense 2L x 2L mask at scale.
   attn_implementation: sdpa

--- a/examples/dllm_sft/qwen3_8b_idlm.yaml
+++ b/examples/dllm_sft/qwen3_8b_idlm.yaml
@@ -74,7 +74,7 @@ distributed:
   sequence_parallel: false
   activation_checkpointing: true   # 8B full FT at seq 4096; trade compute for memory
   mp_policy:
-    param_dtype: bfloat16
+    param_dtype: float32
     reduce_dtype: float32
     output_dtype: float32
   autocast_dtype: bfloat16

--- a/nemo_automodel/components/loss/dllm_loss.py
+++ b/nemo_automodel/components/loss/dllm_loss.py
@@ -58,7 +58,7 @@ def encoder_ar_loss(
     encoder_logits: torch.Tensor,
     input_ids: torch.Tensor,
     valid_mask: torch.Tensor | None = None,
-    num_tokens: int | None = None,
+    num_examples: int | None = None,
 ) -> torch.Tensor:
     """Autoregressive next-token CE on the encoder's causal logits.
 
@@ -70,11 +70,12 @@ def encoder_ar_loss(
         encoder_logits: Encoder logits over the clean sequence, ``[B, S, V]``.
         input_ids: Clean token IDs, ``[B, S]``.
         valid_mask: Boolean non-pad mask ``[B, S]``. If ``None``, all positions count.
-        num_tokens: Optional global denominator (summed across grad-acc microbatches);
-            defaults to the local valid next-token count.
+        num_examples: Optional global count of examples with at least one valid
+            next-token target, summed across data replicas and gradient-accumulation
+            microbatches. Defaults to the local nonempty-example count.
 
     Returns:
-        Scalar AR loss (mean CE over valid next-token positions).
+        Scalar contribution to the mean of per-example AR losses.
     """
     logits = encoder_logits[:, :-1, :]
     targets = input_ids[:, 1:]
@@ -83,9 +84,11 @@ def encoder_ar_loss(
         mask = (valid_mask[:, :-1] & valid_mask[:, 1:]).to(nll.dtype)
     else:
         mask = torch.ones_like(nll)
-    loss = (nll * mask).sum()
-    denom = num_tokens if num_tokens is not None else int(mask.sum().item())
-    return loss / max(denom, 1)
+    token_counts = mask.sum(dim=1)
+    per_example = (nll * mask).sum(dim=1) / token_counts.clamp_min(1)
+    nonempty = token_counts > 0
+    denom = num_examples if num_examples is not None else int(nonempty.sum().item())
+    return (per_example * nonempty).sum() / max(denom, 1)
 
 
 class DLLMLossOutput(NamedTuple):

--- a/nemo_automodel/components/loss/linear_ce.py
+++ b/nemo_automodel/components/loss/linear_ce.py
@@ -217,6 +217,9 @@ class FusedLinearCrossEntropy(nn.Module):
         lm_weight: torch.Tensor,
         num_label_tokens: int | None = None,
         grad_reduce_group: dist.ProcessGroup | None = None,
+        *,
+        label_token_counts: torch.Tensor | None = None,
+        num_label_examples: int | None = None,
     ) -> torch.Tensor:
         """Compute fused linear cross entropy matching PyTorch behavior.
 
@@ -230,6 +233,13 @@ class FusedLinearCrossEntropy(nn.Module):
                 to normalize a sum-reduced loss.
             grad_reduce_group: Group that contributes independent loss shards
                 when ``lm_weight`` is a sharded DTensor.
+            label_token_counts: Full-sequence valid-token counts of shape
+                ``[batch]`` for per-example normalization. Under context
+                parallelism these are replicated full counts while
+                ``hidden_states`` and ``labels`` remain sequence-sharded.
+            num_label_examples: Global number of examples with at least one
+                valid target. Required with ``label_token_counts`` and summed
+                across data replicas and gradient-accumulation microbatches.
 
         Returns:
             Scalar loss tensor on the same device as ``hidden_states``. The
@@ -243,23 +253,50 @@ class FusedLinearCrossEntropy(nn.Module):
             grad_reduce_group=grad_reduce_group,
         )
 
-        # First compute loss with sum reduction to handle normalization ourselves
+        if (label_token_counts is None) != (num_label_examples is None):
+            raise ValueError("label_token_counts and num_label_examples must be provided together")
+        if label_token_counts is not None and num_label_tokens is not None:
+            raise ValueError("token and per-example normalization are mutually exclusive")
+        if label_token_counts is not None:
+            if labels.ndim != 2 or hidden_states.ndim != 3:
+                raise ValueError("per-example normalization requires [batch, sequence] labels and hidden states")
+            if label_token_counts.shape != (labels.shape[0],):
+                raise ValueError(
+                    f"label_token_counts must have shape {(labels.shape[0],)}, got {tuple(label_token_counts.shape)}"
+                )
+
+        # Handle global normalization here instead of inside the fused kernel.
         if self.logit_softcapping == 0:
             self.logit_softcapping = None
 
-        # Compute loss with shift=False to match PyTorch behavior
-        # Set filter_eps=None to avoid any token filtering
+        if label_token_counts is not None:
+            if self.reduction != "sum":
+                raise ValueError("per-example normalization requires reduction='sum'")
+            per_token_loss = linear_cross_entropy(
+                hidden_states,
+                lm_weight,
+                targets=labels,
+                ignore_index=self.ignore_index,
+                softcap=self.logit_softcapping,
+                reduction="none",
+                shift=False,
+                filter_eps=None,
+            )
+            inverse_counts = label_token_counts.clamp_min(1).reciprocal().to(per_token_loss.dtype)
+            return (per_token_loss * inverse_counts[:, None]).sum() / max(int(num_label_examples), 1)
+
         loss = linear_cross_entropy(
             hidden_states,
             lm_weight,
             targets=labels,
             ignore_index=self.ignore_index,
             softcap=self.logit_softcapping,
-            reduction=self.reduction,  # Use sum reduction to handle normalization ourselves
-            shift=False,  # Match PyTorch behavior
-            filter_eps=None,  # No token filtering
+            reduction=self.reduction,
+            shift=False,
+            filter_eps=None,
         )
         if num_label_tokens is not None:
-            assert self.reduction == "sum", "num_label_tokens is only supported when reduction is 'sum'"
+            if self.reduction != "sum":
+                raise ValueError("num_label_tokens is only supported when reduction='sum'")
             loss = loss / num_label_tokens
         return loss

--- a/nemo_automodel/components/loss/linear_ce.py
+++ b/nemo_automodel/components/loss/linear_ce.py
@@ -252,6 +252,15 @@ class FusedLinearCrossEntropy(nn.Module):
             lm_weight,
             grad_reduce_group=grad_reduce_group,
         )
+        device_type = hidden_states.device.type
+        if torch.is_autocast_enabled(device_type):
+            compute_dtype = torch.get_autocast_dtype(device_type)
+            if compute_dtype in (torch.bfloat16, torch.float16):
+                # CCE backward requires both operands in a 16-bit compute dtype.
+                # Keep FP32 resident/master parameters and route gradients back
+                # through these differentiable casts.
+                hidden_states = hidden_states.to(compute_dtype)
+                lm_weight = lm_weight.to(compute_dtype)
 
         if (label_token_counts is None) != (num_label_examples is None):
             raise ValueError("label_token_counts and num_label_examples must be provided together")

--- a/nemo_automodel/components/models/diffusion_gemma/cp.py
+++ b/nemo_automodel/components/models/diffusion_gemma/cp.py
@@ -41,9 +41,13 @@ def _pad_positions(position_ids: torch.Tensor, length: int) -> torch.Tensor:
 
 def _pad_decoder_bias(mask: torch.Tensor, query_len: int, key_len: int, encoder_len: int) -> torch.Tensor:
     """Pad a global additive decoder bias while keeping pad query rows finite."""
-    neg = torch.finfo(mask.dtype).min
+    # TE P2P CP evaluates K/V blocks incrementally. A partial block may be fully
+    # masked even though the complete attention row is not; dtype-min biases can
+    # make that partial softmax produce NaNs. -1e4 still underflows masked
+    # probabilities to zero in FP16/BF16 while keeping every partial block finite.
+    neg = -1.0e4
     padded = torch.full((*mask.shape[:-2], query_len, key_len), neg, dtype=mask.dtype, device=mask.device)
-    padded[..., : mask.shape[-2], : mask.shape[-1]] = mask
+    padded[..., : mask.shape[-2], : mask.shape[-1]] = mask.clamp_min(neg)
     rows = torch.arange(query_len, device=mask.device)
     padded[..., rows, encoder_len + rows] = 0
     return padded

--- a/nemo_automodel/components/models/diffusion_gemma/cp.py
+++ b/nemo_automodel/components/models/diffusion_gemma/cp.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Context-parallel input layout for DiffusionGemma's two sequence streams."""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+
+import torch
+
+from nemo_automodel.components.distributed.context_parallel import ContextParallelSharder
+from nemo_automodel.components.distributed.context_parallel.sharder import (
+    ShardLayout,
+    round_robin_local_indices,
+    shard_token_tensor_by_indices,
+)
+
+
+def _ceil_multiple(value: int, divisor: int) -> int:
+    return ((value + divisor - 1) // divisor) * divisor
+
+
+def _pad(tensor: torch.Tensor, dim: int, length: int, value: int | float | bool) -> torch.Tensor:
+    if tensor.shape[dim] >= length:
+        return tensor
+    shape = list(tensor.shape)
+    shape[dim] = length - tensor.shape[dim]
+    tail = torch.full(shape, value, dtype=tensor.dtype, device=tensor.device)
+    return torch.cat((tensor, tail), dim=dim)
+
+
+def _pad_positions(position_ids: torch.Tensor, length: int) -> torch.Tensor:
+    if position_ids.shape[1] >= length:
+        return position_ids
+    count = length - position_ids.shape[1]
+    start = position_ids[:, -1:] + 1
+    offsets = torch.arange(count, device=position_ids.device, dtype=position_ids.dtype)[None]
+    return torch.cat((position_ids, start + offsets), dim=1)
+
+
+def _pad_decoder_bias(mask: torch.Tensor, query_len: int, key_len: int, encoder_len: int) -> torch.Tensor:
+    """Pad a global additive decoder bias while keeping pad query rows finite."""
+    neg = torch.finfo(mask.dtype).min
+    padded = torch.full((*mask.shape[:-2], query_len, key_len), neg, dtype=mask.dtype, device=mask.device)
+    padded[..., : mask.shape[-2], : mask.shape[-1]] = mask
+    rows = torch.arange(query_len, device=mask.device)
+    padded[..., rows, encoder_len + rows] = 0
+    return padded
+
+
+def shard_diffusion_gemma_batch(
+    cp_mesh,
+    tp_mesh,
+    batch: dict[str, Any],
+    *,
+    loss_mask=None,
+    padding_token_id: int = 0,
+):
+    """Shard encoder-KV and decoder-query streams with independent TE layouts.
+
+    The encoder is extended with one dummy slot per padded canvas token. During
+    decoder attention those slots are replaced with the decoder layer's actual
+    K/V. Thus TE sees one ordinary CP-partitioned cross-attention K/V stream
+    ``[encoder ; canvas]`` without replicating the 100K+ encoder cache.
+    """
+    del tp_mesh, loss_mask
+    cp_size = cp_mesh.size() if cp_mesh is not None else 1
+    divisor = 2 * cp_size
+
+    input_ids = batch["input_ids"]
+    canvas_ids = batch["canvas_ids"]
+    encoder_len = input_ids.shape[1]
+    canvas_len = canvas_ids.shape[1]
+    canvas_padded_len = _ceil_multiple(canvas_len, divisor)
+    combined_padded_len = _ceil_multiple(encoder_len + canvas_padded_len, divisor)
+
+    device = input_ids.device
+    encoder_indices = round_robin_local_indices(cp_mesh, combined_padded_len, device=device)
+    canvas_indices = round_robin_local_indices(cp_mesh, canvas_padded_len, device=device)
+
+    # Extended encoder layout: real clean tokens, replaceable canvas slots, tail pad.
+    extended_ids = _pad(input_ids, 1, combined_padded_len, padding_token_id)
+    encoder_positions = batch["encoder_position_ids"]
+    decoder_positions = _pad_positions(batch["decoder_position_ids"], canvas_padded_len)
+    extended_positions = torch.cat((encoder_positions, decoder_positions), dim=1)
+    extended_positions = _pad_positions(extended_positions, combined_padded_len)
+
+    encoder_padding = batch.get("encoder_padding_mask")
+    if encoder_padding is None:
+        encoder_padding = torch.zeros_like(input_ids, dtype=torch.bool)
+    encoder_padding = _pad(encoder_padding, 1, combined_padded_len, True)
+
+    batch["input_ids"] = shard_token_tensor_by_indices(extended_ids, encoder_indices)
+    batch["encoder_position_ids"] = shard_token_tensor_by_indices(extended_positions, encoder_indices)
+    batch["encoder_padding_mask"] = shard_token_tensor_by_indices(encoder_padding, encoder_indices)
+
+    batch["canvas_ids"] = shard_token_tensor_by_indices(
+        _pad(canvas_ids, 1, canvas_padded_len, padding_token_id), canvas_indices
+    )
+    batch["decoder_position_ids"] = shard_token_tensor_by_indices(decoder_positions, canvas_indices)
+    decoder_padding = batch.get("decoder_padding_mask")
+    if decoder_padding is None:
+        decoder_padding = torch.zeros_like(canvas_ids, dtype=torch.bool)
+    batch["decoder_padding_mask"] = shard_token_tensor_by_indices(
+        _pad(decoder_padding, 1, canvas_padded_len, True), canvas_indices
+    )
+
+    labels = batch.get("encoder_labels")
+    if labels is not None:
+        labels = _pad(labels, 1, combined_padded_len, -100)
+        batch["encoder_labels"] = shard_token_tensor_by_indices(labels, encoder_indices)
+
+    masks = batch["decoder_attention_mask"]
+    # TE p2p CP consumes local query rows but the global K/V bias axis; its ring
+    # slices the latter as K/V blocks circulate.
+    batch["decoder_attention_mask"] = {
+        name: _pad_decoder_bias(mask, canvas_padded_len, combined_padded_len, encoder_len).index_select(
+            -2, canvas_indices
+        )
+        for name, mask in masks.items()
+    }
+
+    # Tensor metadata survives filter_forward_kwargs and is safe under compile.
+    batch["cp_encoder_indices"] = encoder_indices
+    batch["cp_canvas_indices"] = canvas_indices
+    batch["cp_encoder_length"] = encoder_len
+    batch["cp_canvas_padded_length"] = canvas_padded_len
+
+    layout = ShardLayout(
+        local_token_global_indices=canvas_indices,
+        original_seq_len=canvas_len,
+        padded_seq_len=canvas_padded_len,
+    )
+    return contextlib.nullcontext, batch, layout
+
+
+def diffusion_gemma_cp_sharder() -> ContextParallelSharder:
+    """Return the model-owned sharder selected by CP dispatch."""
+    return ContextParallelSharder(
+        shard_batch=shard_diffusion_gemma_batch,
+        local_token_global_indices=round_robin_local_indices,
+    )

--- a/nemo_automodel/components/models/diffusion_gemma/layers.py
+++ b/nemo_automodel/components/models/diffusion_gemma/layers.py
@@ -228,6 +228,13 @@ class DiffusionGemmaAttention(nn.Module):
         value_states = self.v_norm(value_states)
 
         use_te = self.attn_module is not None
+        if use_te:
+            # FP32-resident parameters make RoPE's cos/sin FP32 even under BF16
+            # autocast, so the rotary multiply promotes Q/K while V remains BF16.
+            # TE requires one QKV dtype; restore the projected compute dtype at
+            # its boundary without changing the FP32 parameter/master storage.
+            query_states = query_states.to(value_states.dtype)
+            key_states = key_states.to(value_states.dtype)
         if not use_te:
             query_states = query_states.transpose(1, 2)
             key_states = key_states.transpose(1, 2)

--- a/nemo_automodel/components/models/diffusion_gemma/layers.py
+++ b/nemo_automodel/components/models/diffusion_gemma/layers.py
@@ -39,6 +39,7 @@ the pieces the reference implementation cannot provide:
 from __future__ import annotations
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 from transformers.models.diffusion_gemma.configuration_diffusion_gemma import DiffusionGemmaTextConfig
@@ -57,6 +58,7 @@ from transformers.models.diffusion_gemma.modeling_diffusion_gemma import (
     DiffusionGemmaTextRotaryEmbedding as DiffusionGemmaTextRotaryEmbedding,
 )
 
+from nemo_automodel.components.attention.utils import initialize_attn_module_and_func
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.gemma4_moe.model import Gemma4MoE
 from nemo_automodel.components.moe.layers import MoEConfig
@@ -108,7 +110,7 @@ class DiffusionGemmaAttention(nn.Module):
     KV cache during the causal pass.
     """
 
-    def __init__(self, config: DiffusionGemmaTextConfig, layer_idx: int):
+    def __init__(self, config: DiffusionGemmaTextConfig, layer_idx: int, backend: BackendConfig):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
@@ -123,6 +125,7 @@ class DiffusionGemmaAttention(nn.Module):
         self.num_key_value_groups = config.num_attention_heads // num_key_value_heads
         self.scaling = 1.0
         self.attention_dropout = config.attention_dropout
+        self.backend = backend
 
         self.q_proj = nn.Linear(
             config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
@@ -142,6 +145,61 @@ class DiffusionGemmaAttention(nn.Module):
         self.k_norm = DiffusionGemmaRMSNorm(dim=self.head_dim, eps=config.rms_norm_eps)
         self.v_norm = DiffusionGemmaRMSNorm(dim=self.head_dim, eps=config.rms_norm_eps, with_scale=False)
 
+        self.attn_module = None
+        if backend.attn == "te":
+            self.attn_module, _ = initialize_attn_module_and_func(
+                attn_impl="te",
+                num_attention_heads=self.num_attention_heads,
+                num_qk_channels=self.head_dim,
+                num_v_channels=self.head_dim,
+                softmax_scale=self.scaling,
+                attn_mask_type="causal",
+                qkv_format="bshd",
+                num_gqa_groups=self.num_key_value_heads,
+                attention_dropout=self.attention_dropout,
+            )
+
+    def _set_cp_transport(self, comm_type: str) -> None:
+        module = self.attn_module
+        if module is None or getattr(module, "cp_group", None) is None:
+            return
+        if getattr(module, "cp_comm_type", None) == comm_type:
+            return
+        module.set_context_parallel_group(
+            module.cp_group,
+            getattr(module, "cp_global_ranks", None),
+            getattr(module, "cp_stream", None),
+            cp_comm_type=comm_type,
+        )
+
+    def _set_attention_type(self, attention_type: str) -> None:
+        """Switch the shared TE DPA between encoder self- and decoder cross-attention."""
+        module = self.attn_module
+        if module is None or getattr(module, "attention_type", None) == attention_type:
+            return
+        if hasattr(module, "fast_setattr"):
+            module.fast_setattr("attention_type", attention_type)
+        else:
+            module.attention_type = attention_type
+        for backend_name in ("flash_attention", "fused_attention", "unfused_attention"):
+            backend = getattr(module, backend_name, None)
+            if backend is not None:
+                backend.attention_type = attention_type
+
+    def _gather_canvas(self, tensor: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+        """Differentiably gather BSHD canvas K/V and restore global order."""
+        group = getattr(self.attn_module, "cp_group", None)
+        if group is None or not dist.is_initialized() or dist.get_world_size(group) == 1:
+            return tensor
+        from torch.distributed.nn.functional import all_gather
+
+        parts = list(all_gather(tensor.contiguous(), group=group))
+        index_parts = [torch.empty_like(indices) for _ in range(dist.get_world_size(group))]
+        dist.all_gather(index_parts, indices.contiguous(), group=group)
+        gathered = torch.cat(parts, dim=1)
+        order = torch.argsort(torch.cat(index_parts).to(gathered.device))
+        return gathered.index_select(1, order)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -149,6 +207,9 @@ class DiffusionGemmaAttention(nn.Module):
         attention_mask: torch.Tensor | None,
         encoder_kv: tuple[torch.Tensor, torch.Tensor] | None = None,
         padding_mask: torch.Tensor | None = None,
+        cp_encoder_indices: torch.Tensor | None = None,
+        cp_canvas_indices: torch.Tensor | None = None,
+        cp_encoder_length: int | None = None,
     ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
         input_shape = hidden_states.shape[:-1]
         hidden_shape = (*input_shape, -1, self.head_dim)
@@ -157,37 +218,82 @@ class DiffusionGemmaAttention(nn.Module):
         query_states = self.q_proj(hidden_states).view(hidden_shape)
         query_states = self.q_norm(query_states)
         query_states = apply_rotary_pos_emb(query_states, cos, sin, unsqueeze_dim=2)
-        query_states = query_states.transpose(1, 2)
 
         key_states = self.k_proj(hidden_states).view(hidden_shape)
         value_states = self.v_proj(hidden_states).view(hidden_shape) if self.v_proj is not None else key_states
 
         key_states = self.k_norm(key_states)
         key_states = apply_rotary_pos_emb(key_states, cos, sin, unsqueeze_dim=2)
-        key_states = key_states.transpose(1, 2)
 
         value_states = self.v_norm(value_states)
-        value_states = value_states.transpose(1, 2)
+
+        use_te = self.attn_module is not None
+        if not use_te:
+            query_states = query_states.transpose(1, 2)
+            key_states = key_states.transpose(1, 2)
+            value_states = value_states.transpose(1, 2)
 
         # Freshly computed canvas/clean K/V before any cross-attention concat.
         # The causal pass returns these to populate the read-only encoder KV
         # cache; the bidirectional pass prepends them as ``encoder_kv``.
         layer_kv = (key_states, value_states)
 
-        if encoder_kv is not None:
+        if encoder_kv is not None and use_te and cp_encoder_indices is not None:
+            if cp_canvas_indices is None or cp_encoder_length is None:
+                raise ValueError("DiffusionGemma TE CP decode requires canvas indices and encoder length.")
+            # The encoder cache is already partitioned as [encoder ; canvas-pad].
+            # Replace local canvas-pad slots with the actual per-layer canvas K/V.
+            full_key = self._gather_canvas(key_states, cp_canvas_indices)
+            full_value = self._gather_canvas(value_states, cp_canvas_indices)
             enc_key, enc_value = encoder_kv
-            key_states = torch.cat([enc_key, key_states], dim=2)
-            value_states = torch.cat([enc_value, value_states], dim=2)
+            replace = (cp_encoder_indices >= cp_encoder_length) & (
+                cp_encoder_indices < cp_encoder_length + full_key.shape[1]
+            )
+            destinations = replace.nonzero(as_tuple=False).flatten()
+            sources = cp_encoder_indices[replace] - cp_encoder_length
+            key_states = enc_key.index_copy(1, destinations, full_key.index_select(1, sources))
+            value_states = enc_value.index_copy(1, destinations, full_value.index_select(1, sources))
+        elif encoder_kv is not None:
+            enc_key, enc_value = encoder_kv
+            seq_dim = 1 if use_te else 2
+            key_states = torch.cat([enc_key, key_states], dim=seq_dim)
+            value_states = torch.cat([enc_value, value_states], dim=seq_dim)
 
-        attn_output = eager_attention_forward(
-            self,
-            query_states,
-            key_states,
-            value_states,
-            attention_mask,
-            scaling=self.scaling,
-            dropout=self.attention_dropout if self.training else 0.0,
-        )
+        if use_te:
+            if encoder_kv is None:
+                self._set_attention_type("self")
+                self._set_cp_transport("all_gather" if self.is_sliding else "p2p")
+                attn_output = self.attn_module(
+                    query_states,
+                    key_states,
+                    value_states,
+                    qkv_format="bshd",
+                    attn_mask_type="causal",
+                    window_size=(self.sliding_window - 1, 0) if self.is_sliding else (-1, 0),
+                )
+            else:
+                self._set_attention_type("cross")
+                self._set_cp_transport("p2p")
+                attn_output = self.attn_module(
+                    query_states,
+                    key_states,
+                    value_states,
+                    qkv_format="bshd",
+                    attn_mask_type="no_mask",
+                    window_size=(-1, -1),
+                    core_attention_bias_type="post_scale_bias",
+                    core_attention_bias=attention_mask,
+                )
+        else:
+            attn_output = eager_attention_forward(
+                self,
+                query_states,
+                key_states,
+                value_states,
+                attention_mask,
+                scaling=self.scaling,
+                dropout=self.attention_dropout if self.training else 0.0,
+            )
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
         attn_output = self.o_proj(attn_output)
         return attn_output, layer_kv
@@ -255,7 +361,7 @@ class DiffusionGemmaMoEDecoderLayer(nn.Module):
         self.layer_idx = layer_idx
         self.attention_type = config.layer_types[layer_idx]
 
-        self.self_attn = DiffusionGemmaAttention(config=config, layer_idx=layer_idx)
+        self.self_attn = DiffusionGemmaAttention(config=config, layer_idx=layer_idx, backend=backend)
         # ``DiffusionGemmaMLP`` is the reference's ``DiffusionGemmaText4MLP`` (takes layer_idx).
         self.mlp = DiffusionGemmaMLP(config, layer_idx)
 
@@ -280,6 +386,9 @@ class DiffusionGemmaMoEDecoderLayer(nn.Module):
         attention_mask: torch.Tensor | None,
         encoder_kv: tuple[torch.Tensor, torch.Tensor] | None = None,
         padding_mask: torch.Tensor | None = None,
+        cp_encoder_indices: torch.Tensor | None = None,
+        cp_canvas_indices: torch.Tensor | None = None,
+        cp_encoder_length: int | None = None,
     ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
@@ -288,6 +397,9 @@ class DiffusionGemmaMoEDecoderLayer(nn.Module):
             position_embeddings=position_embeddings,
             attention_mask=attention_mask,
             encoder_kv=encoder_kv,
+            cp_encoder_indices=cp_encoder_indices,
+            cp_canvas_indices=cp_canvas_indices,
+            cp_encoder_length=cp_encoder_length,
         )
         hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = residual + hidden_states

--- a/nemo_automodel/components/models/diffusion_gemma/model.py
+++ b/nemo_automodel/components/models/diffusion_gemma/model.py
@@ -78,12 +78,14 @@ class DiffusionGemmaOutput:
 
     ``logits`` are the canvas-only (response) denoising logits ``[B, canvas_len, V]``.
     ``encoder_logits`` are the causal encoder's next-token logits over the clean
-    full sequence ``[B, S, V]`` for the co-trained AR loss — ``None`` outside
-    training (and when the AR loss is unused).
+    full sequence ``[B, S, V]`` on the non-CP compatibility path.
+    ``encoder_hidden_states`` are the local TE-CP encoder shard used by fused
+    linear CE, which avoids materializing the long-sequence vocabulary logits.
     """
 
     logits: "torch.Tensor"
     encoder_logits: "torch.Tensor | None" = None
+    encoder_hidden_states: "torch.Tensor | None" = None
 
 
 def _make_causal_additive_mask(
@@ -182,22 +184,27 @@ class DiffusionGemmaBackbone(nn.Module):
         dtype = inputs_embeds.dtype
         device = inputs_embeds.device
 
-        full_mask = _make_causal_additive_mask(
-            seq_len,
-            padding_mask=padding_mask,
-            sliding_window=None,
-            batch_size=batch_size,
-            device=device,
-            dtype=dtype,
-        )
-        sliding_mask = _make_causal_additive_mask(
-            seq_len,
-            padding_mask=padding_mask,
-            sliding_window=self.config.sliding_window,
-            batch_size=batch_size,
-            device=device,
-            dtype=dtype,
-        )
+        # TE encodes causality/windowing in the kernel. Never materialize an
+        # O(S^2) mask for the 100K--256K encoder stream.
+        if self.backend.attn == "te":
+            full_mask = sliding_mask = None
+        else:
+            full_mask = _make_causal_additive_mask(
+                seq_len,
+                padding_mask=padding_mask,
+                sliding_window=None,
+                batch_size=batch_size,
+                device=device,
+                dtype=dtype,
+            )
+            sliding_mask = _make_causal_additive_mask(
+                seq_len,
+                padding_mask=padding_mask,
+                sliding_window=self.config.sliding_window,
+                batch_size=batch_size,
+                device=device,
+                dtype=dtype,
+            )
         masks = {"full_attention": full_mask, "sliding_attention": sliding_mask}
         position_embeddings = self._position_embeddings(inputs_embeds, position_ids)
 
@@ -226,6 +233,9 @@ class DiffusionGemmaBackbone(nn.Module):
         decoder_padding_mask: torch.Tensor | None = None,
         self_conditioning_logits: torch.Tensor | None = None,
         self_conditioning_mask: torch.Tensor | None = None,
+        cp_encoder_indices: torch.Tensor | None = None,
+        cp_canvas_indices: torch.Tensor | None = None,
+        cp_encoder_length: int | None = None,
     ) -> torch.Tensor:
         """Bidirectional pass over the noised canvas with cross-attention to the
         encoder KV cache. Returns the final (normed) hidden states.
@@ -257,6 +267,9 @@ class DiffusionGemmaBackbone(nn.Module):
                 attention_mask=decoder_masks[layer.attention_type],
                 encoder_kv=encoder_kv[i],
                 padding_mask=decoder_padding_mask,
+                cp_encoder_indices=cp_encoder_indices,
+                cp_canvas_indices=cp_canvas_indices,
+                cp_encoder_length=cp_encoder_length,
             )
         return self.norm(hidden_states)
 
@@ -275,6 +288,9 @@ class DiffusionGemmaBackbone(nn.Module):
         decoder_padding_mask: torch.Tensor | None = None,
         self_conditioning_logits: torch.Tensor | None = None,
         self_conditioning_mask: torch.Tensor | None = None,
+        cp_encoder_indices: torch.Tensor | None = None,
+        cp_canvas_indices: torch.Tensor | None = None,
+        cp_encoder_length: int | None = None,
     ) -> list[tuple[torch.Tensor, torch.Tensor]] | torch.Tensor:
         """Dispatch encode/decode through ``nn.Module.__call__`` for FSDP hooks.
 
@@ -311,6 +327,9 @@ class DiffusionGemmaBackbone(nn.Module):
                 decoder_padding_mask=decoder_padding_mask,
                 self_conditioning_logits=self_conditioning_logits,
                 self_conditioning_mask=self_conditioning_mask,
+                cp_encoder_indices=cp_encoder_indices,
+                cp_canvas_indices=cp_canvas_indices,
+                cp_encoder_length=cp_encoder_length,
             )
         raise ValueError(f"Unsupported DiffusionGemmaBackbone.forward mode: {mode!r}")
 
@@ -348,13 +367,14 @@ class DiffusionGemmaForBlockDiffusion(HFCheckpointingMixin, MoEFSDPSyncMixin, Pr
     def get_capabilities(cls, config: "DiffusionGemmaConfig") -> "ModelCapabilities":
         """Parallelism support for the DiffusionGemma block-diffusion MoE.
 
-        Single variant: FSDP2 + Expert Parallelism are supported (validated at
-        EP=8). TP is unsupported for the custom MoE; CP/PP are not supported for
-        this encoder-decoder block-diffusion path.
+        FSDP2 + Expert Parallelism are supported (validated at EP=8). TP is
+        unsupported for the custom MoE. CP uses Transformer Engine's native
+        transport with independent encoder/canvas sequence layouts; PP remains
+        unsupported.
         """
         return ModelCapabilities(
             supports_tp=False,
-            supports_cp=False,
+            supports_cp=True,
             supports_pp=False,
             supports_ep=True,
         )
@@ -469,6 +489,15 @@ class DiffusionGemmaForBlockDiffusion(HFCheckpointingMixin, MoEFSDPSyncMixin, Pr
                 elif isinstance(param, torch.Tensor):
                     param.requires_grad_(False)
 
+    def prepare_model_inputs_for_cp(self, batch: dict[str, Any], *, num_chunks: int = 1) -> dict[str, Any]:
+        """Select the mixed encoder/canvas Transformer Engine CP layout."""
+        del num_chunks
+        if self.backend.attn != "te":
+            raise ValueError("DiffusionGemma context parallelism requires backend.attn='te'.")
+        from .cp import diffusion_gemma_cp_sharder
+
+        return {"cp_sharder": diffusion_gemma_cp_sharder()}
+
     @torch.no_grad()
     def initialize_weights(
         self,
@@ -518,6 +547,10 @@ class DiffusionGemmaForBlockDiffusion(HFCheckpointingMixin, MoEFSDPSyncMixin, Pr
         decoder_attention_mask: dict | None = None,
         decoder_padding_mask: torch.Tensor | None = None,
         do_self_conditioning: torch.Tensor | bool | None = None,
+        cp_encoder_indices: torch.Tensor | None = None,
+        cp_canvas_indices: torch.Tensor | None = None,
+        cp_encoder_length: int | None = None,
+        cp_canvas_padded_length: int | None = None,
         **kwargs: Any,
     ) -> "DiffusionGemmaOutput":
         """Training forward — single shared stack run twice + two-pass self-cond.
@@ -557,9 +590,11 @@ class DiffusionGemmaForBlockDiffusion(HFCheckpointingMixin, MoEFSDPSyncMixin, Pr
 
         Returns:
             ``DiffusionGemmaOutput`` with canvas-only ``logits``
-            (``[B, canvas_len, V]``, softcapped) and, during training,
-            ``encoder_logits`` (``[B, S, V]``) for the co-trained AR loss.
+            (``[B, canvas_len, V]``, softcapped) and, during training, either
+            ``encoder_logits`` (non-CP) or local ``encoder_hidden_states``
+            (TE CP) for the co-trained AR loss.
         """
+        del cp_canvas_padded_length
         if input_ids is None:
             raise ValueError("DiffusionGemmaForBlockDiffusion training forward requires input_ids (clean sequence).")
         if canvas_ids is None:
@@ -591,6 +626,7 @@ class DiffusionGemmaForBlockDiffusion(HFCheckpointingMixin, MoEFSDPSyncMixin, Pr
         #    full-sequence lm_head over the large vocab is memory-heavy, so it is
         #    skipped outside training.
         encoder_logits = None
+        encoder_hidden_states = None
         if self.training:
             encoder_kv, encoder_hidden = self.model(
                 mode="encode",
@@ -599,7 +635,12 @@ class DiffusionGemmaForBlockDiffusion(HFCheckpointingMixin, MoEFSDPSyncMixin, Pr
                 padding_mask=encoder_padding_mask,
                 return_hidden=True,
             )
-            encoder_logits = self._softcap_logits(encoder_hidden)
+            if cp_encoder_indices is None:
+                encoder_logits = self._softcap_logits(encoder_hidden)
+            else:
+                # The recipe consumes this local hidden shard with fused linear
+                # CE, avoiding a [100K, vocab] logits allocation.
+                encoder_hidden_states = encoder_hidden
         else:
             encoder_kv = self.model(
                 mode="encode",
@@ -640,6 +681,9 @@ class DiffusionGemmaForBlockDiffusion(HFCheckpointingMixin, MoEFSDPSyncMixin, Pr
                     decoder_masks=decoder_attention_mask,
                     decoder_padding_mask=decoder_padding_mask,
                     self_conditioning_logits=None,
+                    cp_encoder_indices=cp_encoder_indices,
+                    cp_canvas_indices=cp_canvas_indices,
+                    cp_encoder_length=cp_encoder_length,
                 )
                 sc_logits = self._softcap_logits(pass1_hidden).detach()
 
@@ -652,10 +696,17 @@ class DiffusionGemmaForBlockDiffusion(HFCheckpointingMixin, MoEFSDPSyncMixin, Pr
             decoder_padding_mask=decoder_padding_mask,
             self_conditioning_logits=sc_logits,
             self_conditioning_mask=sc_mask,
+            cp_encoder_indices=cp_encoder_indices,
+            cp_canvas_indices=cp_canvas_indices,
+            cp_encoder_length=cp_encoder_length,
         )
         logits = self._softcap_logits(hidden_states)
 
-        return DiffusionGemmaOutput(logits=logits, encoder_logits=encoder_logits)
+        return DiffusionGemmaOutput(
+            logits=logits,
+            encoder_logits=encoder_logits,
+            encoder_hidden_states=encoder_hidden_states,
+        )
 
 
 ModelClass = DiffusionGemmaForBlockDiffusion

--- a/nemo_automodel/recipes/dllm/train_ft.py
+++ b/nemo_automodel/recipes/dllm/train_ft.py
@@ -50,6 +50,7 @@ from nemo_automodel.components.distributed.utils import get_sync_ctx
 from nemo_automodel.components.loggers.metric_logger import MetricsSample
 from nemo_automodel.components.loggers.mlflow_utils import to_float_metrics
 from nemo_automodel.components.loss.dllm_loss import encoder_ar_loss
+from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.components.models.diffusion_gemma.attention_mask import build_block_diffusion_training_mask
 from nemo_automodel.components.training.rng import ScopedRNG
 from nemo_automodel.components.training.utils import (
@@ -859,6 +860,11 @@ class DiffusionGemmaSFTRecipe(DiffusionLMSFTRecipe):
         tok = getattr(self, "tokenizer", None)
         pad_id = getattr(tok, "pad_token_id", None) if tok is not None else None
         self._pad_token_id = int(pad_id) if pad_id is not None else 0
+        self._fused_encoder_loss = FusedLinearCrossEntropy(
+            ignore_index=-100,
+            logit_softcapping=getattr(model, "final_logit_softcapping", 0) or 0,
+            reduction="sum",
+        )
 
         # Freeze the router on the live model (the config flag also freezes it in
         # __init__, but freezing here is idempotent and covers from_config paths).
@@ -907,6 +913,9 @@ class DiffusionGemmaSFTRecipe(DiffusionLMSFTRecipe):
             # the AR denominator counts the same positions the AR loss scores.
             ar = attn.to(dtype=torch.bool) if attn is not None else loss_mask.bool()
             num_ar += int((ar[:, :-1] & ar[:, 1:]).sum().item())
+        # CP ranks hold disjoint token shards of the same examples, so the
+        # denominator is reduced over data replicas only (not multiplied by
+        # CP). Backward's include_cp scaling combines those local numerators.
         num_diffusion = self._dp_allreduce(torch.tensor(num_diffusion, dtype=torch.long)).item()
         num_ar = self._dp_allreduce(torch.tensor(num_ar, dtype=torch.long)).item()
         # Guard a degenerate all-pad step against divide-by-zero in the loss.
@@ -1167,9 +1176,22 @@ class DiffusionGemmaSFTRecipe(DiffusionLMSFTRecipe):
         loss_mask = window["loss_mask"]
         p_mask = window["p_mask"]
 
+        # Align the next-token AR targets before CP changes the encoder layout.
+        # The model-owned sharder extends these with ignored dummy canvas slots.
+        encoder_labels = torch.full_like(clean_input_ids, -100)
+        ar_pairs = ar_full_loss_mask[:, :-1] & ar_full_loss_mask[:, 1:]
+        encoder_labels[:, :-1] = torch.where(ar_pairs, clean_input_ids[:, 1:], -100)
+        batch["encoder_labels"] = encoder_labels
+
         model = self.model_parts[0]
-        cp_sharder = ContextParallelSharder(None, self.device_mesh, batch)
+        cp_sharder = ContextParallelSharder(model, self.device_mesh, batch)
         train_ctx, batch = cp_sharder.shard(batch)
+        encoder_labels = batch.pop("encoder_labels")
+        if "cp_canvas_indices" in batch:
+            target_ids = cp_sharder.shard_token_tensor(target_ids, fill=self._pad_token_id)
+            noise_mask = cp_sharder.shard_token_tensor(noise_mask, fill=False)
+            loss_mask = cp_sharder.shard_token_tensor(loss_mask, fill=False)
+            p_mask = cp_sharder.shard_token_tensor(p_mask, fill=1.0)
         fp8_ctx = self.te_fp8.maybe_te_autocast() if self.te_fp8 is not None else nullcontext()
         sync_ctx = (
             get_sync_ctx(
@@ -1190,6 +1212,7 @@ class DiffusionGemmaSFTRecipe(DiffusionLMSFTRecipe):
             out = model(**batch)
             logits = getattr(out, "logits", out)
             encoder_logits = getattr(out, "encoder_logits", None)
+            encoder_hidden_states = getattr(out, "encoder_hidden_states", None)
             del out
 
             loss_result = self.dllm_loss_fn(
@@ -1225,6 +1248,15 @@ class DiffusionGemmaSFTRecipe(DiffusionLMSFTRecipe):
                     clean_input_ids,
                     valid_mask=ar_full_loss_mask,
                     num_tokens=num_ar_tokens,
+                )
+                microbatch_loss = microbatch_loss + self._encoder_loss_weight * ar_loss
+            elif is_train and encoder_hidden_states is not None and self._encoder_loss_weight > 0.0:
+                ar_loss = self._fused_encoder_loss(
+                    encoder_hidden_states,
+                    encoder_labels,
+                    model.lm_head.weight,
+                    num_label_tokens=num_ar_tokens,
+                    grad_reduce_group=self._get_dp_group(include_cp=True),
                 )
                 microbatch_loss = microbatch_loss + self._encoder_loss_weight * ar_loss
 

--- a/nemo_automodel/recipes/dllm/train_ft.py
+++ b/nemo_automodel/recipes/dllm/train_ft.py
@@ -886,6 +886,7 @@ class DiffusionGemmaSFTRecipe(DiffusionLMSFTRecipe):
         device = self.dist_env.device
         num_diffusion = 0
         num_ar = 0
+        num_ar_examples = 0
         for microbatch_idx, batch in enumerate(batches):
             clean = batch["_clean_input_ids"].to(device)
             noisy = batch["_noisy_input_ids"].to(device)
@@ -912,12 +913,17 @@ class DiffusionGemmaSFTRecipe(DiffusionLMSFTRecipe):
             # that full_valid (prompt+response+EOS, excluding only global pad), so
             # the AR denominator counts the same positions the AR loss scores.
             ar = attn.to(dtype=torch.bool) if attn is not None else loss_mask.bool()
-            num_ar += int((ar[:, :-1] & ar[:, 1:]).sum().item())
+            ar_token_counts = (ar[:, :-1] & ar[:, 1:]).sum(dim=1)
+            num_ar += int(ar_token_counts.sum().item())
+            num_ar_examples += int((ar_token_counts > 0).sum().item())
         # CP ranks hold disjoint token shards of the same examples, so the
         # denominator is reduced over data replicas only (not multiplied by
         # CP). Backward's include_cp scaling combines those local numerators.
         num_diffusion = self._dp_allreduce(torch.tensor(num_diffusion, dtype=torch.long)).item()
         num_ar = self._dp_allreduce(torch.tensor(num_ar, dtype=torch.long)).item()
+        num_ar_examples = self._dp_allreduce(torch.tensor(num_ar_examples, dtype=torch.long)).item()
+        for batch in batches:
+            batch["_num_ar_examples"] = max(num_ar_examples, 1)
         # Guard a degenerate all-pad step against divide-by-zero in the loss.
         return max(num_diffusion, 1), max(num_ar, 1)
 
@@ -1115,6 +1121,7 @@ class DiffusionGemmaSFTRecipe(DiffusionLMSFTRecipe):
         # one-canvas selection). Pop before the to-device sweep, which can't handle
         # the nested decoder-mask dict.
         cached_window = batch.pop("_window", None)
+        num_ar_examples = batch.pop("_num_ar_examples", None)
         batch = {
             k: (
                 {dk: dv.to(self.dist_env.device, non_blocking=True) for dk, dv in v.items() if dv is not None}
@@ -1180,6 +1187,7 @@ class DiffusionGemmaSFTRecipe(DiffusionLMSFTRecipe):
         # The model-owned sharder extends these with ignored dummy canvas slots.
         encoder_labels = torch.full_like(clean_input_ids, -100)
         ar_pairs = ar_full_loss_mask[:, :-1] & ar_full_loss_mask[:, 1:]
+        ar_token_counts = ar_pairs.sum(dim=1)
         encoder_labels[:, :-1] = torch.where(ar_pairs, clean_input_ids[:, 1:], -100)
         batch["encoder_labels"] = encoder_labels
 
@@ -1229,33 +1237,30 @@ class DiffusionGemmaSFTRecipe(DiffusionLMSFTRecipe):
             microbatch_loss = loss_result.total_loss
             dllm_loss = loss_result.dllm_loss.detach().clone()
 
-            # Co-trained autoregressive encoder loss: next-token CE over the clean
-            # sequence, added at encoder_loss_weight, only when training (encoder_logits
-            # is produced by the forward only then). The SCOPE matches Google (full_valid:
-            # prompt + canvas + EOS-fill, via attention_mask); the REDUCTION does NOT —
-            # we use token-normalization (Σ CE / Σ tokens over the global count) whereas
-            # Google takes a per-example mean (Σ_b CE_b / N_b, then mean over B).
-            # Token-norm weights long examples more; it is kept deliberately (#4 decision)
-            # for consistency with the diffusion loss's global-token normalization and the
-            # recipe's `* dp_group_size` backward scaling.
+            # Co-trained autoregressive encoder loss: mean each example's valid
+            # next-token CE first, then average those means over the global batch.
+            # Under CP each rank supplies its local numerator while dividing by the
+            # replicated full-sequence count; include_cp backward scaling combines
+            # the disjoint token shards into the same objective as non-CP.
             if is_train and encoder_logits is not None and self._encoder_loss_weight > 0.0:
-                # Normalize by the GLOBAL supervised-token count (num_ar_tokens),
-                # exactly like the diffusion loss uses num_diffusion_tokens, so the
-                # recipe's `* dp_group_size` backward scaling is correct for both
-                # terms (a local mean here would be over-scaled by dp_group_size).
+                if num_ar_examples is None:
+                    raise RuntimeError("AR example denominator was not computed before the forward pass")
                 ar_loss = encoder_ar_loss(
                     encoder_logits,
                     clean_input_ids,
                     valid_mask=ar_full_loss_mask,
-                    num_tokens=num_ar_tokens,
+                    num_examples=num_ar_examples,
                 )
                 microbatch_loss = microbatch_loss + self._encoder_loss_weight * ar_loss
             elif is_train and encoder_hidden_states is not None and self._encoder_loss_weight > 0.0:
+                if num_ar_examples is None:
+                    raise RuntimeError("AR example denominator was not computed before the forward pass")
                 ar_loss = self._fused_encoder_loss(
                     encoder_hidden_states,
                     encoder_labels,
                     model.lm_head.weight,
-                    num_label_tokens=num_ar_tokens,
+                    label_token_counts=ar_token_counts,
+                    num_label_examples=num_ar_examples,
                     grad_reduce_group=self._get_dp_group(include_cp=True),
                 )
                 microbatch_loss = microbatch_loss + self._encoder_loss_weight * ar_loss

--- a/tests/functional_tests/models/diffusion_gemma/run_te_cp_parity.py
+++ b/tests/functional_tests/models/diffusion_gemma/run_te_cp_parity.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Multi-node TE-CP forward parity probe for DiffusionGemma."""
+
+import os
+
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import init_device_mesh
+
+
+def main():
+    dist.init_process_group("nccl")
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+    rank = dist.get_rank()
+
+    from transformers.models.diffusion_gemma.configuration_diffusion_gemma import DiffusionGemmaConfig
+
+    from nemo_automodel.components.distributed.context_parallel import ContextParallelSharder
+    from nemo_automodel.components.distributed.context_parallel.utils import attach_te_context_parallel
+    from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
+    from nemo_automodel.components.models.common import BackendConfig
+    from nemo_automodel.components.models.diffusion_gemma.attention_mask import build_block_diffusion_training_mask
+    from nemo_automodel.components.models.diffusion_gemma.model import DiffusionGemmaForBlockDiffusion
+
+    text_cfg = dict(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        global_head_dim=16,
+        num_global_key_value_heads=2,
+        sliding_window=8,
+        layer_types=["sliding_attention", "full_attention"],
+        num_experts=4,
+        top_k_experts=2,
+        moe_intermediate_size=32,
+        torch_dtype="bfloat16",
+    )
+    config = DiffusionGemmaConfig(text_config=text_cfg, vision_config=None, canvas_length=5)
+    backend = BackendConfig(attn="te", linear="torch", rms_norm="torch_fp32", experts="torch_mm", dispatcher="torch")
+
+    def make_model():
+        torch.manual_seed(1234)
+        model = DiffusionGemmaForBlockDiffusion(
+            config, backend=backend, self_conditioning=False, freeze_router=False
+        ).to(device=device, dtype=torch.bfloat16)
+        for layer in model.model.layers.values():
+            torch.nn.init.normal_(layer.moe.experts.gate_and_up_projs, std=0.02)
+            torch.nn.init.normal_(layer.moe.experts.down_projs, std=0.02)
+        return model.train()
+
+    cp_model = make_model()
+    reference = make_model()
+    reference.load_state_dict(cp_model.state_dict())
+
+    batch_size, encoder_len, canvas_len = 1, 13, 5
+    generator = torch.Generator(device=device).manual_seed(7)
+    clean = torch.randint(0, 128, (batch_size, encoder_len), generator=generator, device=device)
+    canvas = torch.randint(0, 128, (batch_size, canvas_len), generator=generator, device=device)
+    full, sliding = build_block_diffusion_training_mask(
+        prefix_lengths=8,
+        response_length=canvas_len,
+        enc_len=encoder_len,
+        block_size=5,
+        sliding_window=8,
+        batch_size=batch_size,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    batch = {
+        "input_ids": clean,
+        "canvas_ids": canvas,
+        "encoder_position_ids": torch.arange(encoder_len, device=device)[None],
+        "decoder_position_ids": torch.arange(8, 13, device=device)[None],
+        "encoder_padding_mask": torch.zeros_like(clean, dtype=torch.bool),
+        "decoder_padding_mask": torch.zeros_like(canvas, dtype=torch.bool),
+        "encoder_labels": torch.cat((clean[:, 1:], torch.full_like(clean[:, :1], -100)), dim=1),
+        "decoder_attention_mask": {"full_attention": full, "sliding_attention": sliding},
+        "do_self_conditioning": False,
+    }
+
+    mesh = init_device_mesh("cuda", (dist.get_world_size(),), mesh_dim_names=("cp",))
+    attach_te_context_parallel(cp_model, mesh["cp"])
+    sharder = ContextParallelSharder(cp_model, mesh, batch)
+    _, local_batch = sharder.shard(batch)
+    local_labels = local_batch.pop("encoder_labels")
+    cp_out = cp_model(**local_batch)
+    local_out = cp_out.logits.float()
+
+    reference_out = reference(
+        input_ids=clean,
+        canvas_ids=canvas,
+        encoder_position_ids=torch.arange(encoder_len, device=device)[None],
+        decoder_position_ids=torch.arange(8, 13, device=device)[None],
+        encoder_padding_mask=torch.zeros_like(clean, dtype=torch.bool),
+        decoder_padding_mask=torch.zeros_like(canvas, dtype=torch.bool),
+        decoder_attention_mask={"full_attention": full, "sliding_attention": sliding},
+        do_self_conditioning=False,
+    ).logits.float()
+    valid = local_batch["cp_canvas_indices"] < canvas_len
+    expected = reference_out.index_select(1, local_batch["cp_canvas_indices"][valid])
+    local_valid = local_out[:, valid]
+    difference = (local_valid - expected).abs()
+    relative_mean = difference.mean() / expected.abs().mean().clamp_min(torch.finfo(torch.float32).eps)
+    cosine = torch.nn.functional.cosine_similarity(local_valid.flatten(), expected.flatten(), dim=0)
+    assert cosine.item() > 0.999, cosine.item()
+    assert relative_mean.item() < 0.02, relative_mean.item()
+
+    # Exercise the long-context AR path and TE CP backward. This is deliberately
+    # the same fused linear CE used by the recipe; no [sequence, vocab] encoder
+    # logits are materialized.
+    ar_loss = FusedLinearCrossEntropy(logit_softcapping=30.0, reduction="sum")(
+        cp_out.encoder_hidden_states,
+        local_labels,
+        cp_model.lm_head.weight,
+        num_label_tokens=encoder_len - 1,
+    )
+    (ar_loss + local_valid.square().mean()).backward()
+    grad = cp_model.model.layers["0"].self_attn.q_proj.weight.grad
+    assert grad is not None and torch.isfinite(grad).all()
+    if rank == 0:
+        print(
+            f"PASS world={dist.get_world_size()} nodes={os.environ.get('SLURM_NNODES')} "
+            f"local_logits={tuple(local_out.shape)} max_error={difference.max().item():.6f} "
+            f"relative_mean={relative_mean.item():.6f} cosine={cosine.item():.8f} ar_loss={ar_loss.item():.6f}"
+        )
+
+    del cp_model, reference, cp_out, local_out, reference_out
+    torch.cuda.empty_cache()
+    dist.barrier()
+
+    # A real 100K-token forward/backward exercises padding, RoPE, TE CP
+    # transport, the non-causal decoder bias, and fused AR CE without requiring
+    # the 26B checkpoint. Keep this probe sliding-only so validation finishes
+    # quickly; the dependent job runs the released model/config.
+    long_len, long_canvas = 100_000, 16
+    long_text_cfg = dict(text_cfg)
+    long_text_cfg.update(
+        num_hidden_layers=1,
+        layer_types=["sliding_attention"],
+        sliding_window=64,
+    )
+    long_config = DiffusionGemmaConfig(text_config=long_text_cfg, vision_config=None, canvas_length=long_canvas)
+    torch.manual_seed(5678)
+    long_model = DiffusionGemmaForBlockDiffusion(
+        long_config, backend=backend, self_conditioning=False, freeze_router=False
+    ).to(device=device, dtype=torch.bfloat16)
+    for layer in long_model.model.layers.values():
+        torch.nn.init.normal_(layer.moe.experts.gate_and_up_projs, std=0.02)
+        torch.nn.init.normal_(layer.moe.experts.down_projs, std=0.02)
+    long_model.train()
+    attach_te_context_parallel(long_model, mesh["cp"])
+
+    long_clean = torch.randint(0, 128, (1, long_len), generator=generator, device=device)
+    long_canvas_ids = torch.randint(0, 128, (1, long_canvas), generator=generator, device=device)
+    long_full, long_sliding = build_block_diffusion_training_mask(
+        prefix_lengths=long_len - long_canvas,
+        response_length=long_canvas,
+        enc_len=long_len,
+        block_size=long_canvas,
+        sliding_window=64,
+        batch_size=1,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    long_batch = {
+        "input_ids": long_clean,
+        "canvas_ids": long_canvas_ids,
+        "encoder_position_ids": torch.arange(long_len, device=device)[None],
+        "decoder_position_ids": torch.arange(long_len - long_canvas, long_len, device=device)[None],
+        "encoder_padding_mask": torch.zeros_like(long_clean, dtype=torch.bool),
+        "decoder_padding_mask": torch.zeros_like(long_canvas_ids, dtype=torch.bool),
+        "encoder_labels": torch.cat((long_clean[:, 1:], torch.full_like(long_clean[:, :1], -100)), dim=1),
+        "decoder_attention_mask": {"full_attention": long_full, "sliding_attention": long_sliding},
+        "do_self_conditioning": False,
+    }
+    long_sharder = ContextParallelSharder(long_model, mesh, long_batch)
+    _, long_local = long_sharder.shard(long_batch)
+    long_labels = long_local.pop("encoder_labels")
+    long_out = long_model(**long_local)
+    long_ar_loss = FusedLinearCrossEntropy(logit_softcapping=30.0, reduction="sum")(
+        long_out.encoder_hidden_states,
+        long_labels,
+        long_model.lm_head.weight,
+        num_label_tokens=long_len - 1,
+    )
+    (long_ar_loss + long_out.logits.float().square().mean()).backward()
+    long_grad = long_model.model.layers["0"].self_attn.q_proj.weight.grad
+    assert long_grad is not None and torch.isfinite(long_grad).all()
+    if rank == 0:
+        print(
+            f"PASS_LONG seq={long_len} local_encoder={long_local['input_ids'].shape[1]} "
+            f"local_canvas={long_local['canvas_ids'].shape[1]} ar_loss={long_ar_loss.item():.6f}"
+        )
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional_tests/models/diffusion_gemma/run_te_cp_parity.py
+++ b/tests/functional_tests/models/diffusion_gemma/run_te_cp_parity.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""Multi-node TE-CP forward parity probe for DiffusionGemma."""
+"""Multi-node TE-CP encoder-loss and gradient parity probe for DiffusionGemma."""
 
 import os
 
@@ -15,6 +15,7 @@ def main():
     torch.cuda.set_device(local_rank)
     device = torch.device("cuda", local_rank)
     rank = dist.get_rank()
+    world_size = dist.get_world_size()
 
     from transformers.models.diffusion_gemma.configuration_diffusion_gemma import DiffusionGemmaConfig
 
@@ -76,14 +77,16 @@ def main():
     batch = {
         "input_ids": clean,
         "canvas_ids": canvas,
-        "encoder_position_ids": torch.arange(encoder_len, device=device)[None],
-        "decoder_position_ids": torch.arange(8, 13, device=device)[None],
+        "encoder_position_ids": torch.arange(encoder_len, device=device)[None].expand(batch_size, -1),
+        "decoder_position_ids": torch.arange(8, 13, device=device)[None].expand(batch_size, -1),
         "encoder_padding_mask": torch.zeros_like(clean, dtype=torch.bool),
         "decoder_padding_mask": torch.zeros_like(canvas, dtype=torch.bool),
         "encoder_labels": torch.cat((clean[:, 1:], torch.full_like(clean[:, :1], -100)), dim=1),
         "decoder_attention_mask": {"full_attention": full, "sliding_attention": sliding},
         "do_self_conditioning": False,
     }
+    full_encoder_labels = batch["encoder_labels"].clone()
+    ar_token_counts = full_encoder_labels.ne(-100).sum(dim=1)
 
     mesh = init_device_mesh("cuda", (dist.get_world_size(),), mesh_dim_names=("cp",))
     attach_te_context_parallel(cp_model, mesh["cp"])
@@ -91,26 +94,19 @@ def main():
     _, local_batch = sharder.shard(batch)
     local_labels = local_batch.pop("encoder_labels")
     cp_out = cp_model(**local_batch)
-    local_out = cp_out.logits.float()
 
     reference_out = reference(
         input_ids=clean,
         canvas_ids=canvas,
-        encoder_position_ids=torch.arange(encoder_len, device=device)[None],
-        decoder_position_ids=torch.arange(8, 13, device=device)[None],
+        encoder_position_ids=torch.arange(encoder_len, device=device)[None].expand(batch_size, -1),
+        decoder_position_ids=torch.arange(8, 13, device=device)[None].expand(batch_size, -1),
         encoder_padding_mask=torch.zeros_like(clean, dtype=torch.bool),
         decoder_padding_mask=torch.zeros_like(canvas, dtype=torch.bool),
         decoder_attention_mask={"full_attention": full, "sliding_attention": sliding},
         do_self_conditioning=False,
-    ).logits.float()
-    valid = local_batch["cp_canvas_indices"] < canvas_len
-    expected = reference_out.index_select(1, local_batch["cp_canvas_indices"][valid])
-    local_valid = local_out[:, valid]
-    difference = (local_valid - expected).abs()
-    relative_mean = difference.mean() / expected.abs().mean().clamp_min(torch.finfo(torch.float32).eps)
-    cosine = torch.nn.functional.cosine_similarity(local_valid.flatten(), expected.flatten(), dim=0)
-    assert cosine.item() > 0.999, cosine.item()
-    assert relative_mean.item() < 0.02, relative_mean.item()
+    )
+    assert torch.isfinite(cp_out.encoder_hidden_states).all()
+    assert torch.isfinite(reference_out.encoder_logits).all()
 
     # Exercise the long-context AR path and TE CP backward. This is deliberately
     # the same fused linear CE used by the recipe; no [sequence, vocab] encoder
@@ -119,26 +115,113 @@ def main():
         cp_out.encoder_hidden_states,
         local_labels,
         cp_model.lm_head.weight,
-        num_label_tokens=encoder_len - 1,
+        label_token_counts=ar_token_counts,
+        num_label_examples=batch_size,
     )
-    (ar_loss + local_valid.square().mean()).backward()
+    ar_loss.backward()
     grad = cp_model.model.layers["0"].self_attn.q_proj.weight.grad
     assert grad is not None and torch.isfinite(grad).all()
+
+    # Independent full-logit oracle: mean token CE within each example, then
+    # mean across examples. Sum CP-local loss/grad contributions for comparison.
+    reference_encoder_logits = reference_out.encoder_logits.float()
+    reference_per_token = torch.nn.functional.cross_entropy(
+        reference_encoder_logits.reshape(-1, reference_encoder_logits.shape[-1]),
+        full_encoder_labels.reshape(-1),
+        ignore_index=-100,
+        reduction="none",
+    ).reshape_as(full_encoder_labels)
+    reference_ar_loss = (reference_per_token.sum(dim=1) / ar_token_counts).mean()
+    reference_ar_loss.backward()
+    reference_grad = reference.model.layers["0"].self_attn.q_proj.weight.grad
+    dist.all_reduce(grad)
+    reduced_ar_loss = ar_loss.detach().clone()
+    dist.all_reduce(reduced_ar_loss)
+    grad_cosine = torch.nn.functional.cosine_similarity(grad.float().flatten(), reference_grad.float().flatten(), dim=0)
+    torch.testing.assert_close(reduced_ar_loss, reference_ar_loss, rtol=0.01, atol=0.01)
+    assert grad_cosine.item() > 0.998, grad_cosine.item()
     if rank == 0:
         print(
             f"PASS world={dist.get_world_size()} nodes={os.environ.get('SLURM_NNODES')} "
-            f"local_logits={tuple(local_out.shape)} max_error={difference.max().item():.6f} "
-            f"relative_mean={relative_mean.item():.6f} cosine={cosine.item():.8f} ar_loss={ar_loss.item():.6f}"
+            f"local_encoder={tuple(cp_out.encoder_hidden_states.shape)} "
+            f"ar_loss={reduced_ar_loss.item():.6f} reference_ar_loss={reference_ar_loss.item():.6f} "
+            f"ar_grad_cosine={grad_cosine.item():.8f}"
         )
 
-    del cp_model, reference, cp_out, local_out, reference_out
+    # Exercise the fused per-example reduction itself with unequal lengths and
+    # sequence shards on every rank. This keeps the arithmetic test independent
+    # of the model's current microbatch-size-one TE attention constraint.
+    synthetic_batch, synthetic_len, hidden_size, vocab_size = 2, 17, 9, 23
+    synthetic_generator = torch.Generator(device=device).manual_seed(29)
+    full_hidden = torch.randn(
+        synthetic_batch,
+        synthetic_len,
+        hidden_size,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=synthetic_generator,
+    )
+    full_weight = torch.randn(
+        vocab_size,
+        hidden_size,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=synthetic_generator,
+    )
+    full_labels = torch.randint(
+        0,
+        vocab_size,
+        (synthetic_batch, synthetic_len),
+        device=device,
+        generator=synthetic_generator,
+    )
+    full_labels[1, 7:] = -100
+    full_counts = full_labels.ne(-100).sum(dim=1)
+    local_indices = torch.arange(rank, synthetic_len, world_size, device=device)
+    local_hidden = full_hidden.index_select(1, local_indices).detach().requires_grad_(True)
+    local_weight = full_weight.detach().clone().requires_grad_(True)
+    local_labels = full_labels.index_select(1, local_indices)
+    local_synthetic_loss = FusedLinearCrossEntropy(logit_softcapping=30.0, reduction="sum")(
+        local_hidden,
+        local_labels,
+        local_weight,
+        label_token_counts=full_counts,
+        num_label_examples=synthetic_batch,
+    )
+    local_synthetic_loss.backward()
+    reduced_synthetic_loss = local_synthetic_loss.detach().clone()
+    reduced_weight_grad = local_weight.grad.detach().clone()
+    dist.all_reduce(reduced_synthetic_loss)
+    dist.all_reduce(reduced_weight_grad)
+
+    reference_hidden = full_hidden.detach().requires_grad_(True)
+    reference_weight = full_weight.detach().clone().requires_grad_(True)
+    reference_logits = reference_hidden @ reference_weight.t()
+    reference_logits = torch.tanh(reference_logits / 30.0) * 30.0
+    reference_per_token = torch.nn.functional.cross_entropy(
+        reference_logits.reshape(-1, vocab_size), full_labels.reshape(-1), ignore_index=-100, reduction="none"
+    ).reshape_as(full_labels)
+    reference_synthetic_loss = (reference_per_token.sum(dim=1) / full_counts).mean()
+    reference_synthetic_loss.backward()
+    synthetic_grad_cosine = torch.nn.functional.cosine_similarity(
+        reduced_weight_grad.float().flatten(), reference_weight.grad.float().flatten(), dim=0
+    )
+    torch.testing.assert_close(reduced_synthetic_loss.float(), reference_synthetic_loss.float(), rtol=0.01, atol=0.01)
+    assert synthetic_grad_cosine.item() > 0.999, synthetic_grad_cosine.item()
+    if rank == 0:
+        print(
+            f"PASS_UNEQUAL_COUNTS counts={full_counts.tolist()} loss={reduced_synthetic_loss.item():.6f} "
+            f"reference={reference_synthetic_loss.item():.6f} weight_grad_cosine={synthetic_grad_cosine.item():.8f}"
+        )
+
+    del cp_model, reference, cp_out, reference_out
     torch.cuda.empty_cache()
     dist.barrier()
 
     # A real 100K-token forward/backward exercises padding, RoPE, TE CP
     # transport, the non-causal decoder bias, and fused AR CE without requiring
-    # the 26B checkpoint. Keep this probe sliding-only so validation finishes
-    # quickly; the dependent job runs the released model/config.
+    # the 26B checkpoint. A single tiny layer keeps the probe fast while still
+    # exercising the released model implementation and CP sharder.
     long_len, long_canvas = 100_000, 16
     long_text_cfg = dict(text_cfg)
     long_text_cfg.update(
@@ -188,9 +271,10 @@ def main():
         long_out.encoder_hidden_states,
         long_labels,
         long_model.lm_head.weight,
-        num_label_tokens=long_len - 1,
+        label_token_counts=torch.tensor([long_len - 1], device=device),
+        num_label_examples=1,
     )
-    (long_ar_loss + long_out.logits.float().square().mean()).backward()
+    long_ar_loss.backward()
     long_grad = long_model.model.layers["0"].self_attn.q_proj.weight.grad
     assert long_grad is not None and torch.isfinite(long_grad).all()
     if rank == 0:

--- a/tests/unit_tests/loss/test_dllm_loss.py
+++ b/tests/unit_tests/loss/test_dllm_loss.py
@@ -26,6 +26,7 @@ from nemo_automodel.components.loss.dllm_loss import (
     MDLMCrossEntropyLoss,
     SCDDLoss,
     _compute_per_token_nll,
+    encoder_ar_loss,
     scdd_schedule,
 )
 
@@ -34,6 +35,65 @@ from nemo_automodel.components.loss.dllm_loss import (
 # ---------------------------------------------------------------------------
 
 B, L, V = 2, 8, 32  # batch, seq_len, vocab
+
+
+def test_encoder_ar_loss_is_mean_of_unequal_length_example_means():
+    """AR reduction gives each nonempty example equal weight, not each token."""
+    torch.manual_seed(7)
+    logits = torch.randn(3, 6, 11)
+    input_ids = torch.randint(0, 11, (3, 6))
+    valid_mask = torch.tensor(
+        [
+            [True, True, True, True, True, True],
+            [True, True, True, False, False, False],
+            [True, True, False, False, False, False],
+        ]
+    )
+
+    nll = F.cross_entropy(
+        logits[:, :-1].reshape(-1, logits.shape[-1]), input_ids[:, 1:].reshape(-1), reduction="none"
+    ).reshape(3, 5)
+    pair_mask = valid_mask[:, :-1] & valid_mask[:, 1:]
+    token_counts = pair_mask.sum(dim=1)
+    expected = ((nll * pair_mask).sum(dim=1) / token_counts).mean()
+    token_global_mean = (nll * pair_mask).sum() / token_counts.sum()
+
+    actual = encoder_ar_loss(logits, input_ids, valid_mask, num_examples=3)
+
+    torch.testing.assert_close(actual, expected)
+    assert not torch.isclose(actual, token_global_mean)
+
+
+def test_encoder_ar_loss_matches_reference_gradient_across_microbatches():
+    """Global example denominator preserves the reference loss and gradient."""
+    torch.manual_seed(11)
+    input_ids = torch.randint(0, 13, (3, 6))
+    valid_mask = torch.tensor(
+        [
+            [True, True, True, True, True, True],
+            [True, True, True, False, False, False],
+            [True, False, False, False, False, False],
+        ]
+    )
+    actual_logits = torch.randn(3, 6, 13, requires_grad=True)
+    reference_logits = actual_logits.detach().clone().requires_grad_(True)
+
+    actual = encoder_ar_loss(actual_logits[:2], input_ids[:2], valid_mask[:2], num_examples=2)
+    actual = actual + encoder_ar_loss(actual_logits[2:], input_ids[2:], valid_mask[2:], num_examples=2)
+
+    nll = F.cross_entropy(
+        reference_logits[:, :-1].reshape(-1, 13), input_ids[:, 1:].reshape(-1), reduction="none"
+    ).reshape(3, 5)
+    pair_mask = valid_mask[:, :-1] & valid_mask[:, 1:]
+    counts = pair_mask.sum(dim=1)
+    nonempty = counts > 0
+    expected = (((nll * pair_mask).sum(dim=1) / counts.clamp_min(1)) * nonempty).sum() / nonempty.sum()
+
+    actual.backward()
+    expected.backward()
+
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(actual_logits.grad, reference_logits.grad)
 
 
 @pytest.fixture
@@ -1166,9 +1226,7 @@ class TestSCDDLossChunking:
 
     def _run(self, chunk_size, logits, x0, z_t, loss_mask, p_mask):
         logits = logits.clone().requires_grad_(True)
-        loss_fn = SCDDLoss(
-            mask_token_id=SCDD_MASK_ID, num_timesteps=1000, max_ratio=0.15, chunk_size=chunk_size
-        )
+        loss_fn = SCDDLoss(mask_token_id=SCDD_MASK_ID, num_timesteps=1000, max_ratio=0.15, chunk_size=chunk_size)
         out = loss_fn(
             logits=logits,
             target_ids=x0,

--- a/tests/unit_tests/loss/test_linear_ce.py
+++ b/tests/unit_tests/loss/test_linear_ce.py
@@ -252,6 +252,32 @@ def test_fused_cross_entropy_normalizes_by_num_tokens(monkeypatch):
     assert out.item() == pytest.approx(2.0)
 
 
+def test_fused_cross_entropy_uses_autocast_compute_dtype_with_fp32_parameters(monkeypatch):
+    """FP32 resident parameters reach CCE as BF16 under BF16 autocast."""
+    from nemo_automodel.components.loss import linear_ce as linear_ce_mod
+
+    monkeypatch.setattr(linear_ce_mod, "HAVE_CUT_CROSS_ENTROPY", True)
+    seen_dtypes = None
+
+    def _fake_linear_ce(hidden, weight, **_kwargs):
+        nonlocal seen_dtypes
+        seen_dtypes = (hidden.dtype, weight.dtype)
+        return hidden.sum() + weight.sum()
+
+    monkeypatch.setattr(linear_ce_mod, "linear_cross_entropy", _fake_linear_ce, raising=False)
+    hidden = torch.randn(2, 3, 4, dtype=torch.float32, requires_grad=True)
+    weight = torch.randn(5, 4, dtype=torch.float32, requires_grad=True)
+    labels = torch.zeros(2, 3, dtype=torch.long)
+
+    with torch.autocast(device_type="cpu", dtype=torch.bfloat16):
+        loss = FusedLinearCrossEntropy()(hidden, labels, weight)
+    loss.backward()
+
+    assert seen_dtypes == (torch.bfloat16, torch.bfloat16)
+    assert hidden.grad is not None and hidden.grad.dtype == torch.float32
+    assert weight.grad is not None and weight.grad.dtype == torch.float32
+
+
 def test_fused_cross_entropy_cp_example_mean_matches_reference_gradient(monkeypatch):
     """Summed CP token shards match full-sequence unequal-length example means."""
     from nemo_automodel.components.loss import linear_ce as linear_ce_mod

--- a/tests/unit_tests/loss/test_linear_ce.py
+++ b/tests/unit_tests/loss/test_linear_ce.py
@@ -250,3 +250,75 @@ def test_fused_cross_entropy_normalizes_by_num_tokens(monkeypatch):
     # The stub returns 20, so after division by 10 we expect 2.0
     assert torch.is_tensor(out)
     assert out.item() == pytest.approx(2.0)
+
+
+def test_fused_cross_entropy_cp_example_mean_matches_reference_gradient(monkeypatch):
+    """Summed CP token shards match full-sequence unequal-length example means."""
+    from nemo_automodel.components.loss import linear_ce as linear_ce_mod
+
+    monkeypatch.setattr(linear_ce_mod, "HAVE_CUT_CROSS_ENTROPY", True)
+
+    def _pytorch_linear_ce(hidden, weight, targets=None, ignore_index=-100, reduction="sum", **kwargs):
+        logits = hidden @ weight.t()
+        flat_loss = F.cross_entropy(
+            logits.reshape(-1, logits.shape[-1]),
+            targets.reshape(-1),
+            ignore_index=ignore_index,
+            reduction=reduction,
+        )
+        return flat_loss.reshape_as(targets) if reduction == "none" else flat_loss
+
+    monkeypatch.setattr(linear_ce_mod, "linear_cross_entropy", _pytorch_linear_ce, raising=False)
+    torch.manual_seed(23)
+    labels = torch.tensor(
+        [
+            [1, 2, 3, 4, 5, 6],
+            [2, 3, -100, -100, -100, -100],
+            [-100, -100, -100, -100, -100, -100],
+        ]
+    )
+    token_counts = torch.tensor([6, 2, 0])
+    actual_hidden = torch.randn(3, 6, 4, requires_grad=True)
+    actual_weight = torch.randn(7, 4, requires_grad=True)
+    reference_hidden = actual_hidden.detach().clone().requires_grad_(True)
+    reference_weight = actual_weight.detach().clone().requires_grad_(True)
+
+    loss_fn = FusedLinearCrossEntropy(reduction="sum")
+    actual = sum(
+        loss_fn(
+            actual_hidden[:, shard],
+            labels[:, shard],
+            actual_weight,
+            label_token_counts=token_counts,
+            num_label_examples=2,
+        )
+        for shard in (slice(None, None, 2), slice(1, None, 2))
+    )
+    reference_logits = reference_hidden @ reference_weight.t()
+    per_token = F.cross_entropy(
+        reference_logits.reshape(-1, 7), labels.reshape(-1), ignore_index=-100, reduction="none"
+    ).reshape_as(labels)
+    expected = (per_token.sum(dim=1) / token_counts.clamp_min(1)).sum() / 2
+
+    actual.backward()
+    expected.backward()
+
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(actual_hidden.grad, reference_hidden.grad)
+    torch.testing.assert_close(actual_weight.grad, reference_weight.grad)
+
+
+def test_fused_cross_entropy_requires_complete_example_normalization(monkeypatch):
+    """Per-example normalization metadata must be supplied as a complete pair."""
+    from nemo_automodel.components.loss import linear_ce as linear_ce_mod
+
+    monkeypatch.setattr(linear_ce_mod, "HAVE_CUT_CROSS_ENTROPY", True)
+    loss_fn = FusedLinearCrossEntropy(reduction="sum")
+
+    with pytest.raises(ValueError, match="must be provided together"):
+        loss_fn(
+            torch.randn(2, 3, 4),
+            torch.zeros(2, 3, dtype=torch.long),
+            torch.randn(5, 4),
+            label_token_counts=torch.tensor([3, 3]),
+        )

--- a/tests/unit_tests/models/diffusion_gemma/test_diffusion_gemma_cp.py
+++ b/tests/unit_tests/models/diffusion_gemma/test_diffusion_gemma_cp.py
@@ -59,4 +59,5 @@ def test_mixed_stream_cp_layout_and_bias_padding():
     # Global bias is replicated. Pad query row 3 has a valid own-canvas key and
     # all newly padded non-diagonal locations remain masked.
     assert bias[0, 0, 1, 8].item() == 0
-    assert bias[0, 0, 1, 11].item() == torch.finfo(torch.float32).min
+    assert bias[0, 0, 1, 11].item() == -1.0e4
+    assert bias.isfinite().all()

--- a/tests/unit_tests/models/diffusion_gemma/test_diffusion_gemma_cp.py
+++ b/tests/unit_tests/models/diffusion_gemma/test_diffusion_gemma_cp.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import torch
+
+
+class _FakeCPMesh:
+    def __init__(self, rank: int, size: int = 2):
+        self._rank = rank
+        self._size = size
+
+    def size(self):
+        return self._size
+
+    def get_local_rank(self):
+        return self._rank
+
+
+def _batch():
+    neg = torch.finfo(torch.float32).min
+    mask = torch.full((1, 1, 3, 8), neg)
+    mask[..., :5] = 0
+    for i in range(3):
+        mask[..., i, 5 + i] = 0
+    return {
+        "input_ids": torch.arange(5)[None],
+        "canvas_ids": torch.arange(20, 23)[None],
+        "encoder_position_ids": torch.arange(5)[None],
+        "decoder_position_ids": torch.arange(10, 13)[None],
+        "encoder_padding_mask": torch.zeros((1, 5), dtype=torch.bool),
+        "decoder_padding_mask": torch.zeros((1, 3), dtype=torch.bool),
+        "encoder_labels": torch.tensor([[1, 2, 3, 4, -100]]),
+        "decoder_attention_mask": {"full_attention": mask, "sliding_attention": mask.clone()},
+    }
+
+
+def test_mixed_stream_cp_layout_and_bias_padding():
+    from nemo_automodel.components.models.diffusion_gemma.cp import shard_diffusion_gemma_batch
+
+    shards = []
+    for rank in range(2):
+        batch = _batch()
+        _, sharded, layout = shard_diffusion_gemma_batch(_FakeCPMesh(rank), None, batch, padding_token_id=99)
+        shards.append(sharded)
+        assert layout.original_seq_len == 3
+        assert layout.padded_seq_len == 4
+        assert sharded["input_ids"].shape == (1, 6)
+        assert sharded["canvas_ids"].shape == (1, 2)
+        assert sharded["decoder_attention_mask"]["full_attention"].shape == (1, 1, 2, 12)
+
+    def restore(key):
+        values = torch.cat([s[key] for s in shards], dim=1)
+        indices = torch.cat([s["cp_encoder_indices" if key != "canvas_ids" else "cp_canvas_indices"] for s in shards])
+        return values.index_select(1, torch.argsort(indices))
+
+    assert restore("input_ids").tolist() == [[0, 1, 2, 3, 4, 99, 99, 99, 99, 99, 99, 99]]
+    assert restore("canvas_ids").tolist() == [[20, 21, 22, 99]]
+
+    bias = shards[0]["decoder_attention_mask"]["full_attention"]
+    # Global bias is replicated. Pad query row 3 has a valid own-canvas key and
+    # all newly padded non-diagonal locations remain masked.
+    assert bias[0, 0, 1, 8].item() == 0
+    assert bias[0, 0, 1, 11].item() == torch.finfo(torch.float32).min

--- a/tests/unit_tests/models/diffusion_gemma/test_diffusion_gemma_model.py
+++ b/tests/unit_tests/models/diffusion_gemma/test_diffusion_gemma_model.py
@@ -100,6 +100,29 @@ def test_construct_and_forward_shape():
     assert torch.isfinite(out.logits).all()
 
 
+def test_te_attention_qkv_share_bf16_autocast_dtype_with_fp32_parameters():
+    model, _ = _tiny_model()
+    attention = model.model.layers["0"].self_attn
+
+    class RecordingAttention(torch.nn.Module):
+        cp_group = None
+        attention_type = "self"
+
+        def forward(self, query, key, value, **_kwargs):
+            assert query.dtype == key.dtype == value.dtype == torch.bfloat16
+            return query
+
+    attention.attn_module = RecordingAttention()
+    hidden_states = torch.randn(1, 8, 32, dtype=torch.float32)
+    cos = torch.ones(1, 8, attention.head_dim, dtype=torch.float32)
+    sin = torch.zeros_like(cos)
+
+    with torch.autocast(device_type="cpu", dtype=torch.bfloat16):
+        output, _ = attention(hidden_states, (cos, sin), attention_mask=None)
+
+    assert output.dtype == torch.bfloat16
+
+
 def test_tie_weights_restores_lm_head_alias():
     model, _ = _tiny_model()
     model.lm_head.weight = torch.nn.Parameter(model.lm_head.weight.detach().clone())

--- a/tests/unit_tests/recipes/dllm/test_block_diffusion_recipe_mask.py
+++ b/tests/unit_tests/recipes/dllm/test_block_diffusion_recipe_mask.py
@@ -272,3 +272,37 @@ def test_attention_mask_limits_response_window_and_padding_masks():
     assert not window["decoder_padding_mask"][1, :shorter_response].any()
     assert window["decoder_padding_mask"][1, shorter_response:].all()
     assert window["loss_mask"][1, shorter_response:].sum() == 0
+
+
+def test_loss_denominators_cache_global_nonempty_ar_example_count():
+    """Unequal AR lengths use a DP-global example denominator, not token count."""
+    seq_length = 16
+    recipe = _make_recipe(block_size=4)
+
+    class _DistEnv:
+        device = torch.device("cpu")
+
+    recipe.dist_env = _DistEnv()
+    recipe._dp_allreduce = lambda tensor: tensor * 2
+
+    clean = torch.arange(1, seq_length + 1, dtype=torch.long).unsqueeze(0).repeat(2, 1)
+    attention_mask = torch.zeros(2, seq_length, dtype=torch.long)
+    attention_mask[0, :12] = 1
+    attention_mask[1, :8] = 1
+    loss_mask = torch.zeros_like(attention_mask)
+    loss_mask[:, 4:] = attention_mask[:, 4:]
+    batch = {
+        "_clean_input_ids": clean,
+        "_noisy_input_ids": clean.clone(),
+        "_noise_mask": loss_mask.bool(),
+        "_p_mask": torch.ones_like(clean, dtype=torch.float32),
+        "loss_mask": loss_mask,
+        "attention_mask": attention_mask,
+    }
+
+    _, num_ar_tokens = recipe._compute_loss_denominators([batch], 0, 0)
+
+    # Local examples have 11 and 7 next-token pairs; the fake all-reduce
+    # represents two data replicas.
+    assert num_ar_tokens == 36
+    assert batch["_num_ar_examples"] == 4

--- a/tests/unit_tests/recipes/dllm/test_diffusion_recipe_precision.py
+++ b/tests/unit_tests/recipes/dllm/test_diffusion_recipe_precision.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DIFFUSION_RECIPE_DIR = REPO_ROOT / "examples" / "dllm_sft"
+
+
+def test_diffusion_recipes_keep_fp32_master_parameters() -> None:
+    diffusion_configs: list[tuple[Path, dict]] = []
+    for path in sorted(DIFFUSION_RECIPE_DIR.glob("*.yaml")):
+        config = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if str(config.get("recipe", "")).startswith("Diffusion"):
+            diffusion_configs.append((path, config))
+
+    assert diffusion_configs, "No diffusion recipes found"
+    for path, config in diffusion_configs:
+        mixed_precision = config["distributed"]["mp_policy"]
+        assert mixed_precision["param_dtype"] == "float32", f"{path.name} must retain FP32 master parameters"
+        assert config["distributed"]["autocast_dtype"] == "bfloat16", f"{path.name} must keep BF16 autocast compute"

--- a/tests/unit_tests/recipes/dllm/test_diffusion_recipe_precision.py
+++ b/tests/unit_tests/recipes/dllm/test_diffusion_recipe_precision.py
@@ -29,6 +29,8 @@ def test_diffusion_recipes_keep_fp32_master_parameters() -> None:
 
     assert diffusion_configs, "No diffusion recipes found"
     for path, config in diffusion_configs:
+        model_dtype = config["model"].get("torch_dtype", config["model"].get("dtype"))
+        assert model_dtype == "float32", f"{path.name} must load FP32 resident parameters"
         mixed_precision = config["distributed"]["mp_policy"]
         assert mixed_precision["param_dtype"] == "float32", f"{path.name} must retain FP32 master parameters"
         assert config["distributed"]["autocast_dtype"] == "bfloat16", f"{path.name} must keep BF16 autocast compute"


### PR DESCRIPTION
## Summary

- add model-owned context-parallel sharding for DiffusionGemma encoder and diffusion-canvas streams
- run causal encoder attention and bidirectional diffusion attention through Transformer Engine context parallelism
- compute encoder cross-entropy on local hidden-state shards and align diffusion targets with the canvas CP layout
- preserve the encoder objective as a mean of per-example sequence means under data, gradient-accumulation, and context parallelism
- add a streamed long-context dataset generator and a two-node 100K-token example

## Loss semantics

The diffusion decoder remains non-causal. Its exact block-attention mask is supplied as a post-scale attention bias while Transformer Engine performs context-parallel attention. Padding and dummy cache positions are excluded from the objective.

The encoder AR term first averages valid next-token CE within each example, then averages those per-example means over the global batch. Each CP rank contributes only its local token numerator while using the replicated full-sequence token count. The existing DP x CP backward scaling combines those disjoint contributions into the same objective as the non-CP path. Empty examples are excluded from the denominator.

## Validation

- 85 focused loss unit tests passed; unequal lengths, empty examples, gradient accumulation, and DP-global denominators are covered
- Ruff, compile, and whitespace checks passed
- cw-dfw Slurm `16555164`: two nodes, four H100s, Transformer Engine CP=4, completed successfully
- real model encoder loss: 19.021338 with CP versus 19.028961 from an independent full-logit oracle (0.0401% relative difference)
- real model Q-projection gradient cosine: 0.99997425
- unequal-length fused reduction `[17, 7]`: loss 6.396856 versus 6.406250 and LM-head gradient cosine 0.99997294
- 100,000-token Transformer Engine CP forward/backward completed successfully
