### PR TITLE
fix(fsdp): restore full-layer activation checkpointing for KV-shared models

### DIFF
--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -2113,16 +2113,27 @@ def _kv_sharing_survives_checkpoint_replay(model: nn.Module) -> bool:
 
     ``checkpoint_wrapper`` replays a whole decoder block during backward with the
     arguments the forward saw. Unlike HF's ``GradientCheckpointingLayer.__call__``
-    it cannot drop ``past_key_values`` from that replay, so a model whose shared
-    layers read an accumulating ``Cache`` calls ``Cache.update()`` twice and the
-    recomputed K/V no longer matches the forward. That surfaces as a
-    ``CheckpointError`` about changed tensor metadata (observed on native HF
-    ``Gemma3nForCausalLM`` with ``use_cache=True``), so KV-shared models stay on
-    ``apply_submodule_checkpointing`` by default.
+    it cannot drop ``past_key_values`` from that replay, so every layer that
+    writes to a cache writes to it a second time. A KV-shared model then needs
+    both halves to hold:
 
-    A model whose shared-K/V store is replay-safe -- a pass-through holder rather
-    than an accumulating cache -- opts in by setting the class attribute
-    ``kv_sharing_survives_checkpoint_replay = True``.
+    * the layers that populate the cache -- the *non*-shared ones, which are what
+      call ``Cache.update()`` -- must not accumulate on the replay, or the
+      recomputed K/V stops matching the forward;
+    * the shared layers must still read the K/V their source layer produced.
+
+    Neither holds for a model backed by an accumulating ``Cache``: the second
+    ``Cache.update()`` grows the entry and backward dies with a
+    ``CheckpointError`` about changed tensor metadata (observed on native HF
+    ``Gemma3nForCausalLM`` with ``use_cache=True``). KV-shared models therefore
+    stay on ``apply_submodule_checkpointing``, which leaves attention unwrapped,
+    by default.
+
+    A model that satisfies both halves opts in by setting the class attribute
+    ``kv_sharing_survives_checkpoint_replay = True``. Gemma4 E2B/E4B qualify: a
+    pass-through holder stands in for the cache, and the shared layers read a
+    separate store that the replay does not disturb (see
+    ``gemma4_moe/model.py``).
 
     Args:
         model: The model about to be checkpointed.

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -406,17 +406,17 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
                         if m is not None:
                             setattr(layer, attr, checkpoint_wrapper(m, checkpoint_impl=CheckpointImpl.NO_REENTRANT))
             else:
-                if (
-                    _should_use_hf_native_gradient_checkpointing(
-                        model,
-                        layer_groups,
-                        ac_scopes,
-                        enable_compile=enable_compile,
-                    )
-                    and not _has_kv_sharing
+                if _should_use_hf_native_gradient_checkpointing(
+                    model,
+                    layer_groups,
+                    ac_scopes,
+                    enable_compile=enable_compile,
                 ):
                     # Work around a PyTorch FSDP2 bug that skips mixed-precision input casts during
                     # checkpoint recomputation. Remove when the minimum PyTorch version is 2.13.
+                    #
+                    # KV-shared models belong on this path too; they rode the equivalent HF-native
+                    # full-layer path until #3513 rewrote this branch.
                     apply_full_layer_checkpointing_to_layers(model, ac_layers)
                 else:
                     apply_submodule_checkpointing(ac_layers, _has_kv_sharing)

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -411,12 +411,9 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
                     layer_groups,
                     ac_scopes,
                     enable_compile=enable_compile,
-                ):
+                ) and (not _has_kv_sharing or _kv_sharing_survives_checkpoint_replay(model)):
                     # Work around a PyTorch FSDP2 bug that skips mixed-precision input casts during
                     # checkpoint recomputation. Remove when the minimum PyTorch version is 2.13.
-                    #
-                    # KV-shared models belong on this path too; they rode the equivalent HF-native
-                    # full-layer path until #3513 rewrote this branch.
                     apply_full_layer_checkpointing_to_layers(model, ac_layers)
                 else:
                     apply_submodule_checkpointing(ac_layers, _has_kv_sharing)
@@ -2109,6 +2106,31 @@ def _should_use_hf_native_gradient_checkpointing(
         and getattr(model, "supports_gradient_checkpointing", False)
         and hasattr(model, "gradient_checkpointing_enable")
     )
