### PR TITLE
perf(qwen3.5): reuse packed GDN metadata across layers

### DIFF
--- a/nemo_automodel/components/models/qwen3_5/model.py
+++ b/nemo_automodel/components/models/qwen3_5/model.py
@@ -57,6 +57,10 @@ from nemo_automodel.components.models.common.tie_word_embeddings import (
     reject_unsupported_tie_word_embeddings,
 )
 from nemo_automodel.components.models.common.utils import cast_model_to_dtype
+from nemo_automodel.components.models.qwen3_5.packing import (
+    GatedDeltaPackedMetadata,
+    prepare_gated_delta_packed_metadata,
+)
 from nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn import CPAwareGatedDeltaNet
 from nemo_automodel.components.models.qwen3_next.layers import Qwen3NextRMSNorm
 from nemo_automodel.components.models.qwen3_next.model import Block
@@ -343,8 +347,27 @@ class Qwen3_5DenseBlock(Block):
         attention_mask: torch.Tensor | None = None,
         padding_mask: torch.Tensor | None = None,
         position_ids: torch.Tensor | None = None,
+        packed_gdn_metadata: GatedDeltaPackedMetadata | None = None,
         **attn_kwargs: Any,
     ) -> torch.Tensor:
+        """Run one dense Qwen3.5 decoder block.
+
+        Args:
+            x: Hidden states of shape [batch, sequence, hidden].
+            freqs_cis: Rotary frequencies of shape [axes, batch, sequence,
+                head_dim].
+            attention_mask: Optional validity, indexed document, or backend mask
+                of shape [batch, sequence] or [batch, 1, sequence, sequence].
+            padding_mask: Optional padding mask of shape [batch, sequence].
+            position_ids: Optional positions of shape [batch, sequence] or
+                [axes, batch, sequence].
+            packed_gdn_metadata: Optional model-forward-owned packing metadata;
+                tensor layouts are documented by :class:`GatedDeltaPackedMetadata`.
+            **attn_kwargs: Backend-specific attention arguments.
+
+        Returns:
+            Hidden states of shape [batch, sequence, hidden].
+        """
         if self.layer_type != "linear_attention":
             attn_kwargs = dict(attn_kwargs)
             attn_kwargs.pop("seq_index", None)
@@ -357,24 +380,20 @@ class Qwen3_5DenseBlock(Block):
                 **attn_kwargs,
             )
 
-        from nemo_automodel.components.models.common.packing import get_unpad_data, is_indexed_packed_mask
-
-        cu_seqlens: torch.Tensor | None = None
-        indices: torch.Tensor | None = None
         linear_attn_mask = attention_mask
-        packed_seq_ids = attn_kwargs.get("_packed_seq_ids")
-        if is_indexed_packed_mask(attention_mask):
-            packing_mask = attention_mask
-        elif is_indexed_packed_mask(packed_seq_ids):
-            packing_mask = packed_seq_ids
-        else:
-            packing_mask = None
+        from nemo_automodel.components.distributed.blockdiag_cp import current_blockdiag_cp_state
 
-        if packing_mask is not None:
-            indices_t, cu_seqlens_t, _ = get_unpad_data(packing_mask)
-            cu_seqlens = cu_seqlens_t.to(torch.long)
-            indices = indices_t
-            linear_attn_mask = packing_mask
+        if current_blockdiag_cp_state() is not None:
+            packed_gdn_metadata = None
+            linear_attn_mask = None
+        elif packed_gdn_metadata is None:
+            packed_gdn_metadata = prepare_gated_delta_packed_metadata(
+                attention_mask,
+                attn_kwargs.get("_packed_seq_ids"),
+            )
+
+        if packed_gdn_metadata is not None:
+            linear_attn_mask = packed_gdn_metadata.document_ids
 
         if linear_attn_mask is not None and padding_mask is None:
             padding_mask = linear_attn_mask.bool().logical_not()
@@ -385,8 +404,9 @@ class Qwen3_5DenseBlock(Block):
             attention_mask=linear_attn_mask,
             position_ids=position_ids,
             seq_index=attn_kwargs.get("seq_index"),
