### PR TITLE
test(pp): fail parity tests when neither run trained

### DIFF
--- a/tests/functional_tests/parallelism/compare_parallel_parity.py
+++ b/tests/functional_tests/parallelism/compare_parallel_parity.py
@@ -48,6 +48,10 @@ DEFAULT_LOSS_TOL = 0.05
 # Gradient norm is a sum over every parameter, so it carries more accumulated
 # rounding than a single loss value; compared as a relative delta.
 DEFAULT_GRAD_NORM_RTOL = 0.05
+# Smallest believable spread between the highest and lowest baseline loss across
+# steps. Real runs here span 0.05-0.10 nats batch to batch; a run that computed
+# nothing spans exactly 0.
+MIN_LOSS_SPREAD = 1e-4
 
 
 def read_metrics(jsonl_path: str) -> dict[int, dict[str, float]]:
@@ -75,6 +79,50 @@ def read_metrics(jsonl_path: str) -> dict[int, dict[str, float]]:
                 sample["grad_norm"] = float(grad_norm)
             entries[int(record["step"])] = sample
     return entries
+
+
+def _assert_both_runs_trained(
+    baseline: dict[int, dict[str, float]],
+    parallel: dict[int, dict[str, float]],
+    common_steps: list[int],
+) -> None:
+    """Reject a comparison where neither run actually trained.
+
+    Everything above only checks that the two runs *agree*. Two equally broken
+    runs agree perfectly, so a model that never got initialized passes every
+    check while proving nothing. This happened for real: a proxy whose weights
+    were silently left uninitialized reported zero gradients and a loss pinned
+    at ln(vocab_size) on both legs, and the comparison called it a pass.
+
+    Args:
+        baseline: Per-step metrics from the baseline run.
+        parallel: Per-step metrics from the parallel run.
+        common_steps: Steps present in both runs.
+
+    Raises:
+        AssertionError: If either run shows a zero gradient norm, or the loss
+            does not move across steps that saw different batches.
+    """
+    for name, metrics in (("baseline", baseline), ("parallel", parallel)):
+        dead = [step for step in common_steps if metrics[step].get("grad_norm") == 0.0]
+        assert not dead, (
+            f"The {name} run reported grad_norm exactly 0 at step(s) {dead}. A model that trains "
+            "produces a non-zero gradient norm, so this run never trained and the comparison "
+            "above proves nothing. Check that the model's weights were initialized."
+        )
+
+    # Needs at least two steps to have anything to compare against, and the
+    # steps must have seen different batches -- true for every recipe here,
+    # which draw from a multi-sample dataset without repeating.
+    if len(common_steps) < 2:
+        return
+    losses = [baseline[step]["loss"] for step in common_steps]
+    spread = max(losses) - min(losses)
+    assert spread > MIN_LOSS_SPREAD, (
+        f"The baseline loss is flat across {len(common_steps)} steps (spread {spread:.3e} <= "
+        f"{MIN_LOSS_SPREAD}). Each step sees a different batch, so a loss that never moves means "
+        "the model's output does not depend on its input and the comparison above proves nothing."
+    )
 
 
 def main() -> None:
@@ -144,6 +192,8 @@ def main() -> None:
         "Neither log reported grad_norm, so the gradient-sync half of this check did not run. "
         "Confirm the recipe logs grad_norm to training.jsonl."
     )
+
+    _assert_both_runs_trained(baseline, parallel, common_steps)
 
     print(f"{args.axis} parity OK: {len(common_steps)} steps, {compared_grad_norms} gradient norms compared")
 


### PR DESCRIPTION
## What

Makes the parallelism parity tests fail when neither run (i.e PP=1 v/s PP=2 or EP=1 v/s EP=2) actually trained.

## Why

The comparison only checks that the two runs agree with each other. If both are broken in the same way, they agree perfectly and the test passes while proving nothing.

For ex: A qwen3_5_moe proxy had its weights silently left uninitialized. Both legs reported:

- `grad_norm` of exactly `0.0000` on every step
- a loss frozen at `10.373490`, which is exactly `ln(32000)` — the loss you get from a model whose output ignores its input

The parity check compared them, found a delta of `0.000000`, and reported **pass**. Two dead models agreeing.

## The check

Two new assertions, both cheap:

- **Zero gradient norm.** A model that trains never has a gradient norm of exactly zero.
- **Flat loss.** Each step sees a different batch, so a loss that never moves means the output does not depend on the input. Skipped when there is only one step to compare.

## Verified

| Case | Expected | Result |
|---|---|---|
| Real qwen numbers (zero grads) | fail | fails, names the steps |
| Flat loss, non-zero grads | fail | fails |
| Real deepseek numbers | pass | passes |
| Single-step run | pass | passes |
| Real `L2_Parallelism_DeepSeekV4_EP2_Parity.sh` | pass | passes |
| Real `L2_Parallelism_VLM_Gemma4_PP2_Parity.sh` | pass | passes |
| Real `L2_Parallelism_VLM_Gemma4_TP2_Parity.sh` | pass | passes |

The threshold for a flat loss is `1e-4`. Real runs move well clear of it — gemma4 PP2 spans `12.461`–`12.519` (`0.058`) and deepseek PP2 spans `0.098` — while a dead run spans exactly `0`.

All three tests that use this script were run end to end and still pass. `L2_Parallelism_PP_Grad_Accum_Parity.sh` is unaffected: it compares per-parameter gradients directly and never calls this script.

## Note

This protects all six existing parity tests, not just new ones. Nothing today would catch a change that quietly stops a model from training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
