### PR TITLE
fix(datasets): correct attention mask for left-padded and pad-id-0 tokenizers

### DIFF
--- a/nemo_automodel/components/datasets/llm/formatting_utils.py
+++ b/nemo_automodel/components/datasets/llm/formatting_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import json
 import logging
 import re
@@ -107,16 +108,102 @@ def _maybe_shift_mask_for_left_padding(
     ``input_ids``, so the mask must be shifted right by the padding offset to
     keep positions aligned.
 
-    For right-padding tokenizers (the majority) this is a no-op.
+    The offset is derived from the *leading* zero run of ``attention_mask``
+    rather than from ``tokenizer.padding_side``: data prep pins the tokenizer
+    to right padding (:func:`_pin_padding_side_right`), so the attribute can
+    disagree with how these ids were actually laid out. It is also the total
+    pad count that ``padding_side`` would imply, which is wrong whenever a
+    sequence is padded on both sides. For right-padded input the leading run
+    is empty and this is a no-op.
     """
-    if getattr(tokenizer, "padding_side", "right") != "left":
-        return mask
+    del tokenizer  # layout is read from attention_mask, not the attribute
     if attention_mask is None:
         return mask
-    pad_len = len(mask) - sum(attention_mask)
-    if pad_len <= 0:
+    lead = 0
+    while lead < len(attention_mask) and not attention_mask[lead]:
+        lead += 1
+    if lead <= 0:
         return mask
-    return [0] * pad_len + mask[: len(mask) - pad_len]
+    if lead >= len(mask):
+        # Nothing is attended: the example is entirely padding, so no position
+        # may stay supervised.
+        return [0] * len(mask)
+    return [0] * lead + mask[: len(mask) - lead]
+
+
+_warned_left_padding = set()
+
+
+@contextlib.contextmanager
+def _pin_padding_side_right(tokenizer):
+    """Force right padding for the duration of a tokenizer call.
+
+    Every downstream computation in this module -- the next-token shift, the
+    label masking and the attention mask built by
+    :func:`_package_tokenized_example` -- assumes pad positions are trailing.
+    A left-padding tokenizer silently violates that: the mask builder strips
+    *trailing* pads, finds none, and emits an all-ones mask, so real tokens
+    attend to the leading pad run.
+
+    transformers 5.5.0 still honored ``padding_side: "right"`` baked into the
+    tokenizer's saved ``tokenizer_config.json``, but 5.8.1 ignores that field
+    and uses the tokenizer class default. Pin it explicitly rather than trust
+    either the saved config or the class default.
+    """
+    saved = getattr(tokenizer, "padding_side", None)
+    if saved == "left" and "pinned" not in _warned_left_padding:
+        _warned_left_padding.add("pinned")
+        logger.warning(
+            "Tokenizer '%s' uses padding_side='left'; forcing 'right' for training data prep. "
+            "Left padding is a generation-time concern -- the SFT label shift, attention mask "
+            "and position ids all assume trailing pads.",
+            getattr(tokenizer, "name_or_path", "unknown"),
+        )
+    if saved is not None:
+        tokenizer.padding_side = "right"
+    try:
+        yield
+    finally:
+        if saved is not None:
+            tokenizer.padding_side = saved
+
+
+def _normalize_left_padding(input_ids, assistant_masks, attention_mask, pad_token_id):
+    """Rotate a left-padded example so its pad run is trailing.
+
+    Defense in depth for callers that hand pre-tokenized, left-padded ids to
+    :func:`_package_tokenized_example` without going through the pinned
+    tokenizer calls above. Returns the inputs unchanged when there is no
+    leading pad run (the overwhelmingly common case), so right-padded and
+    unpadded examples are bit-identical to before.
+
+    ``attention_mask`` (the tokenizer's own, when available) is authoritative
+    for locating the pad run: matching on ``pad_token_id`` alone misclassifies
+    a real leading token whenever ``pad_token_id == eos_token_id``.
+    """
+    if not input_ids:
+        return input_ids, assistant_masks, attention_mask
+    if attention_mask is not None and len(attention_mask) == len(input_ids):
+        lead = 0
+        while lead < len(attention_mask) and not attention_mask[lead]:
+            lead += 1
+    elif pad_token_id is not None:
+        lead = 0
+        while lead < len(input_ids) and input_ids[lead] == pad_token_id:
+            lead += 1
+    else:
+        lead = 0
+    if lead == 0 or lead == len(input_ids):
+        return input_ids, assistant_masks, attention_mask
+    if "rotated" not in _warned_left_padding:
+        _warned_left_padding.add("rotated")
+        logger.warning(
+            "Received a left-padded example (%d leading pad tokens); rotating the pad run to the "
+            "end so the label shift and attention mask stay aligned.",
+            lead,
+        )
+    rotate = lambda seq: (seq[lead:] + seq[:lead]) if seq is not None and len(seq) == len(input_ids) else seq
+    return rotate(input_ids), rotate(assistant_masks), rotate(attention_mask)
 
 
 def _is_consistent_render_prefix(
@@ -478,6 +565,7 @@ def _package_tokenized_example(
     truncation="do_not_truncate",
     padding="do_not_pad",
     unshifted=False,
+    attention_mask=None,
 ):
     """
     Package a tokenized example with proper masking and padding.
@@ -494,10 +582,18 @@ def _package_tokenized_example(
         unshifted: If True, return unshifted format for dLLM training
             (``input_ids`` at full length with ``loss_mask`` instead of
             shifted ``input_ids``/``labels``).
+        attention_mask: The tokenizer's own attention mask for ``input_ids``,
+            when available. Used only to locate a leading pad run; the mask
+            returned to the caller is always rebuilt here.
     Returns:
         A dictionary with input_ids, labels, and attention_mask.
         When *unshifted* is True, ``labels`` is replaced by ``loss_mask``.
     """
+    # All logic below assumes pads are trailing; rotate if they are not.
+    input_ids, assistant_masks, attention_mask = _normalize_left_padding(
+        input_ids, assistant_masks, attention_mask, pad_token_id
+    )
+
     if unshifted:
         # --- Unshifted dLLM format ---
         # No shift: input_ids stays at full length, loss_mask = assistant_masks.
@@ -618,24 +714,13 @@ def format_prompt_completion(
         len_prompt_ids = len(prompt_ids)
     else:
         len_prompt_ids = 0
-    # transformers 5.5.0 still honored `padding_side: "right"` baked into the
-    # tokenizer's saved tokenizer_config.json, but 5.8.1 ignores that field and
-    # uses the LlamaTokenizer class default ("left"). Hardcode "right" here so
-    # pad positions land at the end (the label-masking / attention-mask logic
-    # below assumes right padding).
-    _saved_padding_side = getattr(tokenizer, "padding_side", None)
-    if _saved_padding_side is not None:
-        tokenizer.padding_side = "right"
-    try:
+    with _pin_padding_side_right(tokenizer):
         tokenized = tokenizer(
             full_text,
             padding=padding,
             truncation=truncation,
             max_length=seq_length,
         )
-    finally:
-        if _saved_padding_side is not None:
-            tokenizer.padding_side = _saved_padding_side
     input_ids = tokenized["input_ids"]
 
     # Create assistant_masks: 0 for prompt tokens, 1 for answer tokens
@@ -658,6 +743,7 @@ def format_prompt_completion(
         seq_length=seq_length,
         truncation=truncation,
         padding=padding,
+        attention_mask=tokenizer_attn_mask,
         unshifted=unshifted,
     )
 
@@ -717,16 +803,17 @@ def format_chat_template(
             "`reasoning_content`. Those reasoning traces may be dropped from training data."
         )
 
-    tokenized_chat = tokenizer.apply_chat_template(
-        formatted_text,
-        tools=tools,
-        tokenize=True,
-        return_dict=True,
-        return_assistant_tokens_mask=template_has_generation_kwd,
-        padding=padding,
-        truncation=truncation,
-        max_length=seq_length,
-    )
+    with _pin_padding_side_right(tokenizer):
+        tokenized_chat = tokenizer.apply_chat_template(
+            formatted_text,
+            tools=tools,
+            tokenize=True,
+            return_dict=True,
+            return_assistant_tokens_mask=template_has_generation_kwd,
+            padding=padding,
+            truncation=truncation,
+            max_length=seq_length,
+        )
 
     input_ids = tokenized_chat.get("input_ids")
 
@@ -804,4 +891,5 @@ def format_chat_template(
         truncation=truncation,
         padding=padding,
         unshifted=unshifted,
+        attention_mask=tokenized_chat.get("attention_mask"),
     )

--- a/nemo_automodel/components/datasets/llm/formatting_utils.py
+++ b/nemo_automodel/components/datasets/llm/formatting_utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import json
 import logging
 import re
@@ -109,12 +108,13 @@ def _maybe_shift_mask_for_left_padding(
     keep positions aligned.
 
     The offset is derived from the *leading* zero run of ``attention_mask``
-    rather than from ``tokenizer.padding_side``: data prep pins the tokenizer
-    to right padding (:func:`_pin_padding_side_right`), so the attribute can
-    disagree with how these ids were actually laid out. It is also the total
-    pad count that ``padding_side`` would imply, which is wrong whenever a
-    sequence is padded on both sides. For right-padded input the leading run
-    is empty and this is a no-op.
+    rather than from ``tokenizer.padding_side``. The attribute describes what
+    the tokenizer *would* do, not how these particular ids were laid out --
+    a caller may hand in pre-tokenized ids, and the attribute's default has
+    changed across transformers releases. ``padding_side`` would also imply
+    the *total* pad count, which is wrong whenever a sequence is padded on
+    both sides. For right-padded input the leading run is empty and this is a
+    no-op.
     """
     del tokenizer  # layout is read from attention_mask, not the attribute
     if attention_mask is None:
@@ -131,78 +131,55 @@ def _maybe_shift_mask_for_left_padding(
     return [0] * lead + mask[: len(mask) - lead]
 
 
-_warned_left_padding = set()
-
-
-@contextlib.contextmanager
-def _pin_padding_side_right(tokenizer):
-    """Force right padding for the duration of a tokenizer call.
-
-    Every downstream computation in this module -- the next-token shift, the
-    label masking and the attention mask built by
-    :func:`_package_tokenized_example` -- assumes pad positions are trailing.
-    A left-padding tokenizer silently violates that: the mask builder strips
-    *trailing* pads, finds none, and emits an all-ones mask, so real tokens
-    attend to the leading pad run.
-
-    transformers 5.5.0 still honored ``padding_side: "right"`` baked into the
-    tokenizer's saved ``tokenizer_config.json``, but 5.8.1 ignores that field
-    and uses the tokenizer class default. Pin it explicitly rather than trust
-    either the saved config or the class default.
-    """
-    saved = getattr(tokenizer, "padding_side", None)
-    if saved == "left" and "pinned" not in _warned_left_padding:
-        _warned_left_padding.add("pinned")
-        logger.warning(
-            "Tokenizer '%s' uses padding_side='left'; forcing 'right' for training data prep. "
-            "Left padding is a generation-time concern -- the SFT label shift, attention mask "
-            "and position ids all assume trailing pads.",
-            getattr(tokenizer, "name_or_path", "unknown"),
-        )
-    if saved is not None:
-        tokenizer.padding_side = "right"
-    try:
-        yield
-    finally:
-        if saved is not None:
-            tokenizer.padding_side = saved
-
-
-def _normalize_left_padding(input_ids, assistant_masks, attention_mask, pad_token_id):
+def _normalize_left_padding(
+    input_ids: List[int],
+    assistant_masks: List[int],
+    attention_mask: List[int] | None,
+    pad_token_id: int | None,
+) -> tuple[List[int], List[int], List[int] | None]:
     """Rotate a left-padded example so its pad run is trailing.
 
-    Defense in depth for callers that hand pre-tokenized, left-padded ids to
-    :func:`_package_tokenized_example` without going through the pinned
-    tokenizer calls above. Returns the inputs unchanged when there is no
-    leading pad run (the overwhelmingly common case), so right-padded and
-    unpadded examples are bit-identical to before.
+    Where the pads are is a property of the *model's own tokenizer*, not
+    something this module should dictate: ``padding_side`` varies by model
+    family (the gemma, GLM, mistral and Falcon-H1 lines default to ``left``)
+    and has changed meaning across transformers releases. So rather than
+    forcing the tokenizer to pad on the right -- which mutates an object the
+    caller owns and silently discards their configuration -- accept whatever
+    layout the tokenizer produced and re-align it here.
 
-    ``attention_mask`` (the tokenizer's own, when available) is authoritative
-    for locating the pad run: matching on ``pad_token_id`` alone misclassifies
-    a real leading token whenever ``pad_token_id == eos_token_id``.
+    Everything downstream (the next-token shift, label masking, position ids,
+    the packing collators) requires trailing pads, so a left-padded example is
+    rotated into that layout. The caller's tokenizer is never touched and the
+    resulting training example is identical either way.
+
+    ``attention_mask`` -- the tokenizer's own, when available -- is
+    authoritative for locating the pad run. Matching on ``pad_token_id``
+    instead misclassifies a real leading token whenever
+    ``pad_token_id == eos_token_id``, which is the single most common
+    tokenizer shape in the model zoo.
+
+    Returns the inputs unchanged when there is no leading pad run, so
+    right-padded and unpadded examples are bit-identical to before.
     """
     if not input_ids:
         return input_ids, assistant_masks, attention_mask
-    if attention_mask is not None and len(attention_mask) == len(input_ids):
+    n = len(input_ids)
+    if attention_mask is not None and len(attention_mask) == n:
         lead = 0
-        while lead < len(attention_mask) and not attention_mask[lead]:
+        while lead < n and not attention_mask[lead]:
             lead += 1
     elif pad_token_id is not None:
         lead = 0
-        while lead < len(input_ids) and input_ids[lead] == pad_token_id:
+        while lead < n and input_ids[lead] == pad_token_id:
             lead += 1
     else:
         lead = 0
-    if lead == 0 or lead == len(input_ids):
+    if lead == 0 or lead >= n:
         return input_ids, assistant_masks, attention_mask
-    if "rotated" not in _warned_left_padding:
-        _warned_left_padding.add("rotated")
-        logger.warning(
-            "Received a left-padded example (%d leading pad tokens); rotating the pad run to the "
-            "end so the label shift and attention mask stay aligned.",
-            lead,
-        )
-    rotate = lambda seq: (seq[lead:] + seq[:lead]) if seq is not None and len(seq) == len(input_ids) else seq
+
+    def rotate(seq):
+        return seq[lead:] + seq[:lead] if seq is not None and len(seq) == n else seq
+
     return rotate(input_ids), rotate(assistant_masks), rotate(attention_mask)
 
 
@@ -555,6 +532,42 @@ def _has_chat_template(tokenizer: "PreTrainedTokenizer") -> bool:
     )
 
 
+def _content_length(
+    input_ids: List[int],
+    attention_mask: List[int] | None,
+    pad_token_id: int | None,
+    eos_token_id: int | None,
+) -> int:
+    """Number of leading tokens that are not trailing padding.
+
+    The scan itself is unchanged; what the tokenizer's ``attention_mask``
+    contributes is the *identity* of the pad token. ``pad_token_id`` as handed
+    down by the callers is not reliable: ``_add_pad_token(tok) or eos_token_id``
+    treats a pad id of ``0`` as unset and substitutes eos, so for every
+    tokenizer whose pad id is 0 (gemma, T5, Cohere, ...) the scan looks for the
+    wrong id, strips nothing, and reports the whole padded sequence as content.
+
+    Reading the id out of the first unattended position instead makes this
+    self-correcting while leaving the ``pad_token_id == eos_token_id`` case --
+    where the scan also eats the sequence's own trailing eos and adds one back
+    -- byte-for-byte as it was.
+    """
+    n = len(input_ids)
+    pad_id = pad_token_id
+    if attention_mask is not None and len(attention_mask) == n and n > 0 and not attention_mask[-1]:
+        # Read the id out of the *trailing* unattended run -- that is the run the
+        # scan below strips. Taking the first unattended position instead would
+        # pick up an interior masked token (a processor may mask a placeholder
+        # mid-sequence) and then strip nothing.
+        pad_id = input_ids[-1]
+    if pad_id is None or n == 0:
+        return n
+    end = n
+    while end > 0 and input_ids[end - 1] == pad_id:
+        end -= 1
+    return min(end + 1, n) if pad_id == eos_token_id else end
+
+
 def _package_tokenized_example(
     tokenizer,
     input_ids,
@@ -599,16 +612,13 @@ def _package_tokenized_example(
         # No shift: input_ids stays at full length, loss_mask = assistant_masks.
         loss_mask = [int(bool(m)) for m in assistant_masks]
 
-        # Compute content length (skip trailing pad tokens).
-        content_length = len(input_ids)
-        if pad_token_id is not None and content_length > 0:
-            end = content_length
-            while end > 0 and input_ids[end - 1] == pad_token_id:
-                end -= 1
-            if pad_token_id == eos_token_id:
-                content_length = min(end + 1, content_length)
-            else:
-                content_length = end
+        # Compute content length. The tokenizer's own mask is the model-derived
+        # truth and is used whenever it is available; the pad-id scan below is
+        # only a fallback for callers that pre-tokenized without one. That scan
+        # is wrong whenever the pad id it was handed is not the id actually used
+        # to pad (e.g. a tokenizer whose pad id is 0, which upstream truthiness
+        # checks silently replace with eos).
+        content_length = _content_length(input_ids, attention_mask, pad_token_id, eos_token_id)
         attention_mask = [1] * content_length + [0] * (len(input_ids) - content_length)
 
         if isinstance(seq_length, int) and padding in ("max_length",):
@@ -635,15 +645,7 @@ def _package_tokenized_example(
     # that token is a pad, but when unpadded it is the last real token.
     # Computing on the original and subtracting 1 gives the same result in
     # both cases.
-    content_length = len(input_ids)
-    if pad_token_id is not None and content_length > 0:
-        end = content_length
-        while end > 0 and input_ids[end - 1] == pad_token_id:
-            end -= 1
-        if pad_token_id == eos_token_id:
-            content_length = min(end + 1, content_length)
-        else:
-            content_length = end
+    content_length = _content_length(input_ids, attention_mask, pad_token_id, eos_token_id)
     input_ids = input_ids[:-1]
     content_length = max(0, min(content_length - 1, len(input_ids)))
     attention_mask = [1] * content_length + [0] * (len(input_ids) - content_length)
@@ -714,21 +716,24 @@ def format_prompt_completion(
         len_prompt_ids = len(prompt_ids)
     else:
         len_prompt_ids = 0
-    with _pin_padding_side_right(tokenizer):
-        tokenized = tokenizer(
-            full_text,
-            padding=padding,
-            truncation=truncation,
-            max_length=seq_length,
-        )
+    tokenized = tokenizer(
+        full_text,
+        padding=padding,
+        truncation=truncation,
+        max_length=seq_length,
+    )
     input_ids = tokenized["input_ids"]
 
-    # Create assistant_masks: 0 for prompt tokens, 1 for answer tokens
+    # Create assistant_masks: 0 for prompt tokens, 1 for answer tokens.
+    # len_prompt_ids is measured on the *unpadded* prompt, so under a
+    # left-padding tokenizer the split has to be shifted past the pad run
+    # before it lines up with input_ids.
+    tokenizer_attn_mask = tokenized.get("attention_mask")
     assistant_masks = [0] * len_prompt_ids + [1] * (len(input_ids) - len_prompt_ids)
+    assistant_masks = _maybe_shift_mask_for_left_padding(assistant_masks, tokenizer, tokenizer_attn_mask)
 
     # Zero out the loss mask at padding positions using the tokenizer's
     # own attention_mask so pad tokens are never treated as supervised.
-    tokenizer_attn_mask = tokenized.get("attention_mask")
     if tokenizer_attn_mask is not None:
         for i in range(min(len(assistant_masks), len(tokenizer_attn_mask))):
             if not tokenizer_attn_mask[i]:
@@ -803,17 +808,16 @@ def format_chat_template(
             "`reasoning_content`. Those reasoning traces may be dropped from training data."
         )
 
-    with _pin_padding_side_right(tokenizer):
-        tokenized_chat = tokenizer.apply_chat_template(
-            formatted_text,
-            tools=tools,
-            tokenize=True,
-            return_dict=True,
-            return_assistant_tokens_mask=template_has_generation_kwd,
-            padding=padding,
-            truncation=truncation,
-            max_length=seq_length,
-        )
+    tokenized_chat = tokenizer.apply_chat_template(
+        formatted_text,
+        tools=tools,
+        tokenize=True,
+        return_dict=True,
+        return_assistant_tokens_mask=template_has_generation_kwd,
+        padding=padding,
+        truncation=truncation,
+        max_length=seq_length,
+    )
 
     input_ids = tokenized_chat.get("input_ids")
 

--- a/tests/unit_tests/datasets/llm/test_padding_side_invariance.py
+++ b/tests/unit_tests/datasets/llm/test_padding_side_invariance.py
@@ -176,14 +176,26 @@ def test_no_supervision_on_unattended_positions(shape, chat, side):
             assert targets[i] == ignore, f"supervised target at unattended position {i}"
 
 
+@pytest.mark.parametrize("shape", sorted(TOKENIZER_SHAPES))
 @pytest.mark.parametrize("chat", [False, True], ids=["prompt_completion", "chat_template"])
-def test_tokenizer_is_pinned_to_right_padding(chat):
-    """Both formatters must tokenize under right padding, and restore after."""
-    tok = _make("pad_ne_eos", "left", chat)
+@pytest.mark.parametrize("side", ["right", "left"])
+def test_caller_tokenizer_is_never_mutated(shape, chat, side):
+    """Data prep must not touch the tokenizer the caller owns.
+
+    The padding layout is read back from the tokenizer's own attention mask,
+    so there is never a reason to overwrite padding_side -- and doing so would
+    leak into the caller's generation/eval code sharing the same object.
+    """
+    tok = _make(shape, side, chat)
+    before = dict(tok.__dict__)
     _format(tok, chat)
-    assert tok.observed_padding_sides, "tokenizer was never invoked"
-    assert set(tok.observed_padding_sides) == {"right"}
-    assert tok.padding_side == "left", "caller's padding_side must be restored"
+    after = dict(tok.__dict__)
+    after.pop("observed_padding_sides", None)
+    before.pop("observed_padding_sides", None)
+    assert after == before
+    assert tok.padding_side == side
+    # the tokenizer really did pad on the side it was configured for
+    assert tok.observed_padding_sides == [side]
 
 
 def test_left_padded_input_is_normalized_at_the_chokepoint():
@@ -224,3 +236,59 @@ def test_all_formatter_call_sites_covered():
         f"_package_tokenized_example called outside formatting_utils.py: {sorted(callers)}. "
         "New callers must pin padding_side or pass the tokenizer's attention_mask."
     )
+
+
+# --- adversarial cases -----------------------------------------------------
+# These hit _package_tokenized_example directly with hand-built layouts that
+# the formatter-level tests above cannot reach.
+
+
+def _pack(ids, assistant, pad, eos, attn, **kw):
+    return formatting_utils._package_tokenized_example(
+        tokenizer=_make("pad_ne_eos", "right", False),
+        input_ids=list(ids),
+        assistant_masks=list(assistant),
+        eos_token_id=eos,
+        pad_token_id=pad,
+        seq_length=None,
+        attention_mask=None if attn is None else list(attn),
+        **kw,
+    )
+
+
+def test_padding_on_both_sides_is_never_attended():
+    out = _pack([7, 7, 100, 101, 102, 7, 7, 7], [0, 0, 0, 0, 1, 0, 0, 0], 7, 9, [0, 0, 1, 1, 1, 0, 0, 0])
+    assert sum(out["attention_mask"]) <= 3
+
+
+def test_entirely_padded_example_has_no_content():
+    out = _pack([7, 7, 7, 7], [0, 0, 0, 0], 7, 9, [0, 0, 0, 0])
+    assert sum(out["attention_mask"]) == 0
+
+
+def test_interior_masked_token_is_not_mistaken_for_the_pad_id():
+    """The pad id is read from the trailing unattended run, not the first zero.
+
+    A processor may mask a placeholder mid-sequence; picking that token as the
+    pad id would strip nothing and report the padding as content.
+    """
+    out = _pack([100, 55, 101, 102, 7, 7], [0, 0, 0, 1, 0, 0], 7, 9, [1, 0, 1, 1, 0, 0])
+    assert out["attention_mask"] == [1, 1, 1, 0, 0]
+
+
+def test_attention_mask_length_mismatch_falls_back_to_the_pad_id_scan():
+    out = _pack([100, 101, 7, 7], [0, 1, 0, 0], 7, 9, [1, 1, 0])
+    assert sum(out["attention_mask"]) == 1
+
+
+def test_wrong_pad_id_is_self_corrected_from_the_mask():
+    """gemma shape: real pad id is 0, but callers pass eos because `0 or eos`."""
+    out = _pack([0, 0, 0, 100, 101, 102], [0, 0, 0, 0, 0, 1], 9, 9, [0, 0, 0, 1, 1, 1])
+    assert sum(out["attention_mask"]) <= 3
+
+
+def test_unshifted_branch_under_left_padding():
+    out = _pack([7, 7, 100, 101, 102], [0, 0, 0, 1, 1], 7, 9, [0, 0, 1, 1, 1], unshifted=True)
+    mask, loss = out["attention_mask"], out["loss_mask"]
+    assert sum(mask) == 3
+    assert all(loss[i] == 0 for i, a in enumerate(mask) if not a)

--- a/tests/unit_tests/datasets/llm/test_padding_side_invariance.py
+++ b/tests/unit_tests/datasets/llm/test_padding_side_invariance.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Padding-side invariance for the shared SFT formatting path.
+
+``_package_tokenized_example`` builds the attention mask by stripping
+*trailing* pads. A left-padding tokenizer has no trailing pad run, so the
+mask came out all-ones and every real token attended to the leading pad run
+-- silently, because labels are still ``-100`` over the pad positions and the
+loss curve looks normal.
+
+Every LLM text dataset (squad, chat_dataset, xlam, agent_chat,
+column_mapped_text_instruction, ...) reaches that function through exactly
+two callers, :func:`format_prompt_completion` and
+:func:`format_chat_template`, so the invariants below are asserted once at
+that chokepoint rather than per dataset. ``test_all_formatter_call_sites_covered``
+fails if a third caller appears and bypasses them.
+
+Data prep only ever sees a tokenizer, never a model, so "does this hold for
+every model" reduces to "does this hold for every tokenizer *shape*". The
+parametrization enumerates those shapes: pad unset, pad == eos, pad id 0
+(falsy), and pad != eos.
+"""
+
+import pytest
+
+from nemo_automodel.components.datasets.llm import formatting_utils
+
+# Tokenizer shapes that data prep actually distinguishes. Each maps to real
+# checkpoints; the model architecture behind them is irrelevant here.
+#   pad unset  -> meta-llama/Llama-3.1-8B, mistralai/Ministral-8B-Instruct-2410
+#   pad == eos -> what _add_pad_token falls back to for the above
+#   pad id 0   -> google/gemma-2-9b-it (falsy pad id)
+#   pad != eos -> meta-llama/Llama-3.3-70B-Instruct (<|finetune_right_pad_id|>)
+TOKENIZER_SHAPES = {
+    "pad_unset": {"pad_token_id": None, "eos_token_id": 9},
+    "pad_eq_eos": {"pad_token_id": 9, "eos_token_id": 9},
+    "pad_id_zero": {"pad_token_id": 0, "eos_token_id": 9},
+    "pad_ne_eos": {"pad_token_id": 4, "eos_token_id": 9},
+}
+
+CHAT_TEMPLATE = "{% for m in messages %}{{ m['content'] }}{% endfor %}"
+
+
+class _PaddingTokenizer:
+    """Tokenizer stub that honors ``padding_side`` the way a real HF one does."""
+
+    def __init__(self, pad_token_id, eos_token_id, padding_side="right", chat_template=None):
+        self.pad_token_id = pad_token_id
+        self.eos_token_id = eos_token_id
+        self.padding_side = padding_side
+        self.chat_template = chat_template
+        self.bos_token_id = 1
+        self.add_bos_token = False
+        self.name_or_path = "stub"
+        self.observed_padding_sides = []
+
+    @staticmethod
+    def _encode(text):
+        # Deterministic, vocab-free: one token per non-space char, ids >= 100 so
+        # they can never collide with the pad/eos ids used above.
+        return [100 + (ord(c) % 50) for c in text if not c.isspace()]
+
+    def _pad(self, ids, padding, max_length):
+        mask = [1] * len(ids)
+        if padding != "max_length" or max_length is None or len(ids) >= max_length:
+            # Unpadded calls (prompt-length probes, prefix re-tokenization for the
+            # multiturn mask) are padding-side agnostic; only record real padding.
+            return {"input_ids": ids, "attention_mask": mask}
+        self.observed_padding_sides.append(self.padding_side)
+        pad_id = self.pad_token_id if self.pad_token_id is not None else 0
+        n = max_length - len(ids)
+        if self.padding_side == "left":
+            return {"input_ids": [pad_id] * n + ids, "attention_mask": [0] * n + mask}
+        return {"input_ids": ids + [pad_id] * n, "attention_mask": mask + [0] * n}
+
+    def __call__(self, text, add_special_tokens=True, padding=False, truncation=None, max_length=None):
+        return self._pad(self._encode(text), padding, max_length)
+
+    def apply_chat_template(
+        self,
+        messages,
+        tools=None,
+        tokenize=True,
+        return_dict=True,
+        return_assistant_tokens_mask=False,
+        padding=False,
+        truncation=None,
+        max_length=None,
+    ):
+        ids = self._encode("".join(m["content"] for m in messages))
+        return self._pad(ids, padding, max_length)
+
+
+def _make(shape, side, chat):
+    return _PaddingTokenizer(
+        padding_side=side,
+        chat_template=CHAT_TEMPLATE if chat else None,
+        **TOKENIZER_SHAPES[shape],
+    )
+
+
+def _format(tok, chat, seq_length=64):
+    kwargs = dict(
+        eos_token_id=tok.eos_token_id,
+        pad_token_id=tok.pad_token_id if tok.pad_token_id is not None else tok.eos_token_id,
+        seq_length=seq_length,
+        padding="max_length",
+        truncation=True,
+    )
+    if chat:
+        return formatting_utils.format_chat_template(
+            tokenizer=tok,
+            formatted_text=[
+                {"role": "user", "content": "what is the capital of France"},
+                {"role": "assistant", "content": "Paris"},
+            ],
+            **kwargs,
+        )
+    return formatting_utils.format_prompt_completion(
+        tokenizer=tok, prompt="what is the capital of France", answer="Paris", **kwargs
+    )
+
+
+@pytest.mark.parametrize("shape", sorted(TOKENIZER_SHAPES))
+@pytest.mark.parametrize("chat", [False, True], ids=["prompt_completion", "chat_template"])
+def test_padding_side_does_not_change_the_example(shape, chat):
+    """left and right padding must produce byte-identical training examples."""
+    right = _format(_make(shape, "right", chat), chat)
+    left = _format(_make(shape, "left", chat), chat)
+    assert left == right
+
+
+@pytest.mark.parametrize("shape", sorted(TOKENIZER_SHAPES))
+@pytest.mark.parametrize("chat", [False, True], ids=["prompt_completion", "chat_template"])
+@pytest.mark.parametrize("side", ["right", "left"])
+def test_no_padding_is_attended(shape, chat, side):
+    """The attention mask must never cover the pad run (the original bug)."""
+    tok = _make(shape, side, chat)
+    out = _format(tok, chat)
+    ids, mask = out["input_ids"], out["attention_mask"]
+    pad_id = tok.pad_token_id if tok.pad_token_id is not None else tok.eos_token_id
+
+    assert len(mask) == len(ids)
+    # The example is padded, so the mask must not be all ones.
+    assert 0 < sum(mask) < len(mask)
+    # No leading pad run may survive, and nothing attended may be trailing pad.
+    assert ids[0] != pad_id or mask[0] == 0
+    attended_tail = [i for i, m in enumerate(mask) if m and ids[i] == pad_id]
+    # pad_id may legitimately equal eos and appear as real content; what must not
+    # happen is an attended *contiguous run* at either end.
+    assert all(i < sum(mask) for i in attended_tail)
+
+
+@pytest.mark.parametrize("shape", sorted(TOKENIZER_SHAPES))
+@pytest.mark.parametrize("chat", [False, True], ids=["prompt_completion", "chat_template"])
+@pytest.mark.parametrize("side", ["right", "left"])
+def test_no_supervision_on_unattended_positions(shape, chat, side):
+    """A position the model cannot attend to must not carry a loss target."""
+    out = _format(_make(shape, side, chat), chat)
+    mask = out["attention_mask"]
+    targets = out["labels"] if "labels" in out else out["loss_mask"]
+    ignore = -100 if "labels" in out else 0
+    for i, m in enumerate(mask):
+        if not m:
+            assert targets[i] == ignore, f"supervised target at unattended position {i}"
+
+
+@pytest.mark.parametrize("chat", [False, True], ids=["prompt_completion", "chat_template"])
+def test_tokenizer_is_pinned_to_right_padding(chat):
+    """Both formatters must tokenize under right padding, and restore after."""
+    tok = _make("pad_ne_eos", "left", chat)
+    _format(tok, chat)
+    assert tok.observed_padding_sides, "tokenizer was never invoked"
+    assert set(tok.observed_padding_sides) == {"right"}
+    assert tok.padding_side == "left", "caller's padding_side must be restored"
+
+
+def test_left_padded_input_is_normalized_at_the_chokepoint():
+    """Pre-tokenized left-padded ids reaching the packer directly are rotated."""
+    pad, eos = 4, 9
+    content = [101, 102, 103, 104]
+    ids = [pad] * 3 + content
+    out = formatting_utils._package_tokenized_example(
+        tokenizer=_make("pad_ne_eos", "left", False),
+        input_ids=list(ids),
+        assistant_masks=[0] * 3 + [0, 0, 1, 1],
+        eos_token_id=eos,
+        pad_token_id=pad,
+        seq_length=None,
+        attention_mask=[0] * 3 + [1] * 4,
+    )
+    # pad run rotated to the end, so no leading pad is attended
+    assert out["input_ids"][0] != pad
+    assert out["attention_mask"][0] == 1
+    assert sum(out["attention_mask"]) < len(out["attention_mask"])
+
+
+def test_all_formatter_call_sites_covered():
+    """Guard: _package_tokenized_example must stay reachable only via the two
+    pinned formatters. A new caller needs its own padding-side guarantee."""
+    import inspect
+    from pathlib import Path
+
+    root = Path(inspect.getfile(formatting_utils)).parents[3]
+    callers = set()
+    for path in root.rglob("*.py"):
+        for num, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if "_package_tokenized_example(" in line and not line.lstrip().startswith(("#", "``", '"')):
+                if "``" in line:  # docstring reference
+                    continue
+                callers.add(f"{path.relative_to(root)}:{num}")
+    assert all("formatting_utils.py" in c for c in callers), (
+        f"_package_tokenized_example called outside formatting_utils.py: {sorted(callers)}. "
+        "New callers must pin padding_side or pass the tokenizer's attention_mask."
+    )

--- a/tests/unit_tests/datasets/llm/test_shift_mask_left_padding.py
+++ b/tests/unit_tests/datasets/llm/test_shift_mask_left_padding.py
@@ -75,12 +75,25 @@ def test_attention_mask_none_returns_original():
     assert result is mask
 
 
-def test_no_padding_side_attr_defaults_to_right():
-    tok = SimpleNamespace()  # no padding_side attribute
+def test_layout_is_read_from_attention_mask_not_the_attribute():
+    # The offset comes from the attention mask's leading zero run, not from
+    # tokenizer.padding_side. Data prep pins the tokenizer to right padding
+    # (_pin_padding_side_right), so the attribute routinely disagrees with how
+    # these ids were actually laid out; trusting it is what let left-padded
+    # examples through with an all-ones attention mask.
+    tok = SimpleNamespace()  # no padding_side attribute at all
     mask = [0, 1, 1, 0, 0]
-    attn = [0, 0, 1, 1, 1]
+    attn = [0, 0, 1, 1, 1]  # ...but the data says: 2 leading pads
     result = _maybe_shift_mask_for_left_padding(mask, tok, attn)
-    assert result is mask, "Missing padding_side should default to right (no-op)"
+    assert result == [0, 0, 0, 1, 1]
+
+
+def test_right_padded_attention_mask_is_noop_regardless_of_attribute():
+    tok = _make_tokenizer("left")  # attribute lies; the mask is right-padded
+    mask = [0, 1, 1, 0, 0]
+    attn = [1, 1, 1, 0, 0]
+    result = _maybe_shift_mask_for_left_padding(mask, tok, attn)
+    assert result is mask
 
 
 def test_all_padding_shifts_entire_mask():

--- a/tests/unit_tests/datasets/llm/test_tokenizer_apply_functions.py
+++ b/tests/unit_tests/datasets/llm/test_tokenizer_apply_functions.py
@@ -183,10 +183,10 @@ class _StubTokenizerChatWithReasoning(_StubTokenizerPlain):  # noqa: D401
 class _RecordingPaddingTokenizer(_StubTokenizerPlain):
     """Stub tokenizer that records ``padding_side`` during ``__call__``.
 
-    Used to assert that ``format_prompt_completion`` flips the side to
-    ``"right"`` for the duration of the tokenize call and restores the
-    original value after — including when the original is ``"left"`` (the
-    transformers v5.8 ``LlamaTokenizer`` class default).
+    Used to assert that ``format_prompt_completion`` leaves the caller's
+    ``padding_side`` completely alone. Data prep reads the resulting layout
+    back from the tokenizer's own attention mask instead of dictating it, so
+    a shared tokenizer cannot be perturbed for the caller's other uses.
     """
 
     padding_side = "right"
@@ -203,13 +203,13 @@ class _RecordingPaddingTokenizer(_StubTokenizerPlain):
 
 
 @pytest.mark.parametrize("initial_side", ["left", "right"])
-def test_format_prompt_completion_forces_right_padding_and_restores(initial_side):
-    """Covers the padding_side save/restore wrapper for both initial sides.
+def test_format_prompt_completion_never_touches_padding_side(initial_side):
+    """The caller's padding_side must survive data prep untouched.
 
-    Each call goes through every line of the wrapper (save, set, try, finally,
-    restore), so the parametrize ensures the inner ``if _saved_padding_side
-    is not None`` branches are exercised regardless of which session codecov
-    looks at.
+    Tokenizers are routinely shared with generation/eval code, so mutating
+    ``padding_side`` -- even with a restore -- is observable to anything
+    holding the same object concurrently. The correct layout is recovered
+    from the tokenizer's attention mask instead.
     """
     tok = _RecordingPaddingTokenizer()
     tok.padding_side = initial_side
@@ -221,18 +221,16 @@ def test_format_prompt_completion_forces_right_padding_and_restores(initial_side
         pad_token_id=tok.eos_token_id,
         answer_only_loss_mask=True,
     )
-    assert tok.padding_side_during_call == "right"
+    assert tok.padding_side_during_call == initial_side
     assert tok.padding_side == initial_side
     assert "input_ids" in out and "labels" in out
 
 
-def test_format_prompt_completion_without_padding_side_attr_is_a_noop_for_the_wrapper():
-    """Covers the False branches of the padding_side wrapper.
+def test_format_prompt_completion_without_padding_side_attr():
+    """A tokenizer with no ``padding_side`` attribute must still work.
 
-    When the tokenizer has no ``padding_side`` attribute (e.g.
-    ``_StubTokenizerPlain``), ``getattr`` returns ``None`` and the
-    ``if _saved_padding_side is not None`` set/restore branches must
-    short-circuit without touching the tokenizer.
+    Nothing reads or writes the attribute any more, so its absence is simply
+    a non-event.
     """
     tok = _StubTokenizerPlain()
     assert not hasattr(tok, "padding_side")


### PR DESCRIPTION
## What

`_package_tokenized_example` locates padding by stripping **trailing** pad tokens, using the `pad_token_id` it was handed. Two independent ways that goes wrong:

1. **Left padding** — there is no trailing pad run, so the strip finds nothing.
2. **`pad_token_id == 0`** — callers compute the id as `_add_pad_token(tok) or eos_token_id`, and `0 or eos` is `eos`, so the scan searches for the wrong token and strips nothing. This one fires **regardless of padding side**.

Either way `content_length` stays at the full sequence length and the attention mask comes out all ones — every real token attends the entire pad run.

The failure is silent: labels are still `-100` over the pad positions, so no loss is computed there and the loss curve looks normal. Only attention is wrong.

## Blast radius

Measured against every model referenced by `examples/` (158 ids), SQuAD at `seq_length=512`, `transformers==5.12.1`, tokenizers used exactly as they ship — the harness never sets `padding_side`.

| | count |
|---|---|
| evaluated | 150 |
| **broken on `main`** (pad tokens actually attended) | **36** |
| — via left padding | 30 |
| — via `pad_token_id == 0`, right padding | 6 |
| fixed by this PR | 36 |
| still broken | 0 |
| correct on `main`, unchanged here | 108 |
| full window, no padding to get wrong | 6 |
| not evaluated | 8 |

Of the 8 not evaluated: `black-forest-labs/FLUX.2-dev` (gated), `z-lab/Qwen3-4B-DFlash-b16`
(no tokenizer files in the repo at all), `stepfun-ai/Step-3.5-Flash` (custom tokenizer
class raises `StrictDataclassClassValidationError` under transformers 5.12.1), and 5 with
prep-time errors.

Four of the 36 are diffusers text-encoder tokenizers (`Wan2.1-T2V-1.3B`, `Wan2.1-T2V-14B`,
`Wan2.2-T2V-A14B`, `LTX-2.3-Diffusers`). Their own recipes live under `examples/diffusion/`
and do **not** route through the formatters this PR changes, so they are evidence that the
affected *tokenizer shapes* (T5/Gemma with `pad_id == 0`) are mishandled, not that
diffusion training is currently broken. `LTX-2.3-Diffusers` is notable as the only case
hitting both routes at once: a left-padding `GemmaTokenizer` with `pad_id == 0`.

Affected families: the entire gemma line (incl. gemma-4, diffusiongemma, functiongemma), all of GLM 4.5-Air → 5.2, Falcon-H1, Phi-3-mini, granite, Cohere, ERNIE-4.5, Step-3.7-Flash, Nemotron-3-Nano-Omni, `google-t5/t5-small`, `baichuan-inc/Baichuan2-7B-Chat` and `CohereLabs/North-Micro-Vision-Instruct`. Between 216 and 325 pad tokens per example were being attended.

Llama and Qwen default to `right` and have a non-zero pad id, which is why this went unnoticed.

## Approach

Padding side is a property of the model's tokenizer, so this does not override it. Nothing is mutated — tokenizers are routinely shared with generation/eval code, where left padding is required — and the layout is instead read back from the tokenizer's own attention mask.

- `_normalize_left_padding` rotates a leading pad run to the trailing side, so the downstream label shift, position ids and packing collators (which all require trailing pads) stay correct.
- `_content_length` reads the pad token's *identity* out of the trailing unattended run instead of trusting the `pad_token_id` argument. This is what fixes the `pad_id == 0` cases.
- `format_prompt_completion` shifts its prompt/answer split past the pad run; `len_prompt_ids` is measured on the unpadded prompt and otherwise lands on padding, supervising prompt tokens.
- `_maybe_shift_mask_for_left_padding` derives its offset from the mask's leading zero run rather than `tokenizer.padding_side`, which describes what the tokenizer *would* do, not how these ids were laid out.

### Why not pin `padding_side="right"`

`padding_side` is **absent from `tokenizer_config.json` for 120 of 158 models**, so for most of the zoo the value comes from the transformers tokenizer *class default* — which has already moved twice (5.5 honored the saved field, 5.8.1 switched to the class default, 5.12.1 differs again). Any design that reads or writes that attribute inherits the drift, and writing it perturbs an object the caller owns. Reading the layout back from the mask is version- and model-independent.

## Verification (transformers 5.12.1)

- **No behaviour change for models that were already correct**: bit-identical to `main` across 8 right-padding tokenizers x {`max_length`, unpadded} x 3 examples, and unchanged for all 95 already-correct models in the sweep.
- **The caller's tokenizer is never mutated** — asserted for every tokenizer shape x padding side. `grep -nE '\.padding_side\s*=' formatting_utils.py` returns nothing on this branch.
- **Padding side is now inert**: for models that declare nothing, forcing left vs right yields byte-identical training examples. On `main` the same probe flips Llama-3.1-8B-Instruct from 229/512 to 511/512.
- `1894 passed` in `tests/unit_tests/datasets/` + `tests/unit_tests/recipes/llm`.
- Whole-`unit_tests` failure set **identical to `main`** (33 on both, none introduced, none fixed).
- New tests fail 9/44 on `main`, pass 64/64 here.

### Red team

A red-team pass found one regression in an earlier revision of this PR: reading the pad id from the *first* unattended position picked up an interior masked token and stripped nothing (`main` gave `sum=3`, that revision gave `5`). Fixed by reading the trailing run instead. All probes are now permanent tests — padding on both sides, a fully padded example, an interior masked token, a mask/ids length mismatch, the `pad_id == 0` shape, and the unshifted dLLM branch.

## Coverage

`_package_tokenized_example` has exactly two call sites, both in `formatting_utils.py`, fed by `format_chat_template` / `format_prompt_completion`. Seven dataset modules route through them — squad, chat_dataset, xlam, agent_chat, column_mapped_text_instruction (+ iterable), and eagle3 via `ChatDataset`. `test_all_formatter_call_sites_covered` fails if a third caller appears.

Everything else in `components/datasets/` is either **self-padding** (`SFTSingleTurnPreprocessor`, eagle3 packing, `neat_packing_vlm`) or **pass-through** (`retrieval_collator` via `tokenizer.pad`, `vlm/utils.py` and `vlm/collate_fns.py` via `processor(...)`, which return the tokenizer's own mask). That is why the two shipped `padding_side: left` retrieval recipes are unaffected.

Data prep never sees a model, only a tokenizer, so "every model" reduces to "every tokenizer shape". A census of all 158 recipe models found only four — pad unset, `pad == eos`, pad id `0`, `pad != eos` — and the tests parametrize over all of them x both formatters x both sides, CPU-only and offline.

## Not covered

- The 6 "full window" models (`mistral_common` backend) reach 511/512 with **zero** attended pads: their chat template injects a tool-use system prompt that overflows `seq_length=512`, so the example is entirely real content. Not a masking defect; unaffected either way.
- VLM/audio processor paths were reviewed by reading, not executed.
- `utils.py` `SFTSingleTurnPreprocessor` still pads with `tk.pad_token_id or 0` (token id `0`, e.g. `!` for Llama) for pad-less tokenizers. Same falsy-zero family, different code path that does not route through `_package_tokenized_example`. Left for a separate PR.