-            cu_seqlens=cu_seqlens,
-            indices=indices,
+            cu_seqlens=packed_gdn_metadata.cu_seqlens if packed_gdn_metadata is not None else None,
+            cu_seqlens_cpu=packed_gdn_metadata.cu_seqlens_cpu if packed_gdn_metadata is not None else None,
+            indices=packed_gdn_metadata.indices if packed_gdn_metadata is not None else None,
         )
         x = x + attn_out
         mlp_out = self._mlp(x=self.post_attention_layernorm(x), padding_mask=padding_mask)
@@ -452,6 +472,30 @@ class Qwen3_5DenseTextBackbone(nn.Module):
         output_hidden_states: bool | None = None,
         **attn_kwargs: Any,
     ) -> BaseModelOutputWithPast:
+        """Decode text tokens with model-forward-owned packed GDN metadata.
+
+        Args:
+            input_ids: Optional token IDs of shape [batch, sequence].
+            inputs_embeds: Optional token embeddings of shape [batch, sequence,
+                hidden].
+            attention_mask: Optional validity, indexed document, or backend mask
+                of shape [batch, sequence] or [batch, 1, sequence, sequence].
+            position_ids: Optional positions of shape [batch, sequence] or
+                [axes, batch, sequence].
+            cache_position: Optional token positions of shape [sequence].
+            padding_mask: Optional padding mask of shape [batch, sequence].
+            past_key_values: Unsupported recurrent or KV cache.
+            use_cache: Whether to use a cache; only ``False`` or ``None`` is
+                supported.
+            output_hidden_states: Accepted for Hugging Face compatibility and
+                ignored.
+            **attn_kwargs: Backend-specific attention arguments, including optional
+                ``_packed_seq_ids`` of shape [batch, sequence].
+
+        Returns:
+            Model output whose ``last_hidden_state`` has shape [batch, sequence,
+            hidden].
+        """
         del output_hidden_states  # accepted for HF-forward compatibility; ignored
         if past_key_values is not None or use_cache:
             raise NotImplementedError("KV cache is not supported for the Qwen3.5 dense backend implementation.")
@@ -482,6 +526,12 @@ class Qwen3_5DenseTextBackbone(nn.Module):
         cos, sin = self.rotary_emb(hidden_states, position_ids)
         head_dim = cos.shape[-1] // 2
         freqs_cis = torch.cat((cos[..., :head_dim], sin[..., :head_dim]), dim=-1)
+        packed_gdn_metadata = None
+        if not getattr(self, "_cp_enabled", False):
+            packed_gdn_metadata = prepare_gated_delta_packed_metadata(
+                attention_mask,
+                attn_kwargs.get("_packed_seq_ids"),
+            )
 
         for decoder_layer in self.layers.values():
             hidden_states = decoder_layer(
@@ -490,6 +540,7 @@ class Qwen3_5DenseTextBackbone(nn.Module):
                 attention_mask=attention_mask,
                 padding_mask=padding_mask,
                 position_ids=position_ids,
+                packed_gdn_metadata=packed_gdn_metadata,
                 **attn_kwargs,
             )
 