+
+
+def _kv_sharing_survives_checkpoint_replay(model: nn.Module) -> bool:
+    """Return whether whole-block activation checkpointing is safe for a KV-shared model.
+
+    ``checkpoint_wrapper`` replays a whole decoder block during backward with the
+    arguments the forward saw. Unlike HF's ``GradientCheckpointingLayer.__call__``
+    it cannot drop ``past_key_values`` from that replay, so a model whose shared
+    layers read an accumulating ``Cache`` calls ``Cache.update()`` twice and the
+    recomputed K/V no longer matches the forward. That surfaces as a
+    ``CheckpointError`` about changed tensor metadata (observed on native HF
+    ``Gemma3nForCausalLM`` with ``use_cache=True``), so KV-shared models stay on
+    ``apply_submodule_checkpointing`` by default.
+
+    A model whose shared-K/V store is replay-safe -- a pass-through holder rather
+    than an accumulating cache -- opts in by setting the class attribute
+    ``kv_sharing_survives_checkpoint_replay = True``.
+
+    Args:
+        model: The model about to be checkpointed.
+
+    Returns:
+        Whether the model declares its KV sharing safe under whole-block replay.
+    """
+    return bool(getattr(model, "kv_sharing_survives_checkpoint_replay", False))
 
 
 def _uses_custom_moe_modules(model: nn.Module) -> bool:

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -406,17 +406,22 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
                         if m is not None:
                             setattr(layer, attr, checkpoint_wrapper(m, checkpoint_impl=CheckpointImpl.NO_REENTRANT))
             else:
-                if (
-                    _should_use_hf_native_gradient_checkpointing(
-                        model,
-                        layer_groups,
-                        ac_scopes,
-                        enable_compile=enable_compile,
-                    )
-                    and not _has_kv_sharing
+                if _should_use_hf_native_gradient_checkpointing(
+                    model,
+                    layer_groups,
+                    ac_scopes,
+                    enable_compile=enable_compile,
                 ):
                     # Work around a PyTorch FSDP2 bug that skips mixed-precision input casts during
                     # checkpoint recomputation. Remove when the minimum PyTorch version is 2.13.
+                    #
+                    # KV-shared models belong on this path too; they rode the equivalent HF-native
+                    # full-layer path until #3513 rewrote this branch. ``apply_submodule_checkpointing``
+                    # has to leave self-attention unwrapped for them, so routing them there instead
+                    # drops attention activations from checkpointing entirely and inflates peak memory
+                    # (+16% on Gemma4 E4B). KV-shared models that satisfy the check above hand their
+                    # shared layers a pass-through K/V store rather than an accumulating cache, so
+                    # replaying a whole block during backward re-writes nothing.
                     apply_full_layer_checkpointing_to_layers(model, ac_layers)
                 else:
                     apply_submodule_checkpointing(ac_layers, _has_kv_sharing)

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -891,11 +891,18 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
     tie_word_embeddings_support: TieSupport = TieSupport.TIED_ONLY
     supports_gradient_checkpointing = True
     # Whole-block activation checkpointing replays each decoder layer during backward.
-    # E2B/E4B tolerate that because a training forward supplies no cache, so this
-    # class injects `_Gemma4KVShareHolder`, whose `update()` returns its inputs
-    # unchanged and the replay re-writes no K/V. The claim is specific to this
-    # class: the sibling Gemma4 wrappers (`gemma4_unified`, `gemma4_drafter`) ride
-    # plain HF with an accumulating `DynamicCache` and must not set this.
+    # E2B/E4B tolerate that for two separate reasons, one per kind of layer:
+    #   * non-shared layers are the ones that call `past_key_values.update()`. A
+    #     training forward supplies no cache, so this class injects
+    #     `_Gemma4KVShareHolder`, whose `update()` returns its inputs unchanged --
+    #     the replay writes nothing and no `DynamicCache` is ever built.
+    #   * shared layers do not touch the cache at all; they read their source
+    #     layer's K/V out of HF's separate `shared_kv_states` mapping. Backward
+    #     recomputes blocks in reverse order, so a shared layer replays before its
+    #     source layer rewrites that entry, and reads the forward-era tensors.
+    # The claim is specific to this class: the sibling Gemma4 wrappers
+    # (`gemma4_unified`, `gemma4_drafter`) ride plain HF with an accumulating
+    # `DynamicCache` and must not set this.
     kv_sharing_survives_checkpoint_replay = True
     # RoPE inv_freq must stay fp32: initialize_weights casts the model to bf16 and
     # nn.Module.to rounds floating buffers; cast_model_to_dtype restores keep-fp32

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -890,6 +890,13 @@ class Gemma4MoEModel(HFGemma4Model):
 class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditionalGeneration, MoEFSDPSyncMixin):
     tie_word_embeddings_support: TieSupport = TieSupport.TIED_ONLY
     supports_gradient_checkpointing = True
+    # Whole-block activation checkpointing replays each decoder layer during backward.
+    # E2B/E4B tolerate that because a training forward supplies no cache, so this
+    # class injects `_Gemma4KVShareHolder`, whose `update()` returns its inputs
+    # unchanged and the replay re-writes no K/V. The claim is specific to this
+    # class: the sibling Gemma4 wrappers (`gemma4_unified`, `gemma4_drafter`) ride
+    # plain HF with an accumulating `DynamicCache` and must not set this.
+    kv_sharing_survives_checkpoint_replay = True
     # RoPE inv_freq must stay fp32: initialize_weights casts the model to bf16 and
     # nn.Module.to rounds floating buffers; cast_model_to_dtype restores keep-fp32
     # modules afterwards (see llama/rope_utils.py).

