### PR TITLE
ci(convergence): fix gemma4 gate tolerance

### DIFF
--- a/examples/convergence/tulu3/models/gemma4-31b/README.md
+++ b/examples/convergence/tulu3/models/gemma4-31b/README.md
@@ -105,8 +105,16 @@ instruction-level aggregation).
 
 This recipe's `ci.downstream_eval` block registers it in the weekly convergence flow
 (`tests/ci_tests/configs/convergence/convergence_recipes.yml`): train 1000 steps → IFEval → **pass iff
-`|prompt_level_strict_acc − 0.5287| < 2·0.0215`** (band `[0.486, 0.572]`). The base ships no chat
-template; the recipe supplies the `-it` template via `dataset.chat_template`.
+`prompt_level_strict_acc > 0.5287 − 2·0.0455`** (floor `0.4378`). The gate is one-sided, so a higher
+score always passes. The base ships no chat template; the recipe supplies the `-it` template via
+`dataset.chat_template`.
+
+The `stderr` there is the **between-run** sigma of the full train→eval pipeline, not the within-eval
+bootstrap stderr from the table above (`0.0215`) — the two differ by ~2×, since the gate must absorb
+training variance and not just scoring noise. Nine runs of this recipe span 0.4492–0.5619 (stdev
+0.0455). Reproduce a failing run on the same commit before treating it as a regression, and
+re-measure both numbers when the recipe changes materially.
+
 ## Gotchas
 
 - **Base ships no chat template** → the recipe supplies the `-it` template via

--- a/examples/convergence/tulu3/models/gemma4-31b/gemma4_31b_tulu3_packed2k_cp1_gbs32_4node.yaml
+++ b/examples/convergence/tulu3/models/gemma4-31b/gemma4_31b_tulu3_packed2k_cp1_gbs32_4node.yaml
@@ -114,8 +114,8 @@ wandb:
 
 # ── Weekly Tulu-3 convergence CI (train 1000 steps -> IFEval -> threshold gate) ──
 # Regression gate, one-sided: passes iff CI IFEval prompt_level_strict_acc >
-# baseline - k * stderr. A higher score always passes. baseline/stderr
-# measured (see README.md). `tokenizer: checkpoint` -> eval uses the trained checkpoint's
+# baseline - k * stderr. A higher score always passes. baseline measured (see
+# README.md). `tokenizer: checkpoint` -> eval uses the trained checkpoint's
 # tokenizer (it carries the chat_template.jinja).
 # google/gemma-4-31B (base) ships no chat template; it is supplied via dataset.chat_template
 # (applied to the processor by the VLM loader), so no manual staging onto the model dir is needed.
@@ -133,5 +133,11 @@ ci:
     extra_model_args: "max_model_len=8192"
     metric: prompt_level_strict_acc
     baseline: 0.5287
-    stderr: 0.0215
-    k: 3                                 # gemma4 has larger variance
+    # Between-run sigma of the train->eval pipeline, NOT lm-eval's within-eval
+    # bootstrap stderr (0.0215) -- that is ~2x smaller and only covers scoring 541
+    # prompts. Nine runs span 0.4492-0.5619 (stdev 0.0455), so the old 3*0.0215 floor
+    # (0.4642) tripped roughly 1 healthy run in 9: Aug-24 scored 0.4492 and failed, but
+    # re-running that same commit scored 0.5046. Floor 0.4378 clears all nine, while a
+    # real training failure lands near the untuned base (~0.25).
+    stderr: 0.0455
+    k: 2


### PR DESCRIPTION
The Aug-24 gemma4 convergence red did not reproduce: re-running the same commit (`r0.6.0@94387e431`) scored 0.5046 against the failing run's 0.4492, so nothing had regressed.

Root cause is the gate's `stderr` — it was lm-eval's within-eval bootstrap figure (0.0215) used as the between-run sigma, which is ~2x larger; corrected to the measured 0.0455 with `k=2` (floor 0.4378).

🤖 Generated with [Claude Code](https://claude.com/claude-code)