--- a/nemo_automodel/components/models/qwen3_5/packing.py
+++ b/nemo_automodel/components/models/qwen3_5/packing.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared packed-sequence metadata for dense and MoE Qwen3.5 models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+from nemo_automodel.components.models.common.packing import get_unpad_data, is_indexed_packed_mask
+
+
+@dataclass(frozen=True)
+class GatedDeltaPackedMetadata:
+    """Packed-sequence metadata shared by every GatedDeltaNet layer.
+
+    Args:
+        document_ids: Indexed document mask of shape [batch, sequence] on the
+            compute device, with zero denoting padding.
+        indices: Flattened valid-token indices of shape [tokens] on the compute
+            device.
+        cu_seqlens: Cumulative document lengths of shape [documents + 1] on the
+            compute device.
+        cu_seqlens_cpu: CPU mirror of ``cu_seqlens`` with shape [documents + 1]
+            for FLA host-side chunk planning.
+    """
+
+    document_ids: torch.Tensor
+    indices: torch.Tensor
+    cu_seqlens: torch.Tensor
+    cu_seqlens_cpu: torch.Tensor
+
+
+def prepare_gated_delta_packed_metadata(
+    attention_mask: torch.Tensor | None,
+    packed_seq_ids: torch.Tensor | None,
+) -> GatedDeltaPackedMetadata | None:
+    """Build shared GatedDeltaNet metadata once for a model forward.
+
+    Args:
+        attention_mask: Optional indexed document mask of shape [batch,
+            sequence] or a backend-specific attention mask.
+        packed_seq_ids: Optional indexed document IDs of shape [batch,
+            sequence] supplied beside a backend-specific attention mask.
+
+    Returns:
+        Device and CPU packed-sequence metadata whose tensor layouts are
+        documented by :class:`GatedDeltaPackedMetadata`, or ``None`` for an
+        unpacked mask.
+    """
+    if is_indexed_packed_mask(attention_mask):
+        document_ids = attention_mask
+    elif is_indexed_packed_mask(packed_seq_ids):
+        document_ids = packed_seq_ids
+    else:
+        return None
+
+    indices, cu_seqlens, _ = get_unpad_data(document_ids)
+    cu_seqlens = cu_seqlens.to(torch.long)
+    return GatedDeltaPackedMetadata(
+        document_ids=document_ids,
+        indices=indices,
+        cu_seqlens=cu_seqlens,
+        cu_seqlens_cpu=cu_seqlens.detach().cpu(),
+    )

--- a/nemo_automodel/components/models/qwen3_5_moe/cp_linear_attn.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/cp_linear_attn.py
@@ -35,7 +35,7 @@ from torch.autograd import Function
 from torch.distributed.device_mesh import DeviceMesh
 from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeGatedDeltaNet
 
-from nemo_automodel.components.models.common.packing import get_unpad_data, is_indexed_packed_mask
+from nemo_automodel.components.models.qwen3_5.packing import prepare_gated_delta_packed_metadata
 from nemo_automodel.shared.utils import dtype_from_str
 
 if TYPE_CHECKING:
@@ -133,27 +133,27 @@ class CPAwareGatedDeltaNet(Qwen3_5MoeGatedDeltaNet):
         cache_position=None,
         attention_mask: torch.Tensor | None = None,
         cu_seqlens: torch.Tensor | None = None,
+        cu_seqlens_cpu: torch.Tensor | None = None,
         indices: torch.Tensor | None = None,
-    ):
+    ) -> torch.Tensor:
         """HF GatedDeltaNet forward with FSDP-safe fp32 gate computation.
 
-        Mirrors transformers==5.5 ``Qwen3_5GatedDeltaNet.forward`` (per-layer
-        cache API; gate via ``self._compute_gate(a)``) and adds packing-aware
-        plumbing:
+        Args:
+            hidden_states: Hidden states of shape [batch, sequence, hidden].
+            cache_params: Optional Hugging Face recurrent cache.
+            cache_position: Optional token positions of shape [sequence]; unused
+                by the Transformers 5.5-compatible path.
+            attention_mask: Optional validity or indexed document mask of shape
+                [batch, sequence].
+            cu_seqlens: Optional cumulative document lengths of shape
+                [documents + 1] on the compute device.
+            cu_seqlens_cpu: Optional CPU mirror of ``cu_seqlens`` with shape
+                [documents + 1] for FLA host-side chunk planning.
+            indices: Optional flattened valid-token indices of shape [tokens] on
+                the compute device.
 
-        * ``cu_seqlens`` -- per-document cumulative lengths from the indexed
-          attention mask. When supplied, FLA's chunk kernel resets state at
-          every document boundary.
-        * ``indices`` -- non-padding token indices. When supplied AND padding
-          is actually present (B>1 case), the layer unpads activations to
-          ``[1, total_valid, ...]`` before conv/FLA and re-pads on the way
-          out. For B=1 with no padding, ``indices`` covers the whole sequence
-          and unpadding is skipped (preserves the bit-exact fast path).
-
-        Both kwargs are produced by ``Qwen3_5DecoderLayerWithPacking``. As a
-        safety net for direct callers (e.g. unit tests that bypass the
-        decoder-layer subclass), the layer derives them from ``attention_mask``
-        when both are ``None`` and the mask is indexed.
+        Returns:
+            GatedDeltaNet output of shape [batch, sequence, hidden].
         """
         from transformers.models.qwen3_5.modeling_qwen3_5 import apply_mask_to_padding_states
 