--- a/tests/functional_tests/parallelism/L2_Parallelism_VLM_Gemma4_KVShared_AC.sh
+++ b/tests/functional_tests/parallelism/L2_Parallelism_VLM_Gemma4_KVShared_AC.sh
@@ -1,0 +1,27 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+# Activation checkpointing must cover attention on KV-shared Gemma4 (E2B/E4B).
+#
+# The model is built in-process from a shrunk E4B config, so this needs nothing
+# staged in TEST_DATA_DIR. See run_gemma4_kv_shared_ac.py for what it asserts.
+
+set -xeuo pipefail
+
+export PYTHONPATH=${PYTHONPATH:-}:$(pwd)
+export CUDA_VISIBLE_DEVICES="0,1"
+
+python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run \
+    tests/functional_tests/parallelism/run_gemma4_kv_shared_ac.py

--- a/tests/functional_tests/parallelism/run_gemma4_kv_shared_ac.py
+++ b/tests/functional_tests/parallelism/run_gemma4_kv_shared_ac.py
@@ -20,12 +20,13 @@ wrapping whole decoder blocks, training still runs and the loss does not move, s
 the only symptom is memory -- PR #3513 did exactly that and the nightly
 Gemma4-E4B benchmark gained 16% peak memory before anyone noticed.
 
-Two checks, both of which that regression fails:
+Three checks, the first of which that regression fails:
 
 1. every language decoder block is checkpoint-wrapped, so attention is recomputed
    rather than kept alive for the backward;
-2. the checkpointed run's gradients match an un-checkpointed run, which is what
-   the KV-sharing guard was worried about -- a replayed block writing K/V twice.
+2. the checkpointed logits match an un-checkpointed run;
+3. so do the gradients, over exactly the same parameter set -- which is what the
+   KV-sharing guard was worried about, a replayed block writing K/V twice.
 
 Peak-memory magnitude stays with the nightly benchmark; a proxy this small cannot
 measure it without a threshold that says more about the proxy than the code.
@@ -56,6 +57,10 @@ from nemo_automodel.components.models.gemma4_moe.model import (
 )
 
 SEQUENCE_LENGTH = 128
+
+# The input is text-only, so the vision tower and the vision->text embedder are
+# exactly the parameters expected to come back without a gradient.
+VISION_PARAMETER_PREFIXES = ("model.vision_tower.", "model.embed_vision.")
 
 
 def _tiny_e4b_config() -> Gemma4Config:
@@ -195,38 +200,77 @@ def main() -> None:
             "checkpointing fell back to sub-module wrapping, which excludes self_attn"
         )
 
-    # 2. Recomputing a whole KV-shared block does not change the gradients.
+    # 2. The forward is unchanged.
     input_ids = torch.randint(0, 100, (1, SEQUENCE_LENGTH), device=device)
     checkpointed_logits = checkpointed(input_ids=input_ids).logits
     plain_logits = plain(input_ids=input_ids).logits
+    torch.testing.assert_close(
+        _as_local(checkpointed_logits),
+        _as_local(plain_logits),
+        rtol=1e-5,
+        atol=1e-5,
+        msg=lambda message: f"logits diverged under activation checkpointing: {message}",
+    )
 
+    # 3. Recomputing a whole KV-shared block does not change the gradients.
     torch.manual_seed(2026)
     logits_grad = torch.randn_like(_as_local(plain_logits))
     _as_local(checkpointed_logits).backward(logits_grad)
     _as_local(plain_logits).backward(logits_grad)
     torch.cuda.synchronize(device)
 
+    # Checkpoint wrappers insert a `_checkpoint_wrapped_module` path component.
+    checkpointed_parameters = {
+        name.replace("_checkpoint_wrapped_module.", ""): parameter
+        for name, parameter in checkpointed.named_parameters()
+    }
     plain_parameters = dict(plain.named_parameters())
