### PR TITLE
fix(peft): support mixed-dtype memory-efficient LoRA backward

### DIFF
--- a/nemo_automodel/components/_peft/lora.py
+++ b/nemo_automodel/components/_peft/lora.py
@@ -751,11 +751,21 @@ class LoRATritonFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, d_y):
-        """
-        Backward method for memory-efficient LoRA.
+        """Compute gradients for memory-efficient LoRA.
 
         Reshapes 3D tensors into 2D and then updates d_lora_a, d_lora_b, and dx. The PyTorch matmul
         path recomputes ``x @ lora_A.T`` here instead of saving it from forward.
+
+        Args:
+            ctx: Autograd context containing the saved input and LoRA weights.
+            d_y: Tensor of shape ``[tokens, out_features]`` containing the output gradient in the forward compute
+                dtype.
+
+        Returns:
+            Gradients for the custom autograd inputs. The input gradient has shape ``[tokens, in_features]`` or
+            ``[batch, sequence, in_features]`` and matches the original input dtype. LoRA weight gradients have
+            shapes ``[rank, in_features]`` and ``[out_features, rank]`` and match their weight dtypes. When a
+            residual input is present, its gradient matches the original residual shape.
         """
         x, lora_A, lora_B = ctx.saved_tensors
         scale = ctx.scale
@@ -779,17 +789,23 @@ class LoRATritonFunction(torch.autograd.Function):
         else:
             d_x = d_lora_A = d_lora_B = None
             needs_x, needs_lora_A, needs_lora_B = ctx.needs_input_grad[:3]
+            # Custom backward executes outside autocast. Reuse d_y's forward compute dtype for the recomputed
+            # matmuls, then cast each returned gradient to the dtype of its corresponding input.
+            x_compute = x.to(d_y.dtype) if needs_lora_A or needs_lora_B else x
+            lora_A_compute = lora_A.to(d_y.dtype) if needs_x or needs_lora_B else lora_A
+            lora_B_compute = lora_B.to(d_y.dtype) if needs_x or needs_lora_A else lora_B
             if needs_x or needs_lora_A:
-                d_y_lora_B = torch.matmul(d_y, lora_B)
+                d_y_lora_B = torch.matmul(d_y, lora_B_compute)
+                d_y_lora_B.mul_(scale)
                 if needs_x:
-                    d_x = torch.empty_like(x)
-                    d_x.addmm_(d_y_lora_B, lora_A, beta=0, alpha=scale)
+                    d_x = torch.matmul(d_y_lora_B, lora_A_compute).to(x.dtype)
                 if needs_lora_A:
-                    d_lora_A = torch.matmul(d_y_lora_B.t(), x) * scale
+                    d_lora_A = torch.matmul(d_y_lora_B.t(), x_compute).to(lora_A.dtype)
 
             if needs_lora_B:
-                d_lora_B = torch.empty_like(lora_B)
-                d_lora_B.addmm_(d_y.t(), F.linear(x, lora_A), beta=0, alpha=scale)
+                x_lora_A = F.linear(x_compute, lora_A_compute)
+                x_lora_A.mul_(scale)
+                d_lora_B = torch.matmul(d_y.t(), x_lora_A).to(lora_B.dtype)
 
         if reshape and d_x is not None:
             d_x = d_x.view(bs, seq_len, d)

--- a/nemo_automodel/components/_peft/lora.py
+++ b/nemo_automodel/components/_peft/lora.py
@@ -825,7 +825,28 @@ def apply_memory_efficient_lora(x, lora_A, lora_B, scale, use_triton_kernel, res
     autograd Function so the output is never a view). Reshape back to the input rank here; the result
     is an ordinary autograd view, which — unlike a custom-Function output view — a downstream consumer
     may mutate in place (e.g. transformers' gemma3n ``project_per_layer_inputs``).
+
+    Args:
+        x: Activation tensor of shape ``[tokens, in_features]`` or ``[batch, sequence, in_features]``.
+        lora_A: Tensor of shape ``[rank, in_features]``.
+        lora_B: Tensor of shape ``[out_features, rank]``.
+        scale: LoRA scaling factor (``alpha / rank``).
+        use_triton_kernel: Request the Triton kernels; declined when their dtype precondition
+            does not hold (see below).
+        res: Optional base-projection output to fold in, in ``x``'s leading shape with
+            ``out_features`` trailing.
+
+    Returns:
+        Tensor with ``x``'s leading dimensions and ``out_features`` trailing.
     """
+    if use_triton_kernel and not (x.dtype == lora_A.dtype == lora_B.dtype):
+        # The Triton kernels hand their operands straight to ``tl.dot``, which asserts a single dtype
+        # ("Both operands must be same dtype. Got fp32 and bf16"), and they run outside autocast, so
+        # nothing reconciles the two. Mixed precision reaches here whenever an FSDP2 unit's
+        # ``output_dtype=float32`` hands an fp32 activation to bf16 adapters — the layout in #3652,
+        # whose recipe does set ``use_triton: true``. Drop to the torch matmul path below, which
+        # follows the forward compute dtype and casts explicitly.
+        use_triton_kernel = False
     out = LoRATritonFunction.apply(x, lora_A, lora_B, scale, x.dtype, use_triton_kernel, res)
     if x.dim() == 3:
         out = out.reshape(*x.shape[:-1], -1)

--- a/nemo_automodel/components/_peft/lora_mlp.py
+++ b/nemo_automodel/components/_peft/lora_mlp.py
@@ -85,12 +85,22 @@ def _use_triton(*tensors) -> bool:
     return HAVE_TRITON and all(t.is_cuda and t.is_contiguous() for t in tensors)
 
 
-def _cast(dtype, *tensors):
-    """Cast tensors to ``dtype``. ``Tensor.to`` returns the tensor itself when it already matches."""
+def _cast(dtype: torch.dtype, *tensors: torch.Tensor) -> tuple[torch.Tensor, ...]:
+    """Cast tensors to ``dtype``, preserving shape.
+
+    Args:
+        dtype: Target dtype.
+        tensors: Tensors of arbitrary shape; each is returned with the same shape and device.
+
+    Returns:
+        The tensors cast to ``dtype``, in argument order. ``Tensor.to`` returns the tensor object
+        itself when it already has ``dtype``, so a matching cast allocates nothing and preserves
+        aliasing (callers may still mutate such a result in place).
+    """
     return tuple(t.to(dtype) for t in tensors)
 
 
-def _like_input(grad, inp):
+def _like_input(grad: torch.Tensor, inp: torch.Tensor) -> torch.Tensor:
     """Return ``grad`` on the device and in the dtype of the input it belongs to.
 
     Autograd rejects a gradient whose device or dtype differs from its input's.
@@ -102,6 +112,14 @@ def _like_input(grad, inp):
       come out in the lower forward compute dtype while the input they belong to is fp32.
 
     Both are no-ops in normal single-device, uniform-dtype training.
+
+    Args:
+        grad: Gradient tensor, already in ``inp``'s shape.
+        inp: The forward input this gradient belongs to; only its device and dtype are read.
+
+    Returns:
+        Tensor of ``grad``'s shape on ``inp``'s device and in ``inp``'s dtype. Returns ``grad``
+        itself when both already match.
     """
     return grad.to(device=inp.device, dtype=inp.dtype)
 

