### PR TITLE
fix(checkpoint): preserve class-based mappings through model wrappers

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -1254,7 +1254,11 @@ class Checkpointer:
             assert model_name is not None, "model_name is required when loading base model"
             # Get combined key mapping from model attribute and model-type specific conversions
             model_key_mapping = getattr(model, "_checkpoint_conversion_mapping", None)
-            key_mapping = get_combined_key_mapping(model_type, model_key_mapping)
+            key_mapping = get_combined_key_mapping(
+                model_type,
+                model_key_mapping,
+                model=model,
+            )
             # NemotronH remote code (trust_remote_code) uses backbone.* params matching checkpoint keys
             # skip backbone.*→model.* conversion to avoid key mismatch
             if model_type == "nemotron_h" and hasattr(model, "backbone"):

--- a/nemo_automodel/components/checkpoint/conversion_mapping.py
+++ b/nemo_automodel/components/checkpoint/conversion_mapping.py
@@ -186,6 +186,8 @@ _VLM_KEY_MAPPINGS: dict[str, dict[str, str]] = {
 def get_combined_key_mapping(
     model_type: str,
     model_key_mapping: dict[str, str] | None = None,
+    *,
+    model: "nn.Module | None" = None,
 ) -> dict[str, str] | None:
     """
     Get combined key mapping for simple regex-based key renaming.
@@ -201,6 +203,11 @@ def get_combined_key_mapping(
         model_type: The model type string from config.model_type
         model_key_mapping: Optional key mapping from the model's
                           `_checkpoint_conversion_mapping` attribute
+        model: Optional runtime model. Its class hierarchy is checked before
+               falling back to ``model_type`` because some Transformers
+               conversions are specific to a task-head class. Checking the
+               hierarchy keeps those mappings visible through wrappers such
+               as FSDP2's dynamically created subclasses.
 
     Returns:
         Combined key mapping dictionary (regex pattern -> replacement),
@@ -221,7 +228,14 @@ def get_combined_key_mapping(
 
     # Try to get conversion mapping from transformers and extract simple renamings
     if _TRANSFORMERS_AVAILABLE:
-        conversions = get_checkpoint_conversion_mapping(model_type)
+        conversions = None
+        model_class_names = [model_class.__name__ for model_class in type(model).__mro__] if model is not None else []
+        for model_identifier in (*model_class_names, model_type):
+            if model_identifier is None:
+                continue
+            conversions = get_checkpoint_conversion_mapping(model_identifier)
+            if conversions is not None:
+                break
         if conversions:
             for conv in conversions:
                 # Only extract simple WeightRenaming, not WeightConverter

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -2177,6 +2177,53 @@ class TestInitializeModelWeights:
         sig = inspect.signature(Checkpointer.load_base_model)
         assert "peft_init_method" not in sig.parameters
 
+    def test_load_base_model_applies_class_registered_qwen_vl_mapping(self, tmp_path):
+        """Old Qwen-VL checkpoint keys populate both nested in-memory towers."""
+        import torch.nn as nn
+
+        class Qwen2_5_VLForConditionalGeneration(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = SimpleNamespace(model_type="qwen2_5_vl", tie_word_embeddings=False)
+                self.model = nn.Module()
+                self.model.visual = nn.Module()
+                self.model.visual.proj = nn.Linear(2, 2, bias=False)
+                self.model.language_model = nn.Module()
+                self.model.language_model.proj = nn.Linear(2, 2, bias=False)
+
+        model = Qwen2_5_VLForConditionalGeneration()
+        model.model.visual.proj.weight.data.zero_()
+        model.model.language_model.proj.weight.data.zero_()
+
+        vision_weight = torch.arange(4, dtype=torch.float32).view(2, 2)
+        language_weight = torch.arange(4, 8, dtype=torch.float32).view(2, 2)
+        save_file(
+            {
+                "visual.proj.weight": vision_weight,
+                "model.proj.weight": language_weight,
+            },
+            tmp_path / "model.safetensors",
+        )
+
+        checkpointer = Checkpointer.__new__(Checkpointer)
+        checkpointer.config = SimpleNamespace(
+            is_peft=False,
+            cpu_offload=False,
+            dequantize_base_checkpoint=False,
+            skip_task_head_prefixes_for_base_model=None,
+        )
+        checkpointer.moe_mesh = None
+
+        checkpointer.load_base_model(
+            model,
+            torch.device("cpu"),
+            root_dir=str(tmp_path),
+            model_name=str(tmp_path),
+        )
+
+        torch.testing.assert_close(model.model.visual.proj.weight, vision_weight)
+        torch.testing.assert_close(model.model.language_model.proj.weight, language_weight)
+
 
 class TestLmHeadWeightTying:
     """Tests that load_base_model calls tie_weights for tied models."""

--- a/tests/unit_tests/checkpoint/test_conversion_mapping.py
+++ b/tests/unit_tests/checkpoint/test_conversion_mapping.py
@@ -14,6 +14,8 @@
 
 """Tests for ``nemo_automodel.components.checkpoint.conversion_mapping``."""
 
+import pytest
+
 from nemo_automodel.components.checkpoint._backports.hf_storage import _get_key_renaming_mapping
 from nemo_automodel.components.checkpoint.conversion_mapping import get_combined_key_mapping
 
@@ -49,3 +51,30 @@ def test_gemma3_strips_legacy_vision_model_prefix():
         _get_key_renaming_mapping("multi_modal_projector.mm_input_projection_weight", mapping)
         == "model.multi_modal_projector.mm_input_projection_weight"
     )
+
+
+@pytest.mark.parametrize(
+    ("model_type", "model_class_name"),
+    [
+        ("qwen2_5_vl", "Qwen2_5_VLForConditionalGeneration"),
+        ("qwen2_vl", "Qwen2VLForConditionalGeneration"),
+    ],
+)
+def test_qwen_vl_uses_class_registered_checkpoint_mapping(model_type, model_class_name):
+    """Qwen-VL class mappings remain visible through a runtime wrapper."""
+    model_class = type(model_class_name, (), {})
+    wrapped_model_class = type(f"FSDP{model_class_name}", (model_class,), {})
+    mapping = get_combined_key_mapping(model_type, model=wrapped_model_class())
+    assert mapping is not None
+
+    assert (
+        _get_key_renaming_mapping("visual.patch_embed.proj.weight", mapping) == "model.visual.patch_embed.proj.weight"
+    )
+    assert (
+        _get_key_renaming_mapping("model.layers.0.self_attn.q_proj.weight", mapping)
+        == "model.language_model.layers.0.self_attn.q_proj.weight"
+    )
+
+    # In-memory-format keys must not be nested under model.language_model twice.
+    in_memory_key = "model.language_model.layers.0.self_attn.q_proj.weight"
+    assert _get_key_renaming_mapping(in_memory_key, mapping) == in_memory_key


### PR DESCRIPTION
## Summary

Fix checkpoint key mapping for models whose Transformers conversion mappings are registered by model class rather than by `config.model_type`.

This primarily fixes Qwen2-VL and Qwen2.5-VL checkpoint loading, while addressing the underlying wrapper-related lookup issue for other class-registered models as well.

## Problem

AutoModel's DCP-based Hugging Face checkpoint path uses `get_combined_key_mapping()` to build a flat regex mapping before reading safetensors metadata.

Previously, this function queried Transformers only with:

```python
get_checkpoint_conversion_mapping(model_type)
```

However, Transformers registers some conversion mappings by model class name. For example:

- `Qwen2VLForConditionalGeneration`
- `Qwen2_5_VLForConditionalGeneration` through the Qwen2-VL class mapping alias

There is no corresponding direct mapping registered under `qwen2_vl` or `qwen2_5_vl`.

As a result, AutoModel did not apply the required Qwen-VL renames:

```text
visual.*  -> model.visual.*
model.*   -> model.language_model.*
```

This becomes more subtle after FSDP2 parallelization because the runtime model may be represented by a dynamically created subclass. Looking up only `type(model).__name__` would find the wrapper class rather than the original Hugging Face model class.

## Transformers upstream behavior

Transformers introduced fine-grained class-based conversion mappings in [PR #45661](https://github.com/huggingface/transformers/pull/45661), merged as [commit `f397b9e`](https://github.com/huggingface/transformers/commit/f397b9e651dc7387de6bce551895619dfb1ec4f0).

The upstream lookup explicitly checks the concrete model class before falling back to `config.model_type`:

```python
class_name = type(model).__name__
model_type = model.config.model_type

conversions = get_checkpoint_conversion_mapping(class_name)
if conversions is None and model_type:
    conversions = get_checkpoint_conversion_mapping(model_type)
```

That upstream change also moved model-specific mappings such as Qwen-VL to class-based registrations so that different model heads sharing the same `model_type` can use different checkpoint conversions.

AutoModel already consumes Transformers' conversion registry, but its simplified DCP loading path bypassed this model-aware lookup and queried only the low-level `model_type` mapping.

## Root cause

The full Transformers conversion pipeline returns scoped `WeightRenaming` and `WeightConverter` objects and applies them while loading model weights.

AutoModel cannot directly use that pipeline in its standard DCP path because DCP metadata planning requires a flat `{regex: replacement}` mapping before reading tensors. AutoModel therefore extracts simple renaming rules from the Transformers registry.

During that extraction, AutoModel previously looked up only `config.model_type`. This diverged from the class-first behavior introduced by Transformers PR #45661 and made class-registered mappings invisible.

Calling the upstream helper with the wrapped model is not sufficient either: FSDP2 may create a dynamic subclass whose runtime class name is not registered in Transformers.

## Solution

- Pass the runtime model into `get_combined_key_mapping()`.
- Search the runtime class hierarchy in order, allowing transparent wrappers to resolve mappings registered for their underlying Hugging Face model class.
- Fall back to `config.model_type` when no class mapping is registered.
- Continue sourcing the actual conversion rules from Transformers rather than adding Qwen-specific mappings to AutoModel.
- Preserve the existing precedence of AutoModel model-specific and VLM mappings.
- Keep the new `model` argument optional so existing callers retain the previous behavior.

The resulting lookup order is:

```text
runtime wrapper class
    -> underlying model classes in MRO order
    -> config.model_type
```

## Why this is not Qwen-specific

Transformers also registers mappings by class for models such as:

- `LlavaModel`
- `ViTModel`
- `CLIPVisionModel`
- `Qwen2AudioModel`
- `DetrModel`

Any of these mappings can become invisible when a transparent framework wrapper changes the runtime class name.

Resolving the underlying class fixes the general wrapper compatibility issue without maintaining a separate model allowlist or duplicating Transformers conversion rules in AutoModel.

## Testing

Added coverage for:

- Qwen2.5-VL class-registered mappings.
- Qwen2-VL class-registered mappings.
- Dynamically created wrapper subclasses.
- Vision and language tower key renaming.
- Avoiding repeated `model.language_model` prefixes.
- End-to-end loading from a safetensors checkpoint into the expected in-memory model parameters.

Validation:

```text
Before fix: 2 failed, 1 passed
After fix:  4 passed
```

The following checks also pass:

```text
ruff check:        passed
ruff format check: passed
```