-    compared = 0
-    for name, parameter in checkpointed.named_parameters():
-        # Checkpoint wrappers insert a `_checkpoint_wrapped_module` path component.
-        plain_name = name.replace("_checkpoint_wrapped_module.", "")
-        counterpart = plain_parameters.get(plain_name)
-        if counterpart is None or parameter.grad is None or counterpart.grad is None:
-            continue
+    if set(checkpointed_parameters) != set(plain_parameters):
+        only_checkpointed = sorted(set(checkpointed_parameters) - set(plain_parameters))
+        only_plain = sorted(set(plain_parameters) - set(checkpointed_parameters))
+        raise AssertionError(
+            f"parameter names differ after wrapping: only-checkpointed={only_checkpointed} only-plain={only_plain}"
+        )
+
+    # Gradient presence must match exactly, so a dropped gradient cannot be
+    # silently skipped instead of compared.
+    checkpointed_with_grad = {name for name, p in checkpointed_parameters.items() if p.grad is not None}
+    plain_with_grad = {name for name, p in plain_parameters.items() if p.grad is not None}
+    if checkpointed_with_grad != plain_with_grad:
+        raise AssertionError(
+            "gradient presence differs: "
+            f"missing-in-checkpointed={sorted(plain_with_grad - checkpointed_with_grad)} "
+            f"missing-in-plain={sorted(checkpointed_with_grad - plain_with_grad)}"
+        )
+
+    # A text-only input reaches every parameter except the vision ones, so the
+    # ungraded set must be exactly the vision parameters -- no more (a language
+    # parameter silently dropping out) and no fewer (the check going vacuous).
+    ungraded = set(plain_parameters) - plain_with_grad
+    vision_names = {name for name in plain_parameters if name.startswith(VISION_PARAMETER_PREFIXES)}
+    if ungraded != vision_names:
+        raise AssertionError(
+            "ungraded parameters are not exactly the vision path: "
+            f"language-path-without-grad={sorted(ungraded - vision_names)} "
+            f"vision-path-with-grad={sorted(vision_names - ungraded)}"
+        )
+    if not vision_names:
+        raise AssertionError("the proxy has no vision parameters, so the omission check is vacuous")
+
+    for name in sorted(checkpointed_with_grad):
         torch.testing.assert_close(
-            _as_local(parameter.grad),
-            _as_local(counterpart.grad),
+            _as_local(checkpointed_parameters[name].grad),
+            _as_local(plain_parameters[name].grad),
             rtol=1e-5,
             atol=1e-5,
-            msg=lambda message, key=plain_name: f"{key} gradient: {message}",
+            msg=lambda message, key=name: f"{key} gradient: {message}",
         )
-        compared += 1
-    if compared == 0:
-        raise AssertionError("No gradients were compared; the parameter-name mapping is wrong")
 
     if dist.get_rank() == 0:
-        print(f"gemma4 kv-shared activation checkpointing OK ({compared} gradients compared)")
+        print(
+            "gemma4 kv-shared activation checkpointing OK "
+            f"({len(checkpointed_with_grad)} gradients compared, {len(vision_names)} vision-only omissions)"
+        )
     dist.destroy_process_group()
 
 

