### PR TITLE
fix(fsdp): shard untied embeddings as separate units

### DIFF
--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -17,6 +17,7 @@ import inspect
 import logging
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from contextlib import contextmanager
 from functools import lru_cache
 from types import FunctionType
@@ -269,6 +270,78 @@ class ParallelizationStrategy(ABC):
         pass
 
 
+def _fully_shard_untied_input_output_embeddings(
+    model: nn.Module,
+    *,
+    mesh: DeviceMesh,
+    mp_policy: MixedPrecisionPolicy,
+    offload_policy: OffloadPolicy | None,
+    reshard_after_forward: bool,
+    fully_shard_fn: Callable[..., nn.Module],
+) -> None:
+    """Give large trainable untied embedding tables independent FSDP buffers.
+
+    The generic dense path otherwise leaves both tables in the root FSDP unit.
+    With fp32 gradient reduction, that unit allocates one contiguous
+    reduce-scatter input containing both gradients. Keeping the two trainable
+    leaf modules in separate FSDP units bounds that allocation by the larger
+    table instead of their sum. Tied weights stay in one unit to preserve
+    aliasing, and frozen tables stay in the root because they have no gradient
+    communication buffer to split.
+
+    Args:
+        model: Model whose input and output embedding modules may be sharded.
+        mesh: Device mesh that owns the FSDP shards.
+        mp_policy: Mixed-precision policy used by the surrounding FSDP units.
+        offload_policy: Optional offload policy used by the surrounding FSDP
+            units.
+        reshard_after_forward: Whether each embedding unit reshards its
+            parameters after forward.
+        fully_shard_fn: FSDP sharding callable, injectable for unit tests.
+    """
+    ensure_tied_lm_head(model)
+
+    def _resolve(getter_name: str) -> nn.Module | None:
+        getter = getattr(model, getter_name, None)
+        if not callable(getter):
+            return None
+        try:
+            module = getter()
+        except (AttributeError, NotImplementedError):
+            return None
+        return module if isinstance(module, nn.Module) else None
+
+    input_embeddings = _resolve("get_input_embeddings")
+    output_embeddings = _resolve("get_output_embeddings")
+    input_weight = getattr(input_embeddings, "weight", None)
+    output_weight = getattr(output_embeddings, "weight", None)
+    weights_are_tied = input_embeddings is not None and (
+        input_embeddings is output_embeddings or (input_weight is not None and input_weight is output_weight)
+    )
+    if weights_are_tied:
+        logger.info("Keeping tied input/output embeddings in the root FSDP unit")
+        return
+
+    seen: set[int] = set()
+    for role, module in (
+        ("input embedding", input_embeddings),
+        ("output embedding", output_embeddings),
+    ):
+        if module is None or id(module) in seen:
+            continue
+        seen.add(id(module))
+        if not any(param.requires_grad for param in module.parameters()):
+            continue
+        fully_shard_fn(
+            module,
+            mesh=mesh,
+            mp_policy=mp_policy,
+            reshard_after_forward=reshard_after_forward,
+            offload_policy=offload_policy,
+        )
+        logger.info("Sharded %s as an independent FSDP unit", role)
+
+
 class DefaultParallelizationStrategy(ParallelizationStrategy):
     """Default parallelization strategy used by most models."""
 
@@ -447,6 +520,18 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
             fully_shard_fn=fully_shard_fn,
             frozen_multimodal_sharding=frozen_multimodal_sharding,
             ignored_multimodal_params=ignored_multimodal_params,
+        )
+
+        standalone_reshard_after_forward = (
+            reshard_after_forward if reshard_after_forward is not None else not pp_enabled
+        )
+        _fully_shard_untied_input_output_embeddings(
+            model,
+            mesh=dp_mesh,
+            mp_policy=mp_policy,
+            offload_policy=offload_policy,
+            reshard_after_forward=standalone_reshard_after_forward,
+            fully_shard_fn=fully_shard_fn,
         )
 
         # Apply FSDP to the root model

