### PR TITLE
feat(glm): add GLM-5.3 cuDNN training support

### DIFF
--- a/examples/llm_finetune/glm/glm_5.3_tulu3_4k_cudnn_100step.yaml
+++ b/examples/llm_finetune/glm/glm_5.3_tulu3_4k_cudnn_100step.yaml
@@ -43,7 +43,7 @@ distributed:
     layers_per_stage: 2
 
   moe:
-    reshard_after_forward: false
+    reshard_after_forward: true
     wrap_outer_model: false
     ignore_router_for_ac: true
 

--- a/examples/llm_finetune/glm/glm_5.3_tulu3_4k_cudnn_100step.yaml
+++ b/examples/llm_finetune/glm/glm_5.3_tulu3_4k_cudnn_100step.yaml
@@ -1,0 +1,125 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+seed: 1234
+
+step_scheduler:
+  global_batch_size: 256
+  local_batch_size: 4
+  ckpt_every_steps: 100000
+  val_every_steps: 100000
+  gc_every_steps: 10
+  num_epochs: 2
+  max_steps: 100
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 4
+  ep_size: 64
+  sequence_parallel: false
+  activation_checkpointing: true
+
+  pipeline:
+    pp_schedule: interleaved1f1b
+    pp_microbatch_size: 1
+    round_virtual_stages_to_pp_multiple: down
+    scale_grads_in_schedule: false
+    patch_inner_model: false
+    patch_causal_lm_model: false
+    layers_per_stage: 2
+
+  moe:
+    reshard_after_forward: false
+    wrap_outer_model: false
+    ignore_router_for_ac: true
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: zai-org/GLM-5.3
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: cudnn
+    linear: torch
+    rms_norm: torch_fp32
+    rope_fusion: false
+    dispatcher: hybridep
+    gate_precision: float32
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: false
+  dequantize_base_checkpoint: true
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.chat_dataset.ChatDataset
+  path_or_dataset_id: allenai/tulu-3-sft-mixture
+  split: train[:100000]
+  shuffle_seed: 42
+  truncation: true
+  seq_length: 4096
+  padding: false
+  tokenizer:
+    _target_: transformers.AutoTokenizer.from_pretrained
+    pretrained_model_name_or_path: zai-org/GLM-5.3
+
+packed_sequence:
+  packed_sequence_size: 4096
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.packed_sequence_thd_collater
+  shuffle: true
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas:
+  - 0.9
+  - 0.999
+  eps: 1e-8
+  lr: 1e-5
+  weight_decay: 0
+
+wandb:
+  enable: false
+  project: huiyingl_workspace
+  entity: Nemo-automodel
+  name: glm53_tulu3_4k_cudnn_100step
+  group: glm53-dsa-tulu3-4k-cudnn
+  tags: [glm53, dsa, tulu3, 4k, cp1, cudnn, 100step]
+  mode: online
+  resume: never
+
+ci:
+  # pp4 with ep64 requires 256 ranks.
+  recipe_owner: huiyingl
+  nodes: 32
+  time: "02:00:00"
+  max_steps: 100
+  env_vars:
+    # GLM-5.3 is new and may not be present in the shared NeMo-CI Hugging Face cache yet.
+    HF_HUB_OFFLINE: "0"
+    FINETUNE_ARGS: "--wandb.enable=true"
+    REQUIRE_FINITE_METRICS: "true"

--- a/nemo_automodel/components/models/glm_moe_dsa/state_dict_adapter.py
+++ b/nemo_automodel/components/models/glm_moe_dsa/state_dict_adapter.py
@@ -25,6 +25,17 @@ from nemo_automodel.components.models.deepseek_v3.state_dict_adapter import (
     dequantize_from_fp8,
 )
 from nemo_automodel.components.models.glm4_moe.state_dict_adapter import Glm4MoeStateDictAdapter
+from nemo_automodel.components.moe.state_dict_utils import is_dtensor
+
+try:
+    import triton
+    import triton.language as tl
+
+    _GLM_TRITON_AVAILABLE = True
+except Exception:
+    triton = None
+    tl = None
+    _GLM_TRITON_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +56,304 @@ def should_quantize_key(key: str) -> bool:
     if not key.endswith(".weight") or ".lora_" in key:
         return False
     return not any(pattern in key for pattern in NON_QUANTIZED_KEY_PATTERNS)
