### PR TITLE
perf(moe): reuse the DeepEP dispatch layout on activation-checkpoint recompute

### DIFF
--- a/nemo_automodel/components/moe/megatron/fused_a2a.py
+++ b/nemo_automodel/components/moe/megatron/fused_a2a.py
@@ -18,6 +18,8 @@
 # Licensed under the MIT License - https://github.com/deepseek-ai/DeepEP/blob/main/LICENSE
 
 import os
+import threading
+from contextlib import contextmanager
 
 try:
     from deep_ep import Buffer
@@ -47,6 +49,55 @@ import torch
 _buffer = None
 _nvshmem_available = None
 _uccl_buffer = None
+
+
+class HybridEPDispatchReplayRecorder:
+    """Record HybridEP layouts from checkpoint forward for deterministic replay."""
+
+    def __init__(self) -> None:
+        self._records: list = []
+        self._cursor = 0
+        self.replay_misses = 0
+
+    def record(self, entry) -> None:
+        self._records.append(entry)
+
+    def take(self):
+        """Return the next forward dispatch record, or ``None`` on divergence."""
+        if self._cursor >= len(self._records):
+            self.replay_misses += 1
+            return None
+        entry = self._records[self._cursor]
+        self._cursor += 1
+        return entry
+
+    def rewind(self) -> None:
+        self._cursor = 0
+
+
+class _HybridEPDispatchReplayState(threading.local):
+    def __init__(self) -> None:
+        self.recorder: HybridEPDispatchReplayRecorder | None = None
+        self.mode: str | None = None
+
+
+_hybridep_dispatch_replay_state = _HybridEPDispatchReplayState()
+
+
+@contextmanager
+def hybridep_dispatch_replay_scope(recorder: HybridEPDispatchReplayRecorder | None, mode: str):
+    """Bind a HybridEP dispatch recorder for checkpoint forward or recompute."""
+    if mode not in ("record", "replay"):
+        raise ValueError(f"Unsupported HybridEP dispatch replay mode: {mode}")
+    previous_recorder = _hybridep_dispatch_replay_state.recorder
+    previous_mode = _hybridep_dispatch_replay_state.mode
+    _hybridep_dispatch_replay_state.recorder = recorder
+    _hybridep_dispatch_replay_state.mode = mode if recorder is not None else None
+    try:
+        yield
+    finally:
+        _hybridep_dispatch_replay_state.recorder = previous_recorder
+        _hybridep_dispatch_replay_state.mode = previous_mode
 
 
 def _is_nvshmem_available() -> bool:
@@ -423,6 +474,31 @@ class HybridEPDispatch(torch.autograd.Function):
                 num_sms_combine_api,
                 fp8_dispatch,
             )