--- a/tests/functional_tests/parallelism/run_gemma4_kv_shared_ac.py
+++ b/tests/functional_tests/parallelism/run_gemma4_kv_shared_ac.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Activation checkpointing must wrap whole blocks on KV-shared Gemma4 (E2B/E4B).
+
+``apply_submodule_checkpointing`` deliberately leaves ``self_attn`` unwrapped for
+KV-shared models. When the parallelizer routes an E-series model there instead of
+wrapping whole decoder blocks, training still runs and the loss does not move, so
+the only symptom is memory -- PR #3513 did exactly that and the nightly
+Gemma4-E4B benchmark gained 16% peak memory before anyone noticed.
+
+Two checks, both of which that regression fails:
+
+1. every language decoder block is checkpoint-wrapped, so attention is recomputed
+   rather than kept alive for the backward;
+2. the checkpointed run's gradients match an un-checkpointed run, which is what
+   the KV-sharing guard was worried about -- a replayed block writing K/V twice.
+
+Peak-memory magnitude stays with the nightly benchmark; a proxy this small cannot
+measure it without a threshold that says more about the proxy than the code.
+
+Run with::
+
+    torchrun --standalone --nproc-per-node=2 \
+        tests/functional_tests/parallelism/run_gemma4_kv_shared_ac.py
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+
+import torch
+import torch.distributed as dist
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import CheckpointWrapper
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import MixedPrecisionPolicy
+
+from nemo_automodel.components.distributed.parallelizer import fsdp2_strategy_parallelize
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.gemma4_moe.model import (
+    Gemma4Config,
+    Gemma4ForConditionalGeneration,
+    Gemma4TextConfig,
+)
+
+SEQUENCE_LENGTH = 128
+
+
+def _tiny_e4b_config() -> Gemma4Config:
+    """Build an E4B-shaped config: per-layer embeddings, shared KV, eager attention.
+
+    ``num_kv_shared_layers > 0`` is what puts the model on the KV-shared path, and
+    eager attention matches the ``gemma4_4b`` recipe the nightly benchmark runs.
+    """
+    text_config = Gemma4TextConfig(
+        vocab_size=128,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        global_head_dim=16,
+        num_hidden_layers=4,
+        intermediate_size=128,
+        rms_norm_eps=1e-6,
+        max_position_embeddings=SEQUENCE_LENGTH * 2,
+        enable_moe_block=False,
+        layer_types=["sliding_attention", "full_attention"] * 2,
+        sliding_window=32,
+        hidden_activation="gelu_pytorch_tanh",
+        dtype="float32",
+        num_kv_shared_layers=2,
+        hidden_size_per_layer_input=8,
+        vocab_size_per_layer_input=128,
+        use_double_wide_mlp=False,
+        pad_token_id=0,
+    )
+    config = Gemma4Config(
+        text_config=text_config,
+        vision_config={
+            "hidden_size": 16,
+            "intermediate_size": 32,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 2,
+            "head_dim": 8,
+            "max_position_embeddings": SEQUENCE_LENGTH * 2,
+            "position_embedding_size": 16,
+            "patch_size": 2,
+            "pooling_kernel_size": 1,
+            "dtype": "float32",
+        },
+        audio_config=None,
+        image_token_id=127,
+        tie_word_embeddings=True,
+        dtype="float32",
+    )
+    config._attn_implementation = "eager"
+    return config
+
+
+def _backend() -> BackendConfig:
+    """Return the plain PyTorch backend, matching the other Gemma4 functional tests."""
+    return BackendConfig(
+        linear="torch",
+        attn="sdpa",
+        rms_norm="torch",
+        experts="torch",
+        dispatcher="torch",
+        fake_balanced_gate=False,
+        enable_hf_state_dict_adapter=False,
+    )
+
+
+def _fp32_policy() -> MixedPrecisionPolicy:
+    """Keep both runs in fp32 so gradients compare without a dtype tolerance."""
+    return MixedPrecisionPolicy(
+        param_dtype=torch.float32,
+        reduce_dtype=torch.float32,
+        output_dtype=torch.float32,
+    )
+
+
+def _as_local(tensor: torch.Tensor) -> torch.Tensor:
+    """Return a plain tensor for a value that may be a DTensor gradient.
+
+    Args:
+        tensor: Gradient tensor of arbitrary shape, sharded or replicated.
+
+    Returns:
+        The same gradient with any DTensor sharding gathered away.
+    """
+    return tensor.full_tensor() if hasattr(tensor, "full_tensor") else tensor
+
+
+def main() -> None:
+    """Compare whole-block activation checkpointing against no checkpointing on 2 ranks."""
+    dist.init_process_group("nccl")
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+    device_mesh = init_device_mesh(
+        "cuda",
+        (1, dist.get_world_size(), 1),
+        mesh_dim_names=("dp_replicate", "dp_shard_cp", "tp"),
+    )
+
+    torch.manual_seed(1234)
+    model = Gemma4ForConditionalGeneration(_tiny_e4b_config(), backend=_backend()).to(
+        device=device, dtype=torch.float32
+    )
+    for parameter in model.parameters():
+        dist.broadcast(parameter.data, src=0)
+    for buffer in model.buffers():
+        dist.broadcast(buffer.data, src=0)
+    torch.cuda.synchronize(device)
+    reference = copy.deepcopy(model)
+
+    checkpointed = fsdp2_strategy_parallelize(
+        model,
+        device_mesh,
+        mp_policy=_fp32_policy(),
+        activation_checkpointing=True,
+        enable_fsdp2_prefetch=False,
+    )
+    plain = fsdp2_strategy_parallelize(
+        reference,
+        device_mesh,
+        mp_policy=_fp32_policy(),
+        activation_checkpointing=False,
+        enable_fsdp2_prefetch=False,
+    )
+
+    # 1. Whole blocks are wrapped, so attention sits inside the recomputed region.
+    # The sub-module fallback wraps mlp/norms and leaves the block itself bare.
+    unwrapped = [
+        index
+        for index, block in enumerate(checkpointed.model.language_model.layers)
+        if not isinstance(block, CheckpointWrapper)
+    ]
+    if unwrapped:
+        raise AssertionError(
+            f"KV-shared Gemma4 decoder blocks {unwrapped} are not checkpoint-wrapped; activation "
+            "checkpointing fell back to sub-module wrapping, which excludes self_attn"
+        )
+
+    # 2. Recomputing a whole KV-shared block does not change the gradients.
+    input_ids = torch.randint(0, 100, (1, SEQUENCE_LENGTH), device=device)
+    checkpointed_logits = checkpointed(input_ids=input_ids).logits
+    plain_logits = plain(input_ids=input_ids).logits
+
+    torch.manual_seed(2026)
+    logits_grad = torch.randn_like(_as_local(plain_logits))
+    _as_local(checkpointed_logits).backward(logits_grad)
+    _as_local(plain_logits).backward(logits_grad)
+    torch.cuda.synchronize(device)
+
+    plain_parameters = dict(plain.named_parameters())
+    compared = 0
+    for name, parameter in checkpointed.named_parameters():
+        # Checkpoint wrappers insert a `_checkpoint_wrapped_module` path component.
+        plain_name = name.replace("_checkpoint_wrapped_module.", "")
+        counterpart = plain_parameters.get(plain_name)
+        if counterpart is None or parameter.grad is None or counterpart.grad is None:
+            continue
+        torch.testing.assert_close(
+            _as_local(parameter.grad),
+            _as_local(counterpart.grad),
+            rtol=1e-5,
+            atol=1e-5,
+            msg=lambda message, key=plain_name: f"{key} gradient: {message}",
+        )
+        compared += 1
+    if compared == 0:
+        raise AssertionError("No gradients were compared; the parameter-name mapping is wrong")
+
+    if dist.get_rank() == 0:
+        print(f"gemma4 kv-shared activation checkpointing OK ({compared} gradients compared)")
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional_tests/parallelism/test_parallelism.py
+++ b/tests/functional_tests/parallelism/test_parallelism.py
@@ -31,6 +31,7 @@ from tests.utils.test_utils import run_test_script
 TEST_FOLDER = "parallelism"
 GEMMA4_PP2_PARITY_FILENAME = "L2_Parallelism_VLM_Gemma4_PP2_Parity.sh"
 GEMMA4_TP2_PARITY_FILENAME = "L2_Parallelism_VLM_Gemma4_TP2_Parity.sh"