--- a/nemo_automodel/components/_peft/lora_mlp.py
+++ b/nemo_automodel/components/_peft/lora_mlp.py
@@ -94,8 +94,9 @@ def _cast(dtype: torch.dtype, *tensors: torch.Tensor) -> tuple[torch.Tensor, ...
 
     Returns:
         The tensors cast to ``dtype``, in argument order. ``Tensor.to`` returns the tensor object
-        itself when it already has ``dtype``, so a matching cast allocates nothing and preserves
-        aliasing (callers may still mutate such a result in place).
+        itself when it already has ``dtype``, so a matching cast allocates nothing -- which also
+        means a result may alias its input (and, for a reshaped gradient, the caller's ``grad_out``).
+        Treat every result as read-only.
     """
     return tuple(t.to(dtype) for t in tensors)
 
@@ -222,7 +223,7 @@ class LoRASwiGLUMLPFunction(torch.autograd.Function):
         # untouched so the in-place SwiGLU backward keeps writing into the saved buffers.
         compute_dtype = e.dtype
         dY, xc = _cast(compute_dtype, dY, x)
-        gW, uW, dW = _cast(compute_dtype, gW, uW, dW)
+        (dW,) = _cast(compute_dtype, dW)
         gAc, gBc, uAc, uBc, dAc, dBc = _cast(compute_dtype, gA, gB, uA, uB, dA, dB)
 
         # Grad of the down-projection input h = silu(e)*g (does not need h itself):
@@ -252,7 +253,10 @@ class LoRASwiGLUMLPFunction(torch.autograd.Function):
 
         d_x = None
         if needs_x:
-            # gate base+lora (d_e@gW + d_R@gA) plus up base+lora (d_g@uW + d_Q@uA)
+            # gate base+lora (d_e@gW + d_R@gA) plus up base+lora (d_g@uW + d_Q@uA). gW/uW are read
+            # only here, so cast them inside the branch -- they are (inter, hidden) each, and an
+            # eager cast would burn that memory on every backward that does not need d_x.
+            gW, uW = _cast(compute_dtype, gW, uW)
             d_x = torch.addmm(d_e @ gW, d_R, gAc)
             d_x = d_x.addmm_(d_g, uW).addmm_(d_Q, uAc).view(ctx.orig_shape)
 
@@ -278,6 +282,11 @@ def _fusible(module) -> bool:
     if getattr(module, "use_dora", False):
         return False
     if getattr(module, "dropout_p", 0.0) and module.training:
+        return False
+    # The fused forward calls ``F.linear(x, base_weight)`` with no bias term, so a biased base
+    # projection would train on silently wrong math. Models plumb this from the HF config
+    # (``nn.Linear(..., bias=config.mlp_bias)``), so decline and let the per-linear path add it.
+    if getattr(module, "bias", None) is not None:
         return False
     # QLoRA / quantized base weights are stored as packed buffers (e.g. bitsandbytes 4-bit
     # carries a ``quant_state`` and a flattened weight shaped like ``(1, out*in/2)`` rather than
@@ -370,7 +379,7 @@ class LoRAReLU2MLPFunction(torch.autograd.Function):
         # gradient back in its input's dtype. All no-ops when the tensors already share a dtype.
         compute_dtype = e.dtype
         dY, xc = _cast(compute_dtype, dY, x)
-        uW, dW = _cast(compute_dtype, uW, dW)
+        (dW,) = _cast(compute_dtype, dW)
         uAc, uBc, dAc, dBc = _cast(compute_dtype, uA, uB, dA, dB)
 
         relu_e = torch.relu(e)
@@ -394,6 +403,7 @@ class LoRAReLU2MLPFunction(torch.autograd.Function):
 
         d_x = None
         if needs_x:
+            (uW,) = _cast(compute_dtype, uW)  # read only here; see LoRASwiGLUMLPFunction.backward
             d_x = torch.addmm(d_e @ uW, d_Q, uAc).view(ctx.orig_shape)
 
         # Hand every gradient back on its input's device and in its input's dtype (see _like_input).

--- a/nemo_automodel/components/_peft/lora_mlp.py
+++ b/nemo_automodel/components/_peft/lora_mlp.py
@@ -85,6 +85,27 @@ def _use_triton(*tensors) -> bool:
     return HAVE_TRITON and all(t.is_cuda and t.is_contiguous() for t in tensors)
 
 
+def _cast(dtype, *tensors):
+    """Cast tensors to ``dtype``. ``Tensor.to`` returns the tensor itself when it already matches."""
+    return tuple(t.to(dtype) for t in tensors)
+
+
+def _like_input(grad, inp):
+    """Return ``grad`` on the device and in the dtype of the input it belongs to.
+
+    Autograd rejects a gradient whose device or dtype differs from its input's.
+
+    * Device: under pipeline-parallel graph construction torch tracks the LoRA parameters on the meta
+      device while the activations (and the grads computed from them) are on cuda, so it rejected the
+      cuda grads ("invalid gradient ... expected device meta but got cuda").
+    * Dtype: under mixed precision (FSDP2 ``param_dtype=bf16`` with fp32 activations) the gradients
+      come out in the lower forward compute dtype while the input they belong to is fp32.
+
+    Both are no-ops in normal single-device, uniform-dtype training.
+    """
+    return grad.to(device=inp.device, dtype=inp.dtype)
+
+
 def _swiglu_fwd(e, g):
     """h = silu(e) * g."""
     if not _use_triton(e, g):
@@ -137,13 +158,18 @@ class LoRASwiGLUMLPFunction(torch.autograd.Function):
 
         # Build each projection in-place (base buffer += scaled LoRA delta) to avoid an extra
         # tokens x out buffer per projection. forward runs outside autograd, so this is safe.
+        # ``addmm_`` is not autocast-eligible — an in-place op cannot change its output dtype — so
+        # unlike the ``F.linear`` calls its operands are *not* auto-cast and must already be in the
+        # base projection's dtype. They are not when the adapters are held in a different dtype than
+        # the base (``lora_dtype``), which the per-linear path handles via autocast; cast to keep the
+        # fused path identical to it. A no-op when the dtypes already agree.
         e = F.linear(x2, gW)  # gate_out (saved)
-        e.addmm_(F.linear(x2, gA) * gS, gB.t())
+        e.addmm_(*_cast(e.dtype, F.linear(x2, gA) * gS, gB.t()))
         g = F.linear(x2, uW)  # up_out (saved)
-        g.addmm_(F.linear(x2, uA) * uS, uB.t())
+        g.addmm_(*_cast(g.dtype, F.linear(x2, uA) * uS, uB.t()))
         h = _swiglu_fwd(e, g)  # down-projection input (recomputed in backward)
         out = F.linear(h, dW)
-        out.addmm_(F.linear(h, dA) * dS, dB.t())
+        out.addmm_(*_cast(out.dtype, F.linear(h, dA) * dS, dB.t()))
 
         # Save only x / gate_out / up_out; the SwiGLU activation and down-input are recomputed.
         ctx.save_for_backward(x2, e, g, gA, gB, uA, uB, dA, dB)
@@ -167,48 +193,57 @@ class LoRASwiGLUMLPFunction(torch.autograd.Function):
         dY = grad_out.reshape(-1, grad_out.shape[-1])
         needs_x = ctx.needs_input_grad[0]
 
+        # A custom backward runs outside autocast, so nothing re-applies the forward's compute dtype
+        # here. Under mixed precision (FSDP2 ``param_dtype=bf16`` with fp32 activations) the saved
+        # ``x`` is fp32 while the base/LoRA weights are bf16, and the matmuls below would raise
+        # "expected m1 and m2 to have the same dtype". ``e`` is a forward matmul output, so its dtype
+        # *is* the forward compute dtype (the one autocast picked): run everything in it, exactly as
+        # autograd would through autocast's own cast nodes, and hand each gradient back in its
+        # input's dtype. Every cast is a no-op when the dtypes already agree, so the uniform-dtype
+        # path allocates nothing extra; ``e``/``g`` are already in the compute dtype and stay
+        # untouched so the in-place SwiGLU backward keeps writing into the saved buffers.
+        compute_dtype = e.dtype
+        dY, xc = _cast(compute_dtype, dY, x)
+        gW, uW, dW = _cast(compute_dtype, gW, uW, dW)
+        gAc, gBc, uAc, uBc, dAc, dBc = _cast(compute_dtype, gA, gB, uA, uB, dA, dB)
+
         # Grad of the down-projection input h = silu(e)*g (does not need h itself):
         # d_h = dY@dW + dS*(dY@dB)@dA. This is the only new (N, inter) buffer in backward.
-        d_P = dS * (dY @ dB)  # (N, r)
-        d_h = torch.addmm(dY @ dW, d_P, dA)  # (N, inter)
+        d_P = dS * (dY @ dBc)  # (N, r)
+        d_h = torch.addmm(dY @ dW, d_P, dAc)  # (N, inter)
 
         # Recompute SwiGLU and produce (h, d_g, d_e) in the (d_h, e, g) buffers (in place).
         h, d_g, d_e = _swiglu_bwd_inplace(d_h, e, g)
 
         # ---- down LoRA grads (use recomputed h): out = h@dW.T + dS*(h@dA.T)@dB.T ----
-        P = F.linear(h, dA)  # (N, r)
+        P = F.linear(h, dAc)  # (N, r)
         d_dB = dS * (dY.t() @ P)  # (hidden, r)
         d_dA = d_P.t() @ h  # (r, inter)
 
         # ---- up: g = x@uW.T + uS*(x@uA.T)@uB.T ----
-        Q = F.linear(x, uA)  # (N, r)
+        Q = F.linear(xc, uAc)  # (N, r)
         d_uB = uS * (d_g.t() @ Q)  # (inter, r)
-        d_Q = uS * (d_g @ uB)  # (N, r)
-        d_uA = d_Q.t() @ x  # (r, hidden)
+        d_Q = uS * (d_g @ uBc)  # (N, r)
+        d_uA = d_Q.t() @ xc  # (r, hidden)
 
         # ---- gate: e = x@gW.T + gS*(x@gA.T)@gB.T ----
-        R = F.linear(x, gA)  # (N, r)
+        R = F.linear(xc, gAc)  # (N, r)
         d_gB = gS * (d_e.t() @ R)  # (inter, r)
-        d_R = gS * (d_e @ gB)  # (N, r)
-        d_gA = d_R.t() @ x  # (r, hidden)
+        d_R = gS * (d_e @ gBc)  # (N, r)
+        d_gA = d_R.t() @ xc  # (r, hidden)
 
         d_x = None
         if needs_x:
             # gate base+lora (d_e@gW + d_R@gA) plus up base+lora (d_g@uW + d_Q@uA)
-            d_x = torch.addmm(d_e @ gW, d_R, gA)
-            d_x = d_x.addmm_(d_g, uW).addmm_(d_Q, uA).view(ctx.orig_shape)
+            d_x = torch.addmm(d_e @ gW, d_R, gAc)
+            d_x = d_x.addmm_(d_g, uW).addmm_(d_Q, uAc).view(ctx.orig_shape)
 
-        # Each returned gradient must live on the same device as its corresponding input. Under
-        # pipeline-parallel graph construction torch tracks the LoRA parameters on the meta device
-        # while the activations (and the grads computed from them) are on cuda, so it rejected the
-        # cuda grads ("invalid gradient ... expected device meta but got cuda"). Move each LoRA grad
-        # onto its parameter's device: a no-op in normal single-device training, and correct in the
-        # PP/meta graph pass (the real gradients still flow on the cuda execution passes).
-        d_gA, d_gB = d_gA.to(gA.device), d_gB.to(gB.device)
-        d_uA, d_uB = d_uA.to(uA.device), d_uB.to(uB.device)
-        d_dA, d_dB = d_dA.to(dA.device), d_dB.to(dB.device)
+        # Hand every gradient back on its input's device and in its input's dtype (see _like_input).
+        d_gA, d_gB = _like_input(d_gA, gA), _like_input(d_gB, gB)
+        d_uA, d_uB = _like_input(d_uA, uA), _like_input(d_uB, uB)
+        d_dA, d_dB = _like_input(d_dA, dA), _like_input(d_dB, dB)
         if d_x is not None:
-            d_x = d_x.to(x.device)
+            d_x = _like_input(d_x, x)
 
         # order matches forward(x, gW, gA, gB, gS, uW, uA, uB, uS, dW, dA, dB, dS)
         return (d_x, None, d_gA, d_gB, None, None, d_uA, d_uB, None, None, d_dA, d_dB, None)
@@ -289,12 +324,14 @@ class LoRAReLU2MLPFunction(torch.autograd.Function):
         """Compute the fused ReLU² MLP output, saving only x and up_out for backward."""
         orig_shape = x.shape
         x2 = x.reshape(-1, orig_shape[-1])
+        # See LoRASwiGLUMLPFunction.forward: ``addmm_`` is not autocast-eligible, so cast its operands
+        # to the base projection's dtype for a ``lora_dtype`` that differs from the base weights.
         e = F.linear(x2, uW)  # up_out (saved)
-        e.addmm_(F.linear(x2, uA) * uS, uB.t())
+        e.addmm_(*_cast(e.dtype, F.linear(x2, uA) * uS, uB.t()))
         relu_e = torch.relu(e)
         f = relu_e * relu_e  # down-projection input (recomputed in backward)
         out = F.linear(f, dW)
-        out.addmm_(F.linear(f, dA) * dS, dB.t())
+        out.addmm_(*_cast(out.dtype, F.linear(f, dA) * dS, dB.t()))
         ctx.save_for_backward(x2, e, uA, uB, dA, dB)
         ctx.bases = (uW, dW)
         ctx.scales = (uS, dS)
@@ -310,36 +347,42 @@ class LoRAReLU2MLPFunction(torch.autograd.Function):
         dY = grad_out.reshape(-1, grad_out.shape[-1])
         needs_x = ctx.needs_input_grad[0]
 
+        # See LoRASwiGLUMLPFunction.backward: a custom backward runs outside autocast, so recompute in
+        # the forward compute dtype (``e``'s, since ``e`` is a forward matmul output) and hand every
+        # gradient back in its input's dtype. All no-ops when the tensors already share a dtype.
+        compute_dtype = e.dtype
+        dY, xc = _cast(compute_dtype, dY, x)
+        uW, dW = _cast(compute_dtype, uW, dW)
+        uAc, uBc, dAc, dBc = _cast(compute_dtype, uA, uB, dA, dB)
+
         relu_e = torch.relu(e)
         f = relu_e * relu_e  # recompute down-projection input
 
         # ---- down: out = f@dW.T + dS*(f@dA.T)@dB.T ----
-        d_P = dS * (dY @ dB)  # (N, r)
-        P = F.linear(f, dA)  # (N, r)
+        d_P = dS * (dY @ dBc)  # (N, r)
+        P = F.linear(f, dAc)  # (N, r)
         d_dB = dS * (dY.t() @ P)  # (hidden, r)
         d_dA = d_P.t() @ f  # (r, inter)
-        d_f = torch.addmm(dY @ dW, d_P, dA)  # (N, inter)
+        d_f = torch.addmm(dY @ dW, d_P, dAc)  # (N, inter)
 
         # ---- ReLU²: d(relu(e)**2)/de = 2*relu(e). Reuse d_f's buffer for d_e. ----
         d_e = d_f.mul_(2.0 * relu_e)
 
         # ---- up: e = x@uW.T + uS*(x@uA.T)@uB.T ----
-        Q = F.linear(x, uA)  # (N, r)
+        Q = F.linear(xc, uAc)  # (N, r)
         d_uB = uS * (d_e.t() @ Q)  # (inter, r)
-        d_Q = uS * (d_e @ uB)  # (N, r)
-        d_uA = d_Q.t() @ x  # (r, hidden)
+        d_Q = uS * (d_e @ uBc)  # (N, r)
+        d_uA = d_Q.t() @ xc  # (r, hidden)
 
         d_x = None
         if needs_x:
-            d_x = torch.addmm(d_e @ uW, d_Q, uA).view(ctx.orig_shape)
+            d_x = torch.addmm(d_e @ uW, d_Q, uAc).view(ctx.orig_shape)
 
-        # See LoRASwiGLUMLPFunction.backward: return each LoRA grad on its parameter's device so the
-        # pipeline-parallel meta graph pass (params on meta, activations on cuda) doesn't reject the
-        # cuda grads. No-op in normal single-device training.
-        d_uA, d_uB = d_uA.to(uA.device), d_uB.to(uB.device)
-        d_dA, d_dB = d_dA.to(dA.device), d_dB.to(dB.device)
+        # Hand every gradient back on its input's device and in its input's dtype (see _like_input).
+        d_uA, d_uB = _like_input(d_uA, uA), _like_input(d_uB, uB)
+        d_dA, d_dB = _like_input(d_dA, dA), _like_input(d_dB, dB)
         if d_x is not None:
-            d_x = d_x.to(x.device)
+            d_x = _like_input(d_x, x)
 
         # order matches forward(x, uW, uA, uB, uS, dW, dA, dB, dS)
         return (d_x, None, d_uA, d_uB, None, None, d_dA, d_dB, None)

--- a/tests/functional_tests/hf_peft/test_lora_kernel.py
+++ b/tests/functional_tests/hf_peft/test_lora_kernel.py
@@ -73,3 +73,43 @@ def test_db_kernel(lora_params):
     baseline_dlora_b = torch.matmul(dy.t(), torch.matmul(x, lora_a.t())) * scale
     triton_dlora_b = lora_db_update_wrapper(lora_a, x.t(), dy, scale, dtype=dtype)
     assert torch.allclose(baseline_dlora_b, triton_dlora_b, atol=6e-2, rtol=6e-2)
+
+
+@pytest.mark.parametrize("lora_dtype", [torch.bfloat16, torch.float16])
+def test_memory_efficient_lora_declines_triton_on_mixed_dtype(lora_dtype):
+    """Mixed-dtype LoRA must fall back off the Triton kernels and match the torch path exactly.
+
+    The kernels hand their operands to ``tl.dot``, which asserts one dtype, and they run outside
+    autocast — so the FSDP2 ``output_dtype=float32`` layout from issue #3652 (FP32 activations,
+    BF16 adapters) used to abort compilation with "Both operands must be same dtype".
+
+    This calls ``apply_memory_efficient_lora`` directly rather than going through
+    ``apply_lora_to_linear_modules``: ``patch_linear_module`` force-disables Triton whenever
+    TransformerEngine is importable, and the CI image builds TE, so a recipe-level test could never
+    reach the kernels here.
+    """
+    from nemo_automodel.components._peft.lora import apply_memory_efficient_lora
+
+    torch.manual_seed(0)
+    scale = 2.5  # != 1.0 so a dropped scale cannot hide
+    x = torch.randn(64, 128, dtype=torch.float32, device="cuda")
+    lora_a = (0.05 * torch.randn(16, 128, device="cuda")).to(lora_dtype)
+    lora_b = (0.05 * torch.randn(96, 16, device="cuda")).to(lora_dtype)
+    grad_out = torch.randn(64, 96, dtype=torch.float32, device="cuda")
+
+    def run(use_triton_kernel):
+        xg = x.clone().requires_grad_(True)
+        a = lora_a.clone().requires_grad_(True)
+        b = lora_b.clone().requires_grad_(True)
+        with torch.autocast("cuda", dtype=lora_dtype):
+            out = apply_memory_efficient_lora(xg, a, b, scale, use_triton_kernel)
+        (out.float() * grad_out).sum().backward()
+        return out.float(), xg.grad, a.grad, b.grad
+
+    triton_path = run(True)  # must not raise: the kernels are declined for mixed dtype
+    torch_path = run(False)
+
+    assert triton_path[1].dtype == torch.float32
+    for name, got, want in zip(("out", "d_x", "d_lora_A", "d_lora_B"), triton_path, torch_path):
+        # Declining means literally running the torch path, so this is exact, not approximate.
+        torch.testing.assert_close(got, want, rtol=0, atol=0, msg=f"{name} diverged from the torch path")

--- a/tests/functional_tests/hf_peft/test_lora_mixed_precision_fsdp.py
+++ b/tests/functional_tests/hf_peft/test_lora_mixed_precision_fsdp.py
@@ -57,7 +57,7 @@ from torch.distributed.tensor import DTensor
 
 from nemo_automodel.components._peft import lora as lora_module
 from nemo_automodel.components._peft import lora_mlp as lora_mlp_module
-from nemo_automodel.components._peft.lora import PeftConfig, apply_lora_to_linear_modules
+from nemo_automodel.components._peft.lora import HAS_TE, PeftConfig, apply_lora_to_linear_modules
 from nemo_automodel.components.moe.layers import MLP
 
 _RESULT_PREFIX = "LORA_MIXED_PRECISION_FSDP_RESULT "
@@ -117,10 +117,19 @@ class _MLPBlock(nn.Module):
 
 
 _CASES = {
-    # (block factory, LoRA target modules, autograd function expected to run)
-    "per_linear": (lambda: _AttentionBlock(), ["*q_proj", "*o_proj"], "LoRATritonFunction"),
-    "fused_swiglu": (lambda: _MLPBlock("swiglu"), ["*gate_proj", "*up_proj", "*down_proj"], "LoRASwiGLUMLPFunction"),
-    "fused_relu2": (lambda: _MLPBlock("relu2"), ["*up_proj", "*down_proj"], "LoRAReLU2MLPFunction"),
+    # case -> (block factory, LoRA target modules, autograd function expected to run, peft.use_triton)
+    "per_linear": (lambda: _AttentionBlock(), ["*q_proj", "*o_proj"], "LoRATritonFunction", False),
+    "fused_swiglu": (
+        lambda: _MLPBlock("swiglu"),
+        ["*gate_proj", "*up_proj", "*down_proj"],
+        "LoRASwiGLUMLPFunction",
+        False,
+    ),
+    "fused_relu2": (lambda: _MLPBlock("relu2"), ["*up_proj", "*down_proj"], "LoRAReLU2MLPFunction", False),
+    # `use_triton: true` is what the recipe in #3652 actually sets, and 91 example recipes set it
+    # too. It only reaches the Triton kernels when TransformerEngine is absent -- patch_linear_module
+    # force-disables it otherwise -- which is why the issue's own run fell back to the torch path.
+    "per_linear_triton": (lambda: _AttentionBlock(), ["*q_proj", "*o_proj"], "LoRATritonFunction", True),
 }
 
 
@@ -174,7 +183,7 @@ def _observe_lora_dtypes():
 
 def _build_sharded_block(case: str, memory_efficient: bool, mesh, device, reference_state=None):
     """LoRA-patch a block through the production entry point, then shard it with the issue's policy."""
-    block_fn, target_modules, _ = _CASES[case]
+    block_fn, target_modules, _, use_triton = _CASES[case]
     torch.manual_seed(20260825)
     block = block_fn()
     apply_lora_to_linear_modules(
@@ -183,7 +192,7 @@ def _build_sharded_block(case: str, memory_efficient: bool, mesh, device, refere
             target_modules=target_modules,
             dim=RANK,
             alpha=RANK,
-            use_triton=False,
+            use_triton=use_triton,
             use_memory_efficient_lora=memory_efficient,
         ),
     )
@@ -239,7 +248,7 @@ def _relative_error(actual: torch.Tensor, expected: torch.Tensor) -> float:
 def _assert_lora_mixed_precision(case: str, device: torch.device) -> None:
     """Run one LoRA path under the issue's FSDP2 policy and check it against plain autograd."""
     mesh = init_device_mesh("cuda", (dist.get_world_size(),), mesh_dim_names=("dp",))
-    _, _, expected_fn = _CASES[case]
+    _, _, expected_fn, _ = _CASES[case]
 
     generator = torch.Generator(device=device).manual_seed(4242 + dist.get_rank())
     inputs = torch.randn(2, TOKENS, HIDDEN, device=device, dtype=torch.float32, generator=generator)
@@ -287,6 +296,12 @@ def _run_worker() -> None:
         device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
 
         for case in _CASES:
+            if case.endswith("_triton") and HAS_TE:
+                # patch_linear_module force-disables Triton when TE is importable, so this case
+                # would silently duplicate "per_linear" instead of covering the Triton kernels.
+                if dist.get_rank() == 0:
+                    print(f"{_RESULT_PREFIX}SKIP {case} (TransformerEngine present)", flush=True)
+                continue
             _assert_lora_mixed_precision(case, device)
             dist.barrier()
 

--- a/tests/functional_tests/hf_peft/test_lora_mixed_precision_fsdp.py
+++ b/tests/functional_tests/hf_peft/test_lora_mixed_precision_fsdp.py
@@ -57,12 +57,15 @@ from torch.distributed.tensor import DTensor
 
 from nemo_automodel.components._peft import lora as lora_module
 from nemo_automodel.components._peft import lora_mlp as lora_mlp_module
-from nemo_automodel.components._peft.lora import HAS_TE, PeftConfig, apply_lora_to_linear_modules
+from nemo_automodel.components._peft.lora import PeftConfig, apply_lora_to_linear_modules
 from nemo_automodel.components.moe.layers import MLP
 
 _RESULT_PREFIX = "LORA_MIXED_PRECISION_FSDP_RESULT "
 
 HIDDEN, INTER, RANK, TOKENS = 64, 96, 8, 16
+# alpha != dim on purpose: PeftConfig.scale is alpha/dim, and scale==1.0 would hide every
+# dropped-scale bug in the backward.
+ALPHA = 3 * RANK
 
 # The policy from issue #3652: parameters compute in BF16, gradients reduce in FP32, and each
 # FSDP unit casts its output back to FP32 -- which is what puts an FP32 activation in front of
@@ -126,10 +129,11 @@ _CASES = {
         False,
     ),
     "fused_relu2": (lambda: _MLPBlock("relu2"), ["*up_proj", "*down_proj"], "LoRAReLU2MLPFunction", False),
-    # `use_triton: true` is what the recipe in #3652 actually sets, and 91 example recipes set it
-    # too. It only reaches the Triton kernels when TransformerEngine is absent -- patch_linear_module
-    # force-disables it otherwise -- which is why the issue's own run fell back to the torch path.
-    "per_linear_triton": (lambda: _AttentionBlock(), ["*q_proj", "*o_proj"], "LoRATritonFunction", True),
+    # No `use_triton: true` case here on purpose: patch_linear_module force-disables Triton whenever
+    # TransformerEngine is importable, and the CI image builds it (docker/Dockerfile TE_COMMIT), so
+    # such a case would silently duplicate "per_linear". The Triton fallback is covered instead by
+    # test_lora_kernel.py::test_memory_efficient_lora_declines_triton_on_mixed_dtype, which calls
+    # apply_memory_efficient_lora directly and therefore runs regardless of TE.
 }
 
 