+
+
+if _GLM_TRITON_AVAILABLE:
+
+    @triton.jit
+    def _glm_weight_dequant_offset_kernel(
+        x_ptr,
+        s_ptr,
+        y_ptr,
+        M,
+        N,
+        row_offset,
+        col_offset,
+        stride_xm,
+        stride_xn,
+        stride_ym,
+        stride_yn,
+        stride_sm,
+        stride_sn,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """Dequantize a local GLM shard whose origin is inside a global FP8 block."""
+        pid_m = tl.program_id(axis=0)
+        pid_n = tl.program_id(axis=1)
+        offs_m = pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        offs_n = pid_n * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+        x = tl.load(x_ptr + offs_m[:, None] * stride_xm + offs_n[None, :] * stride_xn, mask=mask).to(tl.float32)
+        scale_m = (offs_m + row_offset) // BLOCK_SIZE
+        scale_n = (offs_n + col_offset) // BLOCK_SIZE
+        s = tl.load(
+            s_ptr + scale_m[:, None] * stride_sm + scale_n[None, :] * stride_sn,
+            mask=mask,
+            other=0.0,
+        )
+        y = x * s
+        tl.store(y_ptr + offs_m[:, None] * stride_ym + offs_n[None, :] * stride_yn, y, mask=mask)
+
+
+def _glm_dtensor_local_offsets(
+    weight_dtensor: torch.Tensor,
+    weight_local: torch.Tensor,
+    scale_inv: torch.Tensor,
+    block_size: int,
+) -> tuple[int, int]:
+    """Return the exact global row/column origin of a GLM DTensor shard.
+
+    Args:
+        weight_dtensor: Global two-dimensional DTensor checkpoint destination.
+        weight_local: Rank-local weight shard with shape ``[rows, cols]``.
+        scale_inv: Full global blockwise scale grid. Used only by the fallback
+            placement calculation when checkpoint chunk metadata is unavailable.
+        block_size: Height and width of each square FP8 quantization block.
+
+    Returns:
+        Absolute element offset ``(row, col)`` of the local shard in the global weight.
+    """
+    create_chunks = getattr(weight_dtensor, "__create_chunk_list__", None)
+    if callable(create_chunks):
+        try:
+            chunks = create_chunks()
+            if isinstance(chunks, (list, tuple)) and len(chunks) == 1:
+                offsets = tuple(int(value) for value in chunks[0].offsets)
+                sizes = tuple(int(value) for value in chunks[0].sizes)
+                if sizes != tuple(weight_local.shape):
+                    raise RuntimeError(
+                        f"DTensor checkpoint metadata reports local shape {sizes}, "
+                        f"but to_local() returned {tuple(weight_local.shape)}"
+                    )
+                if len(offsets) != 2:
+                    raise ValueError(f"GLM blockwise FP8 dequantization requires a matrix, got offsets {offsets}")
+                return offsets[0], offsets[1]
+        except (AttributeError, TypeError):
+            # Lightweight unit-test doubles may not expose checkpoint metadata.
+            pass
+
+    from torch.distributed._tensor import Shard
+
+    offsets = [0, 0]
+    global_shape = getattr(weight_dtensor, "shape", None)
+    has_global_shape = isinstance(global_shape, (torch.Size, tuple, list)) and len(global_shape) == 2
+    for mesh_dim, placement in enumerate(weight_dtensor.placements):
+        if not isinstance(placement, Shard):
+            continue
+        shard_dim = placement.dim
+        mesh_dim_size = weight_dtensor.device_mesh.size(mesh_dim)
+        mesh_coord = weight_dtensor.device_mesh.get_local_rank(mesh_dim=mesh_dim)
+        global_size = int(global_shape[shard_dim]) if has_global_shape else int(scale_inv.shape[shard_dim]) * block_size
+        _, shard_offset = placement._local_shard_size_and_offset(global_size, mesh_dim_size, mesh_coord)
+        offsets[shard_dim] = int(shard_offset)
+    return offsets[0], offsets[1]
+
+
+def _slice_glm_scale_for_dtensor(
+    scale_inv: torch.Tensor,
+    weight_dtensor: torch.Tensor,
+    weight_local: torch.Tensor,
+    block_size: int = BLOCK_SIZE,
+) -> torch.Tensor:
+    """Slice the global GLM scale grid for one rank-local weight shard.
+
+    Args:
+        scale_inv: Full global scale grid with shape ``[global_block_rows, global_block_cols]``.
+        weight_dtensor: Global two-dimensional DTensor checkpoint destination.
+        weight_local: Rank-local FP8 weight shard with shape ``[rows, cols]``.
+        block_size: Height and width of each square FP8 quantization block.
+
+    Returns:
+        Contiguous scale grid covering every global block intersected by the local shard.
+    """
+    offsets = _glm_dtensor_local_offsets(weight_dtensor, weight_local, scale_inv, block_size)
+    scale_slices = []
+    for dim, offset in enumerate(offsets):
+        start_block = offset // block_size
+        end_block = (offset + weight_local.shape[dim] + block_size - 1) // block_size
+        scale_slices.append(slice(start_block, min(end_block, scale_inv.shape[dim])))
+    return scale_inv[scale_slices[0], scale_slices[1]].contiguous()
+
+
+def _dequantize_glm_with_torch_offsets(
+    weight: torch.Tensor,
+    scale_inv: torch.Tensor,
+    dtype: torch.dtype,
+    block_size: int,
+    offsets_within_first_block: tuple[int, int],
+) -> torch.Tensor:
+    """Dequantize a GLM local shard while preserving the global FP8 block grid.
+
+    Args:
+        weight: Local FP8 weight shard with shape ``[rows, cols]``.
+        scale_inv: Sliced scale grid with shape ``[block_rows, block_cols]``, where
+            each dimension covers the local shard plus its offset into the first block.
+        dtype: Output floating-point dtype.
+        block_size: Height and width of each square FP8 quantization block.
+        offsets_within_first_block: Element offset ``(row, col)`` of the shard origin
+            within its first global block. Each value is in ``[0, block_size)``.
+
+    Returns:
+        Dequantized local tensor with the same shape as ``weight``.
+    """
+    row_offset, col_offset = offsets_within_first_block
+    row_scale_ids = torch.div(
+        torch.arange(weight.shape[0], device=weight.device) + row_offset,
+        block_size,
+        rounding_mode="floor",
+    )
+    col_scale_ids = torch.div(
+        torch.arange(weight.shape[1], device=weight.device) + col_offset,
+        block_size,
+        rounding_mode="floor",
+    )
+    element_scales = scale_inv.index_select(0, row_scale_ids).index_select(1, col_scale_ids)
+    return (weight.float() * element_scales.float()).to(dtype=dtype)
+
+
+def _dequantize_glm_with_triton_offsets(
+    weight: torch.Tensor,
+    scale_inv: torch.Tensor,
+    dtype: torch.dtype,
+    block_size: int,
+    offsets_within_first_block: tuple[int, int],
+) -> torch.Tensor:
+    """Run offset-aware GLM FP8 dequantization with Triton.
+
+    Args:
+        weight: Local CUDA FP8 weight shard with shape ``[rows, cols]``.
+        scale_inv: Sliced CUDA scale grid covering the shard's intersecting global blocks.
+        dtype: Output floating-point dtype.
+        block_size: Height and width of each square FP8 quantization block.
+        offsets_within_first_block: Element offset ``(row, col)`` of the shard origin
+            within its first global block. Each value is in ``[0, block_size)``.
+
+    Returns:
+        Dequantized local CUDA tensor with the same shape as ``weight``.
+    """
+    if not _GLM_TRITON_AVAILABLE:
+        raise RuntimeError("Triton is not available for GLM FP8 dequantization.")
+
+    m, n = weight.shape
+    output = torch.empty((m, n), device=weight.device, dtype=dtype)
+    grid = (triton.cdiv(m, block_size), triton.cdiv(n, block_size))
+    _glm_weight_dequant_offset_kernel[grid](
+        weight,
+        scale_inv,
+        output,
+        m,
+        n,
+        offsets_within_first_block[0],
+        offsets_within_first_block[1],
+        weight.stride(0),
+        weight.stride(1),
+        output.stride(0),
+        output.stride(1),
+        scale_inv.stride(0),
+        scale_inv.stride(1),
+        BLOCK_SIZE=block_size,
+    )
+    return output
+
+
+def _dequantize_glm_fp8(
+    weight: torch.Tensor,
+    scale_inv: torch.Tensor,
+    dtype: torch.dtype = torch.bfloat16,
+    block_size: int = BLOCK_SIZE,
+    name: str = "",
+) -> torch.Tensor:
+    """Dequantize GLM FP8 weights without changing other model adapters.
+
+    Args:
+        weight: FP8 matrix or DTensor matrix. A DTensor uses its global shape while
+            ``to_local()`` supplies the rank-local ``[rows, cols]`` shard.
+        scale_inv: Matching blockwise scales. For a DTensor weight this is the full
+            global scale grid loaded from the Hugging Face checkpoint.
+        dtype: Output floating-point dtype.
+        block_size: Height and width of each square FP8 quantization block.
+        name: Checkpoint tensor name used in diagnostics.
+
+    Returns:
+        Dequantized tensor preserving the input DTensor mesh and placements when present.
+    """
+    weight_is_dtensor = is_dtensor(weight)
+    scale_is_dtensor = is_dtensor(scale_inv)
+    if not weight_is_dtensor or scale_is_dtensor:
+        return dequantize_from_fp8(weight, scale_inv, dtype=dtype, BLOCK_SIZE=block_size, name=name)
+
+    weight_local = weight.to_local()
+    global_offsets = _glm_dtensor_local_offsets(weight, weight_local, scale_inv, block_size)
+    offsets_within_first_block = (
+        global_offsets[0] % block_size,
+        global_offsets[1] % block_size,
+    )
+    scale_local = _slice_glm_scale_for_dtensor(scale_inv, weight, weight_local, block_size)
+    expected_scale_shape = torch.Size(
+        (
+            (offsets_within_first_block[0] + weight_local.shape[0] + block_size - 1) // block_size,
+            (offsets_within_first_block[1] + weight_local.shape[1] + block_size - 1) // block_size,
+        )
+    )
+    if scale_local.shape != expected_scale_shape:
+        raise RuntimeError(
+            f"{name} scale_inv shape {tuple(scale_local.shape)} does not cover DTensor local weight "
+            f"shape {tuple(weight_local.shape)} at global block offset {offsets_within_first_block}; "
+            f"expected {tuple(expected_scale_shape)}"
+        )
+
+    scale_local = scale_local.to(device=weight_local.device)
+    if not weight_local.is_contiguous():
+        weight_local = weight_local.contiguous()
+    if not scale_local.is_contiguous():
+        scale_local = scale_local.contiguous()
+
+    if offsets_within_first_block == (0, 0):
+        dequantized_local = dequantize_from_fp8(
+            weight_local,
+            scale_local,
+            dtype=dtype,
+            BLOCK_SIZE=block_size,
+            name=name,
+        )
+    else:
+        use_triton = (
+            _GLM_TRITON_AVAILABLE
+            and weight_local.is_cuda
+            and scale_local.is_cuda
+            and weight_local.dim() == 2
+            and scale_local.dim() == 2
+        )
+        if use_triton:
+            try:
+                dequantized_local = _dequantize_glm_with_triton_offsets(
+                    weight_local,
+                    scale_local,
+                    dtype,
+                    block_size,
+                    offsets_within_first_block,
+                )
+            except Exception as exc:
+                logger.warning("GLM Triton dequant failed for %s (%s). Falling back to torch.", name, exc)
+                dequantized_local = _dequantize_glm_with_torch_offsets(
+                    weight_local,
+                    scale_local,
+                    dtype,
+                    block_size,
+                    offsets_within_first_block,
+                )
+        else:
+            dequantized_local = _dequantize_glm_with_torch_offsets(
+                weight_local,
+                scale_local,
+                dtype,
+                block_size,
+                offsets_within_first_block,
+            )
+
+    from torch.distributed._tensor import DTensor
+
+    return DTensor.from_local(dequantized_local, weight.device_mesh, weight.placements)
 
 
 class GlmMoeDsaStateDictAdapter(Glm4MoeStateDictAdapter):
@@ -81,7 +390,7 @@ class GlmMoeDsaStateDictAdapter(Glm4MoeStateDictAdapter):
         for key, weight in state_dict.items():
             scale_key = key + "_scale_inv"
             if key.endswith(".weight") and scale_key in state_dict:
-                state_dict[key] = dequantize_from_fp8(
+                state_dict[key] = _dequantize_glm_fp8(
                     weight,
                     state_dict[scale_key],
                     dtype=self.dtype,

--- a/nemo_automodel/components/models/glm_moe_dsa/state_dict_adapter.py
+++ b/nemo_automodel/components/models/glm_moe_dsa/state_dict_adapter.py
@@ -12,12 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import re
-from typing import Any
+from typing import Any, Optional
 
 import torch
+from torch.distributed.device_mesh import DeviceMesh
 
+from nemo_automodel.components.models.deepseek_v3.state_dict_adapter import (
+    BLOCK_SIZE,
+    create_scale_inv_for_weight,
+    dequantize_from_fp8,
+)
 from nemo_automodel.components.models.glm4_moe.state_dict_adapter import Glm4MoeStateDictAdapter
+
+logger = logging.getLogger(__name__)
+
+# GLM-5.3 keeps these tensors in BF16 while storing the remaining matrix
+# weights as 128x128 blockwise FP8 with ``weight_scale_inv`` siblings.
+NON_QUANTIZED_KEY_PATTERNS = [
+    "norm.weight",
+    "lm_head.weight",
+    "embed_tokens.weight",
+    "mlp.gate.weight",
+    "eh_proj.weight",
+    "indexer.weights_proj.weight",
+]
+
+
+def should_quantize_key(key: str) -> bool:
+    """Return whether ``key`` has a blockwise-FP8 scale in GLM checkpoints."""
+    if not key.endswith(".weight") or ".lora_" in key:
+        return False
+    return not any(pattern in key for pattern in NON_QUANTIZED_KEY_PATTERNS)
 
 
 class GlmMoeDsaStateDictAdapter(Glm4MoeStateDictAdapter):
@@ -35,11 +62,60 @@ class GlmMoeDsaStateDictAdapter(Glm4MoeStateDictAdapter):
         "indexer.weights_proj.weight",
     ]
 
+    def _uses_blockwise_fp8_checkpoint(self) -> bool:
+        quantization_config = getattr(self.config, "quantization_config", None)
+        if isinstance(quantization_config, dict):
+            quant_method = quantization_config.get("quant_method")
+            weight_block_size = quantization_config.get("weight_block_size")
+        else:
+            quant_method = getattr(quantization_config, "quant_method", None)
+            weight_block_size = getattr(quantization_config, "weight_block_size", None)
+
+        if quant_method != "fp8" or not isinstance(weight_block_size, (list, tuple)):
+            return False
+        return tuple(weight_block_size) == (BLOCK_SIZE, BLOCK_SIZE)
+
+    def _dequantize(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        scale_inv_keys = []
+        dequantized_count = 0
+        for key, weight in state_dict.items():
+            scale_key = key + "_scale_inv"
+            if key.endswith(".weight") and scale_key in state_dict:
+                state_dict[key] = dequantize_from_fp8(
+                    weight,
+                    state_dict[scale_key],
+                    dtype=self.dtype,
+                    name=key,
+                )
+                scale_inv_keys.append(scale_key)
+                dequantized_count += 1
+
+        for key in scale_inv_keys:
+            state_dict.pop(key)
+
+        logger.debug(
+            "[GLM FP8 Dequant] Dequantized %d weights and removed %d scale tensors",
+            dequantized_count,
+            len(scale_inv_keys),
+        )
+        return state_dict
+
+    def from_hf(
+        self,
+        hf_state_dict: dict[str, Any],
+        device_mesh: Optional["DeviceMesh"] = None,
+        **kwargs,
+    ) -> dict[str, Any]:
+        """Dequantize blockwise FP8 tensors before merging per-expert weights."""
+        hf_state_dict = self._dequantize(hf_state_dict)
+        return super().from_hf(hf_state_dict, device_mesh=device_mesh, **kwargs)
+
     def convert_single_tensor_to_hf(self, fqn: str, tensor: Any, **kwargs) -> list[tuple[str, Any]]:
-        quantization = kwargs.get("quantization", False)
+        quantization = kwargs.get("quantization", False) and self._uses_blockwise_fp8_checkpoint()
         exclude_key_regex = kwargs.get("exclude_key_regex", None)
 
-        expert_result = self._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, **kwargs)
+        expert_kwargs = {**kwargs, "quantization": quantization} if "quantization" in kwargs else kwargs
+        expert_result = self._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, **expert_kwargs)
         if expert_result is not None:
             result = expert_result
         else:
@@ -51,11 +127,12 @@ class GlmMoeDsaStateDictAdapter(Glm4MoeStateDictAdapter):
         if quantization:
             quantized_result = []
             for key, value in result:
-                if key.endswith(".weight") and not any(
-                    non_quantized_key in key for non_quantized_key in self._indexer_non_quantized_keys
-                ):
+                if should_quantize_key(key):
                     value = value.to(dtype=torch.float8_e4m3fn)
                     quantized_result.append((key, value))
+                    quantized_result.append(
+                        (key + "_scale_inv", create_scale_inv_for_weight(value, block_size=BLOCK_SIZE))
+                    )
                 else:
                     quantized_result.append((key, value))
             return quantized_result

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_state_dict_adapter.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_state_dict_adapter.py
@@ -31,7 +31,10 @@ except ImportError:
 
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.glm4_moe.state_dict_adapter import Glm4MoeStateDictAdapter
-from nemo_automodel.components.models.glm_moe_dsa.state_dict_adapter import GlmMoeDsaStateDictAdapter
+from nemo_automodel.components.models.glm_moe_dsa.state_dict_adapter import (
+    GlmMoeDsaStateDictAdapter,
+    should_quantize_key,
+)
 from nemo_automodel.components.moe.config import MoEConfig
 
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -45,6 +48,10 @@ def config():
     cfg.intermediate_size = 128
     cfg.num_attention_heads = 4
     cfg.num_experts = 4
+    cfg.quantization_config = {
+        "quant_method": "fp8",
+        "weight_block_size": [128, 128],
+    }
     return cfg
 
 
@@ -189,9 +196,11 @@ class TestConvertSingleTensorToHfQuantization:
         with patch.object(adapter, "_convert_single_merged_expert_to_hf_split_experts", return_value=None):
             result = adapter.convert_single_tensor_to_hf(fqn, tensor, quantization=True)
 
-            assert len(result) == 1
+            assert len(result) == 2
             assert result[0][0] == fqn
             assert result[0][1].dtype == torch.float8_e4m3fn
+            assert result[1][0] == fqn + "_scale_inv"
+            assert result[1][1].shape == (1, 1)
 
     def test_quantization_skips_non_weight_keys(self, adapter):
         tensor = torch.randn(64)
@@ -244,9 +253,44 @@ class TestConvertSingleTensorToHfQuantization:
         with patch.object(adapter, "_convert_single_merged_expert_to_hf_split_experts", return_value=None):
             result = adapter.convert_single_tensor_to_hf(fqn, tensor, quantization=True)
 
-            assert len(result) == 1
+            assert len(result) == 2
             assert result[0][0] == fqn
             assert result[0][1].dtype == torch.float8_e4m3fn
+            assert result[1][0] == fqn + "_scale_inv"
+
+    @pytest.mark.parametrize(
+        "fqn",
+        [
+            "model.embed_tokens.weight",
+            "model.layers.0.input_layernorm.weight",
+            "model.layers.0.self_attn.q_a_layernorm.weight",
+            "model.layers.0.mlp.gate.weight",
+            "model.layers.78.eh_proj.weight",
+            "model.layers.78.enorm.weight",
+            "lm_head.weight",
+        ],
+    )
+    def test_quantization_skips_unscaled_glm53_weights(self, adapter, fqn):
+        tensor = torch.randn(64, 64)
+
+        with patch.object(adapter, "_convert_single_merged_expert_to_hf_split_experts", return_value=None):
+            result = adapter.convert_single_tensor_to_hf(fqn, tensor, quantization=True)
+
+        assert len(result) == 1
+        assert result[0][0] == fqn
+        assert result[0][1] is tensor
+
+    def test_quantization_is_not_enabled_for_bf16_checkpoint(self, adapter):
+        adapter.config.quantization_config = None
+        tensor = torch.randn(64, 64)
+        fqn = "model.layers.0.self_attn.q_a_proj.weight"
+
+        with patch.object(adapter, "_convert_single_merged_expert_to_hf_split_experts", return_value=None):
+            result = adapter.convert_single_tensor_to_hf(fqn, tensor, quantization=True)
+
+        assert len(result) == 1
+        assert result[0][0] == fqn
+        assert result[0][1] is tensor
 
     def test_without_quantization_preserves_dtype(self, adapter):
         tensor = torch.randn(64, 64)
@@ -269,3 +313,40 @@ class TestConvertSingleTensorToHfQuantization:
             )
 
             assert len(result) == 0