@@ -166,10 +166,16 @@ class CPAwareGatedDeltaNet(Qwen3_5MoeGatedDeltaNet):
         # Resolve packing kwargs. Fallback to mask-derivation only when neither
         # was passed in (bypasses the decoder-layer subclass).
         if not use_precomputed_states and cu_seqlens is None and indices is None:
-            if is_indexed_packed_mask(attention_mask):
-                indices_t, cu_seqlens_t, _ = get_unpad_data(attention_mask)
-                cu_seqlens = cu_seqlens_t.to(torch.long)
-                indices = indices_t
+            packed_metadata = prepare_gated_delta_packed_metadata(attention_mask, None)
+            if packed_metadata is not None:
+                cu_seqlens = packed_metadata.cu_seqlens
+                cu_seqlens_cpu = packed_metadata.cu_seqlens_cpu
+                indices = packed_metadata.indices
+
+        if cu_seqlens is not None and cu_seqlens_cpu is None:
+            cu_seqlens_cpu = cu_seqlens.detach().cpu()
+        if cu_seqlens_cpu is not None and cu_seqlens_cpu.device.type != "cpu":
+            raise ValueError("cu_seqlens_cpu must reside on CPU for FLA host-side chunk planning.")
 
         is_packed = (not use_precomputed_states) and cu_seqlens is not None
         # Only unpad when there is actually padding to remove. For B=1 packs
@@ -268,6 +274,7 @@ class CPAwareGatedDeltaNet(Qwen3_5MoeGatedDeltaNet):
                     output_final_state=cache_params is not None,
                     use_qk_l2norm_in_kernel=True,
                     cu_seqlens=cu_seqlens,
+                    cu_seqlens_cpu=cu_seqlens_cpu,
                 )
                 if not needs_unpad:
                     core_attn_out = core_attn_out.reshape(batch_size, seq_len, *core_attn_out.shape[2:])
@@ -326,9 +333,10 @@ class CPAwareGatedDeltaNet(Qwen3_5MoeGatedDeltaNet):
         position_ids: torch.Tensor | None = None,
         qkv_format: str | None = None,
         cu_seqlens: torch.Tensor | None = None,
+        cu_seqlens_cpu: torch.Tensor | None = None,
         indices: torch.Tensor | None = None,
         seq_index: torch.Tensor | None = None,
