### PR TITLE
fix(diffusion): rank-symmetric DMD2 all-reduce and deferred FSDP2 grad sync

### DIFF
--- a/nemo_automodel/recipes/diffusion/step_distillation.py
+++ b/nemo_automodel/recipes/diffusion/step_distillation.py
@@ -26,6 +26,7 @@ import torch.distributed as dist
 from torch import nn
 
 from nemo_automodel.components.checkpoint.stateful_wrappers import ModelState, OptimizerState
+from nemo_automodel.components.distributed.utils import get_sync_ctx
 from nemo_automodel.components.training.utils import (
     clip_grad_norm,
     prepare_after_first_microbatch,
@@ -339,7 +340,8 @@ class _DMD2Objective:
         num_microbatches = len(batch_group)
 
         for index, micro_batch in enumerate(batch_group):
-            if index == num_microbatches - 1:
+            is_final_microbatch = index == num_microbatches - 1
+            if is_final_microbatch:
                 prepare_for_final_backward([active_model], pp_enabled=False)
 
             (
@@ -354,30 +356,42 @@ class _DMD2Objective:
                 "encoder_hidden_states": text_embeddings,
                 "encoder_hidden_states_mask": text_mask,
             }
-            if student_phase:
-                losses = self.dmd_pipeline.compute_student_loss(
-                    latents,
-                    noise,
-                    negative_encoder_hidden_states=negative_embeddings,
-                    negative_encoder_hidden_states_mask=negative_mask,
-                    **kwargs,
-                )
-            else:
-                losses = self.dmd_pipeline.compute_fake_score_loss(latents, noise, **kwargs)
+            # Defer FSDP2's gradient reduce-scatter to the last microbatch. The
+            # prepare_for_* helpers above are gated on a method only the MoE mixin
+            # defines, so both are no-ops for a diffusers transformer -- without this
+            # context `fsdp.defer_fsdp_grad_sync` has no effect here and every
+            # microbatch pays a full reduce-scatter set. Mirrors what the non-DMD2
+            # branch of this recipe already does.
+            sync_context = get_sync_ctx(
+                active_model,
+                is_final_microbatch,
+                defer_fsdp_grad_sync=recipe.defer_fsdp_grad_sync,
+            )
+            with sync_context:
+                if student_phase:
+                    losses = self.dmd_pipeline.compute_student_loss(
+                        latents,
+                        noise,
+                        negative_encoder_hidden_states=negative_embeddings,
+                        negative_encoder_hidden_states_mask=negative_mask,
+                        **kwargs,
+                    )
+                else:
+                    losses = self.dmd_pipeline.compute_fake_score_loss(latents, noise, **kwargs)
 
-            total = losses["total"]
-            if recipe.check_loss and not torch.isfinite(total).all():
-                raise FloatingPointError(f"Non-finite DMD2 {phase} loss at step {global_step}.")
-            (total / num_microbatches).backward()
-            reported_total = total.detach()
+                total = losses["total"]
+                if recipe.check_loss and not torch.isfinite(total).all():
+                    raise FloatingPointError(f"Non-finite DMD2 {phase} loss at step {global_step}.")
+                (total / num_microbatches).backward()
+                reported_total = total.detach()
 
-            if not student_phase and self.discriminator_optimizer is not None:
-                discriminator_losses = self.dmd_pipeline.compute_discriminator_loss(latents, noise, **kwargs)
-                discriminator_total = discriminator_losses["total"]
-                if recipe.check_loss and not torch.isfinite(discriminator_total).all():
-                    raise FloatingPointError(f"Non-finite DMD2 discriminator loss at step {global_step}.")
-                (discriminator_total / num_microbatches).backward()
-                reported_total = reported_total + discriminator_total.detach()
+                if not student_phase and self.discriminator_optimizer is not None:
+                    discriminator_losses = self.dmd_pipeline.compute_discriminator_loss(latents, noise, **kwargs)
+                    discriminator_total = discriminator_losses["total"]
+                    if recipe.check_loss and not torch.isfinite(discriminator_total).all():
+                        raise FloatingPointError(f"Non-finite DMD2 discriminator loss at step {global_step}.")
+                    (discriminator_total / num_microbatches).backward()
+                    reported_total = reported_total + discriminator_total.detach()
 
             total_losses.append(reported_total)
             if index == 0:
@@ -577,9 +591,15 @@ class _DMD2Objective:
             return
         dp_size = recipe._get_dp_group_size()
         for parameter in self.discriminator.parameters():
-            if parameter.grad is not None:
-                dist.all_reduce(parameter.grad, op=dist.ReduceOp.SUM, group=recipe._get_dp_group())
-                parameter.grad.div_(dp_size)
+            if parameter.grad is None:
+                # Skipping would make the number of collectives rank-dependent, and one
+                # rank taking a different branch deadlocks the job with no diagnostic --
+                # no timeout message, no rank identification. Materializing a zero costs
+                # one allocation and keeps every rank issuing the same collectives in the
+                # same order.
+                parameter.grad = torch.zeros_like(parameter)
+            dist.all_reduce(parameter.grad, op=dist.ReduceOp.SUM, group=recipe._get_dp_group())
+            parameter.grad.div_(dp_size)
 
     def _require_ready(self) -> None:
         if (

--- a/tests/unit_tests/recipes/test_diffusion_step_distillation.py
+++ b/tests/unit_tests/recipes/test_diffusion_step_distillation.py
@@ -143,6 +143,7 @@ def _training_fixture():
         clip_grad_max_norm=100.0,
         grad_clip_foreach=False,
         check_loss=True,
+        defer_fsdp_grad_sync=True,
     )
     micro_batch = {
         "image_latents": torch.zeros(1, 1, 1, 1),
@@ -212,6 +213,7 @@ def _checkpoint_recipe(checkpoint_dir: Path, base_weight: float) -> TrainDiffusi
     recipe.clip_grad_max_norm = 100.0
     recipe.grad_clip_foreach = False
     recipe.check_loss = True
+    recipe.defer_fsdp_grad_sync = True
     recipe.cpu_offload = False
     recipe.peft_config = None
 


### PR DESCRIPTION
Two independent distributed issues in the DMD2 objective.

Stacked on #3298 — `step_distillation.py` does not exist on `main`, so this targets
that branch rather than `main`.

### 1. Rank-dependent collective count in the discriminator all-reduce

`_synchronize_discriminator_gradients` skipped parameters whose `.grad` was `None`:

```python
for parameter in self.discriminator.parameters():
    if parameter.grad is not None:          # <- makes the collective COUNT rank-dependent
        dist.all_reduce(parameter.grad, ...)
```

NCCL matches collectives by call order, so one rank taking a different branch hangs
the whole job with no diagnostic — no timeout message, no rank identification.

The replicated discriminator uses every parameter on every forward today, so there is
**no reachable trigger from the shipped recipes** — this is a latent hazard rather than
a live bug. But the guard buys nothing: materializing a zero gradient costs one
allocation and keeps every rank issuing the same collectives in the same order.

Verified: the collective count is now constant at 4 whether or not a gradient is
`None`; before the change it was 3 vs 4 across ranks.

### 2. FSDP2 gradient sync was never deferred to the final microbatch

The microbatch loop relies on `prepare_for_grad_accumulation` /
`prepare_for_final_backward`, which are gated on a method only the MoE mixin defines —
so both are **no-ops** for a diffusers transformer, and `fsdp.defer_fsdp_grad_sync` had
no effect on this path.

Measured on a sharded Wan transformer: **20 `reduce_scatter_tensor` calls for 4
microbatches where 5 are needed** — a full reduce-scatter set per microbatch instead of
only on the last.

This is a performance issue, not a correctness one (reduce-scatter of a sum equals the
sum of reduce-scatters), and it is invisible at the shipped configs, whose
`global_batch_size // (local_batch_size * dp_size)` is 1. It becomes real as soon as
`global_batch_size` is raised.

The non-DMD2 branch of this same recipe already handles it via `get_sync_ctx`; the DMD2
branch now does too.

### Testing

- `tests/unit_tests/recipes/test_diffusion_step_distillation.py`: 42 passed
- Wider sweep (`recipes`, `datasets/diffusion`, `_diffusers`, `flow_matching`): 1721
  passed; the 5 `test_base_recipe.py` failures are pre-existing and reproduce on a
  clean `main` checkout
- `ruff check` / `ruff format --check` clean

The test fixtures gain `defer_fsdp_grad_sync`, which the real `TrainDiffusionRecipe`
sets but the partial stand-ins did not — added there rather than defensively
`getattr`-ing it in production, since that would mask the same class of bug later.