+
+
+class TestGlm53Fp8Dequantization:
+    @pytest.mark.parametrize(
+        ("key", "expected"),
+        [
+            ("model.layers.0.self_attn.q_a_proj.weight", True),
+            ("model.layers.10.mlp.experts.3.down_proj.weight", True),
+            ("model.layers.0.self_attn.indexer.wq_b.weight", True),
+            ("model.layers.0.input_layernorm.weight", False),
+            ("model.layers.0.self_attn.indexer.k_norm.weight", False),
+            ("model.layers.0.self_attn.indexer.weights_proj.weight", False),
+            ("model.layers.10.mlp.gate.weight", False),
+            ("model.layers.78.eh_proj.weight", False),
+            ("model.layers.78.enorm.weight", False),
+            ("model.embed_tokens.weight", False),
+            ("lm_head.weight", False),
+        ],
+    )
+    def test_should_quantize_key_matches_glm53_checkpoint(self, key, expected):
+        assert should_quantize_key(key) is expected
+
+    def test_dequantize_applies_scale_and_removes_scale_tensor(self, adapter):
+        weight = torch.full((128, 128), 2.0).to(torch.float8_e4m3fn)
+        scale_inv = torch.full((1, 1), 0.25)
+        state_dict = {
+            "model.layers.0.self_attn.q_a_proj.weight": weight,
+            "model.layers.0.self_attn.q_a_proj.weight_scale_inv": scale_inv,
+            "model.layers.0.input_layernorm.weight": torch.ones(128),
+        }
+
+        result = adapter._dequantize(state_dict)
+
+        assert result["model.layers.0.self_attn.q_a_proj.weight"].dtype == torch.float32
+        assert torch.all(result["model.layers.0.self_attn.q_a_proj.weight"] == 0.5)
+        assert "model.layers.0.self_attn.q_a_proj.weight_scale_inv" not in result
+        assert "model.layers.0.input_layernorm.weight" in result

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_state_dict_adapter.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_state_dict_adapter.py
@@ -32,7 +32,12 @@ except ImportError:
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.glm4_moe.state_dict_adapter import Glm4MoeStateDictAdapter
 from nemo_automodel.components.models.glm_moe_dsa.state_dict_adapter import (
+    _GLM_TRITON_AVAILABLE,
     GlmMoeDsaStateDictAdapter,
+    _dequantize_glm_fp8,
+    _dequantize_glm_with_torch_offsets,
+    _dequantize_glm_with_triton_offsets,
+    _slice_glm_scale_for_dtensor,
     should_quantize_key,
 )
 from nemo_automodel.components.moe.config import MoEConfig
