### PR TITLE
test(pp): add mistral3p5 PP and TP parity tests [4/4]

### DIFF
--- a/tests/functional_tests/parallelism/L2_Parallelism_VLM_Mistral3p5_PP2_Parity.sh
+++ b/tests/functional_tests/parallelism/L2_Parallelism_VLM_Mistral3p5_PP2_Parity.sh
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+# Pipeline-parallel parity for the Mistral3.5 VLM recipe, which ships pp_size 8.
+#
+# mistral3 is one of only two model types with its own VLM pipeline forward
+# (`_PP_VLM_MODEL_TYPES_WITH_DEDICATED_FORWARD`), which routes pixel values
+# through the vision tower on stage 0. The generic PP tests do not cover it.
+#
+# Required CI environment:
+#   * `mistralai/Mistral-Medium-3.5-128B` processor files in the staged HF cache.
+#     Images are generated at test time, so no dataset is needed.
+
+set -xeuo pipefail
+
+export PYTHONPATH=${PYTHONPATH:-}:$(pwd)
+export CUDA_VISIBLE_DEVICES="0,1"
+
+RUN_DIR=$(mktemp -d)
+LOG_FILE="$RUN_DIR/pp2.log"
+PROXY_CKPT="$RUN_DIR/proxy"
+cleanup() { rm -rf "$RUN_DIR"; }
+trap cleanup EXIT
+
+# Build the randomly-initialized proxy checkpoint. Both runs load the same
+# weights, which is what makes the two loss trajectories comparable at all.
+python tests/functional_tests/parallelism/make_mistral3p5_proxy_checkpoint.py \
+    --output-dir "$PROXY_CKPT"
+
+COMMON_ARGS=(
+    --config tests/functional_tests/parallelism/mistral3p5_proxy.yaml
+    --model.pretrained_model_name_or_path "$PROXY_CKPT"
+    --processor.pretrained_model_name_or_path "$PROXY_CKPT"
+    --step_scheduler.max_steps 6
+    --step_scheduler.global_batch_size 4
+    --step_scheduler.local_batch_size 2
+)
+
+# --- Baseline: single rank, no parallelism ---
+TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=1 --nnodes=1 -m coverage run \
+    examples/vlm_finetune/finetune.py \
+    "${COMMON_ARGS[@]}" \
+    --checkpoint.checkpoint_dir "$RUN_DIR/baseline" \
+    --distributed.tp_size 1 \
+    --distributed.cp_size 1 \
+    --distributed.pp_size 1
+
+# --- Pipeline parallel: 2 ranks, pp_size=2 ---
+TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run \
+    examples/vlm_finetune/finetune.py \
+    "${COMMON_ARGS[@]}" \
+    --checkpoint.checkpoint_dir "$RUN_DIR/pp2" \
+    --distributed.tp_size 1 \
+    --distributed.cp_size 1 \
+    --distributed.pp_size 2 \
+    --distributed.pipeline.pp_schedule 1f1b \
+    --distributed.pipeline.pp_microbatch_size 1 \
+    2>&1 | tee "$LOG_FILE"
+
+# Guard against the `_precompute_stage_shapes` bug from PR #2983. Assert the
+# static path positively as well: if the precompute is skipped outright, the
+# fallback log line disappears too and the negative grep alone would pass.
+if grep -Eiq "dynamic .*metadata inference" "$LOG_FILE"; then
+    echo "ERROR: pipeline stages fell back to dynamic metadata inference instead of static metadata"
+    exit 1
+fi
+if ! grep -q "Precomputed pipeline stage shapes" "$LOG_FILE"; then
+    echo "ERROR: pipeline stage shapes were never precomputed; static metadata did not run"
+    exit 1
+fi
+
+# The gradient-norm bound is looser than the loss bound because the single-rank
+# baseline runs unwrapped while the pp2 run goes through FSDP2 in bf16.
+# global_batch_size is twice local_batch_size, so each step accumulates two
+# micro-batches -- the case PR #3530 fixed.
+python tests/functional_tests/parallelism/compare_parallel_parity.py \
+    "$RUN_DIR/baseline/training.jsonl" \
+    "$RUN_DIR/pp2/training.jsonl" \
+    --axis pp \
+    --loss-tol 0.05 \
+    --grad-norm-rtol 0.20