@@ -191,7 +195,7 @@ def _build_sharded_block(case: str, memory_efficient: bool, mesh, device, refere
         PeftConfig(
             target_modules=target_modules,
             dim=RANK,
-            alpha=RANK,
+            alpha=ALPHA,
             use_triton=use_triton,
             use_memory_efficient_lora=memory_efficient,
         ),
@@ -232,6 +236,14 @@ def _lora_grads(block: nn.Module) -> dict[str, torch.Tensor]:
     return grads
 
 
+# Fused vs per-linear differ only by op ordering, so the floor here is bf16 GEMM rounding: measured
+# at <=8.8e-3 (worst over cases and seeds, sm_89). CI also runs A100/H100/GB200, whose bf16 split-k
+# differs, so allow ~3.4x headroom rather than risk a permanent red. Detection is unaffected -- the
+# bugs this guards against are far larger: a dropped LoRA scale, a swapped base weight, or a missing
+# gate term all land at >=1.3e-1, and a uniform 5% gradient error at 5.0e-2.
+_TOLERANCE = 3e-2
+
+
 def _relative_error(actual: torch.Tensor, expected: torch.Tensor) -> float:
     """Max elementwise deviation normalized by ``expected``'s magnitude.
 
@@ -268,23 +280,35 @@ def _assert_lora_mixed_precision(case: str, device: torch.device) -> None:
         f"(observed: {sorted((str(a), str(b)) for a, b in observed[expected_fn])})"
     )
 
-    baseline, _ = _build_sharded_block(case, memory_efficient=False, mesh=mesh, device=device, reference_state=state)
-    x_baseline = inputs.clone().requires_grad_(True)
-    with torch.autocast("cuda", dtype=torch.bfloat16):
-        out_baseline = baseline(x_baseline)
-    (out_baseline.float() * grad_out).sum().backward()
+    # Guard the comparison itself: observe the baseline too and require that it did NOT enter any
+    # memory-efficient autograd function. Without this, a refactor that made fusion unconditional
+    # (or retired `use_memory_efficient_lora`) would turn every check below into self-vs-self, and
+    # they would keep passing while the path under test was silently broken.
+    with _observe_lora_dtypes() as baseline_observed:
+        baseline, _ = _build_sharded_block(
+            case, memory_efficient=False, mesh=mesh, device=device, reference_state=state
+        )
+        x_baseline = inputs.clone().requires_grad_(True)
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            out_baseline = baseline(x_baseline)
+        (out_baseline.float() * grad_out).sum().backward()
+    assert not baseline_observed, (
+        f"{case}: baseline entered {sorted(baseline_observed)}; it must run on plain autograd or "
+        "the parity check compares an implementation against itself"
+    )
 
-    # Gradients must come back in the dtype of the input they belong to.
-    assert x_efficient.grad.dtype == x_baseline.grad.dtype == torch.float32, case
+    # NB: do not assert gradient dtypes here. torch's autograd engine coerces a Function's returned
+    # gradient to its input's dtype (verified on 2.10), so such an assertion can never fail and would
+    # give false confidence. The compute-dtype half of the fix is what the parity checks below catch.
     efficient_grads, baseline_grads = _lora_grads(efficient), _lora_grads(baseline)
     assert efficient_grads.keys() == baseline_grads.keys()
     for name, grad in efficient_grads.items():
         assert torch.isfinite(grad).all(), f"{case}: non-finite gradient for {name}"
 
-    assert _relative_error(out_efficient.float(), out_baseline.float()) < 2e-2, case
-    assert _relative_error(x_efficient.grad, x_baseline.grad) < 2e-2, case
+    assert _relative_error(out_efficient.float(), out_baseline.float()) < _TOLERANCE, case
+    assert _relative_error(x_efficient.grad, x_baseline.grad) < _TOLERANCE, case
     for name, grad in efficient_grads.items():
-        assert _relative_error(grad, baseline_grads[name]) < 2e-2, f"{case}: gradient mismatch for {name}"
+        assert _relative_error(grad, baseline_grads[name]) < _TOLERANCE, f"{case}: gradient mismatch for {name}"
 
 
 def _run_worker() -> None:
@@ -296,12 +320,6 @@ def _run_worker() -> None:
         device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
 
         for case in _CASES:
-            if case.endswith("_triton") and HAS_TE:
-                # patch_linear_module force-disables Triton when TE is importable, so this case
-                # would silently duplicate "per_linear" instead of covering the Triton kernels.
-                if dist.get_rank() == 0:
-                    print(f"{_RESULT_PREFIX}SKIP {case} (TransformerEngine present)", flush=True)
-                continue
             _assert_lora_mixed_precision(case, device)
             dist.barrier()
 
@@ -323,8 +341,9 @@ def test_lora_mixed_precision_fsdp_two_rank() -> None:
         str(Path(__file__).resolve()),
         "--worker",
     ]
+    # Inherit CUDA_VISIBLE_DEVICES: the skipif gate counts the parent's visible devices, so
+    # hardcoding "0,1" here could push the workers onto GPUs this job was not assigned.
     env = os.environ.copy()
-    env["CUDA_VISIBLE_DEVICES"] = "0,1"
     repo_root = str(Path(__file__).resolve().parents[3])
     env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
     completed = subprocess.run(

--- a/tests/functional_tests/hf_peft/test_lora_mixed_precision_fsdp.py
+++ b/tests/functional_tests/hf_peft/test_lora_mixed_precision_fsdp.py
@@ -1,0 +1,338 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Two-rank FSDP2 mixed-precision coverage for the memory-efficient LoRA backward paths.
+
+Regression for issue #3652. Under the FSDP2 policy that NeMo-RL's
+``sft-llama3.1-8b-1n8g-fsdp2tp1-lora`` recipe uses, an FSDP unit's ``output_dtype=float32``
+hands the next module an FP32 activation while ``param_dtype=bfloat16`` keeps its weights in
+BF16. LoRA's memory-efficient autograd functions run their backward *outside* autocast, so
+nothing re-applies the forward compute dtype and the recomputed matmuls raised
+"expected m1 and m2 to have the same dtype".
+
+Two independent paths reach that backward, and this covers both:
+
+* ``LoRATritonFunction`` -- the per-linear path taken by every LoRA-patched ``nn.Linear``
+  (the traceback in the issue);
+* ``LoRASwiGLUMLPFunction`` / ``LoRAReLU2MLPFunction`` -- the fused MLP path that
+  ``apply_lora_to_linear_modules()`` installs automatically once a whole gate/up/down (or
+  up/down) MLP is LoRA-patched, which is what production execution actually enters.
+
+Each case asserts the mixed dtype was really observed, so the test cannot quietly degrade
+into uniform-dtype coverage, and compares gradients against the same model running on plain
+autograd (``use_memory_efficient_lora=False``) under the identical sharded setup.
+
+``tests/unit_tests/_peft`` already covers the dtype contract on CPU, but it constructs the
+mixed dtype by hand. What cannot be covered there -- and is what actually broke in the field --
+is that a real ``MixedPrecisionPolicy`` *produces* this layout: FSDP2's ``output_dtype`` cast is
+the thing that puts an FP32 activation in front of BF16 weights, and it only exists inside a
+sharded, multi-rank graph. Hence two ranks and real ``fully_shard``.
+"""
+
+import argparse
+import contextlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
+from torch.distributed.tensor import DTensor
+
+from nemo_automodel.components._peft import lora as lora_module
+from nemo_automodel.components._peft import lora_mlp as lora_mlp_module
+from nemo_automodel.components._peft.lora import PeftConfig, apply_lora_to_linear_modules
+from nemo_automodel.components.moe.layers import MLP
+
+_RESULT_PREFIX = "LORA_MIXED_PRECISION_FSDP_RESULT "
+
+HIDDEN, INTER, RANK, TOKENS = 64, 96, 8, 16
+
+# The policy from issue #3652: parameters compute in BF16, gradients reduce in FP32, and each
+# FSDP unit casts its output back to FP32 -- which is what puts an FP32 activation in front of
+# BF16 LoRA weights.
+_MP_POLICY = MixedPrecisionPolicy(
+    param_dtype=torch.bfloat16,
+    reduce_dtype=torch.float32,
+    output_dtype=torch.float32,
+)
+
+
+class _AttentionBlock(nn.Module):
+    """Projections fed by their own FSDP unit -- the per-linear ``LoRATritonFunction`` path."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Its own FSDP unit, so output_dtype=float32 makes q_proj's input FP32.
+        self.pre_proj = nn.Linear(HIDDEN, HIDDEN, bias=False)
+        self.q_proj = nn.Linear(HIDDEN, HIDDEN, bias=False)
+        self.o_proj = nn.Linear(HIDDEN, HIDDEN, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run ``o_proj(tanh(q_proj(pre_proj(x))))``.
+
+        Args:
+            x: Tensor of shape [batch, sequence, hidden].
+
+        Returns:
+            Tensor of shape [batch, sequence, hidden].
+        """
+        return self.o_proj(torch.tanh(self.q_proj(self.pre_proj(x))))
+
+
+class _MLPBlock(nn.Module):
+    """A whole MLP fed by its own FSDP unit -- the fused ``LoRA*MLPFunction`` path."""
+
+    def __init__(self, activation: str) -> None:
+        super().__init__()
+        self.pre_proj = nn.Linear(HIDDEN, HIDDEN, bias=False)
+        self.mlp = MLP(dim=HIDDEN, inter_dim=INTER, backend="torch", dtype=torch.float32, activation=activation)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run ``mlp(pre_proj(x))``.
+
+        Args:
+            x: Tensor of shape [batch, sequence, hidden].
+
+        Returns:
+            Tensor of shape [batch, sequence, hidden].
+        """
+        return self.mlp(self.pre_proj(x))
+
+
+_CASES = {
+    # (block factory, LoRA target modules, autograd function expected to run)
+    "per_linear": (lambda: _AttentionBlock(), ["*q_proj", "*o_proj"], "LoRATritonFunction"),
+    "fused_swiglu": (lambda: _MLPBlock("swiglu"), ["*gate_proj", "*up_proj", "*down_proj"], "LoRASwiGLUMLPFunction"),
+    "fused_relu2": (lambda: _MLPBlock("relu2"), ["*up_proj", "*down_proj"], "LoRAReLU2MLPFunction"),
+}
+
+
+@contextlib.contextmanager
+def _observe_lora_dtypes():
+    """Record ``(activation dtype, weight dtype)`` per memory-efficient LoRA autograd function.
+
+    Without this the cases could pass on a uniform-dtype graph -- i.e. never exercise the bug --
+    and still look green.
+    """
+    observed: dict[str, set] = {}
+    originals = {
+        "LoRATritonFunction": lora_module.LoRATritonFunction.forward,
+        "LoRASwiGLUMLPFunction": lora_mlp_module.LoRASwiGLUMLPFunction.forward,
+        "LoRAReLU2MLPFunction": lora_mlp_module.LoRAReLU2MLPFunction.forward,
+    }
+
+    def record(name: str, x: torch.Tensor, weight: torch.Tensor) -> None:
+        """Record the dtype pair one autograd function saw.
+
+        Args:
+            name: Autograd function name.
+            x: Activation tensor of shape [tokens, hidden] or [batch, sequence, hidden]; only its
+                dtype is read.
+            weight: The first weight the function multiplies ``x`` by; only its dtype is read.
+        """
+        observed.setdefault(name, set()).add((x.dtype, weight.dtype))
+
+    def per_linear(x, lora_A, lora_B, scale, dtype, use_triton_kernel=True, res=None):
+        record("LoRATritonFunction", x, lora_A)
+        return originals["LoRATritonFunction"](x, lora_A, lora_B, scale, dtype, use_triton_kernel, res)
+
+    def swiglu(ctx, x, gW, *rest):
+        record("LoRASwiGLUMLPFunction", x, gW)
+        return originals["LoRASwiGLUMLPFunction"](ctx, x, gW, *rest)
+
+    def relu2(ctx, x, uW, *rest):
+        record("LoRAReLU2MLPFunction", x, uW)
+        return originals["LoRAReLU2MLPFunction"](ctx, x, uW, *rest)
+
+    lora_module.LoRATritonFunction.forward = staticmethod(per_linear)
+    lora_mlp_module.LoRASwiGLUMLPFunction.forward = staticmethod(swiglu)
+    lora_mlp_module.LoRAReLU2MLPFunction.forward = staticmethod(relu2)
+    try:
+        yield observed
+    finally:
+        for name, fn in originals.items():
+            owner = lora_module if name == "LoRATritonFunction" else lora_mlp_module
+            getattr(owner, name).forward = staticmethod(fn)
+
+
+def _build_sharded_block(case: str, memory_efficient: bool, mesh, device, reference_state=None):
+    """LoRA-patch a block through the production entry point, then shard it with the issue's policy."""
+    block_fn, target_modules, _ = _CASES[case]
+    torch.manual_seed(20260825)
+    block = block_fn()
+    apply_lora_to_linear_modules(
+        block,
+        PeftConfig(
+            target_modules=target_modules,
+            dim=RANK,
+            alpha=RANK,
+            use_triton=False,
+            use_memory_efficient_lora=memory_efficient,
+        ),
+    )
+    for module in block.modules():
+        # lora_B initializes to zeros, which would leave the LoRA branch's gradients trivial.
+        if hasattr(module, "lora_B"):
+            nn.init.normal_(module.lora_B.weight, std=0.02)
+    if reference_state is not None:
+        block.load_state_dict(reference_state)
+    state = {k: v.detach().clone() for k, v in block.state_dict().items()}
+
+    block.to(device)
+    # pre_proj as its own FSDP unit: output_dtype=float32 makes the LoRA modules' input FP32
+    # while param_dtype=bfloat16 keeps their weights BF16.
+    fully_shard(block.pre_proj, mesh=mesh, mp_policy=_MP_POLICY)
+    fully_shard(block, mesh=mesh, mp_policy=_MP_POLICY)
+    return block, state
+
+
+def _lora_grads(block: nn.Module) -> dict[str, torch.Tensor]:
+    """Collect every LoRA parameter gradient as a full (unsharded) fp32 tensor.
+
+    Args:
+        block: A sharded block whose LoRA gradients are ``DTensor``s sharded across the mesh.
+
+    Returns:
+        Parameter name to the gradient's global (all-rank) shape in fp32 -- ``[rank, in_features]``
+        for ``lora_A`` and ``[out_features, rank]`` for ``lora_B``.
+    """
+    grads = {}
+    for name, param in block.named_parameters():
+        if "lora_" not in name:
+            continue
+        assert param.grad is not None, f"missing gradient for {name}"
+        grad = param.grad
+        grads[name] = (grad.full_tensor() if isinstance(grad, DTensor) else grad).detach().float()
+    return grads
+
+
+def _relative_error(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    """Max elementwise deviation normalized by ``expected``'s magnitude.
+
+    Args:
+        actual: Tensor of any shape.
+        expected: Tensor broadcastable to ``actual``'s shape.
+
+    Returns:
+        The scalar relative error.
+    """
+    return (actual - expected).abs().max().item() / (expected.abs().max().item() + 1e-9)
+
+
+def _assert_lora_mixed_precision(case: str, device: torch.device) -> None:
+    """Run one LoRA path under the issue's FSDP2 policy and check it against plain autograd."""
+    mesh = init_device_mesh("cuda", (dist.get_world_size(),), mesh_dim_names=("dp",))
+    _, _, expected_fn = _CASES[case]
+
+    generator = torch.Generator(device=device).manual_seed(4242 + dist.get_rank())
+    inputs = torch.randn(2, TOKENS, HIDDEN, device=device, dtype=torch.float32, generator=generator)
+    grad_out = torch.randn(2, TOKENS, HIDDEN, device=device, dtype=torch.float32, generator=generator)
+
+    with _observe_lora_dtypes() as observed:
+        efficient, state = _build_sharded_block(case, memory_efficient=True, mesh=mesh, device=device)
+        x_efficient = inputs.clone().requires_grad_(True)
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            out_efficient = efficient(x_efficient)
+        (out_efficient.float() * grad_out).sum().backward()
+
+    # The custom autograd path must actually have run, on the mixed dtype the issue describes.
+    assert expected_fn in observed, f"{case}: {expected_fn} never ran (observed: {sorted(observed)})"
+    assert (torch.float32, torch.bfloat16) in observed[expected_fn], (
+        f"{case}: {expected_fn} never saw FP32 activations against BF16 weights "
+        f"(observed: {sorted((str(a), str(b)) for a, b in observed[expected_fn])})"
+    )
+
+    baseline, _ = _build_sharded_block(case, memory_efficient=False, mesh=mesh, device=device, reference_state=state)
+    x_baseline = inputs.clone().requires_grad_(True)
+    with torch.autocast("cuda", dtype=torch.bfloat16):
+        out_baseline = baseline(x_baseline)
+    (out_baseline.float() * grad_out).sum().backward()
+
+    # Gradients must come back in the dtype of the input they belong to.
+    assert x_efficient.grad.dtype == x_baseline.grad.dtype == torch.float32, case
+    efficient_grads, baseline_grads = _lora_grads(efficient), _lora_grads(baseline)
+    assert efficient_grads.keys() == baseline_grads.keys()
+    for name, grad in efficient_grads.items():
+        assert torch.isfinite(grad).all(), f"{case}: non-finite gradient for {name}"
+
+    assert _relative_error(out_efficient.float(), out_baseline.float()) < 2e-2, case
+    assert _relative_error(x_efficient.grad, x_baseline.grad) < 2e-2, case
+    for name, grad in efficient_grads.items():
+        assert _relative_error(grad, baseline_grads[name]) < 2e-2, f"{case}: gradient mismatch for {name}"
+
+
+def _run_worker() -> None:
+    dist.init_process_group("nccl")
+    try:
+        if dist.get_world_size() != 2:
+            raise RuntimeError(f"This regression requires exactly 2 ranks, got {dist.get_world_size()}.")
+        torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+        device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+
+        for case in _CASES:
+            _assert_lora_mixed_precision(case, device)
+            dist.barrier()
+
+        if dist.get_rank() == 0:
+            print(_RESULT_PREFIX + "PASS", flush=True)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires at least 2 CUDA devices")
+def test_lora_mixed_precision_fsdp_two_rank() -> None:
+    """Per-linear and fused-MLP LoRA backward work under FSDP2 FP32-activation mixed precision."""
+    command = [
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
+        "--standalone",
+        "--nproc_per_node=2",
+        str(Path(__file__).resolve()),
+        "--worker",
+    ]
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = "0,1"
+    repo_root = str(Path(__file__).resolve().parents[3])
+    env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
+    completed = subprocess.run(
+        command,
+        cwd=repo_root,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=600,
+        check=False,
+    )
+    print(completed.stdout)
+    assert completed.returncode == 0, completed.stdout
+    assert _RESULT_PREFIX + "PASS" in completed.stdout
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--worker", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    if _parse_args().worker:
+        _run_worker()

--- a/tests/unit_tests/_peft/test_lora.py
+++ b/tests/unit_tests/_peft/test_lora.py
@@ -774,3 +774,32 @@ def test_linear_lora_negative_last_dim_shard_takes_async_shaping(single_rank_pg)
     bmm_spy.assert_not_called()
     assert isinstance(out, DTensor)
     assert torch.allclose(out.full_tensor(), ref, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("x_dtype", "lora_dtype", "expect_triton"),
+    [
+        (torch.float32, torch.float32, True),  # uniform: the Triton kernels are still used
+        (torch.bfloat16, torch.bfloat16, True),
+        (torch.float32, torch.bfloat16, False),  # issue #3652: fp32 activation, bf16 adapters
+        (torch.bfloat16, torch.float32, False),  # lora_dtype differing from the base weights
+    ],
+)
+def test_memory_efficient_lora_declines_triton_on_mixed_dtype(x_dtype, lora_dtype, expect_triton):
+    """The Triton kernels require one dtype for both matmul operands; mixed input must fall back.
+
+    ``tl.dot`` asserts "Both operands must be same dtype", and the kernels run outside autocast, so
+    nothing reconciles an FP32 activation with BF16 adapters (what FSDP2 ``output_dtype=float32``
+    produces). Declining here routes those to the torch matmul path instead of aborting compilation.
+    """
+    x = torch.randn(4, 8, dtype=x_dtype)
+    lora_A = torch.randn(2, 8, dtype=lora_dtype)
+    lora_B = torch.randn(6, 2, dtype=lora_dtype)
+
+    with patch("nemo_automodel.components._peft.lora.lora_forward_wrapper") as triton_forward:
+        triton_forward.return_value = torch.zeros(4, 6, dtype=x_dtype)
+        # The fallback is the torch matmul path, which relies on autocast to reconcile dtypes.
+        with torch.autocast("cpu", dtype=torch.bfloat16):
+            apply_memory_efficient_lora(x, lora_A, lora_B, 1.5, True)
+
+    assert triton_forward.called is expect_triton

--- a/tests/unit_tests/_peft/test_lora.py
+++ b/tests/unit_tests/_peft/test_lora.py
@@ -194,6 +194,39 @@ def test_memory_efficient_lora_matches_legacy_forward_and_backward(input_shape):
 
 
 @pytest.mark.parametrize("input_shape", [(5, 16), (2, 3, 16)])
+def test_memory_efficient_lora_mixed_dtype_matches_legacy_forward_and_backward(input_shape):
+    """Custom autograd LoRA should preserve mixed-precision output and gradient contracts."""
+    torch.manual_seed(1234)
+    scale = 1.3
+    lora_dim = 4
+    out_features = 12
+
+    x = torch.randn(*input_shape, dtype=torch.float32, requires_grad=True)
+    lora_A = torch.randn(lora_dim, input_shape[-1], dtype=torch.bfloat16, requires_grad=True)
+    lora_B = torch.randn(out_features, lora_dim, dtype=torch.bfloat16, requires_grad=True)
+    x_ref = x.detach().clone().requires_grad_(True)
+    lora_A_ref = lora_A.detach().clone().requires_grad_(True)
+    lora_B_ref = lora_B.detach().clone().requires_grad_(True)
+
+    with torch.autocast("cpu", dtype=torch.bfloat16):
+        efficient = apply_memory_efficient_lora(x, lora_A, lora_B, scale, False).float()
+        legacy = F.linear(F.linear(x_ref, lora_A_ref) * scale, lora_B_ref).float()
+
+    grad = torch.randn_like(legacy)
+    efficient.backward(grad)
+    legacy.backward(grad)
+
+    assert efficient.dtype == legacy.dtype == torch.float32
+    assert x.grad.dtype == x_ref.grad.dtype == torch.float32
+    assert lora_A.grad.dtype == lora_A_ref.grad.dtype == torch.bfloat16
+    assert lora_B.grad.dtype == lora_B_ref.grad.dtype == torch.bfloat16
+    torch.testing.assert_close(efficient, legacy)
+    torch.testing.assert_close(x.grad, x_ref.grad)
+    torch.testing.assert_close(lora_A.grad, lora_A_ref.grad)
+    torch.testing.assert_close(lora_B.grad, lora_B_ref.grad)
+
+
+@pytest.mark.parametrize("input_shape", [(5, 16), (2, 3, 16)])
 def test_memory_efficient_lora_with_residual_matches_legacy_forward_and_backward(input_shape):
     """Custom autograd LoRA should fold residual addition without changing gradients."""
     torch.manual_seed(1234)

--- a/tests/unit_tests/_peft/test_lora_mlp.py
+++ b/tests/unit_tests/_peft/test_lora_mlp.py
@@ -16,6 +16,7 @@
 
 # ruff: noqa: E741
 
+import pytest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -304,3 +305,102 @@ def test_apply_lora_respects_memory_efficient_lora_toggle():
     assert not getattr(mlp, "_lora_mlp_fused", False)
     assert mlp.forward.__func__ is original_forward
     assert install_fused_lora_mlp(mlp) == 0
+
+
+_PROJS = ("gate_proj", "up_proj", "down_proj")
+
+
+def _mixed_precision_mlp(activation, memory_efficient, lora_dtype=None):
+    """A BF16-weight MLP with LoRA applied through the production entry point.
+
+    ``apply_lora_to_linear_modules`` is what training actually calls: it patches the projections and
+    then installs the fused MLP wrapper, so this exercises the real routing rather than reaching for
+    the fused helpers directly.
+    """
+    from nemo_automodel.components._peft.lora import PeftConfig, apply_lora_to_linear_modules
+    from nemo_automodel.components.moe.layers import MLP
+
+    torch.manual_seed(0)
+    # FSDP2 param_dtype=bf16 leaves the frozen base weights in bf16.
+    mlp = MLP(dim=32, inter_dim=48, backend="torch", dtype=torch.bfloat16, activation=activation)
+    config = PeftConfig(
+        target_modules=list(_PROJS),
+        dim=4,
+        alpha=4,
+        use_triton=False,
+        use_memory_efficient_lora=memory_efficient,
+        lora_dtype=lora_dtype,
+    )
+    apply_lora_to_linear_modules(mlp, config)
+    for proj in _PROJS:
+        mod = getattr(mlp, proj, None)
+        if mod is not None:  # lora_B inits to zeros; randomize so the LoRA path is exercised
+            nn.init.normal_(mod.lora_B.weight, std=0.02)
+    return mlp
+
+
+def _lora_grads(mlp):
+    return {
+        f"{proj}.{ab}": getattr(getattr(mlp, proj), ab).weight.grad
+        for proj in _PROJS
+        if getattr(mlp, proj, None) is not None
+        for ab in ("lora_A", "lora_B")
+    }
+
+
+def _autocast_backward(mlp, x0, gout):
+    """Run one forward/backward under BF16 autocast, as mixed-precision training does."""
+    x = x0.clone().requires_grad_(True)
+    with torch.autocast("cpu", dtype=torch.bfloat16):
+        out = mlp(x)
+    (out.float() * gout).sum().backward()
+    return out, x.grad, _lora_grads(mlp)
+
+
+def _rel(a, b):
+    return (a.float() - b.float()).abs().max().item() / (b.float().abs().max().item() + 1e-9)
+
+
+@pytest.mark.parametrize(
+    ("activation", "expected_backward"),
+    [("swiglu", "LoRASwiGLUMLPFunctionBackward"), ("relu2", "LoRAReLU2MLPFunctionBackward")],
+)
+@pytest.mark.parametrize(
+    ("case", "act_dtype", "lora_dtype"),
+    [
+        # FSDP2 param_dtype=bf16 with output_dtype=fp32: fp32 activations meet bf16 compute weights.
+        ("fp32_activations", torch.float32, None),
+        # lora_dtype keeps the adapters in another dtype than the (bf16) base weights.
+        ("fp32_adapters", torch.bfloat16, torch.float32),
+    ],
+)
+def test_fused_mlp_mixed_dtype_matches_unfused(case, act_dtype, lora_dtype, activation, expected_backward):
+    """The fused MLP must handle every mixed-dtype layout the per-linear path handles, and agree with it.
+
+    Both fused paths used to raise "expected m1 and m2 to have the same dtype" here: the custom
+    backward recomputed its matmuls outside autocast (so an fp32 saved activation met bf16 weights),
+    and the forward's ``addmm_`` is not autocast-eligible (so an fp32 adapter met the bf16 base).
+    """
+    lora_grad_dtype = lora_dtype or torch.bfloat16
+    fused = _mixed_precision_mlp(activation, memory_efficient=True, lora_dtype=lora_dtype)
+    unfused = _mixed_precision_mlp(activation, memory_efficient=False, lora_dtype=lora_dtype)
+    assert getattr(fused, "_lora_mlp_fused", False), "production entry point did not install the fused MLP"
+    assert not getattr(unfused, "_lora_mlp_fused", False)
+
+    x0 = torch.randn(2, 8, 32, dtype=act_dtype)
+    gout = torch.randn(2, 8, 32, dtype=torch.float32)
+    with torch.autocast("cpu", dtype=torch.bfloat16):
+        assert type(fused(x0).grad_fn).__name__ == expected_backward  # fusion is really routed to
+
+    out_f, dx_f, grads_f = _autocast_backward(fused, x0, gout)
+    out_u, dx_u, grads_u = _autocast_backward(unfused, x0, gout)
+
+    # Every gradient must come back in the dtype of the input it belongs to.
+    assert dx_f.dtype == dx_u.dtype == act_dtype
+    for name, grad in grads_f.items():
+        assert grad is not None and grad.dtype == lora_grad_dtype, name
+
+    assert _rel(out_f, out_u) < 2e-2
+    assert _rel(dx_f, dx_u) < 2e-2
+    for name in grads_f:
+        assert _rel(grads_f[name], grads_u[name]) < 2e-2, f"grad mismatch for {name}"

--- a/tests/unit_tests/_peft/test_lora_mlp.py
+++ b/tests/unit_tests/_peft/test_lora_mlp.py
@@ -352,7 +352,8 @@ def _mixed_precision_mlp(activation, memory_efficient, lora_dtype=None):
     config = PeftConfig(
         target_modules=list(_PROJS),
         dim=4,
-        alpha=4,
+        # alpha != dim: PeftConfig.scale is alpha/dim, and scale==1.0 would hide a dropped scale.
+        alpha=12,
         use_triton=False,
         use_memory_efficient_lora=memory_efficient,
         lora_dtype=lora_dtype,

--- a/tests/unit_tests/_peft/test_lora_mlp.py
+++ b/tests/unit_tests/_peft/test_lora_mlp.py
@@ -171,6 +171,32 @@ def test_fused_helper_declines_on_dropout_and_dora():
     assert fused_lora_swiglu_mlp(gate, up, down, x) is None
 
 
+def test_fused_helper_declines_on_biased_base():
+    """A biased base projection must decline fusion: the fused forward has no bias term.
+
+    ``F.linear(x, base_weight)`` in the fused path drops the bias, so fusing a biased MLP would
+    train on silently wrong math (models plumb this from ``config.mlp_bias``).
+    """
+    from nemo_automodel.components._peft.lora_mlp import _fusible, install_fused_lora_mlp
+    from nemo_automodel.components.moe.layers import MLP
+
+    torch.manual_seed(0)
+    H, I, R = 64, 96, 8
+    biased = MLP(dim=H, inter_dim=I, backend="torch", dtype=torch.float32, activation="swiglu", bias=True)
+    for proj in ("gate_proj", "up_proj", "down_proj"):
+        setattr(biased, proj, patch_linear_module(getattr(biased, proj), dim=R, alpha=R, use_triton=False))
+        nn.init.normal_(getattr(biased, proj).lora_B.weight, std=0.02)
+        with torch.no_grad():
+            getattr(biased, proj).bias.normal_(std=0.5)
+
+    assert not _fusible(biased.gate_proj)
+    assert install_fused_lora_mlp(biased) == 0
+    assert fused_lora_swiglu_mlp(biased.gate_proj, biased.up_proj, biased.down_proj, torch.randn(2, 16, H)) is None
+
+    # The unbiased counterpart still fuses, so the gate is not over-broad.
+    assert install_fused_lora_mlp(_lora_swiglu_mlp(H, I, R)) == 1
+
+
 def test_fused_helper_declines_on_quantized_base():
     """QLoRA/quantized base weights are packed buffers, not a 2D (out, in) matrix; the fused path
     must decline so the per-linear (dequantizing) path handles them.


### PR DESCRIPTION
# What does this PR do ?

Fix memory-efficient LoRA under mixed-precision FSDP2 when activations and adapter weights have different dtypes (the NeMo-RL failure in #3652).

# Changelog

- Recompute fallback LoRA backward operations in the forward compute dtype, then return gradients in the dtype of their corresponding inputs.
- Support mixed activation/adapter dtypes in the fused LoRA MLP forward and backward paths.
- Decline Triton LoRA kernels for mixed dtypes so those calls use the safe PyTorch path.
- Decline fused LoRA MLP dispatch for biased projections, whose bias semantics are not supported by the fused implementation.
- Add CPU autocast, CUDA kernel, fused-MLP, and real two-rank FSDP2 mixed-precision regression coverage.

# Validation

- GitHub CI at exact head `9d4b0ae62`: linting, type checks, CPU/GPU unit tests, and the standard H100 L2 suites passed (remaining GB200 matrix jobs are still running/queued).
- Local CUDA reference parity: zero output and gradient differences.
- Local two-rank FSDP2 mixed-precision backward: passed.
- cw-dfw Slurm job `16590286`: 8/8 H100 ranks passed the focused BF16/FP32 regression.
- cw-dfw Slurm job `16621610`: the exact NeMo-RL issue recipe completed on 8x H100 with exit code 0 using this PR's exact source hashes. [W&B run](https://wandb.ai/Nemo-automodel/nemo-rl/runs/9aukeum8): validation loss `0.8246825933`, train loss `0.8588075314`, grad norm `0.9352310300`, one optimizer step completed.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (No documentation change required.)

# Additional Information

Fixes #3652.