+
+        recorder = _hybridep_dispatch_replay_state.recorder
+        if recorder is not None and _hybridep_dispatch_replay_state.mode == "replay":
+            replayed = recorder.take()
+            if replayed is not None:
+                handle, tokens_per_expert = replayed
+                replayed_outputs = _hybrid_ep_buffer.dispatch_with_permute(
+                    hidden=x,
+                    probs=probs,
+                    scaling_factor=None,
+                    handle=handle,
+                    pad_multiple=pad_multiple,
+                    num_permuted_tokens=tokens_per_expert.sum(),
+                )
+                dispatched_hidden, dispatched_probs, dispatched_scaling_factor, _, _ = replayed_outputs
+                ctx.handle = handle
+                ctx.pad_multiple = pad_multiple
+                return (
+                    dispatched_hidden,
+                    dispatched_probs,
+                    dispatched_scaling_factor,
+                    tokens_per_expert,
+                    handle,
+                )
+
         non_blocking = num_permuted_tokens is not None
         (
             dispatched_hidden,
@@ -443,6 +519,10 @@ class HybridEPDispatch(torch.autograd.Function):
 
         ctx.handle = handle
         ctx.pad_multiple = pad_multiple
+        if recorder is not None and _hybridep_dispatch_replay_state.mode == "record":
+            # Keep only the reusable layout and its output extent. Recomputed
+            # activations and probabilities are still redispatched through it.
+            recorder.record((handle, tokens_per_expert))
         return (
             dispatched_hidden,
             dispatched_probs,

--- a/nemo_automodel/components/moe/megatron/fused_a2a.py
+++ b/nemo_automodel/components/moe/megatron/fused_a2a.py
@@ -66,7 +66,12 @@ class HybridEPDispatchReplayRecorder:
         """Cache each layout extent after the checkpoint-forward op context exits."""
         for entry in self._records:
             if entry[2] is None:
-                entry[2] = entry[1].sum()
+                # HybridEP's sync-free replay API expects a host integer.  Do
+                # both the reduction and device-to-host scalar conversion only
+                # after the selective-checkpoint context exits; otherwise the
+                # replay-only conversion adds aten._local_scalar_dense to the
+                # recompute trace.
+                entry[2] = int(entry[1].sum().item())
 
     def take(self):
         """Return the next forward dispatch record, or ``None`` on divergence."""

--- a/nemo_automodel/components/moe/megatron/fused_a2a.py
+++ b/nemo_automodel/components/moe/megatron/fused_a2a.py
@@ -59,8 +59,14 @@ class HybridEPDispatchReplayRecorder:
         self._cursor = 0
         self.replay_misses = 0
 
-    def record(self, entry) -> None:
-        self._records.append(entry)
+    def record(self, handle, tokens_per_expert) -> None:
+        self._records.append([handle, tokens_per_expert, None])
+
+    def finalize(self) -> None:
+        """Cache each layout extent after the checkpoint-forward op context exits."""
+        for entry in self._records:
+            if entry[2] is None:
+                entry[2] = entry[1].sum()
 
     def take(self):
         """Return the next forward dispatch record, or ``None`` on divergence."""
@@ -479,14 +485,14 @@ class HybridEPDispatch(torch.autograd.Function):
         if recorder is not None and _hybridep_dispatch_replay_state.mode == "replay":
             replayed = recorder.take()
             if replayed is not None:
-                handle, tokens_per_expert = replayed
+                handle, tokens_per_expert, num_permuted_tokens = replayed
                 replayed_outputs = _hybrid_ep_buffer.dispatch_with_permute(
                     hidden=x,
                     probs=probs,
                     scaling_factor=None,
                     handle=handle,
                     pad_multiple=pad_multiple,
-                    num_permuted_tokens=tokens_per_expert.sum(),
+                    num_permuted_tokens=num_permuted_tokens,
                 )
                 dispatched_hidden, dispatched_probs, dispatched_scaling_factor, _, _ = replayed_outputs
                 ctx.handle = handle
@@ -522,7 +528,7 @@ class HybridEPDispatch(torch.autograd.Function):
         if recorder is not None and _hybridep_dispatch_replay_state.mode == "record":
             # Keep only the reusable layout and its output extent. Recomputed
             # activations and probabilities are still redispatched through it.
-            recorder.record((handle, tokens_per_expert))
+            recorder.record(handle, tokens_per_expert)
         return (
             dispatched_hidden,
             dispatched_probs,

--- a/nemo_automodel/components/moe/megatron/fused_a2a.py
+++ b/nemo_automodel/components/moe/megatron/fused_a2a.py
@@ -18,6 +18,8 @@
 # Licensed under the MIT License - https://github.com/deepseek-ai/DeepEP/blob/main/LICENSE
 
 import os
+import threading
+from contextlib import contextmanager
 
 try:
     from deep_ep import Buffer
@@ -26,6 +28,87 @@ try:
     HAVE_DEEP_EP = True
 except ImportError:
     HAVE_DEEP_EP = False
+
+
+# ── DeepEP dispatch replay across activation-checkpoint recompute ────────────
+#
+# Activation checkpointing replays a block's forward during backward, which
+# re-runs its MoE dispatch from scratch: DeepEP recomputes the routing layout
+# (`get_dispatch_layout` -> `notify_dispatch`) and then moves the tokens. The
+# layout is pure a function of the routing, and the routing is identical on the
+# replay (checkpointing restores the same inputs and the AC policy pins the
+# router's top-k), so that recomputation is redundant.
+#
+# DeepEP already exposes the cheap path: passing the `handle` returned by a
+# previous dispatch skips the layout exchange entirely -- that is what
+# `FusedDispatch.backward` does, and it is why the backward dispatch costs
+# ~4 ms against ~4.4 s for the layout-computing forward dispatches.
+#
+# Recording is scoped to one checkpoint frame: the AC wrapper builds a recorder
+# per checkpointed call, the forward appends each dispatch's handle and routing
+# metadata in call order, and the recompute consumes them in the same order.
+# Only the handle and the (small) per-token routing metadata are retained --
+# the dispatched activations themselves are still re-communicated, so the
+# memory that activation checkpointing saves is preserved.
+class DispatchReplayRecorder:
+    """Per-checkpoint-frame log of DeepEP dispatch results, replayed on recompute."""
+
+    def __init__(self) -> None:
+        self._records: list = []
+        self._cursor = 0
+        self.replay_misses = 0
+
+    def record(self, entry) -> None:
+        self._records.append(entry)
+
+    def take(self):
+        """Next recorded dispatch, or None when the replay outruns the log."""
+        if self._cursor >= len(self._records):
+            # Recompute issued more dispatches than the forward did. Fall back to
+            # a full dispatch rather than replaying a mismatched layout.
+            self.replay_misses += 1
+            return None
+        entry = self._records[self._cursor]
+        self._cursor += 1
+        return entry
+
+    def rewind(self) -> None:
+        self._cursor = 0
+
+
+class _DispatchReplayState(threading.local):
+    """Thread-local replay binding. ``threading.local`` runs ``__init__`` once per
+    thread, so both attributes always exist on every thread that touches it."""
+
+    def __init__(self) -> None:
+        self.recorder: DispatchReplayRecorder | None = None
+        self.mode: str | None = None
+
+
+_dispatch_replay_state = _DispatchReplayState()
+
+
+def _replay_mode() -> str | None:
+    return _dispatch_replay_state.mode
+
+
+def _active_recorder() -> "DispatchReplayRecorder | None":
+    return _dispatch_replay_state.recorder
+
+
+@contextmanager
+def dispatch_replay_scope(recorder: "DispatchReplayRecorder | None", mode: str):
+    """Bind ``recorder`` for the enclosed region. ``mode`` is 'record' or 'replay'."""
+    prev_recorder = _dispatch_replay_state.recorder
+    prev_mode = _dispatch_replay_state.mode
+    _dispatch_replay_state.recorder = recorder
+    _dispatch_replay_state.mode = mode if recorder is not None else None
+    try:
+        yield
+    finally:
+        _dispatch_replay_state.recorder = prev_recorder
+        _dispatch_replay_state.mode = prev_mode
+
 
 try:
     import importlib.util
@@ -154,8 +237,32 @@ class FusedDispatch(torch.autograd.Function):
         previous_event = None
         if async_finish:
             previous_event = EventOverlap(EventHandle())
-        # Calculate layout before actual dispatch
         buffer = get_buffer(group, get_hidden_bytes(x))
+
+        # Activation-checkpoint replay: reuse the layout this dispatch computed
+        # on the original forward instead of recomputing it. Cached-mode dispatch
+        # returns only recv_x, so the routing metadata comes from the record.
+        recorder = _active_recorder()
+        if recorder is not None and _replay_mode() == "replay":
+            replayed = recorder.take()
+            if replayed is not None:
+                cached_handle, recv_token_indices, recv_token_probs, tokens_per_expert = replayed
+                recv_x, _, _, _, _, after_event_overlap = buffer.dispatch(
+                    x,
+                    handle=cached_handle,
+                    previous_event=previous_event,
+                    async_finish=async_finish,
+                    allocate_on_comm_stream=allocate_on_comm_stream,
+                )
+                if async_finish:
+                    after_event_overlap.current_stream_wait()
+                ctx.group = group
+                ctx.handle = cached_handle
+                ctx.async_finish = async_finish
+                ctx.allocate_on_comm_stream = allocate_on_comm_stream
+                return (recv_x, recv_token_indices, recv_token_probs, tokens_per_expert, cached_handle)
+
+        # Calculate layout before actual dispatch
         (
             num_tokens_per_rank,
             num_tokens_per_rdma_rank,
@@ -203,6 +310,11 @@ class FusedDispatch(torch.autograd.Function):
         ctx.async_finish = async_finish
         ctx.allocate_on_comm_stream = allocate_on_comm_stream
         tokens_per_expert = torch.tensor(num_recv_tokens_per_expert_list)
+
+        if recorder is not None and _replay_mode() == "record":
+            # Keep the handle and routing metadata (small) so the recompute can
+            # skip the layout exchange; recv_x is deliberately not retained.
+            recorder.record((handle, recv_token_indices, recv_token_probs, tokens_per_expert))
 
         return (recv_x, recv_token_indices, recv_token_probs, tokens_per_expert, handle)
 

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -459,6 +459,50 @@ def _apply_multimodal_tower_ac(model: nn.Module, scopes: tuple[str, ...]) -> Non
     apply_submodule_checkpointing(tower_layers, has_kv_sharing=False, context_fn=sdpa_backend_snapshot_context_fn)
 
 
+def _replay_hybridep_dispatch_on_recompute(
+    context_fn: Callable[[], tuple[AbstractContextManager, AbstractContextManager]],
+) -> Callable[[], tuple[AbstractContextManager, AbstractContextManager]]:
+    """Reuse checkpoint-forward HybridEP layouts during backward recomputation.
+
+    HybridEP can produce a different receive-token extent when it rebuilds a
+    layout during activation-checkpoint recompute, even when the saved router
+    top-k is identical. Reusing the forward handle keeps the layout stable while
+    still redispatching the recomputed activations, so activation memory remains
+    checkpointed.
+    """
+    from nemo_automodel.components.moe.megatron.fused_a2a import (
+        HybridEPDispatchReplayRecorder,
+        hybridep_dispatch_replay_scope,
+    )
+
+    def checkpoint_context_fn() -> tuple[AbstractContextManager, AbstractContextManager]:
+        forward_context, recompute_context = context_fn()
+        recorder = HybridEPDispatchReplayRecorder()
+
+        @contextmanager
+        def scoped(mode: str, inner: AbstractContextManager):
+            if mode == "replay":
+                recorder.rewind()
+            with hybridep_dispatch_replay_scope(recorder, mode), inner:
+                yield
+
+        return scoped("record", forward_context), scoped("replay", recompute_context)
+
+    return checkpoint_context_fn
+
+
+def _uses_hybridep_dispatch(model: nn.Module) -> bool:
+    """Return whether any expert module uses the HybridEP dispatcher."""
+    modules = getattr(model, "modules", None)
+    if not callable(modules):
+        return False
+    return any(
+        isinstance(module, (GroupedExpertsDeepEP, GroupedExpertsTE))
+        and getattr(module, "dispatcher_backend", None) == "hybridep"
+        for module in modules()
+    )
+
+
 def apply_ac(
     model: nn.Module,
     ignore_router: bool = True,
@@ -479,8 +523,8 @@ def apply_ac(
             first, then falls back to model.config attributes.
         selective: If True, applies TorchTitan-style per-op selective activation checkpointing
             (shared with the dense FSDP2 path) to each block. Takes precedence over
-            ``ignore_router``; the shared policy already saves expert-parallel communication
-            collectives and ``topk``, so it composes with expert parallelism.
+            ``ignore_router``; the shared policy saves ``topk``, and HybridEP reuses the
+            checkpoint-forward dispatch layout while redispatching recomputed activations.
         activation_checkpointing_scope: Which layer groups to checkpoint -- the same field
             and semantics as the generic FSDP2/DDP path. ``"all"`` (the default) checkpoints
             the text/MoE decoder blocks plus the trainable vision tower; ``"language"`` the
@@ -501,6 +545,7 @@ def apply_ac(
 
     scopes = normalize_activation_checkpointing_scope(activation_checkpointing_scope)
     checkpoint_decoder = "all" in scopes or "language" in scopes
+    uses_hybridep_dispatch = checkpoint_decoder and _uses_hybridep_dispatch(model)
     repeated_mtp_moe_block_ids = _repeated_mtp_moe_block_ids(model) if checkpoint_decoder else set()
     if repeated_mtp_moe_block_ids:
         logger.info(
@@ -532,6 +577,8 @@ def apply_ac(
                 transformer_engine_attention_backend_snapshot_context_fn,
                 selective_context_fn,
             )
+            if uses_hybridep_dispatch:
+                attention_context_fn = _replay_hybridep_dispatch_on_recompute(attention_context_fn)
             for parent_layers, layer_id, block in iter_transformer_and_mtp_blocks(model):
                 if id(block) in repeated_mtp_moe_block_ids:
                     continue
@@ -631,14 +678,17 @@ def apply_ac(
             logger.info("Skipping activation checkpointing for model-owned eager block %s", layer_id)
             continue
         if ignore_router:
+            block_context_fn = _preserve_gate_load_during_recompute(
+                block,
+                _with_attention_backend_snapshot(selective_checkpointing_context_fn),
+            )
+            if uses_hybridep_dispatch:
+                block_context_fn = _replay_hybridep_dispatch_on_recompute(block_context_fn)
             block = ptd_checkpoint_wrapper(
                 block,
                 preserve_rng_state=True,
                 determinism_check=_register_moe_checkpoint_determinism_check(),
-                context_fn=_preserve_gate_load_during_recompute(
-                    block,
-                    _with_attention_backend_snapshot(selective_checkpointing_context_fn),
-                ),
+                context_fn=block_context_fn,
             )
         else:
             block = ptd_checkpoint_wrapper(

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -483,8 +483,14 @@ def _replay_hybridep_dispatch_on_recompute(
         def scoped(mode: str, inner: AbstractContextManager):
             if mode == "replay":
                 recorder.rewind()
-            with hybridep_dispatch_replay_scope(recorder, mode), inner:
-                yield
+            with hybridep_dispatch_replay_scope(recorder, mode):
+                with inner:
+                    yield
+                if mode == "record":
+                    # Cache the dispatch extents only after the selective-op
+                    # context exits. Recompute can then reuse them without an
+                    # extra aten.sum that would diverge from the forward trace.
+                    recorder.finalize()
 
         return scoped("record", forward_context), scoped("replay", recompute_context)
 

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -442,6 +442,44 @@ def _apply_multimodal_tower_ac(model: nn.Module, scopes: tuple[str, ...]) -> Non
     apply_submodule_checkpointing(tower_layers, has_kv_sharing=False, context_fn=sdpa_backend_snapshot_context_fn)
 
 
+def _replay_deepep_dispatch_on_recompute(
+    context_fn: Callable[[], tuple[AbstractContextManager, AbstractContextManager]],
+) -> Callable[[], tuple[AbstractContextManager, AbstractContextManager]]:
+    """Let a checkpointed block's recompute reuse the DeepEP layout it already computed.
+
+    Activation checkpointing replays the block during backward, and the replayed
+    MoE dispatch recomputes its routing layout from scratch even though the
+    routing is identical to the forward's. DeepEP skips that exchange when handed
+    the previous dispatch's handle -- the same shortcut its backward already
+    takes, which is why the backward dispatch is ~1000x cheaper than a
+    layout-computing forward one.
+
+    The recorder is built inside ``checkpoint_context_fn``, so each checkpointed
+    call gets its own: a block called once per forward pass keeps its passes'
+    dispatches separate, and the recompute consumes them in the order the
+    matching forward produced them.
+    """
+    from nemo_automodel.components.moe.megatron.fused_a2a import (
+        DispatchReplayRecorder,
+        dispatch_replay_scope,
+    )
+
+    def checkpoint_context_fn() -> tuple[AbstractContextManager, AbstractContextManager]:
+        forward_context, recompute_context = context_fn()
+        recorder = DispatchReplayRecorder()
+
+        @contextmanager
+        def scoped(mode, inner):
+            if mode == "replay":
+                recorder.rewind()
+            with dispatch_replay_scope(recorder, mode), inner:
+                yield
+
+        return scoped("record", forward_context), scoped("replay", recompute_context)
+
+    return checkpoint_context_fn
+
+
 def _uses_hybridep_dispatch(model: nn.Module) -> bool:
     """True when any expert module dispatches tokens through HybridEP."""
     return any(
@@ -637,14 +675,20 @@ def apply_ac(
         if mtp_repeated and id(block) in mtp_block_ids:
             continue
         if ignore_router:
+            # Only this branch pins routing across recompute (the policy saves the
+            # router projection and top-k), which is what makes replaying the
+            # DeepEP layout sound. Do not extend the replay to the else-branch:
+            # there the router is recomputed and may route differently, so a
+            # replayed layout would silently mis-route instead of failing loudly.
+            block_context_fn = _preserve_gate_load_during_recompute(
+                block,
+                _with_attention_backend_snapshot(selective_checkpointing_context_fn),
+            )
             block = ptd_checkpoint_wrapper(
                 block,
                 preserve_rng_state=True,
                 determinism_check=_register_moe_checkpoint_determinism_check(),
-                context_fn=_preserve_gate_load_during_recompute(
-                    block,
-                    _with_attention_backend_snapshot(selective_checkpointing_context_fn),
-                ),
+                context_fn=_replay_deepep_dispatch_on_recompute(block_context_fn),
             )
         else:
             block = ptd_checkpoint_wrapper(

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -482,9 +482,16 @@ def _replay_deepep_dispatch_on_recompute(
 
 def _uses_hybridep_dispatch(model: nn.Module) -> bool:
     """True when any expert module dispatches tokens through HybridEP."""
+    modules = getattr(model, "modules", None)
+    if not callable(modules):
+        # Duck-typed models (tests, custom wrappers) need not expose
+        # nn.Module.modules(); this check only gates a warning, so skip it
+        # rather than making apply_ac require more of the model than the
+        # checkpointing itself does.
+        return False
     return any(
         isinstance(m, (GroupedExpertsDeepEP, GroupedExpertsTE)) and m.dispatcher_backend == "hybridep"
-        for m in model.modules()
+        for m in modules()
     )
 
 

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -442,6 +442,14 @@ def _apply_multimodal_tower_ac(model: nn.Module, scopes: tuple[str, ...]) -> Non
     apply_submodule_checkpointing(tower_layers, has_kv_sharing=False, context_fn=sdpa_backend_snapshot_context_fn)
 
 
+def _uses_hybridep_dispatch(model: nn.Module) -> bool:
+    """True when any expert module dispatches tokens through HybridEP."""
+    return any(
+        isinstance(m, (GroupedExpertsDeepEP, GroupedExpertsTE)) and m.dispatcher_backend == "hybridep"
+        for m in model.modules()
+    )
+
+
 def apply_ac(
     model: nn.Module,
     ignore_router: bool = True,
@@ -484,6 +492,21 @@ def apply_ac(
 
     scopes = normalize_activation_checkpointing_scope(activation_checkpointing_scope)
     checkpoint_decoder = "all" in scopes or "language" in scopes
+    if checkpoint_decoder and _uses_hybridep_dispatch(model):
+        logger.warning(
+            "Activation checkpointing is enabled with the HybridEP token dispatcher. "
+            "HybridEP's dispatch is not reproducible under checkpoint recompute: replaying it "
+            "with bit-identical routing can return a different number of tokens than the "
+            "forward pass produced, which surfaces as torch.utils.checkpoint.CheckpointError "
+            "('Recomputed values ... have different metadata', e.g. [2791, hidden] vs "
+            "[2701, hidden]). Verified on 8xH100 with DiffusionGemma-26B-A4B: the router's "
+            "top-k selection matched exactly on every rank across forward and recompute, so "
+            "the drift originates in the dispatch, not in routing -- ignore_router_for_ac "
+            "cannot prevent it. If this run dies with CheckpointError, either switch to "
+            "dispatcher='deepep' (reproducible under recompute) or disable activation "
+            "checkpointing (HybridEP is fastest in that mode)."
+        )
+
     if checkpoint_decoder and not selective and not ignore_router:
         logger.warning(
             "Activation checkpointing is enabled with ignore_router_for_ac=False. The MoE "

--- a/tests/unit_tests/moe/test_fused_a2a.py
+++ b/tests/unit_tests/moe/test_fused_a2a.py
@@ -78,10 +78,16 @@ class _DriftingHybridEPBuffer:
         self.full_dispatches = 0
         self.cached_dispatches = 0
         self.input_shape = None
+        self.replayed_num_permuted_tokens = None
 
     def dispatch_with_permute(self, *, hidden, routing_map=None, probs=None, handle=None, **kwargs):
         if handle is not None:
             self.cached_dispatches += 1
+            self.replayed_num_permuted_tokens = kwargs["num_permuted_tokens"]
+            # Model the scalar conversion performed by HybridEP when its
+            # sync-free token extent is accidentally passed as a tensor.
+            if isinstance(self.replayed_num_permuted_tokens, torch.Tensor):
+                int(self.replayed_num_permuted_tokens.item())
             dispatched_hidden = torch.cat((hidden, hidden[:1]), dim=0)
             dispatched_probs = torch.cat((probs[:, :1], probs[:1, :1]), dim=0)
             return dispatched_hidden, dispatched_probs, None, None, None
@@ -153,19 +159,25 @@ def test_hybridep_checkpoint_reuses_forward_layout_on_recompute():
     assert buffer.cached_dispatches == 1
 
 
-def test_hybridep_checkpoint_replay_does_not_add_sum_to_selective_recompute():
+def test_hybridep_checkpoint_replay_preserves_selective_op_trace():
     from nemo_automodel.components.moe.parallelizer import _replay_hybridep_dispatch_on_recompute
 
     buffer = _DriftingHybridEPBuffer()
     fused_a2a._hybrid_ep_buffer = buffer
     aten_sum = torch.ops.aten.sum.default
+    aten_local_scalar_dense = torch.ops.aten._local_scalar_dense.default
 
-    def save_sums_policy(ctx, func, *args, **kwargs):
-        return CheckpointPolicy.MUST_SAVE if func == aten_sum else CheckpointPolicy.PREFER_RECOMPUTE
+    def save_replay_sensitive_ops(ctx, func, *args, **kwargs):
+        replay_sensitive_ops = (aten_sum, aten_local_scalar_dense)
+        return CheckpointPolicy.MUST_SAVE if func in replay_sensitive_ops else CheckpointPolicy.PREFER_RECOMPUTE
 
-    context_fn = _replay_hybridep_dispatch_on_recompute(lambda: create_selective_checkpoint_contexts(save_sums_policy))
+    context_fn = _replay_hybridep_dispatch_on_recompute(
+        lambda: create_selective_checkpoint_contexts(save_replay_sensitive_ops)
+    )
 
     _run_checkpointed_hybridep(context_fn)
 
     assert buffer.full_dispatches == 1
     assert buffer.cached_dispatches == 1
+    assert buffer.replayed_num_permuted_tokens == 5
+    assert isinstance(buffer.replayed_num_permuted_tokens, int)

--- a/tests/unit_tests/moe/test_fused_a2a.py
+++ b/tests/unit_tests/moe/test_fused_a2a.py
@@ -19,7 +19,7 @@ from unittest import mock
 
 import pytest
 import torch
-from torch.utils.checkpoint import CheckpointError, checkpoint
+from torch.utils.checkpoint import CheckpointError, CheckpointPolicy, checkpoint, create_selective_checkpoint_contexts
 
 import nemo_automodel.components.moe.megatron.fused_a2a as fused_a2a
 
@@ -146,6 +146,24 @@ def test_hybridep_checkpoint_reuses_forward_layout_on_recompute():
     buffer = _DriftingHybridEPBuffer()
     fused_a2a._hybrid_ep_buffer = buffer
     context_fn = _replay_hybridep_dispatch_on_recompute(lambda: (nullcontext(), nullcontext()))
+
+    _run_checkpointed_hybridep(context_fn)
+
+    assert buffer.full_dispatches == 1
+    assert buffer.cached_dispatches == 1
+
+
+def test_hybridep_checkpoint_replay_does_not_add_sum_to_selective_recompute():
+    from nemo_automodel.components.moe.parallelizer import _replay_hybridep_dispatch_on_recompute
+
+    buffer = _DriftingHybridEPBuffer()
+    fused_a2a._hybrid_ep_buffer = buffer
+    aten_sum = torch.ops.aten.sum.default
+
+    def save_sums_policy(ctx, func, *args, **kwargs):
+        return CheckpointPolicy.MUST_SAVE if func == aten_sum else CheckpointPolicy.PREFER_RECOMPUTE
+
+    context_fn = _replay_hybridep_dispatch_on_recompute(lambda: create_selective_checkpoint_contexts(save_sums_policy))
 
     _run_checkpointed_hybridep(context_fn)
 

--- a/tests/unit_tests/moe/test_fused_a2a.py
+++ b/tests/unit_tests/moe/test_fused_a2a.py
@@ -12,23 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for DeepEP buffer teardown (``fused_a2a.free_buffer``)."""
+"""Unit tests for fused DeepEP and HybridEP dispatch helpers."""
 
+from contextlib import nullcontext
 from unittest import mock
 
 import pytest
+import torch
+from torch.utils.checkpoint import CheckpointError, checkpoint
 
 import nemo_automodel.components.moe.megatron.fused_a2a as fused_a2a
 
 
 @pytest.fixture(autouse=True)
 def _restore_buffer():
-    """Save/restore the module-global ``_buffer`` so tests don't leak state."""
+    """Save/restore module-global dispatch state so tests don't leak state."""
     saved = fused_a2a._buffer
+    saved_hybridep = fused_a2a._hybrid_ep_buffer
+    saved_recorder = fused_a2a._hybridep_dispatch_replay_state.recorder
+    saved_mode = fused_a2a._hybridep_dispatch_replay_state.mode
     try:
         yield
     finally:
         fused_a2a._buffer = saved
+        fused_a2a._hybrid_ep_buffer = saved_hybridep
+        fused_a2a._hybridep_dispatch_replay_state.recorder = saved_recorder
+        fused_a2a._hybridep_dispatch_replay_state.mode = saved_mode
 
 
 def test_free_buffer_destroys_and_clears():
@@ -60,3 +69,85 @@ def test_free_buffer_swallows_destroy_errors():
 
     boom.destroy.assert_called_once_with()
     assert fused_a2a._buffer is None
+
+
+class _DriftingHybridEPBuffer:
+    """Fake a full-layout replay that returns a different receive-token count."""
+
+    def __init__(self):
+        self.full_dispatches = 0
+        self.cached_dispatches = 0
+        self.input_shape = None
+
+    def dispatch_with_permute(self, *, hidden, routing_map=None, probs=None, handle=None, **kwargs):
+        if handle is not None:
+            self.cached_dispatches += 1
+            dispatched_hidden = torch.cat((hidden, hidden[:1]), dim=0)
+            dispatched_probs = torch.cat((probs[:, :1], probs[:1, :1]), dim=0)
+            return dispatched_hidden, dispatched_probs, None, None, None
+
+        self.full_dispatches += 1
+        self.input_shape = hidden.shape
+        # The first call models checkpoint forward. A second full-layout call
+        # models HybridEP's nondeterministic recompute and deliberately drifts.
+        if self.full_dispatches == 1:
+            dispatched_hidden = torch.cat((hidden, hidden[:1]), dim=0)
+            dispatched_probs = torch.cat((probs[:, :1], probs[:1, :1]), dim=0)
+            tokens_per_expert = torch.tensor([2, 3])
+        else:
+            dispatched_hidden = hidden[:-1]
+            dispatched_probs = probs[:-1, :1]
+            tokens_per_expert = torch.tensor([1, 2])
+        return dispatched_hidden, dispatched_probs, None, tokens_per_expert, "forward-layout"
+
+    def combine_with_unpermute(self, *, hidden, probs=None, **kwargs):
+        combined_hidden = hidden[: self.input_shape[0]]
+        combined_probs = None if probs is None else torch.zeros(self.input_shape[0], 2, dtype=probs.dtype)
+        return combined_hidden, combined_probs
+
+
+def _run_checkpointed_hybridep(context_fn):
+    x = torch.randn(4, 3, requires_grad=True)
+    routing_map = torch.ones(4, 2, dtype=torch.bool)
+    probs = torch.full((4, 2), 0.5, requires_grad=True)
+
+    def block(hidden, token_probs):
+        dispatched_hidden, dispatched_probs, _, _, _ = fused_a2a.HybridEPDispatch.apply(
+            hidden,
+            routing_map,
+            token_probs,
+            object(),
+            1,
+            24,
+            24,
+            None,
+            None,
+        )
+        return dispatched_hidden.sin().sum() + dispatched_probs.square().sum()
+
+    loss = checkpoint(block, x, probs, use_reentrant=False, context_fn=context_fn)
+    loss.backward()
+
+
+def test_hybridep_checkpoint_without_layout_replay_detects_shape_drift():
+    buffer = _DriftingHybridEPBuffer()
+    fused_a2a._hybrid_ep_buffer = buffer
+
+    with pytest.raises(CheckpointError, match="different metadata"):
+        _run_checkpointed_hybridep(lambda: (nullcontext(), nullcontext()))
+
+    assert buffer.full_dispatches == 2
+    assert buffer.cached_dispatches == 0
+
+
+def test_hybridep_checkpoint_reuses_forward_layout_on_recompute():
+    from nemo_automodel.components.moe.parallelizer import _replay_hybridep_dispatch_on_recompute
+
+    buffer = _DriftingHybridEPBuffer()
+    fused_a2a._hybrid_ep_buffer = buffer
+    context_fn = _replay_hybridep_dispatch_on_recompute(lambda: (nullcontext(), nullcontext()))
+
+    _run_checkpointed_hybridep(context_fn)
+
+    assert buffer.full_dispatches == 1
+    assert buffer.cached_dispatches == 1

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -748,6 +748,38 @@ def test_apply_ac_warns_when_router_is_recomputed(monkeypatch):
     logger_mock.warning.assert_not_called()
 
 
+@pytest.mark.parametrize("selective", [False, True])
+def test_apply_ac_replays_hybridep_layout_for_full_and_selective_ac(monkeypatch, selective):
+    P = _import_parallelizer_with_stubs(monkeypatch)
+    expert = P.GroupedExpertsDeepEP()
+    expert.dispatcher_backend = "hybridep"
+
+    class HybridEPModel(DummyModel):
+        def modules(self):
+            return iter((self, expert))
+
+    if selective:
+        activation_checkpointing_stub = sys.modules["nemo_automodel.components.distributed.activation_checkpointing"]
+        activation_checkpointing_stub.make_selective_checkpoint_context_fn = lambda: (
+            lambda: (nullcontext(), nullcontext())
+        )
+        activation_checkpointing_stub.SELECTIVE_AC_WRAPPER_FLAG = "_nemo_selective_ac"
+
+    replay_wrapper = MagicMock(side_effect=lambda context_fn: context_fn)
+    monkeypatch.setattr(P, "_replay_hybridep_dispatch_on_recompute", replay_wrapper)
+    monkeypatch.setattr(P, "ptd_checkpoint_wrapper", MagicMock(side_effect=lambda block, **kwargs: block))
+
+    P.apply_ac(
+        HybridEPModel([DummyBlock()]),
+        ignore_router=True,
+        hidden_size=7168,
+        num_experts=384,
+        selective=selective,
+    )
+
+    replay_wrapper.assert_called_once()
+
+
 def test_apply_ac_uses_generic_wrapper_even_when_block_local_checkpointing_is_available(monkeypatch):
     P = _import_parallelizer_with_stubs(monkeypatch)
 

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -14,10 +14,15 @@
 
 import sys
 import types
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+# torch.utils.checkpoint.create_selective_checkpoint_contexts returns
+# ``(forward_ctx, recompute_ctx)``, and apply_ac's context wrappers unpack it,
+# so the stubs below must return a pair rather than a bare sentinel.
+SELECTIVE_CTX = ("CTX_FORWARD", "CTX_RECOMPUTE")
 
 
 class DummyParam:
@@ -258,7 +263,7 @@ def _install_torch_and_layers_stubs(monkeypatch):
         PREFER_RECOMPUTE = 2
 
     def create_selective_checkpoint_contexts(policy_factory):
-        return "CTX"
+        return SELECTIVE_CTX
 
     utils_checkpoint_stub.CheckpointPolicy = CheckpointPolicy
     utils_checkpoint_stub._allowed_determinism_checks_to_fns = {"default": object(), "none": object()}
@@ -472,6 +477,31 @@ def _import_parallelizer_with_stubs(monkeypatch):
         activation_checkpointing_stub,
     )
 
+    # apply_ac wraps each block's context in the DeepEP dispatch-replay recorder,
+    # which imports fused_a2a lazily. Stub it so this module does not depend on
+    # some earlier test having imported it under the real torch.
+    fused_a2a_stub = types.ModuleType("nemo_automodel.components.moe.megatron.fused_a2a")
+
+    class _StubDispatchReplayRecorder:
+        def __init__(self):
+            self.replay_misses = 0
+            self.rewind_count = 0
+
+        def rewind(self):
+            self.rewind_count += 1
+
+    @contextmanager
+    def _stub_dispatch_replay_scope(recorder, mode):
+        yield
+
+    fused_a2a_stub.DispatchReplayRecorder = _StubDispatchReplayRecorder
+    fused_a2a_stub.dispatch_replay_scope = _stub_dispatch_replay_scope
+    monkeypatch.setitem(
+        sys.modules,
+        "nemo_automodel.components.moe.megatron.fused_a2a",
+        fused_a2a_stub,
+    )
+
     distributed_config_stub = types.ModuleType("nemo_automodel.components.distributed.config")
     distributed_config_stub.normalize_activation_checkpointing_scope = lambda value: (
         (value,) if isinstance(value, str) else tuple(value or ("all",))
@@ -668,7 +698,7 @@ def test_apply_ac_wraps_blocks_with_and_without_context(monkeypatch):
         return wrapper_returns.pop(0)
 
     wrapper_mock = MagicMock(side_effect=fake_wrapper)
-    ctx_mock = MagicMock(return_value="CTX")
+    ctx_mock = MagicMock(return_value=SELECTIVE_CTX)
     monkeypatch.setattr(P, "ptd_checkpoint_wrapper", wrapper_mock)
     monkeypatch.setattr(P, "create_selective_checkpoint_contexts", ctx_mock)
 
@@ -698,7 +728,7 @@ def test_apply_ac_wraps_blocks_with_and_without_context(monkeypatch):
 def test_apply_ac_warns_when_router_is_recomputed(monkeypatch):
     P = _import_parallelizer_with_stubs(monkeypatch)
     monkeypatch.setattr(P, "ptd_checkpoint_wrapper", MagicMock(side_effect=lambda block, **kw: block))
-    monkeypatch.setattr(P, "create_selective_checkpoint_contexts", MagicMock(return_value="CTX"))
+    monkeypatch.setattr(P, "create_selective_checkpoint_contexts", MagicMock(return_value=SELECTIVE_CTX))
     logger_mock = MagicMock()
     monkeypatch.setattr(P, "logger", logger_mock)
 
@@ -747,12 +777,16 @@ def test_apply_ac_custom_policy_saves_router_projection_and_topk(monkeypatch):
     def fake_create_selective_checkpoint_contexts(policy_cb):
         nonlocal captured_policy
         captured_policy = policy_cb
-        return "CTX"
+        return SELECTIVE_CTX
 
     def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         assert preserve_rng_state is True
         assert callable(context_fn)
-        assert context_fn() == "CTX"
+        # The selective contexts are wrapped for DeepEP dispatch replay, so what
+        # comes back is the wrapper's pair rather than SELECTIVE_CTX itself.
+        forward_ctx, recompute_ctx = context_fn()
+        assert hasattr(forward_ctx, "__enter__")
+        assert hasattr(recompute_ctx, "__enter__")
         return block
 
     monkeypatch.setattr(P, "create_selective_checkpoint_contexts", fake_create_selective_checkpoint_contexts)
@@ -2164,7 +2198,7 @@ def test_apply_ac_derives_hidden_size_and_num_experts_from_config(monkeypatch):
                     break
             if captured_hidden_size is not None:
                 break
-        return "CTX"
+        return SELECTIVE_CTX
 
     def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
@@ -2240,7 +2274,7 @@ def test_apply_ac_derives_num_experts_from_num_local_experts(monkeypatch):
             result = policy_cb(None, torch_stub.ops.aten.mm.default, object(), rhs)
             if result == P.CheckpointPolicy.MUST_SAVE:
                 captured_num_experts = ne
-        return "CTX"
+        return SELECTIVE_CTX
 
     def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
@@ -2282,7 +2316,7 @@ def test_apply_ac_accepts_explicit_hidden_size_and_num_experts(monkeypatch):
         if result == P.CheckpointPolicy.MUST_SAVE:
             captured_hidden_size = 512
             captured_num_experts = 32
-        return "CTX"
+        return SELECTIVE_CTX
 
     def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
@@ -2321,7 +2355,7 @@ def test_apply_ac_explicit_params_override_config(monkeypatch):
         if result == P.CheckpointPolicy.MUST_SAVE:
             captured_hidden_size = 1024
             captured_num_experts = 64
-        return "CTX"
+        return SELECTIVE_CTX
 
     def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
@@ -2369,7 +2403,7 @@ def test_apply_ac_derives_from_llm_config(monkeypatch):
                     break
             if captured_hidden_size is not None:
                 break
-        return "CTX"
+        return SELECTIVE_CTX
 
     def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
@@ -2417,7 +2451,7 @@ def test_apply_ac_text_config_takes_priority_over_llm_config(monkeypatch):
                     break
             if captured_hidden_size is not None:
                 break
-        return "CTX"
+        return SELECTIVE_CTX
 
     monkeypatch.setattr(P, "create_selective_checkpoint_contexts", fake_create_selective_checkpoint_contexts)
     monkeypatch.setattr(
@@ -2476,7 +2510,7 @@ def test_apply_ac_routes_through_get_text_module(monkeypatch):
         return m.language_model if hasattr(m, "language_model") else m
 
     monkeypatch.setattr(P, "get_text_module", vlm_get_text_module)
-    monkeypatch.setattr(P, "create_selective_checkpoint_contexts", MagicMock(return_value="CTX"))
+    monkeypatch.setattr(P, "create_selective_checkpoint_contexts", MagicMock(return_value=SELECTIVE_CTX))
     monkeypatch.setattr(P, "ptd_checkpoint_wrapper", MagicMock(side_effect=lambda b, **kw: b))
 
     lm_blocks = [DummyBlock(), DummyBlock()]
@@ -2738,7 +2772,7 @@ def test_apply_ac_derives_num_experts_from_moe_num_experts(monkeypatch):
             if result == P.CheckpointPolicy.MUST_SAVE:
                 captured_num_experts = ne
                 break
-        return "CTX"
+        return SELECTIVE_CTX
 
     def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
@@ -2781,7 +2815,7 @@ def test_apply_ac_prefers_num_experts_over_moe_num_experts(monkeypatch):
             if result == P.CheckpointPolicy.MUST_SAVE:
                 captured_num_experts = ne
                 break
-        return "CTX"
+        return SELECTIVE_CTX
 
     def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
@@ -2825,7 +2859,7 @@ def test_apply_ac_derives_num_experts_from_moe_config(monkeypatch):
             if result == P.CheckpointPolicy.MUST_SAVE:
                 captured_num_experts = ne
                 break
-        return "CTX"
+        return SELECTIVE_CTX
 
     def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
@@ -2873,7 +2907,7 @@ def test_apply_ac_prefers_moe_config_over_config_attrs(monkeypatch):
             if result == P.CheckpointPolicy.MUST_SAVE:
                 captured_num_experts = ne
                 break
-        return "CTX"
+        return SELECTIVE_CTX
 
     def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:
@@ -3074,7 +3108,7 @@ def test_apply_ac_derives_hidden_size_and_num_experts_from_text_config(monkeypat
                     break
             if captured_hidden_size is not None:
                 break
-        return "CTX"
+        return SELECTIVE_CTX
 
     def fake_wrapper(block, preserve_rng_state, determinism_check=None, context_fn=None):
         if context_fn is not None:


### PR DESCRIPTION
Two shared-MoE changes found while profiling DiffusionGemma-26B-A4B on 8×H100. Neither is dLLM-specific — both apply to any MoE model using expert parallelism with activation checkpointing.

---

# 1. Reuse the DeepEP dispatch layout on recompute (the optimization)

Activation checkpointing replays a block's forward during backward, and the replayed MoE dispatch recomputes its routing layout from scratch — `get_dispatch_layout()` plus DeepEP's `notify_dispatch` — even though the routing is identical to the forward's. The AC policy pins the router projection and top-k precisely so recompute routes the same way, so recomputing the layout from that identical routing is redundant.

DeepEP already exposes the shortcut: handing `dispatch()` the handle from a previous dispatch skips the layout exchange. `FusedDispatch.backward` already does exactly this, and the profile shows what it's worth. Per step, rank 0:

| | launches | GPU time |
| --- | ---: | ---: |
| forward dispatch (computes layout) | 150 | 4420 ms |
| **backward dispatch (reuses `ctx.handle`)** | 60 | **3.96 ms** |
| `notify_dispatch` (forward) | 150 | 4844 ms |
| `cached_notify_dispatch` | 60 | 797 ms |

Of those 150 forward dispatches the model only needs **90** (30 layers × 3 passes: causal encoder, `no_grad` self-conditioning decode, real decode). The other **60 are activation checkpointing replaying** the encoder and decode-2 passes.

### How

A recorder is created **per checkpointed call**, so the forward logs each dispatch's handle and routing metadata in call order and the recompute consumes them in the same order — a block called once per pass keeps its passes separate, which matters here because the three passes route differently.

Cached-mode `dispatch()` returns only `recv_x` (`recv_topk_idx`, `recv_topk_weights` and `num_recv_tokens_per_expert_list` all come back `None`), so the routing metadata comes from the record. **`recv_x` itself is deliberately not retained**, so the activation memory checkpointing saves is preserved — only the handle and per-token routing metadata are held, ~1.7% of the dispatched activation. If a replay ever outruns its log, the recorder falls back to a full dispatch rather than replaying a mismatched layout.

Scoped to the `ignore_router` branch on purpose: that is the path that pins routing across recompute. On the other branch the router is recomputed and may route differently, where a replayed layout would silently mis-route instead of failing loudly.

### Measured

eos, 8×H100, 8 steps, DiffusionGemma-26B-A4B SFT with `dispatcher=deepep`:

| | step time |
| --- | ---: |
| before | 10.6 s |
| **after** | **9.77 s** (−7.8%) |

**Loss, `dllm_loss` and `grad_norm` are bit-identical to the unpatched run for all 8 steps** — matching `grad_norm` means the backward produces identical gradients, which is the correctness bar for this change.

Two DeepEP knobs were measured on the same workload and make no difference, so they are not used: `dispatcher_async_dispatch=True` (10.66 s/step) and `dispatcher_num_sms=32` (10.61 s/step).

---

### Note (not fixed here)

The `torch.ops.deepep.dispatch` / `hybridep.dispatch` entries in `activation_checkpointing.py`'s selective-AC save list are **inert**: dispatch runs through `FusedDispatch.apply`, an `autograd.Function`, which a `__torch_dispatch__` policy never observes. Those four entries have never matched anything. Worth a separate fix.

The dLLM recipe change that motivated this profiling is #3654 (recipe YAMLs only).