--- a/tests/functional_tests/parallelism/L2_Parallelism_VLM_Mistral3p5_TP2_Parity.sh
+++ b/tests/functional_tests/parallelism/L2_Parallelism_VLM_Mistral3p5_TP2_Parity.sh
@@ -1,0 +1,75 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+# Tensor-parallel parity for the Mistral3.5 VLM recipe, which ships tp_size 8.
+#
+# Runs the Mistral3.5 proxy twice with the same seed and data order -- once on a
+# single rank, once at tp_size=2 -- and asserts both follow the same loss and
+# gradient-norm trajectory. `dp_size` is 1 in both runs, so any divergence is
+# attributable to the tensor-parallel sharding.
+#
+# Required CI environment:
+#   * `mistralai/Mistral-Medium-3.5-128B` processor files in the staged HF cache.
+#     Images are generated at test time, so no dataset is needed.
+
+set -xeuo pipefail
+
+export PYTHONPATH=${PYTHONPATH:-}:$(pwd)
+export CUDA_VISIBLE_DEVICES="0,1"
+
+RUN_DIR=$(mktemp -d)
+PROXY_CKPT="$RUN_DIR/proxy"
+cleanup() { rm -rf "$RUN_DIR"; }
+trap cleanup EXIT
+
+# Build the randomly-initialized proxy checkpoint. Both runs load the same
+# weights, which is what makes the two loss trajectories comparable at all.
+python tests/functional_tests/parallelism/make_mistral3p5_proxy_checkpoint.py \
+    --output-dir "$PROXY_CKPT"
+
+COMMON_ARGS=(
+    --config tests/functional_tests/parallelism/mistral3p5_proxy.yaml
+    --model.pretrained_model_name_or_path "$PROXY_CKPT"
+    --processor.pretrained_model_name_or_path "$PROXY_CKPT"
+    --step_scheduler.max_steps 6
+    --step_scheduler.global_batch_size 2
+    --step_scheduler.local_batch_size 2
+    --distributed.pp_size 1
+    --distributed.cp_size 1
+)
+
+# --- Baseline: single rank, no parallelism ---
+TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=1 --nnodes=1 -m coverage run \
+    examples/vlm_finetune/finetune.py \
+    "${COMMON_ARGS[@]}" \
+    --checkpoint.checkpoint_dir "$RUN_DIR/baseline" \
+    --distributed.tp_size 1
+
+# --- Tensor parallel: 2 ranks, tp_size=2 ---
+TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run \
+    examples/vlm_finetune/finetune.py \
+    "${COMMON_ARGS[@]}" \
+    --checkpoint.checkpoint_dir "$RUN_DIR/tp2" \
+    --distributed.tp_size 2
+
+# See the PP2 test for why the gradient-norm bound is looser than the loss bound:
+# FSDP2Manager skips parallelization at world_size 1, so the baseline runs
+# unwrapped while the tp2 run gets FSDP2's default bf16 MixedPrecisionPolicy.
+python tests/functional_tests/parallelism/compare_parallel_parity.py \
+    "$RUN_DIR/baseline/training.jsonl" \
+    "$RUN_DIR/tp2/training.jsonl" \
+    --axis tp \
+    --loss-tol 0.05 \
+    --grad-norm-rtol 0.20