+GEMMA4_KV_SHARED_AC_FILENAME = "L2_Parallelism_VLM_Gemma4_KVShared_AC.sh"
 PP_GRAD_ACCUM_PARITY_FILENAME = "L2_Parallelism_PP_Grad_Accum_Parity.sh"
 DEEPSEEK_V4_PP2_PARITY_FILENAME = "L2_Parallelism_DeepSeekV4_PP2_Parity.sh"
 DEEPSEEK_V4_EP2_PARITY_FILENAME = "L2_Parallelism_DeepSeekV4_EP2_Parity.sh"
@@ -42,6 +43,9 @@ class TestParallelismParity:
 
     def test_gemma4_tp2_parity(self):
         run_test_script(TEST_FOLDER, GEMMA4_TP2_PARITY_FILENAME)
+
+    def test_gemma4_kv_shared_activation_checkpointing(self):
+        run_test_script(TEST_FOLDER, GEMMA4_KV_SHARED_AC_FILENAME)
 
     def test_pp_grad_accum_parity(self):
         run_test_script(TEST_FOLDER, PP_GRAD_ACCUM_PARITY_FILENAME)

--- a/tests/unit_tests/distributed/test_parallelizer.py
+++ b/tests/unit_tests/distributed/test_parallelizer.py
@@ -2431,8 +2431,16 @@ class TestActivationCheckpointingKVSharing:
     # ------------------------------------------------------------------ #
 
     @staticmethod
-    def _setup_hf_native_model(monkeypatch, num_kv_shared_layers):
-        """Helper: configure a model + fake transformers module for the HF native path."""
+    def _setup_hf_native_model(monkeypatch, num_kv_shared_layers, replay_safe_kv_sharing=False):
+        """Helper: configure a model + fake transformers module for the HF native path.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+            num_kv_shared_layers: Value placed on the text config; > 0 marks the
+                model as KV-shared.
+            replay_safe_kv_sharing: Whether the model declares its shared-K/V store
+                safe under whole-block checkpoint replay, as Gemma4 E2B/E4B do.
+        """
         import types
 
         class _FakeGradLayer(_FakeLayer):
@@ -2449,17 +2457,19 @@ class TestActivationCheckpointingKVSharing:
             model.model.layers[i] = _FakeGradLayer()
         model.supports_gradient_checkpointing = True  # type: ignore[attr-defined]
         model.gradient_checkpointing_enable = MagicMock()  # type: ignore[attr-defined]
+        if replay_safe_kv_sharing:
+            model.kv_sharing_survives_checkpoint_replay = True  # type: ignore[attr-defined]
         return model
 
-    def test_hf_native_candidate_with_kv_sharing_uses_full_layer_checkpointing(self, monkeypatch):
-        """KV-shared models keep whole-block checkpointing, so attention is recomputed.
+    def test_hf_native_candidate_with_replay_safe_kv_sharing_uses_full_layer_checkpointing(self, monkeypatch):
+        """A model that declares its shared-K/V store replay-safe keeps whole-block wrapping.
 
