### PR TITLE
feat(recipes): add model-ready hooks

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -59,6 +59,26 @@ Only load configuration files and `_target_` values from trusted sources. A YAML
 
 </Warning>
 
+## Run Hooks Before Distributed Wrapping
+
+The LLM and VLM fine-tuning recipes accept a top-level `model_ready_hooks` list for out-of-tree model setup that must happen before optimizer construction:
+
+```yaml
+model_ready_hooks:
+  - _target_: your_package.training.configure_model
+    trainable_pattern: "extension.*"
+```
+
+Each `_target_` is called once, in list order, with the unwrapped model as its first positional argument and the remaining fields as keyword arguments. For the preceding example, the callable signature is `configure_model(model, trainable_pattern: str)`. The return value is ignored.
+
+Hooks run after configured PEFT and freezing, but before tensor, pipeline, or data-parallel wrapping and before optimizer construction. Use them to configure existing model-owned extensions or select the final trainable parameter set. Running before distributed wrapping ensures DDP and FSDP include the same trainable parameters as the optimizer. An exception aborts recipe setup. Omitting `model_ready_hooks` leaves setup unchanged.
+
+<Note>
+With meta-device initialization or post-shard checkpoint loading, pretrained tensor values are not available at hook time. Hooks may update trainability and non-tensor metadata on existing modules, but must not register new parameters or inspect or restore pretrained tensor data.
+</Note>
+
+This extension point is implemented in the `TrainFinetuneRecipeForNextTokenPrediction` and `FinetuneRecipeForVLM` setup paths. Subclasses that call these implementations with `super().setup()` inherit the hook, including the LLM and VLM knowledge-distillation recipes, diffusion-LM SFT recipes, and next-token benchmarking. Multi-model composite targets must define which component owns the hook and are rejected until they do; other recipe families do not run these hooks unless they explicitly add support.
+
 ## Distributed Section (Strategy-Based)
 
 The `distributed:` section is **not** instantiated using `_target_`. Recipes parse it with a fixed schema. Use `strategy: fsdp2`, `strategy: ddp`, or `strategy: megatron_fsdp`. You can also configure parallelism sizes, such as `dp_size`, `tp_size`, and `pp_size`, and strategy-specific options. When pipeline parallelism is enabled (`pp_size > 1`), add a `pipeline:` subsection with options such as `pp_schedule`, `pp_microbatch_size`, and `layers_per_stage`. For examples, see the [Pipeline Parallelism with AutoPipeline](/development/pipeline-parallelism) guide and the recipe configs.

--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -74,7 +74,8 @@ Each `_target_` is called once, in list order, with the unwrapped model as its f
 Hooks run after configured PEFT and freezing, but before tensor, pipeline, or data-parallel wrapping and before optimizer construction. Use them to configure existing model-owned extensions or select the final trainable parameter set. Running before distributed wrapping ensures DDP and FSDP include the same trainable parameters as the optimizer. An exception aborts recipe setup. Omitting `model_ready_hooks` leaves setup unchanged.
 
 <Note>
-With meta-device initialization or post-shard checkpoint loading, pretrained tensor values are not available at hook time. Hooks may update trainability and non-tensor metadata on existing modules, but must not register new parameters or inspect or restore pretrained tensor data.
+With meta-device initialization or post-shard checkpoint loading, pretrained tensor values are not available at hook time. Hooks can update trainability and non-tensor metadata on existing modules, but must not register new parameters or inspect or restore pretrained tensor data.
+
 </Note>
 
 This extension point is implemented in the `TrainFinetuneRecipeForNextTokenPrediction` and `FinetuneRecipeForVLM` setup paths. Subclasses that call these implementations with `super().setup()` inherit the hook, including the LLM and VLM knowledge-distillation recipes, diffusion-LM SFT recipes, and next-token benchmarking. Multi-model composite targets must define which component owns the hook and are rejected until they do; other recipe families do not run these hooks unless they explicitly add support.

--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -416,6 +416,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
         kwargs = dict(kwargs)  # Defensive copy so retries get clean state
         has_packed_sequence = kwargs.pop("has_packed_sequence", False)
         freeze_config = kwargs.pop("freeze_config", None)
