### PR TITLE
fix(qwen2_5_omni): place thinker prefix inside base_model.model on PEFT saves

### DIFF
--- a/nemo_automodel/components/models/qwen2_5_omni/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen2_5_omni/state_dict_adapter.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 _THINKER_PREFIX = "thinker."
+_PEFT_PREFIX = "base_model.model."
 _DROP_PREFIXES = ("talker.", "token2wav.")
 
 # Keys the NeMo Thinker class deletes at __init__ time (so the HF base
@@ -71,7 +72,13 @@ class Qwen2_5OmniStateDictAdapter(StateDictAdapter):
         **kwargs,
     ) -> dict[str, Any]:
         if self._uses_thinker_prefix:
-            hf_state_dict = {_THINKER_PREFIX + k: v for k, v in state_dict.items()}
+            hf_state_dict = {}
+            for k, v in state_dict.items():
+                if k.startswith(_PEFT_PREFIX):
+                    new_k = f"{_PEFT_PREFIX}{_THINKER_PREFIX}{k[len(_PEFT_PREFIX) :]}"
+                else:
+                    new_k = _THINKER_PREFIX + k
+                hf_state_dict[new_k] = v
         else:
             hf_state_dict = dict(state_dict)
 
@@ -91,19 +98,36 @@ class Qwen2_5OmniStateDictAdapter(StateDictAdapter):
         for key, value in hf_state_dict.items():
             if key.startswith(_DROP_PREFIXES):
                 continue
-            stripped = key[len(_THINKER_PREFIX) :] if key.startswith(_THINKER_PREFIX) else key
+            if key.startswith(_PEFT_PREFIX):
+                after_peft = key[len(_PEFT_PREFIX) :]
+                if after_peft.startswith(_THINKER_PREFIX):
+                    stripped = f"{_PEFT_PREFIX}{after_peft[len(_THINKER_PREFIX) :]}"
+                    saw_thinker = True
+                else:
+                    stripped = key
+            elif key.startswith(_THINKER_PREFIX):
+                stripped = key[len(_THINKER_PREFIX) :]
+                saw_thinker = True
+            else:
+                stripped = key
+
             # Drop keys for parameters the NeMo Thinker deletes at __init__.
             if any(sub in stripped for sub in _DROP_THINKER_KEY_SUBSTRINGS):
                 continue
-            if key.startswith(_THINKER_PREFIX):
-                saw_thinker = True
             out[stripped] = value
         self._uses_thinker_prefix = saw_thinker or self._uses_thinker_prefix
         return out
 
     def convert_single_tensor_to_hf(self, fqn: str, tensor: Any, **kwargs) -> list[tuple[str, Any]]:
         exclude_key_regex = kwargs.get("exclude_key_regex", None)
-        key = _THINKER_PREFIX + fqn if self._uses_thinker_prefix else fqn
+        if self._uses_thinker_prefix:
+            if fqn.startswith(_PEFT_PREFIX):
+                key = f"{_PEFT_PREFIX}{_THINKER_PREFIX}{fqn[len(_PEFT_PREFIX) :]}"
+            else:
+                key = _THINKER_PREFIX + fqn
+        else:
+            key = fqn
+
         if exclude_key_regex:
             if re.match(exclude_key_regex, key):
                 return []

--- a/tests/unit_tests/models/qwen2_5_omni/test_qwen2_5_omni_state_dict_adapter.py
+++ b/tests/unit_tests/models/qwen2_5_omni/test_qwen2_5_omni_state_dict_adapter.py
@@ -130,11 +130,55 @@ class TestToHF:
             assert key in restored, f"missing key after round-trip: {key}"
             assert torch.equal(restored[key], value), f"value mismatch for {key}"
 