@@ -350,3 +355,72 @@ class TestGlm53Fp8Dequantization:
         assert torch.all(result["model.layers.0.self_attn.q_a_proj.weight"] == 0.5)
         assert "model.layers.0.self_attn.q_a_proj.weight_scale_inv" not in result
         assert "model.layers.0.input_layernorm.weight" in result
+
+    def test_unaligned_shard_slices_scales_from_checkpoint_metadata(self):
+        """A 72-row shard starting at row 72 spans two global 128-row blocks."""
+        from torch.distributed.checkpoint.metadata import ChunkStorageMetadata
+
+        class FakeDTensor:
+            def __create_chunk_list__(self):
+                return [ChunkStorageMetadata(offsets=torch.Size((72, 0)), sizes=torch.Size((72, 128)))]
+
+        scale_inv = torch.tensor([[1.0], [2.0], [3.0], [4.0], [5.0]])
+        weight_local = torch.ones((72, 128), dtype=torch.float8_e4m3fn)
+
+        result = _slice_glm_scale_for_dtensor(scale_inv, FakeDTensor(), weight_local)
+
+        torch.testing.assert_close(result, scale_inv[:2])
+
+    def test_torch_dequant_preserves_global_block_boundaries(self):
+        """Rows 72..143 use 56 values from block 0 and 16 from block 1."""
+        weight = torch.ones((72, 128), dtype=torch.float8_e4m3fn)
+        scale_inv = torch.tensor([[2.0], [4.0]], dtype=torch.float32)
+
+        result = _dequantize_glm_with_torch_offsets(
+            weight,
+            scale_inv,
+            torch.float32,
+            128,
+            offsets_within_first_block=(72, 0),
+        )
+
+        assert torch.all(result[:56] == 2.0)
+        assert torch.all(result[56:] == 4.0)
+
+    def test_full_dtensor_path_uses_global_block_offsets(self):
+        local_weight = torch.ones((72, 128), dtype=torch.float8_e4m3fn)
+        global_scale = torch.tensor([[2.0], [4.0], [6.0], [8.0], [10.0]])
+        mock_weight = Mock()
+        mock_weight.to_local.return_value = local_weight
+        mock_weight.device_mesh = Mock()
+        mock_weight.placements = [Mock()]
+
+        with (
+            patch(
+                "nemo_automodel.components.models.glm_moe_dsa.state_dict_adapter.is_dtensor",
+                side_effect=lambda value: value is mock_weight,
+            ),
+            patch(
+                "nemo_automodel.components.models.glm_moe_dsa.state_dict_adapter._glm_dtensor_local_offsets",
+                return_value=(72, 0),
+            ),
+            patch(
+                "torch.distributed._tensor.DTensor.from_local",
+                side_effect=lambda local, *_args: local,
+            ),
+        ):
+            result = _dequantize_glm_fp8(mock_weight, global_scale, dtype=torch.float32)
+
+        assert torch.all(result[:56] == 2.0)
+        assert torch.all(result[56:] == 4.0)
+
+    @pytest.mark.skipif(not _GLM_TRITON_AVAILABLE, reason="Triton is required")
+    def test_triton_offset_dequant_matches_torch(self):
+        weight = torch.ones((72, 128), dtype=torch.float8_e4m3fn, device="cuda")
+        scale_inv = torch.tensor([[2.0], [4.0]], dtype=torch.float32, device="cuda")
+        offsets = (72, 0)
+
+        expected = _dequantize_glm_with_torch_offsets(weight, scale_inv, torch.float32, 128, offsets)
+        actual = _dequantize_glm_with_triton_offsets(weight, scale_inv, torch.float32, 128, offsets)
+
+        torch.testing.assert_close(actual, expected)