--- a/tests/functional_tests/parallelism/make_mistral3p5_proxy_checkpoint.py
+++ b/tests/functional_tests/parallelism/make_mistral3p5_proxy_checkpoint.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build a small random Mistral3.5 checkpoint for the parallelism parity tests.
+
+Same shape as `examples/vlm_finetune/mistral3p5/mistral3p5_128b_medpix.yaml`,
+just small enough for a 2-GPU runner. Writes the weights plus the real
+processor, so the test has one directory to point at.
+
+The processor is saved from the cached `mistralai/Mistral-Medium-3.5-128B`,
+which is why `vocab_size` and `image_token_index` stay at their real values --
+the processor emits those token ids and the embedding has to cover them.
+
+Usage:
+    python make_mistral3p5_proxy_checkpoint.py --output-dir DIR
+"""
+
+import argparse
+from pathlib import Path
+
+import torch
+
+SOURCE_MODEL = "mistralai/Mistral-Medium-3.5-128B"
+
+# Kept at the real values because the processor depends on them.
+VOCAB_SIZE = 131072
+IMAGE_TOKEN_INDEX = 10
+SPATIAL_MERGE_SIZE = 2
+# Shrunk, except the vision patch size, which has to match the processor.
+TEXT_HIDDEN = 256
+VISION_HIDDEN = 128
+
+
+def build_config():
+    """Build the shrunk Mistral3 config.
+
+    Returns:
+        A ``Mistral3Config`` with a ministral3 text tower and a pixtral vision
+        tower, both scaled down but keeping the fields the processor and the
+        parallelism code depend on.
+    """
+    from transformers.models.mistral3.configuration_mistral3 import Mistral3Config
+
+    text_config = {
+        "model_type": "ministral3",
+        "vocab_size": VOCAB_SIZE,
+        "hidden_size": TEXT_HIDDEN,
+        "intermediate_size": 512,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 8,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "max_position_embeddings": 4096,
+        "rms_norm_eps": 1e-5,
+        # Same yarn setup as the real config, retuned for the shorter context:
+        # factor 1.0 with original == max keeps it consistent. The fields are
+        # not optional -- ministral3 attention reads
+        # `original_max_position_embeddings` and `llama_4_scaling_beta`.
+        "rope_parameters": {
+            "rope_type": "yarn",
+            "type": "yarn",
+            "rope_theta": 1000000.0,
+            "factor": 1.0,
+            "original_max_position_embeddings": 4096,
+            "beta_fast": 4.0,
+            "beta_slow": 1.0,
+            "mscale": 1.0,
+            "mscale_all_dim": 0.0,
+            "llama_4_scaling_beta": 0,
+        },
+        "bos_token_id": 1,
+        "eos_token_id": 2,
+        "tie_word_embeddings": False,
+        "use_cache": False,
+        # pad_token_id is deliberately left out: it would give the embedding a
+        # padding_idx, and under FSDP2 that makes weight initialization get
+        # skipped. Harmless here because the checkpoint carries real weights,
+        # but it keeps the config honest about what the test relies on.
+    }
+    vision_config = {
+        "model_type": "pixtral",
+        "hidden_size": VISION_HIDDEN,
+        "intermediate_size": 256,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "head_dim": 32,
+        "image_size": 1024,
+        # Must match the processor: PixtralImageProcessor uses patch_size 14,
+        # and a mismatch makes the image-token count disagree with the number
+        # of vision features.
+        "patch_size": 14,
+    }
+    config = Mistral3Config(
+        text_config=text_config,
+        vision_config=vision_config,
+        image_token_index=IMAGE_TOKEN_INDEX,
+        spatial_merge_size=SPATIAL_MERGE_SIZE,
+        multimodal_projector_bias=False,
+        projector_hidden_act="gelu",
+        tie_word_embeddings=False,
+    )
+    config.architectures = ["Mistral3ForConditionalGeneration"]
+    return config
+
+
+def main() -> None:
+    """Write the proxy checkpoint and its processor."""
+    parser = argparse.ArgumentParser(description="Build a Mistral3.5 proxy checkpoint")
+    parser.add_argument("--output-dir", required=True, help="Directory to write the checkpoint into")
+    parser.add_argument("--seed", type=int, default=1234, help="Seed for weight initialization")
+    args = parser.parse_args()
+
+    # Built with the stock HF class, not the NeMo subclass: this only produces
+    # an on-disk artifact, and NeMo's save_pretrained needs a live checkpointer.
+    # The saved `architectures` still routes from_pretrained to the NeMo class.
+    from transformers import AutoProcessor
+    from transformers.models.mistral3.modeling_mistral3 import Mistral3ForConditionalGeneration
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    torch.manual_seed(args.seed)
+    model = Mistral3ForConditionalGeneration(build_config()).to(torch.bfloat16)
+
+    embed_absmax = float(model.get_input_embeddings().weight.detach().abs().max())
+    if embed_absmax == 0.0:
+        raise RuntimeError(
+            "Proxy checkpoint would be all zeros: HF initialization did not run. "
+            "A zero model emits uniform logits and zero gradients, which makes the "
+            "parity comparison meaningless."
+        )
+
+    model.save_pretrained(str(output_dir))
+    AutoProcessor.from_pretrained(SOURCE_MODEL).save_pretrained(str(output_dir))
+
+    print(f"Wrote Mistral3.5 proxy checkpoint to {output_dir} (embed absmax {embed_absmax:.6f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional_tests/parallelism/mistral3p5_proxy.yaml
+++ b/tests/functional_tests/parallelism/mistral3p5_proxy.yaml
@@ -1,0 +1,121 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Small randomly-initialized Mistral3.5 for the 2-GPU runners, shrunk from
+# `examples/vlm_finetune/mistral3p5/mistral3p5_128b_medpix.yaml` (tp8, pp8).
+#
+# The weights and the processor both come from the checkpoint that
+# `make_mistral3p5_proxy_checkpoint.py` writes at test time, so there is one
+# directory to point at and nothing to download during the run.
+#
+# Images are generated rather than read from a dataset, so only the processor
+# has to be staged.
+
+recipe: FinetuneRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 4
+  local_batch_size: 2
+  ckpt_every_steps: 1000
+  val_every_steps: 1000
+  max_steps: 6
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: /dev/null  # overridden per-test
+  torch_dtype: torch.bfloat16
+  attn_implementation: eager
+  use_liger_kernel: false
+  use_sdpa_patching: false
+
+processor:
+  _target_: transformers.AutoProcessor.from_pretrained
+  pretrained_model_name_or_path: /dev/null  # overridden per-test
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: vlm_checkpoints/mistral3p5_proxy/
+  model_save_format: torch_save
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 1
+
+  sequence_parallel: false
+  activation_checkpointing: true
+
+  pipeline:
+    pp_schedule: 1f1b
+    pp_microbatch_size: 1
+    scale_grads_in_schedule: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+# Random-noise images and a fixed prompt, so no dataset has to be staged. The
+# processor turns them into pixel values through the normal path, which is what
+# the pipeline split has to carry across stages.
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.mock.build_mock_vlm_dataset
+  num_samples: 32
+  num_images_per_sample: 1
+  image_size: [224, 224]
+  seed: 42
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 0
+  pin_memory: true
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.default_collate_fn
+    max_length: 2048
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.vlm.mock.build_mock_vlm_dataset
+  num_samples: 8
+  num_images_per_sample: 1
+  image_size: [224, 224]
+  seed: 7
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 0
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.default_collate_fn
+    max_length: 2048
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 1e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+
+# Recipe values.
+freeze_config:
+  freeze_vision_tower: true
+  freeze_language_model: false

--- a/tests/functional_tests/parallelism/test_parallelism.py
+++ b/tests/functional_tests/parallelism/test_parallelism.py
@@ -37,6 +37,8 @@ DEEPSEEK_V4_PP2_PARITY_FILENAME = "L2_Parallelism_DeepSeekV4_PP2_Parity.sh"
 DEEPSEEK_V4_EP2_PARITY_FILENAME = "L2_Parallelism_DeepSeekV4_EP2_Parity.sh"
 QWEN3_5_MOE_PP2_PARITY_FILENAME = "L2_Parallelism_Qwen3_5MoE_PP2_Parity.sh"
 QWEN3_5_MOE_EP2_PARITY_FILENAME = "L2_Parallelism_Qwen3_5MoE_EP2_Parity.sh"
+MISTRAL3P5_PP2_PARITY_FILENAME = "L2_Parallelism_VLM_Mistral3p5_PP2_Parity.sh"
+MISTRAL3P5_TP2_PARITY_FILENAME = "L2_Parallelism_VLM_Mistral3p5_TP2_Parity.sh"
 
 
 class TestParallelismParity:
@@ -63,3 +65,9 @@ class TestParallelismParity:
 
     def test_qwen3_5_moe_ep2_parity(self):
         run_test_script(TEST_FOLDER, QWEN3_5_MOE_EP2_PARITY_FILENAME)
+
+    def test_mistral3p5_pp2_parity(self):
+        run_test_script(TEST_FOLDER, MISTRAL3P5_PP2_PARITY_FILENAME)
+
+    def test_mistral3p5_tp2_parity(self):
+        run_test_script(TEST_FOLDER, MISTRAL3P5_TP2_PARITY_FILENAME)


### PR DESCRIPTION
## What

Two parity tests for Mistral3.5, plus the config and generator they use. This is 4/4 of the series started in #3529.

| File | What it does |
|---|---|
| `L2_Parallelism_VLM_Mistral3p5_PP2_Parity.sh` | Trains a small Mistral3.5 twice — once on 1 GPU, once split over 2 with pipeline parallelism — and fails if the loss or gradient-norm curves drift apart. |
| `L2_Parallelism_VLM_Mistral3p5_TP2_Parity.sh` | Same for tensor parallelism. |
| `make_mistral3p5_proxy_checkpoint.py` | Builds the small random checkpoint at test time and saves the real processor next to it. |
| `mistral3p5_proxy.yaml` | A shrunk `mistral3p5_128b_medpix.yaml` (4 text layers, 2 vision layers). |

## Why

`mistral3p5_128b_medpix.yaml` runs `tp_size: 8` and `pp_size: 8`, and neither was checked.

`mistral3` is also one of only two model types with its own VLM pipeline forward:

```python
_PP_VLM_MODEL_TYPES_WITH_DEDICATED_FORWARD = ("gemma4", "mistral3")
```

That forward routes image features through the vision tower on stage 0. The generic PP tests use text-only models and never touch it. gemma4 is covered by 1/4; this covers the other one.

## What has to be staged

Only the `mistralai/Mistral-Medium-3.5-128B` processor (about 17 MB of tokenizer and config files, no weights). The test generates its own images and its own weights, so there is no dataset to stage and nothing downloaded during the run.

Three config values are kept at their real values because the processor depends on them: `vocab_size` 131072, `image_token_index` 10, and the vision `patch_size` 14. A mismatch on the last one makes the image-token count disagree with the number of vision features.

## Measured

| Test | Bounds | Worst seen |
|---|---|---|
| PP2 | loss 0.05, grad-norm 20% | 0.000094 |
| TP2 | loss 0.05, grad-norm 20% | 0.000217 |

Losses move between steps (11.78–11.82), gradient norms are 6.2–6.9, and 1078 tokens are supervised per step — so the runs are doing real work, not agreeing by being equally broken.

Both are tighter than the gemma4 equivalents because the vision tower and embeddings are frozen, the same as the shipped recipe.

## Note

An earlier version of this had `max_length: 512` on the collate, which truncated the whole assistant response away: 0 supervised tokens, loss exactly 0, zero gradients — and both tests still reported pass. It now uses 2048, matching the recipe. The check added in #3701 catches that class of failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