--- a/tests/unit_tests/distributed/test_fsdp_embedding_split_gloo.py
+++ b/tests/unit_tests/distributed/test_fsdp_embedding_split_gloo.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real FSDP numerical coverage for independently sharded embedding tables."""
+
+from __future__ import annotations
+
+import copy
+import os
+import socket
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
+from torch.distributed.fsdp import FSDPModule, MixedPrecisionPolicy, fully_shard
+from torch.distributed.tensor import DTensor
+
+from nemo_automodel.components.distributed.parallelizer import _fully_shard_untied_input_output_embeddings
+
+
+class _ToyLM(nn.Module):
+    def __init__(self, *, tied: bool) -> None:
+        super().__init__()
+        self.config = SimpleNamespace(tie_word_embeddings=tied)
+        self.embed_tokens = nn.Embedding(32, 8)
+        self.body = nn.Linear(8, 8)
+        self.lm_head = nn.Linear(8, 32, bias=False)
+        if tied:
+            self.lm_head.weight = self.embed_tokens.weight
+
+    def get_input_embeddings(self) -> nn.Module:
+        return self.embed_tokens
+
+    def get_output_embeddings(self) -> nn.Module:
+        return self.lm_head
+
+    def forward(self, token_ids: torch.Tensor) -> torch.Tensor:
+        """Compute token logits.
+
+        Args:
+            token_ids: Token IDs of shape [batch, sequence].
+
+        Returns:
+            Logits of shape [batch, sequence, vocab].
+        """
+        return self.lm_head(torch.tanh(self.body(self.embed_tokens(token_ids))))
+
+
+def _full_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    """Materialize a distributed tensor for numerical comparison.
+
+    Args:
+        tensor: Tensor of arbitrary shape, optionally a DTensor sharded on its
+            first dimension.
+
+    Returns:
+        Replicated tensor with the same global shape and values as ``tensor``.
+    """
+    return tensor.full_tensor() if isinstance(tensor, DTensor) else tensor
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _run_case(mesh: DeviceMesh, *, tied: bool) -> None:
+    torch.manual_seed(2026)
+    model = _ToyLM(tied=tied)
+    reference = copy.deepcopy(model)
+    mp_policy = MixedPrecisionPolicy(reduce_dtype=torch.float32)
+
+    _fully_shard_untied_input_output_embeddings(
+        model,
+        mesh=mesh,
+        mp_policy=mp_policy,
+        offload_policy=None,
+        reshard_after_forward=True,
+        fully_shard_fn=fully_shard,
+    )
+    fully_shard(model, mesh=mesh, mp_policy=mp_policy, reshard_after_forward=False)
+
+    assert isinstance(model, FSDPModule)
+    if tied:
+        assert not isinstance(model.embed_tokens, FSDPModule)
+        assert not isinstance(model.lm_head, FSDPModule)
+    else:
+        assert isinstance(model.embed_tokens, FSDPModule)
+        assert isinstance(model.lm_head, FSDPModule)
+
+    token_ids = torch.tensor([[1, 2, 3], [4, 5, 6]])
+    model_optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
+    reference_optimizer = torch.optim.SGD(reference.parameters(), lr=0.05)
+
+    actual = model(token_ids)
+    expected = reference(token_ids)
+    torch.testing.assert_close(actual, expected)
+    actual.square().mean().backward()
+    expected.square().mean().backward()
+
+    actual_parameters = dict(model.named_parameters())
+    actual_grad_norms = []
+    expected_grad_norms = []
+    for name, expected_parameter in reference.named_parameters():
+        actual_gradient = _full_tensor(actual_parameters[name].grad)
+        expected_gradient = expected_parameter.grad
+        torch.testing.assert_close(actual_gradient, expected_gradient)
+        actual_grad_norms.append(actual_gradient.float().norm())
+        expected_grad_norms.append(expected_gradient.float().norm())
+    actual_global_norm = torch.stack(actual_grad_norms).norm()
+    expected_global_norm = torch.stack(expected_grad_norms).norm()
+    torch.testing.assert_close(actual_global_norm, expected_global_norm)
+
+    model_optimizer.step()
+    reference_optimizer.step()
+    actual_state = model.state_dict()
+    expected_state = reference.state_dict()
+    for name, expected_parameter in expected_state.items():
+        torch.testing.assert_close(_full_tensor(actual_state[name]), expected_parameter)
+
+
+def _worker(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+    try:
+        mesh = init_device_mesh("cpu", (world_size,), mesh_dim_names=("dp",))
+        _run_case(mesh, tied=False)
+        _run_case(mesh, tied=True)
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("world_size", [1, 2])
+def test_split_embedding_fsdp_matches_unsharded_reference(world_size: int) -> None:
+    mp.spawn(_worker, args=(world_size, _free_port()), nprocs=world_size, join=True)

--- a/tests/unit_tests/distributed/test_parallelization_strategies.py
+++ b/tests/unit_tests/distributed/test_parallelization_strategies.py
@@ -349,6 +349,78 @@ class TestDefaultParallelizationStrategy:
         mock_distributed_env["apply_fsdp"].assert_called_once()
         mock_distributed_env["fully_shard"].assert_called()
 
+    def test_parallelize_splits_untied_input_and_output_embeddings(
+        self, strategy, mock_device_mesh, mock_distributed_env
+    ):
+        """Untied trainable tables become separate FSDP units before the root."""
+        mesh, _, _, _ = mock_device_mesh
+        model = MockModel()
+        model.model.embed_tokens = nn.Embedding(32, 10)
+        model.lm_head = nn.Linear(10, 32, bias=False)
+        model.get_input_embeddings = lambda: model.model.embed_tokens
+        model.get_output_embeddings = lambda: model.lm_head
+
+        strategy.parallelize(
+            model=model,
+            device_mesh=mesh,
+            sequence_parallel=False,
+            activation_checkpointing=False,
+        )
+
+        calls = mock_distributed_env["fully_shard"].call_args_list
+        modules = [item.args[0] for item in calls]
+        assert model.model.embed_tokens in modules
+        assert model.lm_head in modules
+        assert modules[-1] is model
+        embed_call = next(item for item in calls if item.args[0] is model.model.embed_tokens)
+        head_call = next(item for item in calls if item.args[0] is model.lm_head)
+        assert embed_call.kwargs["reshard_after_forward"] is True
+        assert head_call.kwargs["reshard_after_forward"] is True
+
+    def test_parallelize_keeps_tied_embeddings_in_root(self, strategy, mock_device_mesh, mock_distributed_env):
+        """A shared input/output parameter must not acquire two FSDP owners."""
+        mesh, _, _, _ = mock_device_mesh
+        model = MockModel()
+        model.config.tie_word_embeddings = True
+        model.model.embed_tokens = nn.Embedding(32, 10)
+        model.lm_head = nn.Linear(10, 32, bias=False)
+        model.lm_head.weight = model.model.embed_tokens.weight
+        model.get_input_embeddings = lambda: model.model.embed_tokens
+        model.get_output_embeddings = lambda: model.lm_head
+
+        strategy.parallelize(
+            model=model,
+            device_mesh=mesh,
+            sequence_parallel=False,
+            activation_checkpointing=False,
+        )
+
+        modules = [item.args[0] for item in mock_distributed_env["fully_shard"].call_args_list]
+        assert model.model.embed_tokens not in modules
+        assert model.lm_head not in modules
+        assert modules[-1] is model
+
+    def test_parallelize_keeps_frozen_embeddings_in_root(self, strategy, mock_device_mesh, mock_distributed_env):
+        """Frozen tables do not need standalone gradient communication units."""
+        mesh, _, _, _ = mock_device_mesh
+        model = MockModel()
+        model.model.embed_tokens = nn.Embedding(32, 10).requires_grad_(False)
+        model.lm_head = nn.Linear(10, 32, bias=False).requires_grad_(False)
+        model.get_input_embeddings = lambda: model.model.embed_tokens
+        model.get_output_embeddings = lambda: model.lm_head
+
+        strategy.parallelize(
+            model=model,
+            device_mesh=mesh,
+            sequence_parallel=False,
+            activation_checkpointing=False,
+        )
+
+        modules = [item.args[0] for item in mock_distributed_env["fully_shard"].call_args_list]
+        assert model.model.embed_tokens not in modules
+        assert model.lm_head not in modules
+        assert modules[-1] is model
+
     def test_parallelize_with_tensor_parallel(self, strategy, mock_device_mesh, mock_distributed_env):
         """Test parallelization with tensor parallelism enabled."""
         mesh, dp_replicate_mesh, dp_shard_mesh, tp_mesh = mock_device_mesh


### PR DESCRIPTION
# What does this PR do ?

Shard large trainable untied input embeddings and LM heads as independent FSDP units instead of placing both gradient tensors in the root unit's reduce-scatter input.

For large-vocabulary dense models with fp32 gradient reduction, grouping both tables at the root requires one contiguous communication buffer containing both gradients. Splitting their FSDP ownership bounds the largest such allocation by one table. Tied parameters remain together to preserve aliasing, and frozen tables remain at the root because they do not allocate gradient communication buffers.

# Changelog

- Give trainable untied input and output embedding modules independent FSDP ownership before sharding the root model.
- Preserve tied-weight aliasing and skip standalone units for frozen tables.
- Follow the existing pipeline-parallel default for `reshard_after_forward`.
- Add unit coverage for untied, tied, and frozen ownership.
- Add real 1-rank and 2-rank Gloo FSDP numerical coverage against an unsharded fp32 reference.

# Validation

- Default parallelization strategy tests — 10 passed.
- Real 1-rank/2-rank FSDP test — 2 passed; per-parameter gradients, global norm, and parameters after one optimizer step match the unsharded reference.
- Linear-CE and Qwen3.5 tied-weight tests — 11 passed, 1 skipped.
- Targeted Ruff formatting/lint and `git diff --check` passed.

GPU validation is intentionally still pending while this PR is a draft:

- Peak-memory and TPS A/B measurements on the reported large-vocabulary multi-node workload.
- Standard and fused-linear-CE loss/gradient/optimizer-step parity with real CUDA FSDP collectives.
- Confirmation that the former root reduce-scatter allocation is split into the expected per-table allocations.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused unit and real multi-process tests.
- [x] No user-facing documentation change is required for this ownership fix.

# Additional Information

- Related to #2985.
- Draft until real-GPU correctness and memory validation is attached.