### PR DESCRIPTION
# What does this PR do ?

Add a 100-step GLM-5.3 full-parameter training recipe for the cuDNN DSA and HybridEP path, and load the released GLM-5.3 128x128 blockwise-FP8 checkpoint correctly under DTensor expert/FSDP sharding.

# Changelog

- Add a GLM-5.3 Tulu3 4K recipe using cuDNN attention, HybridEP, PP4, EP64, activation checkpointing, and 32 nodes / 256 GPUs.
- Dequantize GLM-5.3 FP8 weights before merging per-expert tensors, while preserving the BF16 tensors that do not have scale siblings.
- Add a GLM-local offset-aware Torch/Triton path that derives exact DTensor shard origins from checkpoint metadata and applies the correct FP8 blocks when a shard starts inside a 128x128 block.
- Keep the shared DeepSeek-V3 state-dict adapter unchanged so this GLM feature does not alter checkpoint behavior for other model families.
- Add GLM checkpoint-key, dequantization, scale-removal, unaligned-shard, Triton parity, and BF16 GLM-5.2 compatibility tests.

# Validation

- GLM state-dict adapter GPU tests, Slurm job `16883290`: **40 passed**.
- Real released-checkpoint offset probe, Slurm job `16883927`: a `288x6144` local shard at global row offset 288 (offset 32 within its first FP8 block) matched the global reference exactly: **exact fraction 1.0, max abs 0, relative L2 0**.
- `ruff check`, `ruff format --check`, and `git diff --check`: **passed**.
- Single-node 8-GPU, 4-layer end-to-end smoke completed forward, backward, activation checkpointing, HybridEP/cuDNN execution, and optimizer steps.
- First four layers compared against Hugging Face: logits relative L2 **0.639%**, top-1 agreement **96.61%**; representative distributed checkpoint weights were bit-exact.
- Full 32-node / 256-GPU run, Slurm job `16878255`: **100/100 steps completed**, exit code 0.
  - step 0 loss: **1.33347**
  - step 99 loss: **0.53756**
  - steps 10-99 mean loss: **0.55548**
  - steps 10-99 mean throughput: **41,664 tokens/s**
  - no non-finite metrics, FP8 scale-shape warnings, or critical rank errors
  - [Weights & Biases run](https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/glm53-tulu3-4k-cudnn-100s-3b421de0da32-16878255)

<img width="608" height="285" alt="image" src="https://github.com/user-attachments/assets/58b1ea6f-57f0-419a-b5bc-bf2e381f11ff" />

The distributed checkpoint/topology validation used deterministic prepacked Tulu3 4K tokens to compare against the established GLM-5.2 baseline. The checked-in recipe retains the public raw `ChatDataset` preprocessing path and enables W&B in NeMo-CI through `FINETUNE_ARGS`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

The GLM-5.3 model architecture is unchanged from GLM-5.2; the checkpoint storage format is the relevant difference addressed here. The official GLM-5.2 checkpoint has no blockwise-FP8 configuration or scale tensors and remains on its BF16 path.