-    ):
+    ) -> torch.Tensor:
         """Run GatedDeltaNet with dense, round-robin CP, or packed contiguous CP.
 
         Args:
@@ -342,7 +350,9 @@ class CPAwareGatedDeltaNet(Qwen3_5MoeGatedDeltaNet):
                 ``[axes, batch, sequence]``.
             qkv_format: Optional attention layout tag; unused by this module.
             cu_seqlens: Optional packed boundaries of shape
-                ``[num_documents + 1]`` for the non-CP path.
+                [documents + 1] for the non-CP path.
+            cu_seqlens_cpu: Optional CPU mirror of ``cu_seqlens`` with shape
+                [documents + 1] for FLA host-side chunk planning.
             indices: Optional valid-token indices of shape ``[tokens]`` for the
                 non-CP packed path.
             seq_index: Optional global token positions of shape ``[sequence]``
@@ -359,6 +369,7 @@ class CPAwareGatedDeltaNet(Qwen3_5MoeGatedDeltaNet):
                 cache_params=cache_params,
                 attention_mask=attention_mask,
                 cu_seqlens=cu_seqlens,
+                cu_seqlens_cpu=cu_seqlens_cpu,
                 indices=indices,
             )
 

--- a/nemo_automodel/components/models/qwen3_5_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/model.py
@@ -87,6 +87,10 @@ from nemo_automodel.components.models.common.tie_word_embeddings import (
     reject_unsupported_tie_word_embeddings,
 )
 from nemo_automodel.components.models.common.utils import cast_model_to_dtype, compute_lm_head_logits
+from nemo_automodel.components.models.qwen3_5.packing import (
+    GatedDeltaPackedMetadata,
+    prepare_gated_delta_packed_metadata,
+)
 from nemo_automodel.components.models.qwen3_next.layers import Qwen3NextAttention, Qwen3NextRMSNorm
 from nemo_automodel.components.models.qwen3_next.model import Block
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
@@ -166,16 +170,26 @@ class Qwen3_5MoeBlock(Block):
         attention_mask: torch.Tensor | None = None,
         padding_mask: torch.Tensor | None = None,
         position_ids: torch.Tensor | None = None,
+        packed_gdn_metadata: GatedDeltaPackedMetadata | None = None,
         **attn_kwargs: Any,
     ) -> torch.Tensor:
-        """Mirror :meth:`Block.forward` but thread NEAT-packing kwargs into
-        ``CPAwareGatedDeltaNet``.
+        """Run one Qwen3.5-MoE decoder block.
 
-        The parent ``Block.forward`` calls ``linear_attn`` with only
-        ``hidden_states`` and ``attention_mask``; for packed sequences the
-        gated_delta_rule kernel additionally needs ``cu_seqlens`` /
-        ``indices`` to reset state at document boundaries (issue #2131).
-        Derived once per forward from the indexed attention mask.
+        Args:
+            x: Hidden states of shape [batch, sequence, hidden].
+            freqs_cis: Rotary frequencies of shape [axes, batch, sequence,
+                head_dim].
+            attention_mask: Optional validity, indexed document, or backend mask
+                of shape [batch, sequence] or [batch, 1, sequence, sequence].
+            padding_mask: Optional padding mask of shape [batch, sequence].
+            position_ids: Optional positions of shape [batch, sequence] or
+                [axes, batch, sequence].
+            packed_gdn_metadata: Optional model-forward-owned packing metadata;
+                tensor layouts are documented by :class:`GatedDeltaPackedMetadata`.
+            **attn_kwargs: Backend-specific attention arguments.
+
+        Returns:
+            Hidden states of shape [batch, sequence, hidden].
         """
         if self.layer_type != "linear_attention":
             attn_kwargs = dict(attn_kwargs)
@@ -189,26 +203,20 @@ class Qwen3_5MoeBlock(Block):
                 **attn_kwargs,
             )
 
-        # Local imports to avoid pulling packing utilities into the module
-        # import graph for non-Qwen3.5 callers.
-        from nemo_automodel.components.models.common.packing import get_unpad_data, is_indexed_packed_mask
-
-        cu_seqlens: torch.Tensor | None = None
-        indices: torch.Tensor | None = None
         linear_attn_mask = attention_mask
-        packed_seq_ids = attn_kwargs.get("_packed_seq_ids")
-        if is_indexed_packed_mask(attention_mask):
-            packing_mask = attention_mask
-        elif is_indexed_packed_mask(packed_seq_ids):
-            packing_mask = packed_seq_ids
-        else:
-            packing_mask = None
+        from nemo_automodel.components.distributed.blockdiag_cp import current_blockdiag_cp_state
 
