### PR TITLE
ci: merge L2 matrix entries so the e2e stage fits max-parallel: 10

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -473,9 +473,14 @@ jobs:
             timeout: 30
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
+          # Merged with hf_transformer_llm + data. The matrix gets `max-parallel: 10`;
+          # as 13 separate entries the last three could not start until a wave-1 job
+          # freed a runner. These are the three cheapest suites (3.6 + 5.2 + 6.0 =
+          # 14.8 min median), well under the 16.6 min L2_HF_Transformer_Finetune that
+          # sets the stage floor. Timeout is the sum of the three originals.
           - test-name: L2_HF_Transformer
-            test-folder: hf_transformer
-            timeout: 20
+            test-folder: hf_transformer,hf_transformer_llm,data
+            timeout: 80
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           - test-name: L2_HF_Transformer_Finetune
@@ -483,19 +488,9 @@ jobs:
             timeout: 40
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
-          - test-name: L2_HF_Transformer_LLM
-            test-folder: hf_transformer_llm
-            timeout: 40
-            runner: ${{ needs.pre-flight.outputs.runner_prefix }}
-            test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           - test-name: L2_HF_Transformer_VLM
             test-folder: hf_transformer_vlm
             timeout: 60
-            runner: ${{ needs.pre-flight.outputs.runner_prefix }}
-            test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
-          - test-name: L2_Datasets
-            test-folder: data
-            timeout: 20
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           - test-name: L2_Context_Parallel
@@ -513,16 +508,13 @@ jobs:
             timeout: 30
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
-          - test-name: L2_MoE
-            test-folder: moe
-            timeout: 20
-            runner: ${{ needs.pre-flight.outputs.runner_prefix }}
-            test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
-          - test-name: L2_Parallelism
-            test-folder: parallelism
-            # Each parity test runs the proxy twice (1-rank baseline + 2-rank
-            # parallel), so the budget is roughly double a single smoke test.
-            timeout: 40
+          # moe + parallelism merged (2.8 + 5.8 = 8.6 min median) to fit `max-parallel: 10`.
+          # Each parity test in `parallelism` runs the proxy twice (1-rank baseline +
+          # 2-rank parallel), so the budget is roughly double a single smoke test;
+          # timeout is the sum of the two originals.
+          - test-name: L2_Distributed
+            test-folder: moe,parallelism
+            timeout: 60
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
     needs: [pre-flight, cicd-unit-tests]
@@ -578,34 +570,29 @@ jobs:
             test-folder: hf_peft
             timeout: 30
             is-optional: "true"
+          # Merged with hf_transformer_llm + data, mirroring cicd-e2e-tests
+          # (2.4 + 3.8 + 4.3 = 10.5 min median, under the 13.2 min L2_Context_Parallel
+          # floor). Leaves this matrix at 9 entries, one slot of headroom.
           - test-name: L2_HF_Transformer
-            test-folder: hf_transformer
-            timeout: 20
+            test-folder: hf_transformer,hf_transformer_llm,data
+            timeout: 80
           - test-name: L2_HF_Transformer_Finetune
             test-folder: hf_transformer_finetune
-            timeout: 40
-          - test-name: L2_HF_Transformer_LLM
-            test-folder: hf_transformer_llm
             timeout: 40
           - test-name: L2_HF_Transformer_VLM
             test-folder: hf_transformer_vlm
             timeout: 60
             is-optional: "true"
-          - test-name: L2_Datasets
-            test-folder: data
-            timeout: 20
           - test-name: L2_Context_Parallel
             test-folder: context_parallel
             timeout: 20
           - test-name: L2_Retrieval
             test-folder: retrieval
             timeout: 20
-          - test-name: L2_MoE
-            test-folder: moe
-            timeout: 20
-          - test-name: L2_Parallelism
-            test-folder: parallelism
-            timeout: 40
+          # moe + parallelism merged (2.1 + 4.1 = 6.2 min median), mirroring cicd-e2e-tests.
+          - test-name: L2_Distributed
+            test-folder: moe,parallelism
+            timeout: 60
     needs: [pre-flight, cicd-unit-tests, cicd-container-build]
     runs-on: ${{ matrix.runner || 'nemo-ci-gcp-gpu-x2' }}
     name: gb200_${{ matrix.test-name }}

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -477,10 +477,11 @@ jobs:
           # as 13 separate entries the last three could not start until a wave-1 job
           # freed a runner. These are the three cheapest suites (3.6 + 5.2 + 6.0 =
           # 14.8 min median), well under the 16.6 min L2_HF_Transformer_Finetune that
-          # sets the stage floor. Timeout is the sum of the three originals.
+          # sets the stage floor. A 40-minute timeout leaves more than 2x headroom
+          # over the measured merged runtime while bounding timeout retries.
           - test-name: L2_HF_Transformer
             test-folder: hf_transformer,hf_transformer_llm,data
-            timeout: 80
+            timeout: 40
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           - test-name: L2_HF_Transformer_Finetune
@@ -510,11 +511,11 @@ jobs:
             test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           # moe + parallelism merged (2.8 + 5.8 = 8.6 min median) to fit `max-parallel: 10`.
           # Each parity test in `parallelism` runs the proxy twice (1-rank baseline +