+        model_ready_hooks = kwargs.pop("model_ready_hooks", None)
         cache_dir = kwargs.pop("cache_dir", hf_constants.HF_HUB_CACHE)
 
         def _retry(**override):
@@ -426,6 +427,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
                 **kwargs,
                 "has_packed_sequence": has_packed_sequence,
                 "freeze_config": freeze_config,
+                "model_ready_hooks": model_ready_hooks,
                 "cache_dir": cache_dir,
             }
             return cls._build_model(
@@ -636,6 +638,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
             freeze_config=freeze_config,
             weights_already_loaded=weights_already_loaded,
             inject_te_attention=inject_te_attention,
+            model_ready_hooks=model_ready_hooks,
         )
 
         return model

--- a/nemo_automodel/_transformers/infrastructure.py
+++ b/nemo_automodel/_transformers/infrastructure.py
@@ -77,6 +77,7 @@ from nemo_automodel.components.utils.model_utils import (
     init_empty_weights,
     print_trainable_parameters,
 )
+from nemo_automodel.shared.parameter_names import canonical_parameter_fqn
 from nemo_automodel.shared.tied_weights import ensure_tied_lm_head
 
 if TYPE_CHECKING:
@@ -483,6 +484,7 @@ def apply_model_infrastructure(
     pretrained_model_name_or_path="",
     weights_already_loaded=False,
     inject_te_attention: bool = False,
+    model_ready_hooks=None,
     **_kwargs,
 ):
     """Apply sharding, PEFT, quantization, and checkpoint loading to a model.
@@ -521,6 +523,8 @@ def apply_model_infrastructure(
         inject_te_attention: When True, inject TransformerEngine DotProductAttention
             into all ``self_attn`` modules of HF models (has no effect on custom
             models that already use TE via BackendConfig). Default: False.
+        model_ready_hooks: Config-instantiable hooks run after model transforms and
+            freezing, but before distributed wrapping. Default: None.
         **_kwargs: Additional keyword arguments (ignored, allows passing extra kwargs)
 
     Returns:
@@ -636,6 +640,27 @@ def apply_model_infrastructure(
     # NemotronOmni RADIO: opt into the fused SDPA path on ViT attention blocks.
     enable_radio_vit_fused_attn(model)
 
+    # Explicit trainability overrides must run before distributed wrappers
+    # inspect requires_grad. Existing PEFT-only configurations retain their
+    # post-shard freeze path below.
+    preserve_pre_wrap_trainability = peft_config is not None and bool(model_ready_hooks)
+    if preserve_pre_wrap_trainability:
+        for name, param in model.named_parameters():
+            if "lora_" not in name and param.requires_grad:
+                param.requires_grad_(False)
+
+    for hook_cfg in model_ready_hooks or []:
+        hook_cfg.instantiate(model)
+
+    pre_shard_trainability = (
+        {
+            canonical_parameter_fqn(name).replace("_orig_mod.", ""): param.requires_grad
+            for name, param in model.named_parameters(remove_duplicate=False)
+        }
+        if preserve_pre_wrap_trainability
+        else None
+    )
+
     # Loss function check
     if not _supports_logits_to_keep(model) and not isinstance(loss_fn, MaskedCrossEntropy):
         loss_fn = MaskedCrossEntropy()
@@ -724,9 +749,23 @@ def apply_model_infrastructure(
         checkpoint_loaded=bool(checkpoint_already_loaded or weights_already_loaded or should_load_checkpoint),
     )
 
-    # Freeze parameters after checkpoint loading and parallelization
-    # This catches params created during parallelization (e.g., GroupedExpertsTE in init_token_dispatcher)
-    if peft_config is not None:
+    # Sharding and checkpoint materialization may replace Parameter objects.
+    # Under PEFT, restore the pre-wrap policy by name and freeze unmatched
+    # parameters created during parallelization.
+    if pre_shard_trainability is not None:
+        if hasattr(model, "parts"):
+            trainability_models = model.parts
+        elif isinstance(model_wrapper, (DDPManager, MegatronFSDPManager)):
+            trainability_models = [getattr(model, "module", model)]
+        else:
+            trainability_models = [model]
+        for mp in trainability_models:
+            for name, param in mp.named_parameters():
+                name = canonical_parameter_fqn(name).replace("_orig_mod.", "")
+                requires_grad = pre_shard_trainability.get(name, "lora_" in name)
+                if param.requires_grad != requires_grad:
+                    param.requires_grad_(requires_grad)
+    elif peft_config is not None:
         models_to_freeze = model.parts if hasattr(model, "parts") else [model]
         for mp in models_to_freeze:
             for name, param in mp.named_parameters():

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -183,6 +183,7 @@ def build_model(
     distributed_setup: DistributedSetup | None = None,
     cfg_qat=None,
     unfreeze_modules: list[str] | None = None,
+    model_ready_hooks=None,
     sdpa_method: list[str] | None = None,
     device_mesh=None,
 ) -> tuple[nn.Module | AutoPipeline, list["Optimizer"]]:  # noqa: F821
@@ -199,6 +200,7 @@ def build_model(
         distributed_setup: Resolved distributed topology and policy object.
         cfg_qat: Configuration for QAT (will be instantiated to QATConfig).
         unfreeze_modules: List of module names/substrings to unfreeze.
+        model_ready_hooks: Config-instantiable hooks to run before distributed wrapping.
         sdpa_method: Explicit list of SDPA backend name strings (e.g.
             ``["flash_attention", "efficient_attention"]``), or ``None`` to
             auto-select based on CP / activation checkpointing.
@@ -208,6 +210,7 @@ def build_model(
         kwargs = {
             "has_packed_sequence": has_packed_sequence,
             "peft_config": cfg_peft,
+            "model_ready_hooks": model_ready_hooks,
             "sdpa_method": sdpa_method,
         }
         if distributed_setup is not None:
@@ -292,6 +295,7 @@ def build_model(
                 pretrained_model_name_or_path=None,
                 load_base_model=False,
                 cache_dir=hf_constants.HF_HUB_CACHE,
+                model_ready_hooks=model_ready_hooks,
             )
 
     # Explicitly unfreeze specified modules (e.g. task heads) that need full fine-tuning
@@ -620,6 +624,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             cfg_quantization=self.cfg.get("quantization", None),
             distributed_setup=self.distributed_setup,
             cfg_qat=self.cfg.get("qat", None),
+            model_ready_hooks=self.cfg.get("model_ready_hooks", None),
             sdpa_method=self.cfg.get("sdpa_method", None),
         )
         self.embedding_row_repair_report = None

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -178,6 +178,7 @@ def build_model(
     cfg_compile=None,
     distributed_setup: DistributedSetup | None = None,
     cfg_quantization=None,
+    model_ready_hooks=None,
 ) -> tuple[nn.Module | AutoPipeline, list["Optimizer"]]:  # noqa: F821
     """Build and initialize a model for VLM.
 