-        if packing_mask is not None:
-            indices_t, cu_seqlens_t, _ = get_unpad_data(packing_mask)
-            cu_seqlens = cu_seqlens_t.to(torch.long)
-            indices = indices_t
-            linear_attn_mask = packing_mask
+        if current_blockdiag_cp_state() is not None:
+            packed_gdn_metadata = None
+            linear_attn_mask = None
+        elif packed_gdn_metadata is None:
+            packed_gdn_metadata = prepare_gated_delta_packed_metadata(
+                attention_mask,
+                attn_kwargs.get("_packed_seq_ids"),
+            )
+
+        if packed_gdn_metadata is not None:
+            linear_attn_mask = packed_gdn_metadata.document_ids
 
         if linear_attn_mask is not None and padding_mask is None:
             padding_mask = linear_attn_mask.bool().logical_not()
@@ -219,8 +227,9 @@ class Qwen3_5MoeBlock(Block):
             attention_mask=linear_attn_mask,
             position_ids=position_ids,
             seq_index=attn_kwargs.get("seq_index"),
-            cu_seqlens=cu_seqlens,
-            indices=indices,
+            cu_seqlens=packed_gdn_metadata.cu_seqlens if packed_gdn_metadata is not None else None,
+            cu_seqlens_cpu=packed_gdn_metadata.cu_seqlens_cpu if packed_gdn_metadata is not None else None,
+            indices=packed_gdn_metadata.indices if packed_gdn_metadata is not None else None,
         )
         x = x + attn_out
 
@@ -685,6 +694,28 @@ class Qwen3_5MoeTextModelBackend(nn.Module):
         use_cache: bool | None = None,
         **attn_kwargs: Any,
     ) -> Qwen3_5MoeModelOutputWithPast:
+        """Decode text tokens with model-forward-owned packed GDN metadata.
+
+        Args:
+            input_ids: Optional token IDs of shape [batch, sequence].
+            inputs_embeds: Optional token embeddings of shape [batch, sequence,
+                hidden].
+            attention_mask: Optional validity, indexed document, or backend mask
+                of shape [batch, sequence] or [batch, 1, sequence, sequence].
+            position_ids: Optional positions of shape [batch, sequence] or
+                [axes, batch, sequence].
+            cache_position: Optional token positions of shape [sequence].
+            padding_mask: Optional padding mask of shape [batch, sequence].
+            past_key_values: Unsupported recurrent or KV cache.
+            use_cache: Whether to use a cache; only ``False`` or ``None`` is
+                supported.
+            **attn_kwargs: Backend-specific attention arguments, including optional
+                ``_packed_seq_ids`` of shape [batch, sequence].
+
+        Returns:
+            Model output whose ``last_hidden_state`` has shape [batch, sequence,
+            hidden].
+        """
         if past_key_values is not None or use_cache:
             raise NotImplementedError("KV cache is not supported for the Qwen3.5-MoE backend implementation.")
 
@@ -736,6 +767,12 @@ class Qwen3_5MoeTextModelBackend(nn.Module):
         cos, sin = self.rotary_emb(hidden_states, position_ids)
         head_dim = cos.shape[-1] // 2
         freqs_cis = torch.cat((cos[..., :head_dim], sin[..., :head_dim]), dim=-1)
+        packed_gdn_metadata = None
+        if not getattr(self, "_cp_enabled", False):
+            packed_gdn_metadata = prepare_gated_delta_packed_metadata(
+                attention_mask,
+                attn_kwargs.get("_packed_seq_ids"),
+            )
 
         # --- Decoder layers (Qwen3Next Block, unmodified) ---
         for decoder_layer in self.layers.values():
@@ -745,6 +782,7 @@ class Qwen3_5MoeTextModelBackend(nn.Module):
                 attention_mask=attention_mask,
                 padding_mask=padding_mask,
                 position_ids=position_ids,
+                packed_gdn_metadata=packed_gdn_metadata,
                 **attn_kwargs,
             )
 

--- a/tests/unit_tests/models/qwen3_5/test_qwen3_5_dense_backbone.py
+++ b/tests/unit_tests/models/qwen3_5/test_qwen3_5_dense_backbone.py
@@ -22,16 +22,20 @@ fp32-safe rotary embedding. All tests are CPU-only.
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 import torch
 import torch.nn as nn
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import CheckpointImpl, checkpoint_wrapper
 
 pytest.importorskip("transformers.models.qwen3_5")
 pytest.importorskip("transformers.models.qwen3_5_moe")
 
 from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
 