-          # 2-rank parallel), so the budget is roughly double a single smoke test;
-          # timeout is the sum of the two originals.
+          # 2-rank parallel), so the budget is roughly double a single smoke test.
+          # A 30-minute timeout leaves more than 2x measured-runtime headroom.
           - test-name: L2_Distributed
             test-folder: moe,parallelism
-            timeout: 60
+            timeout: 30
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
     needs: [pre-flight, cicd-unit-tests]
@@ -575,7 +576,7 @@ jobs:
           # floor). Leaves this matrix at 9 entries, one slot of headroom.
           - test-name: L2_HF_Transformer
             test-folder: hf_transformer,hf_transformer_llm,data
-            timeout: 80
+            timeout: 40
           - test-name: L2_HF_Transformer_Finetune
             test-folder: hf_transformer_finetune
             timeout: 40
@@ -592,7 +593,7 @@ jobs:
           # moe + parallelism merged (2.1 + 4.1 = 6.2 min median), mirroring cicd-e2e-tests.
           - test-name: L2_Distributed
             test-folder: moe,parallelism
-            timeout: 60
+            timeout: 30
     needs: [pre-flight, cicd-unit-tests, cicd-container-build]
     runs-on: ${{ matrix.runner || 'nemo-ci-gcp-gpu-x2' }}
     name: gb200_${{ matrix.test-name }}


### PR DESCRIPTION
## Problem

`cicd-e2e-tests` declares `max-parallel: 10` but carries **13** matrix entries; `cicd-e2e-tests-gb200` carries **12**. Every entry resolves to the same runner label (`nemo-ci-aws-gpu-x2` / `nemo-ci-gcp-gpu-x2`), so the entries that don't fit the first wave cannot start until a wave-1 job frees a slot.

Measured across every `CICD NeMo` run from 2026-04-27 to 2026-08-26 — **4,175 runs, 100,481 jobs** — restricted to green, first-attempt runs that reached the L2 stage. Per run, the stage decomposes exactly into `wait for a free runner` + `run time of whichever suite finishes last`:

| Month | Runs | Waiting | Running slowest | Wait share | Stage p50 |
|---|---:|---:|---:|---:|---:|
| 2026-04 | 61 | 0.2 | 13.7 | 1% | 14.4 |
| 2026-05 | 355 | 0.7 | 13.9 | 4% | 17.8 |
| 2026-06 | 646 | 1.4 | 16.9 | 7% | 20.7 |
| 2026-07 | 533 | 10.3 | 14.7 | 41% | 25.2 |
| 2026-08 | 430 | 13.4 | 16.2 | 43% | 31.4 |

Minutes, medians. **The tests did not get slower** — the slowest suite's run time moved 13.7 → 16.2 min in four months. The wait for a runner went 0.2 → 13.4 min, and hit 27.1 min (69% of the stage) the week of Aug 24.

### Where the wait lands

For each suite that ends the stage, July–August:

| Suite | Times it ended the stage | Median wait | Median run |
|---|---:|---:|---:|
| `L2_Pretrain_and_KD` | 260 | 0.3 | 17.2 |
| `L2_HF_Transformer_Finetune` | 246 | 1.9 | 17.3 |
| **`L2_MoE`** | 204 | **68.8** | 2.8 |
| `L2_Context_Parallel` | 125 | 12.6 | 15.6 |
| `L2_HF_PEFT` | 52 | 18.3 | 13.4 |
| **`L2_Parallelism`** | 26 | **69.5** | 7.4 |

`L2_MoE` runs in under 3 minutes and waits 69. It is not slow, it is starved — and the cause is start order:

| Suite | Median start rank | Median queue | Median run |
|---|---:|---:|---:|
| `L2_HF_PEFT`, `L2_HF_DCP`, `L2_HF_Transformer`, `L2_Pretrain_and_KD`, `L2_HF_Transformer_LLM`, `L2_HF_Transformer_Finetune` | 5 | 3.2–3.4 | — |
| `L2_Context_Parallel`, `L2_HF_Transformer_VLM`, `L2_Retrieval`, `L2_Datasets` | 6 | 3.3–3.6 | — |
| `L2_MoE` | **11** | 9.1 | 2.8 |
| `L2_Diffusion` | **11** | 10.2 | 2.0 |
| `L2_Parallelism` | **13** | 11.4 | 5.8 |

Ranks 1–10 wait ~3.4 min. Ranks 11+ are the three most recently added entries, which sit at the end of the matrix. Max observed concurrency inside a run is exactly 10 (627 of 963 sampled runs), never higher.

## Change

Fold the cheapest suites into existing entries so each matrix fits its slot budget. `test-folder` already accepts a comma-separated list — `L2_Pretrain_and_KD` uses `llm_pretrain_and_kd,speculative` today — and `run_test.sh` splits on it. **No test is dropped, added, or reordered.**

`cicd-e2e-tests`, 13 → 10 entries:

| Job | `test-folder` | timeout | Group total |
|---|---|---:|---:|
| `L2_HF_Transformer` | `hf_transformer,hf_transformer_llm,data` | 80 | 14.8m |
| `L2_Distributed` | `moe,parallelism` | 60 | 8.6m |

`cicd-e2e-tests-gb200`, 12 → 9 entries: the same two merges (10.5m and 6.2m). The ninth-of-ten leaves one slot of deliberate headroom for the next suite someone adds.

## Effect

The stage floor is the longest single suite — `L2_HF_Transformer_Finetune` at 16.6 min on x86, `L2_Context_Parallel` at 13.2 min on gb200. Every merged group lands below it, so the merge costs no wall-clock and removes the second wave:

| | today | after |
|---|---:|---:|
| L2 stage, median | 31.4 min | **~20.0 min** |
| Wait share | 43% | ~17% (wave-1 acquisition only) |

**~11 minutes off the median PR pipeline**, which currently sits at 2h 2m end-to-end.

### Validation

Before `L2_MoE` was added the x86 matrix had ≤10 entries and there was no second wave. In April the stage measured **14.4 min** against a longest suite of 13.6 min plus 0.2 min of wave-1 wait — the model reproduces the pre-overflow regime to within 0.6 min, which is what gives confidence in the 20.0 min projection.

## Why not just raise `max-parallel`

Identical makespan for a single run, but it raises peak runner demand 30% for *every* concurrent PR against a shared pool — that relocates the contention rather than removing it. Merging holds peak demand at 10 while cutting the makespan.

## Trade-offs

- `fail-fast` is off, so today a red suite is isolated to its own job. Merged, one failing folder takes the whole group's job red and a re-run repeats both folders. `run_test.sh` still names the folder in its output, so triage isn't blind, but the Actions UI gets coarser.
- `L2_Datasets`, `L2_HF_Transformer_LLM`, `L2_MoE` and `L2_Parallelism` disappear as check names. Branch protection on `main` requires only the aggregate `Nemo_CICD_Test`, so nothing needs updating there.
- `L2_Distributed` now installs the `vlm-media` extra for the `moe` folder too — the `*,parallelism,*` case in `run_test.sh` still matches inside the merged list. Cheap, and it already happened for the `parallelism` job.
- `L2_Diffusion` and `L2_Retrieval` are deliberately left on their own entries.

## Next lever

With 112 min of x86 work across 10 slots the theoretical floor is 11.2 min. After this change the gap from 20 → 15 min is entirely the four 14–17 min suites (`Finetune`, `Pretrain_and_KD`, `Context_Parallel`, `PEFT`); the test-template action already supports `shard-id` / `num-shards` if we want to split them.

<details>
<summary>Weekly wait/run split, x86 lane</summary>

| Week of | Runs | Waiting | Running slowest | Wait share | Stage p50 |
|---|---:|---:|---:|---:|---:|
| 2026-04-27 | 76 | 0.2 | 13.8 | 1% | 14.6 |
| 2026-05-04 | 71 | 0.2 | 15.6 | 1% | 18.0 |
| 2026-05-11 | 61 | 11.2 | 13.5 | 46% | 23.3 |
| 2026-05-18 | 65 | 0.2 | 13.9 | 2% | 15.3 |
| 2026-05-25 | 94 | 0.2 | 14.9 | 1% | 17.8 |
| 2026-06-01 | 135 | 6.7 | 16.9 | 28% | 24.4 |
| 2026-06-08 | 144 | 0.3 | 17.1 | 2% | 20.5 |
| 2026-06-15 | 136 | 0.2 | 17.1 | 1% | 18.8 |
| 2026-06-22 | 146 | 2.1 | 17.0 | 11% | 21.2 |
| 2026-06-29 | 80 | 0.2 | 17.2 | 1% | 19.6 |
| 2026-07-06 | 52 | 1.7 | 17.3 | 9% | 20.8 |
| 2026-07-13 | 75 | 0.2 | 15.1 | 2% | 18.2 |
| 2026-07-20 | 129 | 5.3 | 15.5 | 26% | 21.9 |
| 2026-07-27 | 132 | 9.5 | 15.8 | 38% | 25.9 |
| 2026-08-03 | 115 | 17.8 | 16.0 | 53% | 33.7 |
| 2026-08-10 | 100 | 11.3 | 16.3 | 41% | 28.1 |
| 2026-08-17 | 101 | 10.3 | 17.9 | 37% | 30.6 |
| 2026-08-24 | 35 | 5.7 | 19.7 | 22% | 26.6 |

</details>

<details>
<summary>Method</summary>

Source: GitHub Actions REST API, workflow `CICD NeMo`. Population = runs that reached the L2 stage, so doc-only and early-skipped runs are excluded; runs auto-cancelled by the concurrency group are excluded (their short duration is an artefact) and so are re-run attempts (GitHub carries the first attempt's passing jobs forward with their original timestamps, inflating spans by days). For each run the L2 stage starts when the last `cicd-unit-tests` job finishes and ends when the last L2 job finishes; `wait` is the interval before the critical job starts, `run` is its duration, and the two sum exactly to the stage. Medians throughout — p99 stage duration runs into tens of hours on runner starvation, so means are not representative.

</details>