@@ -185,10 +186,12 @@ def build_model(
         The instantiated model and optimizer.
     """
     with ScopedRNG(seed=seed, ranked=True):
+        target = cfg_model.get("_target_", None)
         # Build infrastructure kwargs
         kwargs = {
             "peft_config": cfg_peft,
             "freeze_config": cfg_freeze.to_dict() if cfg_freeze is not None else None,
+            "model_ready_hooks": model_ready_hooks,
         }
         if distributed_setup is not None:
             kwargs["distributed_setup"] = distributed_setup
@@ -204,7 +207,12 @@ def build_model(
 
             kwargs["quantization_config"] = create_bnb_config(cfg_quantization)
 
-        if _is_recipe_target(cfg_model.get("_target_", None)):
+        if _is_recipe_target(target):
+            if model_ready_hooks and target not in _model_ready_hook_targets():
+                raise ValueError(
+                    "model_ready_hooks require a single-model NeMoAutoModel target; "
+                    f"composite target {target} must define its own pre-wrapping hook semantics"
+                )
             model = cfg_model.instantiate(**kwargs)
         else:
             raise ValueError(
@@ -212,9 +220,21 @@ def build_model(
                 "Add the entrypoint to `_accepted_targets()` in this module "
                 "if you're onboarding a new wrapper that absorbs the recipe's "
                 "infrastructure kwargs. "
-                f"Got model target: {cfg_model.get('_target_', None)}"
+                f"Got model target: {target}"
             )
     return model
+
+
+def _model_ready_hook_targets() -> set:
+    """Return single-model entrypoints that can run hooks before distributed wrapping."""
+    return {
+        NeMoAutoModelForCausalLM.from_pretrained,
+        NeMoAutoModelForCausalLM.from_config,
+        NeMoAutoModelForImageTextToText.from_pretrained,
+        NeMoAutoModelForImageTextToText.from_config,
+        NeMoAutoModelForMultimodalLM.from_pretrained,
+        NeMoAutoModelForMultimodalLM.from_config,
+    }
 
 
 def _accepted_targets() -> set:
@@ -235,14 +255,7 @@ def _accepted_targets() -> set:
     requires the optional ``transformers.models.gemma4_assistant`` module
     that ships with ``transformers>=5.8.0.dev``.
     """
-    accepted = {
-        NeMoAutoModelForCausalLM.from_pretrained,
-        NeMoAutoModelForCausalLM.from_config,
-        NeMoAutoModelForImageTextToText.from_pretrained,
-        NeMoAutoModelForImageTextToText.from_config,
-        NeMoAutoModelForMultimodalLM.from_pretrained,
-        NeMoAutoModelForMultimodalLM.from_config,
-    }
+    accepted = _model_ready_hook_targets()
     try:
         from nemo_automodel.components.models.gemma4_drafter.composite import (
             Gemma4WithDrafter,
@@ -541,6 +554,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
             cfg_compile=self.cfg.get("compile", None),
             distributed_setup=self.distributed_setup,
             cfg_quantization=self.cfg.get("quantization", None),
+            model_ready_hooks=self.cfg.get("model_ready_hooks", None),
         )
         capability_model = model.parts[0] if isinstance(model, AutoPipeline) else model
         _validate_cp_vision_frame_sharding_support(capability_model, self.cp_vision_frame_sharding)

--- a/tests/unit_tests/_transformers/test_auto_model.py
+++ b/tests/unit_tests/_transformers/test_auto_model.py
@@ -1739,6 +1739,8 @@ class TestBuildModelRetryDepth:
         build_kwargs["is_hf_model"] = False
         dummy_manager_cls = type("DummyManager", (), {})
         build_kwargs["model_wrapper"] = dummy_manager_cls()
+        model_ready_hooks = [object()]
+        build_kwargs["model_ready_hooks"] = model_ready_hooks
         sentinel_model = MagicMock()
         captured = {}
 
@@ -1763,6 +1765,7 @@ class TestBuildModelRetryDepth:
 
         assert captured["is_meta_device"] is False
         assert captured["weights_already_loaded"] is False
+        assert captured["model_ready_hooks"] is model_ready_hooks
 
 
 class TestNeMoAutoModelForMultimodalLM:

--- a/tests/unit_tests/_transformers/test_infrastructure.py
+++ b/tests/unit_tests/_transformers/test_infrastructure.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+from datetime import timedelta
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
@@ -148,6 +151,151 @@ class _DummyModel(torch.nn.Module):
         super().__init__()
         self.linear = torch.nn.Linear(4, 4)
         self.config = SimpleNamespace()
+
+
+class _TinyDDPModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.base = torch.nn.Linear(1, 1, bias=False)
+        self.extension = torch.nn.Linear(1, 1, bias=False)
+        self.extension.weight.requires_grad_(False)
+        self.config = SimpleNamespace()
+
+    def forward(self, inputs, logits_to_keep=None):
+        return self.base(inputs) + self.extension(inputs)
+
+
+class _SelectTrainableParameter:
+    def __init__(self, name):
+        self.name = name
+        self.calls = 0
+
+    def instantiate(self, model):
+        self.calls += 1
+        for name, parameter in model.named_parameters():
+            parameter.requires_grad_(name == self.name)
+
+
+def _run_model_ready_hook_ddp(rank: int, world_size: int, init_file: str, result_dir: str) -> None:
+    os.environ["GLOO_SOCKET_IFNAME"] = "lo"
+    torch.distributed.init_process_group(
+        "gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        from nemo_automodel._transformers.infrastructure import apply_model_infrastructure
+        from nemo_automodel.components.distributed.config import DDPConfig
+        from nemo_automodel.components.distributed.ddp import DDPManager
+
+        hook = _SelectTrainableParameter("extension.weight")
+        model = apply_model_infrastructure(
+            model=_TinyDDPModel(),
+            is_meta_device=False,
+            device=torch.device("cpu"),
+            load_base_model=False,
+            model_wrapper=DDPManager(DDPConfig()),
+            model_ready_hooks=[hook],
+        )
+
+        for _ in range(2):
+            model.zero_grad(set_to_none=True)
+            model(torch.tensor([[float(rank + 1)]])).sum().backward()
+
+        assert hook.calls == 1
+        assert model.module.base.weight.grad is None
+        Path(result_dir, f"rank_{rank}.txt").write_text(str(model.module.extension.weight.grad.item()))
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+def test_model_ready_hooks_run_before_ddp_reducer_construction(tmp_path):
+    """Hook-selected parameters are synchronized and excluded parameters stay out of DDP."""
+    torch.multiprocessing.spawn(
+        _run_model_ready_hook_ddp,
+        args=(2, str(tmp_path / "gloo_init"), str(tmp_path)),
+        nprocs=2,
+        join=True,
+    )
+
+    assert [float((tmp_path / f"rank_{rank}.txt").read_text()) for rank in range(2)] == [1.5, 1.5]
+
+
+def test_metadata_only_hook_does_not_freeze_parameter_created_during_parallelization():
+    """Hook presence alone must not turn trainability into a closed-world policy."""
+    from nemo_automodel._transformers.infrastructure import apply_model_infrastructure
+
+    model = _DummyModel()
+    hook = MagicMock()
+
+    def add_parallel_parameter(model, *_args, **_kwargs):
+        model.register_parameter("parallel_parameter", torch.nn.Parameter(torch.ones(1)))
+        return model
+
+    with (
+        patch(f"{_INFRA_MODULE}.get_world_size_safe", return_value=1),
+        patch(f"{_INFRA_MODULE}._supports_logits_to_keep", return_value=True),
+        patch(f"{_INFRA_MODULE}.print_trainable_parameters"),
+        patch(f"{_INFRA_MODULE}._should_load_before_shard", return_value=False),
+        patch(f"{_INFRA_MODULE}._shard_ep_fsdp", side_effect=add_parallel_parameter),
+        patch(f"{_INFRA_MODULE}.Checkpointer") as MockCheckpointer,
+    ):
+        MockCheckpointer.return_value.config.dequantize_base_checkpoint = False
+        apply_model_infrastructure(
+            model=model,
+            is_meta_device=False,
+            device=torch.device("cpu"),
+            load_base_model=False,
+            model_ready_hooks=[hook],
+        )
+
+    hook.instantiate.assert_called_once_with(model)
+    assert model.parallel_parameter.requires_grad
+
+
+@pytest.mark.parametrize("use_hook", [False, True])
+def test_peft_trainability_paths_freeze_new_parallel_parameter(use_hook):
+    """PEFT preserves hook overrides without changing its default freeze path."""
+    from nemo_automodel._transformers.infrastructure import apply_model_infrastructure
+
+    model = _TinyDDPModel()
+    model.register_parameter("lora_disabled", torch.nn.Parameter(torch.ones(1)))
+    hook = _SelectTrainableParameter("extension.weight")
+    peft_config = SimpleNamespace(lora_A_init=None, use_triton=False)
+    selection_kwargs = {"model_ready_hooks": [hook]} if use_hook else {}
+
+    def replace_and_add_parameters(model, *_args, **_kwargs):
+        for module in (model.base, model.extension):
+            module.weight = torch.nn.Parameter(module.weight.detach().clone())
+        model.lora_disabled = torch.nn.Parameter(model.lora_disabled.detach().clone())
+        model.register_parameter("parallel_parameter", torch.nn.Parameter(torch.ones(1)))
+        return model
+
+    with (
+        patch(f"{_INFRA_MODULE}.get_world_size_safe", return_value=1),
+        patch(f"{_INFRA_MODULE}._supports_logits_to_keep", return_value=True),
+        patch(f"{_INFRA_MODULE}.print_trainable_parameters"),
+        patch(f"{_INFRA_MODULE}._should_load_before_shard", return_value=False),
+        patch(f"{_INFRA_MODULE}._apply_peft_and_lower_precision", return_value=model),
+        patch(f"{_INFRA_MODULE}._shard_ep_fsdp", side_effect=replace_and_add_parameters),
+        patch(f"{_INFRA_MODULE}.Checkpointer") as MockCheckpointer,
+    ):
+        MockCheckpointer.return_value.config.dequantize_base_checkpoint = False
+        apply_model_infrastructure(
+            model=model,
+            is_meta_device=False,
+            device=torch.device("cpu"),
+            load_base_model=False,
+            peft_config=peft_config,
+            **selection_kwargs,
+        )
+
+    assert not model.base.weight.requires_grad
+    assert model.extension.weight.requires_grad is use_hook
+    assert model.lora_disabled.requires_grad is not use_hook
+    assert not model.parallel_parameter.requires_grad
 
 
 def test_safe_moe_tp_requires_real_checkpoint_source_and_rejects_peft():

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -183,8 +183,8 @@ def test_build_model_and_optimizer_basic():
     assert isinstance(optim[0], torch.optim.Optimizer)
 
 
-def test_build_model_passes_freeze_config():
-    """Test that freeze_config is passed to model instantiation."""
+def test_build_model_passes_freeze_config_and_model_ready_hooks():
+    """Freeze config and model-ready hooks are passed to model instantiation."""
     from nemo_automodel._transformers import NeMoAutoModelForImageTextToText
 
     captured_kwargs = {}
@@ -206,17 +206,20 @@ def test_build_model_passes_freeze_config():
         def to_dict(self):
             return {"freeze_language_model": False, "freeze_vision_tower": True}
 
+    model_ready_hooks = [object()]
     with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
         build_model(
             cfg_model=cfg_model,
             cfg_freeze=FreezeConfig(),
             cfg_peft=None,
             seed=123,
+            model_ready_hooks=model_ready_hooks,
         )
 
     # Verify freeze_config was passed to model instantiation
     assert "freeze_config" in captured_kwargs
     assert captured_kwargs["freeze_config"] == {"freeze_language_model": False, "freeze_vision_tower": True}
+    assert captured_kwargs["model_ready_hooks"] is model_ready_hooks
 
 
 def test_build_model_passes_distributed_setup():
@@ -2775,6 +2778,31 @@ class TestRecipeTargetAllowlist:
         targets = _accepted_targets()
         assert Gemma4WithDrafter.from_pretrained in targets
 
+    def test_model_ready_hooks_reject_composite_target(self, monkeypatch):
+        """A composite must define which submodel owns a pre-wrapping hook."""
+
+        class Gemma4WithDrafter:
+            @classmethod
+            def from_pretrained(cls):
+                return cls()
+
+        fake_mod = types.ModuleType(_GEMMA4_COMPOSITE_MOD)
+        fake_mod.Gemma4WithDrafter = Gemma4WithDrafter
+        monkeypatch.setitem(sys.modules, _GEMMA4_COMPOSITE_MOD, fake_mod)
+        cfg_model = SimpleNamespace(
+            _target_=Gemma4WithDrafter.from_pretrained,
+            get=lambda key, default=None: getattr(cfg_model, key, default),
+        )
+
+        with pytest.raises(ValueError, match="single-model NeMoAutoModel"):
+            build_model(
+                cfg_model=cfg_model,
+                cfg_freeze=None,
+                cfg_peft=None,
+                seed=42,
+                model_ready_hooks=[object()],
+            )
+
     def test_is_recipe_target_none_returns_false(self):
         from nemo_automodel.recipes.vlm.finetune import _is_recipe_target
 
@@ -2841,7 +2869,13 @@ def _patch_vlm_setup_minimals(monkeypatch, cp_size):
     )
     dummy_model = DummyModel()
     dummy_opt = SimpleNamespace(param_groups=[{"lr": 0.01}], step=lambda: None, zero_grad=lambda **k: None)
-    monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.build_model", lambda *a, **k: dummy_model)
+
+    def _build_model(*args, model_ready_hooks=None, **kwargs):
+        for hook_cfg in model_ready_hooks or []:
+            hook_cfg.instantiate(dummy_model)
+        return dummy_model
+
+    monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.build_model", _build_model)
     monkeypatch.setattr(
         "nemo_automodel.recipes._typed_config.RecipeConfig.optimizer",
         property(lambda self: SimpleNamespace(build=lambda *a, **k: [dummy_opt])),
@@ -2921,6 +2955,43 @@ def _minimal_vlm_cfg(
     if prewarm is not None:
         cfg["prewarm"] = prewarm
     return ConfigNode(cfg)
+
+
+def select_vlm_trainable_parameter(model: nn.Module, name: str) -> None:
+    """Config-instantiable hook that leaves only ``name`` trainable."""
+    for parameter_name, parameter in model.named_parameters():
+        parameter.requires_grad_(parameter_name == name)
+
+
+def test_vlm_model_ready_hooks_run_before_optimizer_build(monkeypatch):
+    """The VLM optimizer observes trainability changes made by model_ready_hooks."""
+    cfg = _minimal_vlm_cfg(cp_size=1, rope_fusion=False)
+    cfg.model_ready_hooks = [
+        ConfigNode(
+            {
+                "_target_": "tests.unit_tests.recipes.test_finetune_vlm_helpers.select_vlm_trainable_parameter",
+                "name": "language_model.weight",
+            }
+        )
+    ]
+    _patch_vlm_setup_minimals(monkeypatch, cp_size=1)
+    trainable_at_optimizer_build = []
+
+    def _opt_build(model, *a, **k):
+        trainable_at_optimizer_build.extend(
+            name for name, parameter in model.named_parameters() if parameter.requires_grad
+        )
+        return [SimpleNamespace(param_groups=[{"lr": 0.01}], step=lambda: None, zero_grad=lambda **k: None)]
+
+    monkeypatch.setattr(
+        "nemo_automodel.recipes._typed_config.RecipeConfig.optimizer",
+        property(lambda self: SimpleNamespace(build=_opt_build)),
+    )
+
+    trainer = FinetuneRecipeForVLM(cfg)
+    trainer.setup()
+
+    assert trainable_at_optimizer_build == ["language_model.weight"]
 
 
 def test_vlm_setup_applies_prewarm_config(monkeypatch):

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -953,9 +953,15 @@ def _patch_setup_minimals(monkeypatch, patch_fn):
     # Stub model/optimizer creation
     dummy_model = DummyModel()
     dummy_opt = SimpleNamespace(param_groups=[{"lr": 0.01}], step=lambda: None, zero_grad=lambda: None)
+
+    def _build_model(*args, model_ready_hooks=None, **kwargs):
+        for hook_cfg in model_ready_hooks or []:
+            hook_cfg.instantiate(dummy_model)
+        return dummy_model
+
     monkeypatch.setattr(
         "nemo_automodel.recipes.llm.train_ft.build_model",
-        lambda *a, **k: dummy_model,
+        _build_model,
     )
     monkeypatch.setattr(
         "nemo_automodel.recipes._typed_config.RecipeConfig.optimizer",
@@ -1107,6 +1113,55 @@ def test_setup_does_not_change_storage_dtype_for_non_kd_recipe(monkeypatch):
     trainer.setup()
 
     assert not hasattr(cfg.model, "torch_dtype")
+
+
+def select_trainable_parameter(model: nn.Module, name: str) -> None:
+    """Config-instantiable hook that leaves only ``name`` trainable."""
+    for parameter_name, parameter in model.named_parameters():
+        parameter.requires_grad_(parameter_name == name)
+
+
+def test_model_ready_hooks_run_before_optimizer_build(monkeypatch):
+    """The optimizer observes trainability changes made by model_ready_hooks."""
+    cfg = _minimal_cfg_with_nvtx(nvtx_value=False)
+    cfg.model_ready_hooks = [
+        ConfigNode(
+            {
+                "_target_": "tests.unit_tests.recipes.test_train_ft.select_trainable_parameter",
+                "name": "layer2.weight",
+            }
+        )
+    ]
+
+    _patch_setup_minimals(monkeypatch, lambda *a, **k: None)
+    trainable_at_optimizer_build = []
+
+    def _opt_build(model, *a, **k):
+        trainable_at_optimizer_build.extend(
+            name for name, parameter in model.named_parameters() if parameter.requires_grad
+        )
+        return [SimpleNamespace(param_groups=[{"lr": 0.01}], step=lambda: None, zero_grad=lambda: None)]
+
+    monkeypatch.setattr(
+        "nemo_automodel.recipes._typed_config.RecipeConfig.optimizer",
+        property(lambda self: SimpleNamespace(build=_opt_build)),
+    )
+
+    trainer = TrainFinetuneRecipeForNextTokenPrediction(cfg)
+    trainer.setup()
+
+    assert trainable_at_optimizer_build == ["layer2.weight"]
+
+
+def test_model_ready_hooks_absent_is_noop(monkeypatch):
+    """Without a model_ready_hooks section, setup is unchanged."""
+    cfg = _minimal_cfg_with_nvtx(nvtx_value=False)
+    _patch_setup_minimals(monkeypatch, lambda *a, **k: None)
+
+    trainer = TrainFinetuneRecipeForNextTokenPrediction(cfg)
+    trainer.setup()
+
+    assert all(parameter.requires_grad for parameter in trainer.model_parts[0].parameters())
 
 
 def test_nvtx_true_pipeline_patches_all_parts(monkeypatch):


### PR DESCRIPTION
The finetune recipes currently have no safe extension point for selecting model trainability after PEFT/freezing,but before distributed wrapping and optimizer construction. 

Running such a callback after model construction is too late: DDP may already have captured its reducer parameters, so a newly enabled parameter can be optimized independently on each rank.

For instance, if we're doing LlaVa-style training where we want to train both 1. our input projector and 2. the LoRA parameters, the current sequence is:

```
Build model
→ apply PEFT, which freezes non-LoRA parameters
→ construct DDP/FSDP
→ a monkeypatch to re-enable the projector (which i'd like to remove)
→ construct optimizer
```

This PR adds `model_ready_hooks`, `_target_`-callables accepted by the LLM and VLM finetune setup paths:

```yaml
model_ready_hooks:
  - _target_: your_package.training.configure_model
    trainable_pattern: "extension.*"
```

Each hook receives the unwrapped model and runs once, in list order, after PEFT and configured freezing but before DDP/FSDP/TP/PP wrapping and optimizer construction. In the PEFT path, the hook-selected requires_grad policy is preserved across sharding and checkpoint materialization.

With meta-device initialization or post-shard loading, pretrained values are not available at hook time. Hooks may update trainability and non-tensor metadata on existing modules, but must not register parameters or inspect or restore pretrained tensor data.

The next-token and VLM knowledge-distillation recipes, diffusion-LM SFT recipes, and next-token benchmark recipe inherit the hook through their parent setup. Multi-model composite targets are rejected until target/draft/teacher ownership is defined; unrelated recipe families are not changed. 

The hook path is a no-op when not configured.

For the example above, the flow would now be

```
Build model
→ apply PEFT/freezing
→ model-ready hook selects final trainability
→ construct DDP/FSDP
→ construct optimizer
```