+    def test_peft_lora_keys_to_hf(self, adapter):
+        # PEFT keys should have thinker prefix placed inside base_model.model.
+        nemo_peft_state = {
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight": torch.randn(4, 4),
+            "base_model.model.model.layers.0.self_attn.v_proj.lora_B.weight": torch.randn(4, 4),
+        }
+        hf_state = adapter.to_hf(nemo_peft_state)
+        assert "base_model.model.thinker.model.layers.0.self_attn.q_proj.lora_A.weight" in hf_state
+        assert "base_model.model.thinker.model.layers.0.self_attn.v_proj.lora_B.weight" in hf_state
+        assert not any(k.startswith("thinker.base_model.model.") for k in hf_state)
+
+    def test_peft_lora_keys_from_hf(self, adapter):
+        hf_peft_state = {
+            "base_model.model.thinker.model.layers.0.self_attn.q_proj.lora_A.weight": torch.randn(4, 4),
+            "base_model.model.thinker.model.layers.0.self_attn.v_proj.lora_B.weight": torch.randn(4, 4),
+        }
+        restored = adapter.from_hf(hf_peft_state)
+        assert "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight" in restored
+        assert "base_model.model.model.layers.0.self_attn.v_proj.lora_B.weight" in restored
+        assert adapter._uses_thinker_prefix is True
+
+    def test_peft_lora_round_trip(self, adapter):
+        nemo_peft_state = {
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight": torch.randn(4, 4),
+            "base_model.model.model.layers.0.self_attn.v_proj.lora_B.weight": torch.randn(4, 4),
+        }
+        hf_state = adapter.to_hf(nemo_peft_state)
+        restored = adapter.from_hf(hf_state)
+        for key, value in nemo_peft_state.items():
+            assert key in restored, f"missing PEFT key after round-trip: {key}"
+            assert torch.equal(restored[key], value)
+
 
 class TestSingleTensorConversion:
     def test_prefixes_key(self, adapter):
         out = adapter.convert_single_tensor_to_hf("model.embed_tokens.weight", torch.zeros(2, 2))
         assert out == [("thinker.model.embed_tokens.weight", out[0][1])]
+
+    def test_prefixes_peft_key(self, adapter):
+        out = adapter.convert_single_tensor_to_hf(
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight",
+            torch.zeros(2, 2),
+        )
+        assert out == [
+            (
+                "base_model.model.thinker.model.layers.0.self_attn.q_proj.lora_A.weight",
+                out[0][1],
+            )
+        ]
 
     def test_respects_exclude_regex(self, adapter):
         out = adapter.convert_single_tensor_to_hf("drop.me", torch.zeros(1), exclude_key_regex=r"^thinker\.drop")


### PR DESCRIPTION
Fixes NVIDIA-NeMo/Automodel#3655.

### Problem
When saving LoRA adapters for \qwen2_5_omni\, parameter keys already start with the PEFT prefix \ase_model.model.\.
\Qwen2_5OmniStateDictAdapter.to_hf\ previously prepended \	hinker.\ directly to the entire key, producing:
\\\	ext
thinker.base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight
\\\
instead of the expected Hugging Face PEFT format:
\\\	ext
base_model.model.thinker.model.layers.0.self_attn.q_proj.lora_A.weight
\\\
This prevented external Hugging Face PEFT from loading saved adapters and broke bidirectional conversion in \rom_hf\.

### Solution
1. In \	o_hf\: Check for \ase_model.model.\ prefix and place \	hinker.\ inside it (\ase_model.model.thinker...\).
2. In \rom_hf\: Strip \	hinker.\ when nested inside \ase_model.model.\, preserving the PEFT prefix.
3. In \convert_single_tensor_to_hf\: Apply identical prefix nesting logic for single tensor conversions.
4. Added comprehensive unit tests for PEFT LoRA key conversion, bidirectional round-trip serialization, and single-tensor export.

### Testing
- Passed 13/13 unit tests in \	ests/unit_tests/models/qwen2_5_omni/test_qwen2_5_omni_state_dict_adapter.py\.