### PR TITLE
fix(moe): replay HybridEP layouts under activation checkpointing

### DIFF
--- a/nemo_automodel/components/moe/megatron/fused_a2a.py
+++ b/nemo_automodel/components/moe/megatron/fused_a2a.py
@@ -18,6 +18,8 @@
 # Licensed under the MIT License - https://github.com/deepseek-ai/DeepEP/blob/main/LICENSE
 
 import os
+import threading
+from contextlib import contextmanager
 
 try:
     from deep_ep import Buffer
@@ -47,6 +49,55 @@ import torch
 _buffer = None
 _nvshmem_available = None
 _uccl_buffer = None
+
+
+class HybridEPDispatchReplayRecorder:
+    """Record HybridEP layouts from checkpoint forward for deterministic replay."""
+
+    def __init__(self) -> None:
+        self._records: list = []
+        self._cursor = 0
+        self.replay_misses = 0
+
+    def record(self, entry) -> None:
+        self._records.append(entry)
+
+    def take(self):
+        """Return the next forward dispatch record, or ``None`` on divergence."""
+        if self._cursor >= len(self._records):
+            self.replay_misses += 1
+            return None
+        entry = self._records[self._cursor]
+        self._cursor += 1
+        return entry
+
+    def rewind(self) -> None:
+        self._cursor = 0
+
+
+class _HybridEPDispatchReplayState(threading.local):
+    def __init__(self) -> None:
+        self.recorder: HybridEPDispatchReplayRecorder | None = None
+        self.mode: str | None = None
+
+
+_hybridep_dispatch_replay_state = _HybridEPDispatchReplayState()
+
+
+@contextmanager
+def hybridep_dispatch_replay_scope(recorder: HybridEPDispatchReplayRecorder | None, mode: str):
+    """Bind a HybridEP dispatch recorder for checkpoint forward or recompute."""
+    if mode not in ("record", "replay"):
+        raise ValueError(f"Unsupported HybridEP dispatch replay mode: {mode}")
+    previous_recorder = _hybridep_dispatch_replay_state.recorder
+    previous_mode = _hybridep_dispatch_replay_state.mode
+    _hybridep_dispatch_replay_state.recorder = recorder
+    _hybridep_dispatch_replay_state.mode = mode if recorder is not None else None
+    try:
+        yield
+    finally:
+        _hybridep_dispatch_replay_state.recorder = previous_recorder
+        _hybridep_dispatch_replay_state.mode = previous_mode
 
 
 def _is_nvshmem_available() -> bool:
@@ -423,6 +474,31 @@ class HybridEPDispatch(torch.autograd.Function):
                 num_sms_combine_api,
                 fp8_dispatch,
             )