-from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.common import BackendConfig, packing
+from nemo_automodel.components.models.qwen3_5 import packing as qwen3_5_packing
 from nemo_automodel.components.models.qwen3_5.model import (
     Fp32SafeQwen3_5TextRotaryEmbedding,
     Qwen3_5DenseTextBackbone,
@@ -240,6 +244,41 @@ class TestDenseTextBackbone:
         embeds = torch.randn(1, 4, cfg.hidden_size)
         out = backbone(inputs_embeds=embeds)
         assert out.last_hidden_state.shape == (1, 4, cfg.hidden_size)
+
+    def test_reuses_packed_metadata_across_checkpointed_layers(self):
+        torch.manual_seed(123)
+        cfg = _tiny_config(layer_types=("linear_attention", "linear_attention"))
+        backbone = Qwen3_5DenseTextBackbone(cfg, _backend()).float().train()
+        linear_attn_modules = []
+        for name in list(backbone.layers):
+            linear_attn_modules.append(backbone.layers[name].linear_attn)
+            backbone.layers[name] = checkpoint_wrapper(
+                backbone.layers[name],
+                checkpoint_impl=CheckpointImpl.NO_REENTRANT,
+            )
+
+        get_unpad_data = MagicMock(wraps=packing.get_unpad_data)
+        chunk_gated_delta_rule = MagicMock(side_effect=lambda *args, **_kwargs: (args[2], None))
+        for linear_attn in linear_attn_modules:
+            linear_attn.causal_conv1d_fn = MagicMock(side_effect=lambda **kwargs: kwargs["x"])
+            linear_attn.chunk_gated_delta_rule = chunk_gated_delta_rule
+
+        with patch.object(qwen3_5_packing, "get_unpad_data", get_unpad_data):
+            output = backbone(
+                input_ids=torch.tensor([[1, 2, 3, 4]]),
+                attention_mask=torch.tensor([[1, 1, 2, 2]]),
+            ).last_hidden_state
+            output.backward(torch.randn_like(output))
+
+        assert get_unpad_data.call_count == 1
+        assert chunk_gated_delta_rule.call_count == 4
+        call_kwargs = [call.kwargs for call in chunk_gated_delta_rule.call_args_list]
+        device_cu_seqlens = call_kwargs[0]["cu_seqlens"]
+        cpu_cu_seqlens = call_kwargs[0]["cu_seqlens_cpu"]
+        assert cpu_cu_seqlens.device.type == "cpu"
+        assert cpu_cu_seqlens.tolist() == [0, 2, 4]
+        assert all(kwargs["cu_seqlens"] is device_cu_seqlens for kwargs in call_kwargs)
+        assert all(kwargs["cu_seqlens_cpu"] is cpu_cu_seqlens for kwargs in call_kwargs)
 
     def test_kv_cache_not_supported(self):
         cfg = _tiny_config(layer_types=("full_attention",))

--- a/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_packed_metadata.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_packed_metadata.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU regression coverage for checkpointed Qwen3.5-MoE packed metadata."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import CheckpointImpl, checkpoint_wrapper
+
+pytest.importorskip("transformers.models.qwen3_5_moe")
+
+from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import Qwen3_5MoeTextConfig
+
+from nemo_automodel.components.models.common import BackendConfig, packing
+from nemo_automodel.components.models.qwen3_5 import packing as qwen3_5_packing
+from nemo_automodel.components.models.qwen3_5_moe.model import Qwen3_5MoeTextModelBackend
+
+
+def test_reuses_packed_metadata_across_checkpointed_moe_layers():
+    torch.manual_seed(123)
+    config = Qwen3_5MoeTextConfig(
+        vocab_size=32,
+        hidden_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        intermediate_size=32,
+        moe_intermediate_size=16,
+        shared_expert_intermediate_size=16,
+        num_experts=2,
+        num_experts_per_tok=1,
+        max_position_embeddings=16,
+        rms_norm_eps=1e-6,
+        router_aux_loss_coef=0.01,
+        pad_token_id=0,
+        layer_types=["linear_attention", "linear_attention"],
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_num_key_heads=2,
+        linear_num_value_heads=2,
+        use_cache=False,
+        torch_dtype="float32",
+    )
+    backend = BackendConfig(
+        linear="torch",
+        attn="sdpa",
+        rms_norm="torch",
+        dispatcher="torch",
+        fake_balanced_gate=False,
+        enable_hf_state_dict_adapter=False,
+    )
+    model = Qwen3_5MoeTextModelBackend(config, backend).float().train()
+    linear_attn_modules = []
+    for name in list(model.layers):
+        linear_attn_modules.append(model.layers[name].linear_attn)
+        model.layers[name] = checkpoint_wrapper(
+            model.layers[name],
+            checkpoint_impl=CheckpointImpl.NO_REENTRANT,
+        )
+
+    get_unpad_data = MagicMock(wraps=packing.get_unpad_data)
+    chunk_gated_delta_rule = MagicMock(side_effect=lambda *args, **_kwargs: (args[2], None))
+    for linear_attn in linear_attn_modules:
+        linear_attn.causal_conv1d_fn = MagicMock(side_effect=lambda **kwargs: kwargs["x"])
+        linear_attn.chunk_gated_delta_rule = chunk_gated_delta_rule
+
+    with patch.object(qwen3_5_packing, "get_unpad_data", get_unpad_data):
+        output = model(
+            input_ids=torch.tensor([[1, 2, 3, 4]]),
+            attention_mask=torch.tensor([[1, 1, 2, 2]]),
+        ).last_hidden_state
+        output.backward(torch.randn_like(output))
+
+    assert get_unpad_data.call_count == 1
+    assert chunk_gated_delta_rule.call_count == 4
+    call_kwargs = [call.kwargs for call in chunk_gated_delta_rule.call_args_list]
+    device_cu_seqlens = call_kwargs[0]["cu_seqlens"]
+    cpu_cu_seqlens = call_kwargs[0]["cu_seqlens_cpu"]
+    assert cpu_cu_seqlens.device.type == "cpu"
+    assert cpu_cu_seqlens.tolist() == [0, 2, 4]
+    assert all(kwargs["cu_seqlens"] is device_cu_seqlens for kwargs in call_kwargs)
+    assert all(kwargs["cu_seqlens_cpu"] is cpu_cu_seqlens for kwargs in call_kwargs)


### PR DESCRIPTION
# What does this PR do ?

Reuse Qwen3.5 packed GatedDeltaNet metadata across decoder layers and activation-checkpoint recomputation.

Previously, each dense or MoE linear-attention layer rebuilt valid-token indices and cumulative document lengths from the indexed packing mask. With activation checkpointing, the same work ran again during backward. In the FLA path this also recreated the CPU boundary data used for host-side chunk planning.

# Changelog

- Build packed GDN metadata once in the dense or MoE text-backbone forward.
- Reuse the same device boundaries, valid-token indices, and CPU boundaries in every linear-attention layer and checkpoint recomputation.
- Preserve the existing direct-block fallback and block-diagonal context-parallel ownership path.
- Add CPU regressions for two checkpointed dense layers and two checkpointed MoE layers.

# Validation

- `pytest -q tests/unit_tests/models/qwen3_5` — 74 passed, 1 skipped.
- Focused MoE block, CP-linear-attention, fp32-GDN, and packed-metadata tests — 9 passed, 1 skipped.
- Targeted Ruff formatting/lint and `git diff --check` passed.

GPU validation is intentionally still pending while this PR is a draft:

- Real FLA/causal-conv packed forward and gradient parity for dense and MoE, with activation checkpointing on and off.
- TPS and peak-memory A/B measurements on the reported Qwen3.5 workload.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused unit tests.
- [x] No user-facing documentation change is required for this internal optimization.

# Additional Information

- Related to #2985.
- Draft until real-GPU correctness and performance validation is attached.
