### PR TITLE
fix(fsdp): shard untied embeddings as separate units

### DIFF
--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -276,7 +276,7 @@ def _fully_shard_untied_input_output_embeddings(
     mesh: DeviceMesh,
     mp_policy: MixedPrecisionPolicy,
     offload_policy: OffloadPolicy | None,
-    reshard_after_forward: bool,
+    input_reshard_after_forward: bool,
     fully_shard_fn: Callable[..., nn.Module],
 ) -> None:
     """Give large trainable untied embedding tables independent FSDP buffers.
@@ -295,11 +295,11 @@ def _fully_shard_untied_input_output_embeddings(
         mp_policy: Mixed-precision policy used by the surrounding FSDP units.
         offload_policy: Optional offload policy used by the surrounding FSDP
             units.
-        reshard_after_forward: Whether each embedding unit reshards its
-            parameters after forward.
+        input_reshard_after_forward: Whether the input embedding unit reshards
+            its parameters after forward.
         fully_shard_fn: FSDP sharding callable, injectable for unit tests.
     """
-    ensure_tied_lm_head(model)
+    weights_are_tied = ensure_tied_lm_head(model)
 
     def _resolve(getter_name: str) -> nn.Module | None:
         getter = getattr(model, getter_name, None)
@@ -315,17 +315,21 @@ def _fully_shard_untied_input_output_embeddings(
     output_embeddings = _resolve("get_output_embeddings")
     input_weight = getattr(input_embeddings, "weight", None)
     output_weight = getattr(output_embeddings, "weight", None)
-    weights_are_tied = input_embeddings is not None and (
+    weights_are_physically_tied = input_embeddings is not None and (
         input_embeddings is output_embeddings or (input_weight is not None and input_weight is output_weight)
     )
-    if weights_are_tied:
+    if weights_are_tied or weights_are_physically_tied:
         logger.info("Keeping tied input/output embeddings in the root FSDP unit")
         return
 
     seen: set[int] = set()
-    for role, module in (
-        ("input embedding", input_embeddings),
-        ("output embedding", output_embeddings),
+    for role, module, module_reshard_after_forward in (
+        ("input embedding", input_embeddings, input_reshard_after_forward),
+        # The output projection is the last compute unit. Keep it gathered until
+        # backward, matching the old root-owned behavior and allowing
+        # FusedLinearCrossEntropy to consume its mixed-precision compute weight
+        # outside the module's forward.
+        ("output embedding", output_embeddings, False),
     ):
         if module is None or id(module) in seen:
             continue
@@ -336,7 +340,7 @@ def _fully_shard_untied_input_output_embeddings(
             module,
             mesh=mesh,
             mp_policy=mp_policy,
-            reshard_after_forward=reshard_after_forward,
+            reshard_after_forward=module_reshard_after_forward,
             offload_policy=offload_policy,
         )
         logger.info("Sharded %s as an independent FSDP unit", role)
@@ -522,7 +526,7 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
             ignored_multimodal_params=ignored_multimodal_params,
         )
 
-        standalone_reshard_after_forward = (
+        input_embedding_reshard_after_forward = (
             reshard_after_forward if reshard_after_forward is not None else not pp_enabled
         )
         _fully_shard_untied_input_output_embeddings(
@@ -530,7 +534,7 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
             mesh=dp_mesh,
             mp_policy=mp_policy,
             offload_policy=offload_policy,
-            reshard_after_forward=standalone_reshard_after_forward,
+            input_reshard_after_forward=input_embedding_reshard_after_forward,
             fully_shard_fn=fully_shard_fn,
         )
 

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -17,6 +17,7 @@ import inspect
 import logging
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from contextlib import contextmanager
 from functools import lru_cache
 from types import FunctionType
@@ -269,6 +270,78 @@ class ParallelizationStrategy(ABC):
         pass
 
 
+def _fully_shard_untied_input_output_embeddings(
+    model: nn.Module,
+    *,
+    mesh: DeviceMesh,
+    mp_policy: MixedPrecisionPolicy,
+    offload_policy: OffloadPolicy | None,
+    reshard_after_forward: bool,
+    fully_shard_fn: Callable[..., nn.Module],
+) -> None:
+    """Give large trainable untied embedding tables independent FSDP buffers.
+
+    The generic dense path otherwise leaves both tables in the root FSDP unit.
+    With fp32 gradient reduction, that unit allocates one contiguous
+    reduce-scatter input containing both gradients. Keeping the two trainable
+    leaf modules in separate FSDP units bounds that allocation by the larger
+    table instead of their sum. Tied weights stay in one unit to preserve
+    aliasing, and frozen tables stay in the root because they have no gradient
+    communication buffer to split.
+
+    Args:
+        model: Model whose input and output embedding modules may be sharded.
+        mesh: Device mesh that owns the FSDP shards.
+        mp_policy: Mixed-precision policy used by the surrounding FSDP units.
+        offload_policy: Optional offload policy used by the surrounding FSDP
+            units.
+        reshard_after_forward: Whether each embedding unit reshards its
+            parameters after forward.
+        fully_shard_fn: FSDP sharding callable, injectable for unit tests.
+    """
+    ensure_tied_lm_head(model)
+
+    def _resolve(getter_name: str) -> nn.Module | None:
+        getter = getattr(model, getter_name, None)
+        if not callable(getter):
+            return None
+        try:
+            module = getter()
+        except (AttributeError, NotImplementedError):
+            return None
+        return module if isinstance(module, nn.Module) else None
+
+    input_embeddings = _resolve("get_input_embeddings")
+    output_embeddings = _resolve("get_output_embeddings")
+    input_weight = getattr(input_embeddings, "weight", None)
+    output_weight = getattr(output_embeddings, "weight", None)
+    weights_are_tied = input_embeddings is not None and (
+        input_embeddings is output_embeddings or (input_weight is not None and input_weight is output_weight)
+    )
+    if weights_are_tied:
+        logger.info("Keeping tied input/output embeddings in the root FSDP unit")
+        return
+
+    seen: set[int] = set()
+    for role, module in (
+        ("input embedding", input_embeddings),
+        ("output embedding", output_embeddings),
+    ):
+        if module is None or id(module) in seen:
+            continue
+        seen.add(id(module))
+        if not any(param.requires_grad for param in module.parameters()):
+            continue
+        fully_shard_fn(
+            module,
+            mesh=mesh,
+            mp_policy=mp_policy,
+            reshard_after_forward=reshard_after_forward,
+            offload_policy=offload_policy,
+        )
+        logger.info("Sharded %s as an independent FSDP unit", role)
+
+
 class DefaultParallelizationStrategy(ParallelizationStrategy):
     """Default parallelization strategy used by most models."""
 
@@ -447,6 +520,18 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
             fully_shard_fn=fully_shard_fn,
             frozen_multimodal_sharding=frozen_multimodal_sharding,
             ignored_multimodal_params=ignored_multimodal_params,
+        )
+
+        standalone_reshard_after_forward = (
+            reshard_after_forward if reshard_after_forward is not None else not pp_enabled
+        )
+        _fully_shard_untied_input_output_embeddings(
+            model,
+            mesh=dp_mesh,
+            mp_policy=mp_policy,
+            offload_policy=offload_policy,
+            reshard_after_forward=standalone_reshard_after_forward,
+            fully_shard_fn=fully_shard_fn,
         )
 
         # Apply FSDP to the root model

--- a/tests/unit_tests/distributed/test_fsdp_embedding_split_gloo.py
+++ b/tests/unit_tests/distributed/test_fsdp_embedding_split_gloo.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real FSDP numerical coverage for independently sharded embedding tables."""
+
+from __future__ import annotations
+
+import copy
+import os
+import socket
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
+from torch.distributed.fsdp import FSDPModule, MixedPrecisionPolicy, fully_shard
+from torch.distributed.tensor import DTensor
+
+from nemo_automodel.components.distributed.parallelizer import _fully_shard_untied_input_output_embeddings
+
+
+class _ToyLM(nn.Module):
+    def __init__(self, *, tied: bool) -> None:
+        super().__init__()
+        self.config = SimpleNamespace(tie_word_embeddings=tied)
+        self.embed_tokens = nn.Embedding(32, 8)
+        self.body = nn.Linear(8, 8)
+        self.lm_head = nn.Linear(8, 32, bias=False)
+        if tied:
+            self.lm_head.weight = self.embed_tokens.weight
+
+    def get_input_embeddings(self) -> nn.Module:
+        return self.embed_tokens
+
+    def get_output_embeddings(self) -> nn.Module:
+        return self.lm_head
+
+    def forward(self, token_ids: torch.Tensor) -> torch.Tensor:
+        """Compute token logits.
+
+        Args:
+            token_ids: Token IDs of shape [batch, sequence].
+
+        Returns:
+            Logits of shape [batch, sequence, vocab].
+        """
+        return self.lm_head(torch.tanh(self.body(self.embed_tokens(token_ids))))
+
+
+def _full_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    """Materialize a distributed tensor for numerical comparison.
+
+    Args:
+        tensor: Tensor of arbitrary shape, optionally a DTensor sharded on its
+            first dimension.
+
+    Returns:
+        Replicated tensor with the same global shape and values as ``tensor``.
+    """
+    return tensor.full_tensor() if isinstance(tensor, DTensor) else tensor
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _run_case(mesh: DeviceMesh, *, tied: bool) -> None:
+    torch.manual_seed(2026)
+    model = _ToyLM(tied=tied)
+    reference = copy.deepcopy(model)
+    mp_policy = MixedPrecisionPolicy(reduce_dtype=torch.float32)
+
+    _fully_shard_untied_input_output_embeddings(
+        model,
+        mesh=mesh,
+        mp_policy=mp_policy,
+        offload_policy=None,
+        reshard_after_forward=True,
+        fully_shard_fn=fully_shard,
+    )
+    fully_shard(model, mesh=mesh, mp_policy=mp_policy, reshard_after_forward=False)
+
+    assert isinstance(model, FSDPModule)
+    if tied:
+        assert not isinstance(model.embed_tokens, FSDPModule)
+        assert not isinstance(model.lm_head, FSDPModule)
+    else:
+        assert isinstance(model.embed_tokens, FSDPModule)
+        assert isinstance(model.lm_head, FSDPModule)
+
+    token_ids = torch.tensor([[1, 2, 3], [4, 5, 6]])
+    model_optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
+    reference_optimizer = torch.optim.SGD(reference.parameters(), lr=0.05)
+
+    actual = model(token_ids)
+    expected = reference(token_ids)
+    torch.testing.assert_close(actual, expected)
+    actual.square().mean().backward()
+    expected.square().mean().backward()
+
+    actual_parameters = dict(model.named_parameters())
+    actual_grad_norms = []
+    expected_grad_norms = []
+    for name, expected_parameter in reference.named_parameters():
+        actual_gradient = _full_tensor(actual_parameters[name].grad)
+        expected_gradient = expected_parameter.grad
+        torch.testing.assert_close(actual_gradient, expected_gradient)
+        actual_grad_norms.append(actual_gradient.float().norm())
+        expected_grad_norms.append(expected_gradient.float().norm())
+    actual_global_norm = torch.stack(actual_grad_norms).norm()
+    expected_global_norm = torch.stack(expected_grad_norms).norm()
+    torch.testing.assert_close(actual_global_norm, expected_global_norm)
+
+    model_optimizer.step()
+    reference_optimizer.step()
+    actual_state = model.state_dict()
+    expected_state = reference.state_dict()
+    for name, expected_parameter in expected_state.items():
+        torch.testing.assert_close(_full_tensor(actual_state[name]), expected_parameter)
+
+
+def _worker(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+    try:
+        mesh = init_device_mesh("cpu", (world_size,), mesh_dim_names=("dp",))
+        _run_case(mesh, tied=False)
+        _run_case(mesh, tied=True)
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("world_size", [1, 2])
+def test_split_embedding_fsdp_matches_unsharded_reference(world_size: int) -> None:
+    mp.spawn(_worker, args=(world_size, _free_port()), nprocs=world_size, join=True)

--- a/tests/unit_tests/distributed/test_fsdp_embedding_split_gloo.py
+++ b/tests/unit_tests/distributed/test_fsdp_embedding_split_gloo.py
@@ -91,7 +91,7 @@ def _run_case(mesh: DeviceMesh, *, tied: bool) -> None:
         mesh=mesh,
         mp_policy=mp_policy,
         offload_policy=None,
-        reshard_after_forward=True,
+        input_reshard_after_forward=True,
         fully_shard_fn=fully_shard,
     )
     fully_shard(model, mesh=mesh, mp_policy=mp_policy, reshard_after_forward=False)

--- a/tests/unit_tests/distributed/test_parallelization_strategies.py
+++ b/tests/unit_tests/distributed/test_parallelization_strategies.py
@@ -349,8 +349,18 @@ class TestDefaultParallelizationStrategy:
         mock_distributed_env["apply_fsdp"].assert_called_once()
         mock_distributed_env["fully_shard"].assert_called()
 
+    @pytest.mark.parametrize(
+        ("reshard_after_forward", "expected_input_reshard", "expected_output_reshard"),
+        [(None, True, False), (True, True, False), (False, False, False)],
+    )
     def test_parallelize_splits_untied_input_and_output_embeddings(
-        self, strategy, mock_device_mesh, mock_distributed_env
+        self,
+        strategy,
+        mock_device_mesh,
+        mock_distributed_env,
+        reshard_after_forward,
+        expected_input_reshard,
+        expected_output_reshard,
     ):
         """Untied trainable tables become separate FSDP units before the root."""
         mesh, _, _, _ = mock_device_mesh
@@ -365,6 +375,7 @@ class TestDefaultParallelizationStrategy:
             device_mesh=mesh,
             sequence_parallel=False,
             activation_checkpointing=False,
+            reshard_after_forward=reshard_after_forward,
         )
 
         calls = mock_distributed_env["fully_shard"].call_args_list
@@ -374,17 +385,19 @@ class TestDefaultParallelizationStrategy:
         assert modules[-1] is model
         embed_call = next(item for item in calls if item.args[0] is model.model.embed_tokens)
         head_call = next(item for item in calls if item.args[0] is model.lm_head)
-        assert embed_call.kwargs["reshard_after_forward"] is True
-        assert head_call.kwargs["reshard_after_forward"] is True
+        assert embed_call.kwargs["reshard_after_forward"] is expected_input_reshard
+        assert head_call.kwargs["reshard_after_forward"] is expected_output_reshard
 
     def test_parallelize_keeps_tied_embeddings_in_root(self, strategy, mock_device_mesh, mock_distributed_env):
-        """A shared input/output parameter must not acquire two FSDP owners."""
+        """Input/output parameters sharing storage must not acquire two FSDP owners."""
         mesh, _, _, _ = mock_device_mesh
         model = MockModel()
         model.config.tie_word_embeddings = True
         model.model.embed_tokens = nn.Embedding(32, 10)
         model.lm_head = nn.Linear(10, 32, bias=False)
-        model.lm_head.weight = model.model.embed_tokens.weight
+        model.lm_head.weight = nn.Parameter(model.model.embed_tokens.weight.detach())
+        assert model.lm_head.weight is not model.model.embed_tokens.weight
+        assert model.lm_head.weight.data_ptr() == model.model.embed_tokens.weight.data_ptr()
         model.get_input_embeddings = lambda: model.model.embed_tokens
         model.get_output_embeddings = lambda: model.lm_head
 

--- a/tests/unit_tests/distributed/test_parallelization_strategies.py
+++ b/tests/unit_tests/distributed/test_parallelization_strategies.py
@@ -349,6 +349,78 @@ class TestDefaultParallelizationStrategy:
         mock_distributed_env["apply_fsdp"].assert_called_once()
         mock_distributed_env["fully_shard"].assert_called()
 
+    def test_parallelize_splits_untied_input_and_output_embeddings(
+        self, strategy, mock_device_mesh, mock_distributed_env
+    ):
+        """Untied trainable tables become separate FSDP units before the root."""
+        mesh, _, _, _ = mock_device_mesh
+        model = MockModel()
+        model.model.embed_tokens = nn.Embedding(32, 10)
+        model.lm_head = nn.Linear(10, 32, bias=False)
+        model.get_input_embeddings = lambda: model.model.embed_tokens
+        model.get_output_embeddings = lambda: model.lm_head
+
+        strategy.parallelize(
+            model=model,
+            device_mesh=mesh,
+            sequence_parallel=False,
+            activation_checkpointing=False,
+        )
+
+        calls = mock_distributed_env["fully_shard"].call_args_list
+        modules = [item.args[0] for item in calls]
+        assert model.model.embed_tokens in modules
+        assert model.lm_head in modules
+        assert modules[-1] is model
+        embed_call = next(item for item in calls if item.args[0] is model.model.embed_tokens)
+        head_call = next(item for item in calls if item.args[0] is model.lm_head)
+        assert embed_call.kwargs["reshard_after_forward"] is True
+        assert head_call.kwargs["reshard_after_forward"] is True
+
+    def test_parallelize_keeps_tied_embeddings_in_root(self, strategy, mock_device_mesh, mock_distributed_env):
+        """A shared input/output parameter must not acquire two FSDP owners."""
+        mesh, _, _, _ = mock_device_mesh
+        model = MockModel()
+        model.config.tie_word_embeddings = True
+        model.model.embed_tokens = nn.Embedding(32, 10)
+        model.lm_head = nn.Linear(10, 32, bias=False)
+        model.lm_head.weight = model.model.embed_tokens.weight
+        model.get_input_embeddings = lambda: model.model.embed_tokens
+        model.get_output_embeddings = lambda: model.lm_head
+
+        strategy.parallelize(
+            model=model,
+            device_mesh=mesh,
+            sequence_parallel=False,
+            activation_checkpointing=False,
+        )
+
+        modules = [item.args[0] for item in mock_distributed_env["fully_shard"].call_args_list]
+        assert model.model.embed_tokens not in modules
+        assert model.lm_head not in modules
+        assert modules[-1] is model
+
+    def test_parallelize_keeps_frozen_embeddings_in_root(self, strategy, mock_device_mesh, mock_distributed_env):
+        """Frozen tables do not need standalone gradient communication units."""
+        mesh, _, _, _ = mock_device_mesh
+        model = MockModel()
+        model.model.embed_tokens = nn.Embedding(32, 10).requires_grad_(False)
+        model.lm_head = nn.Linear(10, 32, bias=False).requires_grad_(False)
+        model.get_input_embeddings = lambda: model.model.embed_tokens
+        model.get_output_embeddings = lambda: model.lm_head
+
+        strategy.parallelize(
+            model=model,
+            device_mesh=mesh,
+            sequence_parallel=False,
+            activation_checkpointing=False,
+        )
+
+        modules = [item.args[0] for item in mock_distributed_env["fully_shard"].call_args_list]
+        assert model.model.embed_tokens not in modules
+        assert model.lm_head not in modules
+        assert modules[-1] is model
+
     def test_parallelize_with_tensor_parallel(self, strategy, mock_device_mesh, mock_distributed_env):
         """Test parallelization with tensor parallelism enabled."""
         mesh, dp_replicate_mesh, dp_shard_mesh, tp_mesh = mock_device_mesh


### PR DESCRIPTION
# What does this PR do?

Shard trainable untied input embeddings and LM heads as independent FSDP units in the generic/default FSDP2 path, instead of placing both gradients in the root unit's reduce-scatter input.

For a vocabulary table with shape `[vocab_size, hidden_size]`, fp32 gradient reduction needs:

```
vocab_size * hidden_size * 4 bytes
```

When input and output tables are untied and owned by one FSDP unit, their gradients can be coalesced into one contiguous allocation twice that size. Splitting ownership does not change the reduction math or total communicated bytes; it bounds the largest contiguous reduction input by one table.

# Original production evidence

This change follows [@zhiqi-li's report from a 64-H100 Qwen3.8-27B training campaign](https://github.com/NVIDIA-NeMo/Automodel/issues/2985#issuecomment-5322924931), reproduced against `main@cb03cf61` on 2026-08-17.

[Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B/blob/main/config.json) has:

- `tie_word_embeddings=false`
- `vocab_size=248320`
- `hidden_size=5120`
- two trainable `248320 x 5120` vocabulary tables

Each table contains `1,271,398,400` parameters. Coalescing both gradients for fp32 reduction requires:

```
2 * 248,320 * 5,120 * 4 bytes
  = 10,171,187,200 bytes
  = 9.473 GiB
```

In the reported 64-H100 run, post-backward failed at step 8 while requesting **9.47 GiB**, with approximately **9.42 GiB** driver-visible as free. The request size exactly matched the two-table fp32 reduction input and was not associated with a special or all-padding batch.

With separate embedding/head FSDP ownership, the largest input becomes one table, **4.736 GiB**. Zhiqi's targeted rerun completed **20/20 steps**, and a longer run passed the original failure point.

The issue report does not attach the full training YAML or all topology settings beyond the 64-H100 Qwen3.8-27B campaign, so this PR does not claim an independently reproduced Qwen3.8-27B full-recipe run. The PR-specific real-model validation below uses the tracked Qwen3.5-9B VLM fine-tuning path instead.

# Scope, including EP/MoE

This PR changes the generic/default FSDP2 strategy. It applies automatically when that strategy sees trainable input/output embedding modules whose weights are physically untied. Tied and frozen tables remain in their existing ownership path.

EP/MoE is **not excluded from the memory principle**. Embeddings and the LM head are dense parameters, independent of expert routing. The reason this PR does not modify the EP/MoE implementation is that `ep_size > 1` routes through the dedicated MoE parallelizer, which already:

- restores configured embedding/head ties;
- detects physical tying;
- gives untied `embed_tokens` and `lm_head` separate FSDP ownership before the root wrap.

This PR brings the generic/default dense path to parity with that existing MoE ownership policy. MoE models that do not use the dedicated EP path may still receive this behavior when they route through the default strategy.

# Changelog

- Give trainable untied input and output embedding modules independent FSDP ownership before sharding the root model.
- Preserve tied-weight aliasing, including distinct parameters that share storage.
- Skip standalone units for frozen tables.
- Let the input embedding follow the configured/default reshard policy.
- Keep the output projection gathered through backward, matching its former root-owned lifecycle and allowing `FusedLinearCrossEntropy` to consume the mixed-precision compute weight outside `lm_head.forward()`.
- Add ownership tests and real one-/two-rank Gloo FSDP numerical coverage.

# PR validation

## What was run

No full Qwen3.8-27B AutoModel recipe was run specifically for this PR. The real-GPU PR validation used controlled CUDA/NCCL A/B runs with the PR code:

1. A real Qwen3.5-9B VLM fine-tuning recipe A/B loaded the complete 17.98 GB checkpoint and cached `mmoukouba/MedPix-VQA` dataset. It trained 9,197,093,888 parameters for four AdamW steps with fused linear CE, then completed the full validation set (341,257 label tokens). Topology was DP=2, local batch 1, global batch 2; the vision tower was frozen and the language model, including both untied vocabulary tables, was trainable.
2. A second real Qwen3.5-9B recipe A/B set `model.torch_dtype=float32`, giving FSDP fp32 resident/master parameters, bf16 forward/backward parameters, and fp32 gradient reduction. It used DP=4, local batch 1, global batch 4, trained the same 9,197,093,888 parameters for two AdamW steps with fused linear CE, and completed the same full validation set. Instrumentation recorded both the post-sharding storage dtype and the tensors delivered to fused CE.
3. A small untied causal LM (`vocab_size=257`, `hidden_size=64`, one hidden layer) compared root versus split ownership for standard CE and `FusedLinearCrossEntropy`.
4. An exact Qwen3.8 vocabulary-table-shape benchmark with two trainable `248320 x 5120` tables, one `5120 x 5120` hidden layer, fp32 gradient reduction, and 16 global tokens per step.
5. One warmup plus three measured exact-shape steps for a narrow throughput-overhead guard.

Environment: 2x and 4x NVIDIA H100 80GB, Torch 2.13.0a0+8145d630e8.nv26.06, CUDA 13.3, NCCL 2.30.5, Transformers 5.12.1.

## Correctness

Standard CE and fused linear CE both have exact root-vs-split parity after one SGD step:

| Check | Root-owned | Split units | Maximum absolute difference |
| -- | --: | --: | --: |
| Standard CE loss | 5.5674252510 | 5.5674252510 | 0.0 |
| Standard CE global grad norm | 0.8494461775 | 0.8494461775 | 0.0 |
| Fused linear CE loss | 5.5674200058 | 5.5674200058 | 0.0 |
| Fused linear CE global grad norm | 0.8494154811 | 0.8494154811 | 0.0 |
| Every parameter gradient | — | — | 0.0 |
| Parameters after optimizer step | — | — | 0.0 |

The first GPU run caught a correctness issue in the draft implementation: resharing the standalone LM head exposed its fp32 master shard to fused linear CE beside bf16 hidden states. Keeping the output projection gathered through backward fixes that lifecycle mismatch; the corrected run passes both loss paths exactly.

The real Qwen3.5-9B treatments used identical checkpoint, data order, seed, optimizer, and PR commit. The baseline disabled only the new embedding-split helper. Both completed all optimizer steps and full validation with finite metrics:

| Check | Root-owned | Split units | Absolute difference |
| -- | --: | --: | --: |
| Step-0 loss | 3.2696311 | 3.2696331 | 0.0000019 |
| Step-3 loss | 2.4933345 | 2.4904807 | 0.0028539 |
| Full-validation loss | 1.7855777 | 1.7865659 | 0.0009883 |

Changing FSDP ownership changes bf16 reduction grouping/order, so the multi-step real-model trajectories are not expected to remain bitwise identical. The focused small-model run separately establishes exact loss, gradient, global-norm, and post-update parity; the real recipe establishes stable end-to-end optimization and validation.

The fp32-master recipe directly exercises the LM-head lifecycle raised in review. Immediately after FSDP setup, both treatments exposed an fp32 sharded `lm_head.weight`; only the split treatment reported the head itself as an independent FSDP unit. At the actual fused-CE call in both treatments, the hidden states and materialized LM-head weight were regular bf16 tensors with shapes `[1, 204, 4096]` and `[248320, 4096]`, respectively. Both treatments completed backward, AdamW updates, and validation:

| Check | Root-owned | Split units | Absolute difference |
| -- | --: | --: | --: |
| Step-0 loss | 1.8865188 | 1.8866801 | 0.0001613 |
| Step-1 loss | 2.1660161 | 2.1670527 | 0.0010366 |
| Full-validation loss | 1.8164629 | 1.8129602 | 0.0035027 |

## BF16-storage Qwen3.5-9B recipe memory A/B

Qwen3.5-9B declares `tie_word_embeddings=false`, `vocab_size=248320`, and text `hidden_size=4096`. Its fp32 input-embedding or LM-head gradient is 3.789 GiB.

| Metric | Root-owned | Split units | Delta |
| -- | --: | --: | --: |
| Largest FSDP reduction input | 7.578140 GiB | 3.789062 GiB | -3.789078 GiB (-50.00%) |
| Peak allocated CUDA memory during training | 50.7437 GiB | 46.1408 GiB | -4.6028 GiB (-9.07%) |

The real baseline reduction group was `8,136,966,144` fp32 bytes with shapes `[[248320, 4096], [4096], [248320, 4096]]`; it contained both vocabulary-table gradients plus one 4096-element vector. The split run's largest group was one `248320 x 4096` gradient, `4,068,474,880` bytes. The memory figures are the recipe's per-step peak-allocator metric.

This sequential recipe A/B is not used for a throughput claim: the root treatment ran first and populated shared Triton/kernel caches before the split treatment. The controlled exact-shape harness below remains the narrow overhead guard.

## FP32-master Qwen3.5-9B recipe memory A/B

The four-H100 follow-up kept fp32 resident/model parameters while FSDP used bf16 compute and fp32 reduction. It therefore validates both the intended stable-optimizer configuration and the exact storage/compute dtype boundary discussed in review.

| Metric | Root-owned | Split units | Delta |
| -- | --: | --: | --: |
| Largest FSDP reduction input | 7.578140 GiB | 3.789062 GiB | -3.789078 GiB (-50.00%) |
| Peak allocated CUDA memory during training | 46.9546 GiB | 44.2462 GiB | -2.7084 GiB (-5.77%) |

The reduction groups had the same shapes and fp32 byte counts as in the bf16-storage recipe A/B. The smaller percentage memory change is expected because four-way sharding reduces each rank's resident fp32 parameters and AdamW state, while the unsharded reduction-input saving remains one full vocabulary table. This sequential run is also correctness/memory evidence only, not a throughput comparison.

## Exact-shape memory and overhead A/B

| Metric | Root-owned | Split units | Delta |
| -- | --: | --: | --: |
| Largest FSDP reduction input | 9.473 GiB (both tables) | 4.736 GiB (one table) | -50.0% |
| Peak allocated CUDA memory | 23.945 GiB | 21.630 GiB | -2.316 GiB (-9.67%) |
| Incremental backward peak | 14.298 GiB | 9.565 GiB | -4.733 GiB |
| Synthetic throughput | 265.82 tokens/s | 261.59 tokens/s | -1.59% |

The reduction probe observed one `10,171,187,200`-byte fp32 group before the split and two `5,085,593,600`-byte groups after it. The incremental backward saving matches one table's communication-buffer size.

The throughput result is only an overhead guard from a tiny one-layer, 16-global-token harness; it is not a full-model TPS claim.

## CPU and repository CI

- 7 focused tests passed: untied/tied/frozen ownership and real one-/two-rank Gloo FSDP loss, per-parameter gradient, global-norm, and post-step parameter parity.
- Targeted Ruff formatting/lint, Python bytecode compilation, and `git diff --check` passed.
- The full PR CI matrix passed, including L0 CPU, both L0 GPU shards, L2 Distributed, HF Transformer/finetune/VLM, DCP, PEFT, context-parallel, H100, and GB200 jobs.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused unit and real multi-process tests.
- [x] Completed real Qwen3.5-9B recipe A/Bs with both bf16 storage and fp32 master parameters, plus CUDA/NCCL correctness and exact-shape memory validation.
- [x] Completed the full repository CI matrix.
- [x] No user-facing documentation change is required for this ownership fix.

# Additional Information

- Related to #2985.
- Supersedes #3703, whose head branch was accidentally submitted from a fork.