+
+        recorder = _hybridep_dispatch_replay_state.recorder
+        if recorder is not None and _hybridep_dispatch_replay_state.mode == "replay":
+            replayed = recorder.take()
+            if replayed is not None:
+                handle, tokens_per_expert = replayed
+                replayed_outputs = _hybrid_ep_buffer.dispatch_with_permute(
+                    hidden=x,
+                    probs=probs,
+                    scaling_factor=None,
+                    handle=handle,
+                    pad_multiple=pad_multiple,
+                    num_permuted_tokens=tokens_per_expert.sum(),
+                )
+                dispatched_hidden, dispatched_probs, dispatched_scaling_factor, _, _ = replayed_outputs
+                ctx.handle = handle
+                ctx.pad_multiple = pad_multiple
+                return (
+                    dispatched_hidden,
+                    dispatched_probs,
+                    dispatched_scaling_factor,
+                    tokens_per_expert,
+                    handle,
+                )
+
         non_blocking = num_permuted_tokens is not None
         (
             dispatched_hidden,
@@ -443,6 +519,10 @@ class HybridEPDispatch(torch.autograd.Function):
 
         ctx.handle = handle
         ctx.pad_multiple = pad_multiple
+        if recorder is not None and _hybridep_dispatch_replay_state.mode == "record":
+            # Keep only the reusable layout and its output extent. Recomputed
+            # activations and probabilities are still redispatched through it.
+            recorder.record((handle, tokens_per_expert))
         return (
             dispatched_hidden,
             dispatched_probs,

--- a/nemo_automodel/components/moe/megatron/fused_a2a.py
+++ b/nemo_automodel/components/moe/megatron/fused_a2a.py
@@ -66,7 +66,12 @@ class HybridEPDispatchReplayRecorder:
         """Cache each layout extent after the checkpoint-forward op context exits."""
         for entry in self._records:
             if entry[2] is None:
-                entry[2] = entry[1].sum()
+                # HybridEP's sync-free replay API expects a host integer.  Do
+                # both the reduction and device-to-host scalar conversion only
+                # after the selective-checkpoint context exits; otherwise the
+                # replay-only conversion adds aten._local_scalar_dense to the
+                # recompute trace.
+                entry[2] = int(entry[1].sum().item())
 
     def take(self):
         """Return the next forward dispatch record, or ``None`` on divergence."""

--- a/nemo_automodel/components/moe/megatron/fused_a2a.py
+++ b/nemo_automodel/components/moe/megatron/fused_a2a.py
@@ -59,8 +59,14 @@ class HybridEPDispatchReplayRecorder:
         self._cursor = 0
         self.replay_misses = 0
 
-    def record(self, entry) -> None:
-        self._records.append(entry)
+    def record(self, handle, tokens_per_expert) -> None:
+        self._records.append([handle, tokens_per_expert, None])
+
+    def finalize(self) -> None:
+        """Cache each layout extent after the checkpoint-forward op context exits."""
+        for entry in self._records:
+            if entry[2] is None:
+                entry[2] = entry[1].sum()
 
     def take(self):
         """Return the next forward dispatch record, or ``None`` on divergence."""
@@ -479,14 +485,14 @@ class HybridEPDispatch(torch.autograd.Function):
         if recorder is not None and _hybridep_dispatch_replay_state.mode == "replay":
             replayed = recorder.take()
             if replayed is not None:
-                handle, tokens_per_expert = replayed
+                handle, tokens_per_expert, num_permuted_tokens = replayed
                 replayed_outputs = _hybrid_ep_buffer.dispatch_with_permute(
                     hidden=x,
                     probs=probs,
                     scaling_factor=None,
                     handle=handle,
                     pad_multiple=pad_multiple,
-                    num_permuted_tokens=tokens_per_expert.sum(),
+                    num_permuted_tokens=num_permuted_tokens,
                 )
                 dispatched_hidden, dispatched_probs, dispatched_scaling_factor, _, _ = replayed_outputs
                 ctx.handle = handle
@@ -522,7 +528,7 @@ class HybridEPDispatch(torch.autograd.Function):
         if recorder is not None and _hybridep_dispatch_replay_state.mode == "record":
             # Keep only the reusable layout and its output extent. Recomputed
             # activations and probabilities are still redispatched through it.
-            recorder.record((handle, tokens_per_expert))
+            recorder.record(handle, tokens_per_expert)
         return (
             dispatched_hidden,
             dispatched_probs,

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -459,6 +459,50 @@ def _apply_multimodal_tower_ac(model: nn.Module, scopes: tuple[str, ...]) -> Non
     apply_submodule_checkpointing(tower_layers, has_kv_sharing=False, context_fn=sdpa_backend_snapshot_context_fn)
 
 
+def _replay_hybridep_dispatch_on_recompute(
+    context_fn: Callable[[], tuple[AbstractContextManager, AbstractContextManager]],
+) -> Callable[[], tuple[AbstractContextManager, AbstractContextManager]]:
+    """Reuse checkpoint-forward HybridEP layouts during backward recomputation.
+
+    HybridEP can produce a different receive-token extent when it rebuilds a
+    layout during activation-checkpoint recompute, even when the saved router
+    top-k is identical. Reusing the forward handle keeps the layout stable while
+    still redispatching the recomputed activations, so activation memory remains
+    checkpointed.
+    """
+    from nemo_automodel.components.moe.megatron.fused_a2a import (
+        HybridEPDispatchReplayRecorder,
+        hybridep_dispatch_replay_scope,
+    )
+
+    def checkpoint_context_fn() -> tuple[AbstractContextManager, AbstractContextManager]:
+        forward_context, recompute_context = context_fn()
+        recorder = HybridEPDispatchReplayRecorder()
+
+        @contextmanager
+        def scoped(mode: str, inner: AbstractContextManager):
+            if mode == "replay":
+                recorder.rewind()
+            with hybridep_dispatch_replay_scope(recorder, mode), inner:
+                yield
+
+        return scoped("record", forward_context), scoped("replay", recompute_context)
+
+    return checkpoint_context_fn
+
+
+def _uses_hybridep_dispatch(model: nn.Module) -> bool:
+    """Return whether any expert module uses the HybridEP dispatcher."""
+    modules = getattr(model, "modules", None)
+    if not callable(modules):
+        return False
+    return any(
+        isinstance(module, (GroupedExpertsDeepEP, GroupedExpertsTE))
+        and getattr(module, "dispatcher_backend", None) == "hybridep"
+        for module in modules()
+    )
+
+
 def apply_ac(
     model: nn.Module,
     ignore_router: bool = True,
@@ -479,8 +523,8 @@ def apply_ac(
             first, then falls back to model.config attributes.
         selective: If True, applies TorchTitan-style per-op selective activation checkpointing
             (shared with the dense FSDP2 path) to each block. Takes precedence over
-            ``ignore_router``; the shared policy already saves expert-parallel communication
-            collectives and ``topk``, so it composes with expert parallelism.
+            ``ignore_router``; the shared policy saves ``topk``, and HybridEP reuses the
+            checkpoint-forward dispatch layout while redispatching recomputed activations.
         activation_checkpointing_scope: Which layer groups to checkpoint -- the same field
             and semantics as the generic FSDP2/DDP path. ``"all"`` (the default) checkpoints
             the text/MoE decoder blocks plus the trainable vision tower; ``"language"`` the
@@ -501,6 +545,7 @@ def apply_ac(
 
     scopes = normalize_activation_checkpointing_scope(activation_checkpointing_scope)
     checkpoint_decoder = "all" in scopes or "language" in scopes
+    uses_hybridep_dispatch = checkpoint_decoder and _uses_hybridep_dispatch(model)
     repeated_mtp_moe_block_ids = _repeated_mtp_moe_block_ids(model) if checkpoint_decoder else set()
     if repeated_mtp_moe_block_ids:
         logger.info(
@@ -532,6 +577,8 @@ def apply_ac(
                 transformer_engine_attention_backend_snapshot_context_fn,
                 selective_context_fn,
             )
+            if uses_hybridep_dispatch:
+                attention_context_fn = _replay_hybridep_dispatch_on_recompute(attention_context_fn)
             for parent_layers, layer_id, block in iter_transformer_and_mtp_blocks(model):
                 if id(block) in repeated_mtp_moe_block_ids:
                     continue
@@ -631,14 +678,17 @@ def apply_ac(
             logger.info("Skipping activation checkpointing for model-owned eager block %s", layer_id)
             continue
         if ignore_router:
+            block_context_fn = _preserve_gate_load_during_recompute(
+                block,
+                _with_attention_backend_snapshot(selective_checkpointing_context_fn),
+            )
+            if uses_hybridep_dispatch:
+                block_context_fn = _replay_hybridep_dispatch_on_recompute(block_context_fn)
             block = ptd_checkpoint_wrapper(
                 block,
                 preserve_rng_state=True,
                 determinism_check=_register_moe_checkpoint_determinism_check(),
-                context_fn=_preserve_gate_load_during_recompute(
-                    block,
-                    _with_attention_backend_snapshot(selective_checkpointing_context_fn),
-                ),
+                context_fn=block_context_fn,
             )
         else:
             block = ptd_checkpoint_wrapper(

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -483,8 +483,14 @@ def _replay_hybridep_dispatch_on_recompute(
         def scoped(mode: str, inner: AbstractContextManager):
             if mode == "replay":
                 recorder.rewind()
-            with hybridep_dispatch_replay_scope(recorder, mode), inner:
-                yield
+            with hybridep_dispatch_replay_scope(recorder, mode):
+                with inner:
+                    yield
+                if mode == "record":
+                    # Cache the dispatch extents only after the selective-op
+                    # context exits. Recompute can then reuse them without an
+                    # extra aten.sum that would diverge from the forward trace.
+                    recorder.finalize()
 
         return scoped("record", forward_context), scoped("replay", recompute_context)
 

--- a/tests/unit_tests/moe/test_fused_a2a.py
+++ b/tests/unit_tests/moe/test_fused_a2a.py
@@ -78,10 +78,16 @@ class _DriftingHybridEPBuffer:
         self.full_dispatches = 0
         self.cached_dispatches = 0
         self.input_shape = None
+        self.replayed_num_permuted_tokens = None
 
     def dispatch_with_permute(self, *, hidden, routing_map=None, probs=None, handle=None, **kwargs):
         if handle is not None:
             self.cached_dispatches += 1
+            self.replayed_num_permuted_tokens = kwargs["num_permuted_tokens"]
+            # Model the scalar conversion performed by HybridEP when its
+            # sync-free token extent is accidentally passed as a tensor.
+            if isinstance(self.replayed_num_permuted_tokens, torch.Tensor):
+                int(self.replayed_num_permuted_tokens.item())
             dispatched_hidden = torch.cat((hidden, hidden[:1]), dim=0)
             dispatched_probs = torch.cat((probs[:, :1], probs[:1, :1]), dim=0)
             return dispatched_hidden, dispatched_probs, None, None, None
@@ -153,19 +159,25 @@ def test_hybridep_checkpoint_reuses_forward_layout_on_recompute():
     assert buffer.cached_dispatches == 1
 
 
-def test_hybridep_checkpoint_replay_does_not_add_sum_to_selective_recompute():
+def test_hybridep_checkpoint_replay_preserves_selective_op_trace():
     from nemo_automodel.components.moe.parallelizer import _replay_hybridep_dispatch_on_recompute
 
     buffer = _DriftingHybridEPBuffer()
     fused_a2a._hybrid_ep_buffer = buffer
     aten_sum = torch.ops.aten.sum.default
+    aten_local_scalar_dense = torch.ops.aten._local_scalar_dense.default
 
-    def save_sums_policy(ctx, func, *args, **kwargs):
-        return CheckpointPolicy.MUST_SAVE if func == aten_sum else CheckpointPolicy.PREFER_RECOMPUTE
+    def save_replay_sensitive_ops(ctx, func, *args, **kwargs):
+        replay_sensitive_ops = (aten_sum, aten_local_scalar_dense)
+        return CheckpointPolicy.MUST_SAVE if func in replay_sensitive_ops else CheckpointPolicy.PREFER_RECOMPUTE
 
-    context_fn = _replay_hybridep_dispatch_on_recompute(lambda: create_selective_checkpoint_contexts(save_sums_policy))
+    context_fn = _replay_hybridep_dispatch_on_recompute(
+        lambda: create_selective_checkpoint_contexts(save_replay_sensitive_ops)
+    )
 
     _run_checkpointed_hybridep(context_fn)
 
     assert buffer.full_dispatches == 1
     assert buffer.cached_dispatches == 1
+    assert buffer.replayed_num_permuted_tokens == 5
+    assert isinstance(buffer.replayed_num_permuted_tokens, int)

--- a/tests/unit_tests/moe/test_fused_a2a.py
+++ b/tests/unit_tests/moe/test_fused_a2a.py
@@ -19,7 +19,7 @@ from unittest import mock
 
 import pytest
 import torch
-from torch.utils.checkpoint import CheckpointError, checkpoint
+from torch.utils.checkpoint import CheckpointError, CheckpointPolicy, checkpoint, create_selective_checkpoint_contexts
 
 import nemo_automodel.components.moe.megatron.fused_a2a as fused_a2a
 
@@ -146,6 +146,24 @@ def test_hybridep_checkpoint_reuses_forward_layout_on_recompute():
     buffer = _DriftingHybridEPBuffer()
     fused_a2a._hybrid_ep_buffer = buffer
     context_fn = _replay_hybridep_dispatch_on_recompute(lambda: (nullcontext(), nullcontext()))
+
+    _run_checkpointed_hybridep(context_fn)
+
+    assert buffer.full_dispatches == 1
+    assert buffer.cached_dispatches == 1
+
+
+def test_hybridep_checkpoint_replay_does_not_add_sum_to_selective_recompute():
+    from nemo_automodel.components.moe.parallelizer import _replay_hybridep_dispatch_on_recompute
+
+    buffer = _DriftingHybridEPBuffer()
+    fused_a2a._hybrid_ep_buffer = buffer
+    aten_sum = torch.ops.aten.sum.default
+
+    def save_sums_policy(ctx, func, *args, **kwargs):
+        return CheckpointPolicy.MUST_SAVE if func == aten_sum else CheckpointPolicy.PREFER_RECOMPUTE
+
+    context_fn = _replay_hybridep_dispatch_on_recompute(lambda: create_selective_checkpoint_contexts(save_sums_policy))
 
     _run_checkpointed_hybridep(context_fn)
 

--- a/tests/unit_tests/moe/test_fused_a2a.py
+++ b/tests/unit_tests/moe/test_fused_a2a.py
@@ -12,23 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for DeepEP buffer teardown (``fused_a2a.free_buffer``)."""
+"""Unit tests for fused DeepEP and HybridEP dispatch helpers."""
 
+from contextlib import nullcontext
 from unittest import mock
 
 import pytest
+import torch
+from torch.utils.checkpoint import CheckpointError, checkpoint
 
 import nemo_automodel.components.moe.megatron.fused_a2a as fused_a2a
 
 
 @pytest.fixture(autouse=True)
 def _restore_buffer():
-    """Save/restore the module-global ``_buffer`` so tests don't leak state."""
+    """Save/restore module-global dispatch state so tests don't leak state."""
     saved = fused_a2a._buffer
+    saved_hybridep = fused_a2a._hybrid_ep_buffer
+    saved_recorder = fused_a2a._hybridep_dispatch_replay_state.recorder
+    saved_mode = fused_a2a._hybridep_dispatch_replay_state.mode
     try:
         yield
     finally:
         fused_a2a._buffer = saved
+        fused_a2a._hybrid_ep_buffer = saved_hybridep
+        fused_a2a._hybridep_dispatch_replay_state.recorder = saved_recorder
+        fused_a2a._hybridep_dispatch_replay_state.mode = saved_mode
 
 
 def test_free_buffer_destroys_and_clears():
@@ -60,3 +69,85 @@ def test_free_buffer_swallows_destroy_errors():
 
     boom.destroy.assert_called_once_with()
     assert fused_a2a._buffer is None
+
+
+class _DriftingHybridEPBuffer:
+    """Fake a full-layout replay that returns a different receive-token count."""
+
+    def __init__(self):
+        self.full_dispatches = 0
+        self.cached_dispatches = 0
+        self.input_shape = None
+
+    def dispatch_with_permute(self, *, hidden, routing_map=None, probs=None, handle=None, **kwargs):
+        if handle is not None:
+            self.cached_dispatches += 1
+            dispatched_hidden = torch.cat((hidden, hidden[:1]), dim=0)
+            dispatched_probs = torch.cat((probs[:, :1], probs[:1, :1]), dim=0)
+            return dispatched_hidden, dispatched_probs, None, None, None
+
+        self.full_dispatches += 1
+        self.input_shape = hidden.shape
+        # The first call models checkpoint forward. A second full-layout call
+        # models HybridEP's nondeterministic recompute and deliberately drifts.
+        if self.full_dispatches == 1:
+            dispatched_hidden = torch.cat((hidden, hidden[:1]), dim=0)
+            dispatched_probs = torch.cat((probs[:, :1], probs[:1, :1]), dim=0)
+            tokens_per_expert = torch.tensor([2, 3])
+        else:
+            dispatched_hidden = hidden[:-1]
+            dispatched_probs = probs[:-1, :1]
+            tokens_per_expert = torch.tensor([1, 2])
+        return dispatched_hidden, dispatched_probs, None, tokens_per_expert, "forward-layout"
+
+    def combine_with_unpermute(self, *, hidden, probs=None, **kwargs):
+        combined_hidden = hidden[: self.input_shape[0]]
+        combined_probs = None if probs is None else torch.zeros(self.input_shape[0], 2, dtype=probs.dtype)
+        return combined_hidden, combined_probs
+
+
+def _run_checkpointed_hybridep(context_fn):
+    x = torch.randn(4, 3, requires_grad=True)
+    routing_map = torch.ones(4, 2, dtype=torch.bool)
+    probs = torch.full((4, 2), 0.5, requires_grad=True)
+
+    def block(hidden, token_probs):
+        dispatched_hidden, dispatched_probs, _, _, _ = fused_a2a.HybridEPDispatch.apply(
+            hidden,
+            routing_map,
+            token_probs,
+            object(),
+            1,
+            24,
+            24,
+            None,
+            None,
+        )
+        return dispatched_hidden.sin().sum() + dispatched_probs.square().sum()
+
+    loss = checkpoint(block, x, probs, use_reentrant=False, context_fn=context_fn)
+    loss.backward()
+
+
+def test_hybridep_checkpoint_without_layout_replay_detects_shape_drift():
+    buffer = _DriftingHybridEPBuffer()
+    fused_a2a._hybrid_ep_buffer = buffer
+
+    with pytest.raises(CheckpointError, match="different metadata"):
+        _run_checkpointed_hybridep(lambda: (nullcontext(), nullcontext()))
+
+    assert buffer.full_dispatches == 2
+    assert buffer.cached_dispatches == 0
+
+
+def test_hybridep_checkpoint_reuses_forward_layout_on_recompute():
+    from nemo_automodel.components.moe.parallelizer import _replay_hybridep_dispatch_on_recompute
+
+    buffer = _DriftingHybridEPBuffer()
+    fused_a2a._hybrid_ep_buffer = buffer
+    context_fn = _replay_hybridep_dispatch_on_recompute(lambda: (nullcontext(), nullcontext()))
+
+    _run_checkpointed_hybridep(context_fn)
+
+    assert buffer.full_dispatches == 1
+    assert buffer.cached_dispatches == 1

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -748,6 +748,38 @@ def test_apply_ac_warns_when_router_is_recomputed(monkeypatch):
     logger_mock.warning.assert_not_called()
 
 
+@pytest.mark.parametrize("selective", [False, True])
+def test_apply_ac_replays_hybridep_layout_for_full_and_selective_ac(monkeypatch, selective):
+    P = _import_parallelizer_with_stubs(monkeypatch)
+    expert = P.GroupedExpertsDeepEP()
+    expert.dispatcher_backend = "hybridep"
+
+    class HybridEPModel(DummyModel):
+        def modules(self):
+            return iter((self, expert))
+
+    if selective:
+        activation_checkpointing_stub = sys.modules["nemo_automodel.components.distributed.activation_checkpointing"]
+        activation_checkpointing_stub.make_selective_checkpoint_context_fn = lambda: (
+            lambda: (nullcontext(), nullcontext())
+        )
+        activation_checkpointing_stub.SELECTIVE_AC_WRAPPER_FLAG = "_nemo_selective_ac"
+
+    replay_wrapper = MagicMock(side_effect=lambda context_fn: context_fn)
+    monkeypatch.setattr(P, "_replay_hybridep_dispatch_on_recompute", replay_wrapper)
+    monkeypatch.setattr(P, "ptd_checkpoint_wrapper", MagicMock(side_effect=lambda block, **kwargs: block))
+
+    P.apply_ac(
+        HybridEPModel([DummyBlock()]),
+        ignore_router=True,
+        hidden_size=7168,
+        num_experts=384,
+        selective=selective,
+    )
+
+    replay_wrapper.assert_called_once()
+
+
 def test_apply_ac_uses_generic_wrapper_even_when_block_local_checkpointing_is_available(monkeypatch):
     P = _import_parallelizer_with_stubs(monkeypatch)
 


### PR DESCRIPTION
## Why

Activation checkpointing runs each checkpointed MoE block twice: once in the training forward, then again during backward recomputation. AutoModel already saves the router projection and top-k selection, so both executions choose the same experts. That is necessary, but it is not sufficient for HybridEP.

HybridEP independently rebuilds its distributed receive/permute layout on the second execution. At scale, that rebuild is not reproducible even with bit-identical routing. An 8xH100 reproduction recorded identical top-k checksums on every rank and all 30 MoE layers, while HybridEP returned 2,791 local token rows in forward and 2,701 in recompute. The Kimi K3 32-node Expert LoRA run hit the same failure with per-rank mismatches such as 925 vs 952 and 841 vs 821.

Those row counts must match. The expert GEMM output and dispatched router probabilities are paired one row per routed token. When HybridEP changes the receive layout during recompute, ordinary Expert LoRA exposes it immediately in the weighted SwiGLU multiply; other expert implementations usually surface it later as `torch.utils.checkpoint.CheckpointError` because saved and recomputed tensor metadata differ.

This remains a main-branch bug: the 8-GPU reproduction already included the later HybridEP token-count equalization fix, and `HybridEPDispatch` has not changed between that baseline and current main.

Selective AC does not avoid the problem. HybridEP dispatch is wrapped in a custom `autograd.Function`, so selective checkpoint policies do not observe the inner `torch.ops.hybridep.dispatch` call; the apparent HybridEP save-list entry is therefore inert. Disabling AC avoids recompute but is not a viable memory configuration for K3, and switching away from HybridEP gives up the required large-scale dispatcher path.

## What changes

- record each checkpoint-forward HybridEP dispatch handle and output extent
- reuse that exact layout during activation-checkpoint recompute while redispatching the recomputed activations and router probabilities
- apply the replay contract to both full and selective activation checkpointing
- add a deterministic regression that reproduces the receive-token shape drift and verifies backward succeeds with replay

HybridEP already supports cached-handle dispatch; its existing dispatch backward path uses the same API. The recorder retains layout metadata, not dispatched hidden states, so activation checkpointing keeps its activation-memory savings.

This turns the HybridEP limitation described in #3684 into a correctness fix rather than requiring users to disable AC or switch dispatchers.

## Validation

- `ruff check` on changed files
- `ruff format --check` on changed files
- `pytest -q tests/unit_tests/moe/test_fused_a2a.py tests/unit_tests/moe/test_parallelizer.py`: 99 passed
- regression control without replay deterministically raises `CheckpointError` on a simulated 5-row forward / 3-row recompute
- replay path performs one full dispatch plus one cached dispatch and completes backward

GB200 4-layer K3 Expert LoRA full-AC validation passed 4/4 steps on commit `5b3738554` with HybridEP, `torch_mm`, EP4, ordinary expert LoRA, and reshard-after-forward (train loss 13.2424 -> 12.9688; validation loss 12.8113; peak memory 101.7 GiB/GPU). The first 32-node replay run exposed an extra recompute-only `aten.sum` in the cached-layout path before step 0; commit `d2f3a6382` moves extent caching outside the selective-op context and adds a regression for the exact operator-trace mismatch. The updated 32-node/100-step nightly validation is [NeMo-CI pipeline 65232165](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/65232165).