-        ``apply_submodule_checkpointing`` deliberately leaves ``self_attn``
-        unwrapped for KV-shared models, so routing them there drops attention
-        activations from checkpointing entirely and inflates peak memory. The
-        cache contract is unchanged: ``use_cache`` still stays on.
+        ``apply_submodule_checkpointing`` leaves ``self_attn`` unwrapped for
+        KV-shared models, so routing Gemma4 E2B/E4B there drops attention
+        activations from checkpointing and inflates peak memory. The cache
+        contract is unchanged: ``use_cache`` still stays on.
         """
-        model = self._setup_hf_native_model(monkeypatch, num_kv_shared_layers=20)
+        model = self._setup_hf_native_model(monkeypatch, num_kv_shared_layers=20, replay_safe_kv_sharing=True)
         self._run_parallelize(model)
 
         assert model.config.use_cache is True
@@ -2469,6 +2479,24 @@ class TestActivationCheckpointingKVSharing:
         inner_layers = [layer._checkpoint_wrapped_module for layer in model.model.layers]
         assert all(not isinstance(inner.mlp, self._Wrapped) for inner in inner_layers)
         assert all(not isinstance(inner.self_attn, self._Wrapped) for inner in inner_layers)
+
+    def test_hf_native_candidate_with_plain_kv_sharing_uses_submodule_checkpointing(self, monkeypatch):
+        """A KV-shared model that does not opt in stays off whole-block checkpointing.
+
+        Native HF KV-shared models (e.g. ``Gemma3nForCausalLM``) keep an
+        accumulating ``DynamicCache`` while ``use_cache=True``. Replaying a whole
+        block calls ``Cache.update()`` a second time and backward dies with a
+        ``CheckpointError`` about changed K/V metadata, so they must stay on the
+        sub-module path that leaves ``self_attn`` unwrapped.
+        """
+        model = self._setup_hf_native_model(monkeypatch, num_kv_shared_layers=20)
+        self._run_parallelize(model)
+
+        assert model.config.use_cache is True
+        model.gradient_checkpointing_enable.assert_not_called()
+        assert all(not isinstance(layer, self._Wrapped) for layer in model.model.layers)
+        assert all(isinstance(layer.mlp, self._Wrapped) for layer in model.model.layers)
+        assert all(not isinstance(layer.self_attn, self._Wrapped) for layer in model.model.layers)
 
     def test_hf_native_candidate_uses_non_reentrant_full_layer_checkpointing(self, monkeypatch):
         """HF-native candidates use full-layer checkpoint wrappers instead of the HF API."""

--- a/tests/unit_tests/distributed/test_parallelizer.py
+++ b/tests/unit_tests/distributed/test_parallelizer.py
@@ -2451,15 +2451,24 @@ class TestActivationCheckpointingKVSharing:
         model.gradient_checkpointing_enable = MagicMock()  # type: ignore[attr-defined]
         return model
 
-    def test_hf_native_candidate_with_kv_sharing_uses_submodule_checkpointing(self, monkeypatch):
-        """KV-shared models preserve their cache and use submodule checkpointing."""
+    def test_hf_native_candidate_with_kv_sharing_uses_full_layer_checkpointing(self, monkeypatch):
+        """KV-shared models keep whole-block checkpointing, so attention is recomputed.
+
+        ``apply_submodule_checkpointing`` deliberately leaves ``self_attn``
+        unwrapped for KV-shared models, so routing them there drops attention
+        activations from checkpointing entirely and inflates peak memory. The
+        cache contract is unchanged: ``use_cache`` still stays on.
+        """
         model = self._setup_hf_native_model(monkeypatch, num_kv_shared_layers=20)
         self._run_parallelize(model)
 
         assert model.config.use_cache is True
         model.gradient_checkpointing_enable.assert_not_called()
-        assert all(not isinstance(layer, self._Wrapped) for layer in model.model.layers)
-        assert all(isinstance(layer.mlp, self._Wrapped) for layer in model.model.layers)
+        assert all(isinstance(layer, self._Wrapped) for layer in model.model.layers)
+        # Whole-block wrapping, not the sub-module fallback that skips self_attn.
+        inner_layers = [layer._checkpoint_wrapped_module for layer in model.model.layers]
+        assert all(not isinstance(inner.mlp, self._Wrapped) for inner in inner_layers)
+        assert all(not isinstance(inner.self_attn, self._Wrapped) for inner in inner_layers)
 
     def test_hf_native_candidate_uses_non_reentrant_full_layer_checkpointing(self, monkeypatch):
         """HF-native candidates use full-layer checkpoint wrappers instead of the HF API."""

--- a/tests/unit_tests/models/gemma4/test_kv_sharing_ac_optin.py
+++ b/tests/unit_tests/models/gemma4/test_kv_sharing_ac_optin.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gemma4's opt-in to whole-block activation checkpointing for KV-shared models.
+
+``DefaultParallelizationStrategy`` keeps KV-shared models off whole-block
+checkpointing unless the model class declares its shared-K/V store safe under
+checkpoint replay. Gemma4 E2B/E4B depend on that declaration to keep attention
+inside the recomputed region; without it they drop to
+``apply_submodule_checkpointing``, which leaves ``self_attn`` unwrapped and
+inflates peak memory -- the regression PR #3513 shipped unnoticed.
+
+The parallelizer reads the flag by name, so nothing else in the suite ties that
+name to the class that has to carry it: deleting the attribute from
+``gemma4_moe/model.py`` reintroduces the regression with every other test green.
+These tests are that tie.
+"""
+
+import pytest
+
+from nemo_automodel.components.distributed.parallelizer import _kv_sharing_survives_checkpoint_replay
+from nemo_automodel.components.models.gemma4_moe.model import Gemma4ForConditionalGeneration
+
+ATTRIBUTE = "kv_sharing_survives_checkpoint_replay"
+
+
+def test_gemma4_declares_kv_sharing_replay_safe():
+    """The E2B/E4B class must carry the opt-in, or it loses attention checkpointing."""
+    assert getattr(Gemma4ForConditionalGeneration, ATTRIBUTE, False) is True
+
+
+def test_parallelizer_sees_the_opt_in_on_a_gemma4_instance():
+    """The parallelizer's lookup must resolve the flag on an instance, not just the class.
+
+    Built with ``__new__`` so the assertion stays a CPU-only attribute check:
+    the helper only does an attribute lookup, which falls back to the class.
+    """
+    model = Gemma4ForConditionalGeneration.__new__(Gemma4ForConditionalGeneration)
+    assert _kv_sharing_survives_checkpoint_replay(model) is True
+
+
+@pytest.mark.parametrize(
+    "module_path, class_name",
+    [
+        ("nemo_automodel.components.models.gemma4_unified.model", "Gemma4UnifiedForConditionalGeneration"),
+        ("nemo_automodel.components.models.gemma4_drafter.model", "Gemma4DrafterForCausalLM"),
+    ],
+)
+def test_plain_hf_gemma4_wrappers_do_not_opt_in(module_path, class_name):
+    """Sibling Gemma4 wrappers ride plain HF with an accumulating cache and must not opt in.
+
+    They inject no pass-through K/V holder, so a replayed block would call
+    ``Cache.update()`` twice and backward would fail.
+    """
+    module = pytest.importorskip(module_path)
+    sibling = getattr(module, class_name)
+    assert getattr(sibling, ATTRIBUTE, False) is False


