### PR TITLE
fix(release): set version to 0.6.0

### DIFF
--- a/nemo_automodel/package_info.py
+++ b/nemo_automodel/package_info.py
@@ -14,8 +14,8 @@
 
 
 MAJOR = 0
-MINOR = 5
-PATCH = 1
+MINOR = 6
+PATCH = 0
 PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)


### PR DESCRIPTION
# What does this PR do ?

Set the `r0.6.0` release branch package version to 0.6.0 before running the release pipeline.

# Changelog

- Update NeMo AutoModel package metadata from 0.5.1 to 0.6.0.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (No new test is necessary for a version-only change; the imported version and built wheel metadata were verified locally.)
- [x] Did you add or update any necessary documentation? (No documentation change is necessary.)