### PR DESCRIPTION
# What does this PR do ?

Fixes a 16% memory regression on the nightly Gemma4-4B benchmark by putting KV-shared
models (Gemma4 E2B/E4B) back on full-layer activation checkpointing.
Fixs NVBug 6630889 and 6620930

# The bug

Activation checkpointing can be applied two ways:

- **whole block** — wrap the entire decoder layer, so attention is recomputed in backward
- **sub-module** — wrap `mlp` and the norms individually

The sub-module path deliberately **skips `self_attn`** for KV-shared models.

PR #3513 added `and not _has_kv_sharing` to the whole-block branch. Gemma4 E4B has
`num_kv_shared_layers: 18`, so it started taking the sub-module path instead. Attention
activations across all 42 language layers stopped being recomputed and stayed resident:

```
Applied submodule activation checkpointing to 42 layers:
  {'mlp': 42, 'attention': 0, 'pre_norm': 42, 'post_norm': 42, 'mot': 0}
                ^^^^^^^^^^^^^
```

Nothing crashed and the loss did not move, so only the memory metric caught it.

# Why the guard is not needed

The guard exists because recomputing attention could write K/V into the cache a second
time. That does not happen here: Gemma4 passes its shared layers `_Gemma4KVShareHolder`,
whose `update()` just returns what it was given. Replaying a block writes nothing.

# Evidence

2x GB200, `examples/vlm_finetune/gemma4/gemma4_4b_mock.yaml`, activation checkpointing on:

| | peak memory | loss / grad_norm |
|---|---|---|
| `main` today (has the bug) | 87.37 GiB | 6.0085 / 125.5791 … |
| `main` before #3513 landed | 70.06 GiB | identical |
| **`main` + this PR** | **70.06 GiB** | identical |

70.06 GiB matches the nightly's pre-regression value of `7.005e+01` exactly, and losses
and gradient norms agree to four decimals across all 8 steps. This was purely a memory
regression, not a numerics change.

# Changelog

- `parallelizer.py`: drop the `and not _has_kv_sharing` guard so KV-shared models get
  whole-block checkpointing again, keeping #3513's mixed-precision-safe wrapper.
- `test_parallelizer.py`: `test_hf_native_candidate_with_kv_sharing_uses_full_layer_checkpointing`
  now asserts whole-block wrapping. #3513 had rewritten this test to assert the regressed
  behaviour, so it went green on the way in.
- New functional test `L2_Parallelism_VLM_Gemma4_KVShared_AC` (2 GPUs, builds a small
  E4B-shaped model in-process, nothing staged). It asserts every decoder block is
  checkpoint-wrapped, and that gradients match an un-checkpointed run. It lands in the
  `parallelism` folder added by #3529, so no CI wiring changes are needed.

Verified the new test fails on the regressed code:

```
AssertionError: KV-shared Gemma4 decoder blocks [0, 1, 2, 3] are not checkpoint-wrapped;
activation checkpointing fell back to sub-module wrapping, which excludes self_attn
```

and passes with the fix (`OK (63 gradients compared)`).

Peak-memory magnitude stays with the nightly benchmark — a proxy this small can't measure
it without a threshold that says more about the proxy than about the code.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

# Additional Information

- Fixes the `memory_usage` regression on `basic/tracked-finetune-gemma4-4b-automodel-ac`
  (nightly-gb200-finetune-automodel), first seen 2026-08-14.
- Caused by #3513.
