### PR TITLE
perf(qwen3.5-vl): avoid dynamic multimodal splice sync

### DIFF
--- a/nemo_automodel/components/models/qwen3_5/model.py
+++ b/nemo_automodel/components/models/qwen3_5/model.py
@@ -108,6 +108,32 @@ def _qwen3_5_backend(backend: BackendConfig | None = None) -> BackendConfig:
     return resolved
 
 
+def _splice_multimodal_features(
+    inputs_embeds: torch.Tensor,
+    input_ids: torch.Tensor,
+    features: torch.Tensor,
+    token_id: int,
+    modality: str,
+) -> torch.Tensor:
+    """Replace multimodal placeholder rows without dynamic-size indexing.
+
+    ``masked_scatter`` implements its source gradient through ``masked_select``.
+    On CUDA that dynamic-size selection synchronizes the stream before allocating
+    its result. The feature row count is already known, so use fixed-size
+    ``nonzero_static`` indices and ``index_copy`` instead. Its backward is the
+    asynchronous ``index_fill``/``index_select`` pair.
+    """
+    token_mask = input_ids.eq(token_id).reshape(-1)
+    num_features = features.shape[0]
+    torch._assert_async(
+        token_mask.sum().eq(num_features),
+        f"{modality} features and placeholder tokens do not match",
+    )
+    token_indices = torch.nonzero_static(token_mask, size=num_features).squeeze(-1)
+    flat_embeds = inputs_embeds.reshape(-1, inputs_embeds.shape[-1])
+    return flat_embeds.index_copy(0, token_indices, features).view_as(inputs_embeds)
+
+
 def build_mtp_config_from_hf(
     config: Any,
     *,
@@ -615,6 +641,60 @@ class Qwen3_5Model(HFQwen3_5Model):
             media_tensor = pixel_values if pixel_values is not None else pixel_values_videos
             if isinstance(media_tensor, torch.Tensor) and hasattr(self.visual, "rotary_pos_emb"):
                 self.visual.rotary_pos_emb.to(media_tensor.device)
+
+            # With token IDs available, keep the HF vision/position path but
+            # replace its dynamic masked-scatter backward with fixed-size indices.
+            # The inputs-embeds-only generation path retains the upstream fallback.
+            if input_ids_for_super is not None:
+                if inputs_embeds_for_super is None:
+                    inputs_embeds_for_super = embed_tokens(input_ids_for_super)
+                if pixel_values is not None:
+                    image_outputs = self.get_image_features(pixel_values, image_grid_thw, return_dict=True)
+                    image_embeds = torch.cat(image_outputs.pooler_output, dim=0).to(
+                        inputs_embeds_for_super.device, inputs_embeds_for_super.dtype
+                    )
+                    inputs_embeds_for_super = _splice_multimodal_features(
+                        inputs_embeds_for_super,
+                        input_ids_for_super,
+                        image_embeds,
+                        self.config.image_token_id,
+                        "Image",
+                    )
+                if pixel_values_videos is not None:
+                    video_outputs = self.get_video_features(pixel_values_videos, video_grid_thw, return_dict=True)
+                    video_embeds = torch.cat(video_outputs.pooler_output, dim=0).to(
+                        inputs_embeds_for_super.device, inputs_embeds_for_super.dtype
+                    )
+                    inputs_embeds_for_super = _splice_multimodal_features(
+                        inputs_embeds_for_super,
+                        input_ids_for_super,
+                        video_embeds,
+                        self.config.video_token_id,
+                        "Video",
+                    )
+                if position_ids is None:
+                    position_ids = self.compute_3d_position_ids(
+                        input_ids=input_ids_for_super,
+                        inputs_embeds=inputs_embeds_for_super,
+                        image_grid_thw=image_grid_thw,
+                        video_grid_thw=video_grid_thw,
+                        attention_mask=attention_mask,
+                        past_key_values=past_key_values,
+                        mm_token_type_ids=kwargs.get("mm_token_type_ids"),
+                    )
+                return super().forward(
+                    input_ids=None,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    past_key_values=past_key_values,
+                    inputs_embeds=inputs_embeds_for_super,
+                    pixel_values=None,
+                    pixel_values_videos=None,
+                    image_grid_thw=image_grid_thw,
+                    video_grid_thw=video_grid_thw,
+                    cache_position=cache_position,
+                    **kwargs,
+                )
             return super().forward(
                 input_ids=input_ids_for_super,
                 attention_mask=attention_mask,
@@ -1201,12 +1281,13 @@ class Qwen3_5ForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5ForConditio
                     image_grid_thw,
                     is_video=False,
                 ).to(inputs_embeds.device, inputs_embeds.dtype)
-                image_mask, _ = self.model.get_placeholder_mask(
+                inputs_embeds = _splice_multimodal_features(
+                    inputs_embeds,
                     input_ids,
-                    inputs_embeds=inputs_embeds,
-                    image_features=image_embeds,
+                    image_embeds,
+                    self.config.image_token_id,
+                    "Image",
                 )
-                inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
 
             if pixel_values_videos is not None:
                 if hasattr(self.model.visual, "rotary_pos_emb"):
@@ -1216,12 +1297,13 @@ class Qwen3_5ForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5ForConditio
                     video_grid_thw,
                     is_video=True,
                 ).to(inputs_embeds.device, inputs_embeds.dtype)
-                _, video_mask = self.model.get_placeholder_mask(
+                inputs_embeds = _splice_multimodal_features(
+                    inputs_embeds,
                     input_ids,
-                    inputs_embeds=inputs_embeds,
-                    video_features=video_embeds,
+                    video_embeds,
+                    self.config.video_token_id,
+                    "Video",
                 )
-                inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
 
         return inputs_embeds
 

--- a/tests/unit_tests/models/qwen3_5/test_qwen3_5_cp_preembed.py
+++ b/tests/unit_tests/models/qwen3_5/test_qwen3_5_cp_preembed.py
@@ -28,6 +28,7 @@ from nemo_automodel.components.models.qwen3_5.model import (
     HFQwen3_5Model,
     Qwen3_5ForConditionalGeneration,
     Qwen3_5Model,
+    _splice_multimodal_features,
 )
 
 
@@ -209,6 +210,51 @@ class TestPopStagedVlmMedia:
 class TestEmbedAndSpliceForCP:
     """The in-forward embed + vision splice (moved out of the CP hook)."""
 
+    def test_static_splice_matches_masked_scatter_forward_and_gradients(self):
+        input_ids = torch.tensor([[7, 99, 8, 99]])
+        inputs_embeds = torch.randn(1, 4, 3, requires_grad=True)
+        features = torch.randn(2, 3, requires_grad=True)
+        grad_output = torch.randn_like(inputs_embeds)
+
+        actual = _splice_multimodal_features(inputs_embeds, input_ids, features, 99, "Image")
+        actual.backward(grad_output, retain_graph=True)
+        actual_input_grad = inputs_embeds.grad.detach().clone()
+        actual_feature_grad = features.grad.detach().clone()
+
+        inputs_embeds.grad = None
+        features.grad = None
+        mask = input_ids.eq(99).unsqueeze(-1).expand_as(inputs_embeds)
+        expected = inputs_embeds.masked_scatter(mask, features)
+        expected.backward(grad_output)
+
+        torch.testing.assert_close(actual, expected)
+        torch.testing.assert_close(actual_input_grad, inputs_embeds.grad)
+        torch.testing.assert_close(actual_feature_grad, features.grad)
+
+    def test_static_splice_backward_has_no_dynamic_selection(self):
+        input_ids = torch.tensor([[7, 99, 8, 99]])
+        inputs_embeds = torch.randn(1, 4, 3, requires_grad=True)
+        features = torch.randn(2, 3, requires_grad=True)
+
+        with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU]) as profiler:
+            _splice_multimodal_features(inputs_embeds, input_ids, features, 99, "Image").sum().backward()
+
+        operator_names = {event.key for event in profiler.key_averages()}
+        assert "aten::nonzero_static" in operator_names
+        assert "aten::nonzero" not in operator_names
+        assert "aten::masked_select" not in operator_names
+
+    def test_static_splice_rejects_placeholder_feature_mismatch(self):
+        input_ids = torch.tensor([[7, 99, 8, 99]])
+        with pytest.raises(RuntimeError, match="Image features and placeholder tokens do not match"):
+            _splice_multimodal_features(
+                torch.randn(1, 4, 3),
+                input_ids,
+                torch.randn(1, 3),
+                99,
+                "Image",
+            )
+
     def test_image_features_scattered_into_embeds(self):
         """pixel_values path: image features replace image-token embeddings via masked_scatter."""
         model = _build_model(image_token_id=99)
@@ -303,13 +349,20 @@ class TestQwen3_5ModelForward:
         model = Qwen3_5Model.__new__(Qwen3_5Model)
         nn.Module.__init__(model)
         model.visual = types.SimpleNamespace(rotary_pos_emb=types.SimpleNamespace(to=lambda device: None))
-        model.get_input_embeddings = lambda: lambda input_ids: pytest.fail("media forward should keep input_ids")
+        model.config = types.SimpleNamespace(image_token_id=99, video_token_id=98)
+        model.get_input_embeddings = lambda: (
+            lambda input_ids: input_ids.unsqueeze(-1).expand(*input_ids.shape, 4).float()
+        )
         return model
 
-    def test_media_forward_keeps_input_ids_for_hf_placeholder_mask(self, monkeypatch):
+    def test_media_forward_splices_with_static_indices_before_hf_forward(self, monkeypatch):
         model = self._build_inner_model()
         captured = {}
         sentinel = object()
+        image_features = torch.full((1, 4), 8.0)
+        position_ids = torch.arange(3).view(1, 3)
+        model.get_image_features = lambda *args, **kwargs: types.SimpleNamespace(pooler_output=[image_features])
+        model.compute_3d_position_ids = lambda **kwargs: position_ids
 
         def _fake_hf_forward(self, **kwargs):
             captured.update(kwargs)
@@ -326,9 +379,11 @@ class TestQwen3_5ModelForward:
         )
 
         assert out is sentinel
-        assert captured["input_ids"] is input_ids
-        assert captured["inputs_embeds"] is None
-        assert captured["pixel_values"] is pixel_values
+        assert captured["input_ids"] is None
+        assert captured["pixel_values"] is None
+        assert captured["position_ids"] is position_ids
+        torch.testing.assert_close(captured["inputs_embeds"][0, 0], torch.full((4,), 5.0))
+        torch.testing.assert_close(captured["inputs_embeds"][0, 1], image_features[0])
 
     def test_media_forward_accepts_hidden_states_as_input_ids(self, monkeypatch):
         model = self._build_inner_model()


### PR DESCRIPTION
## Stack

- Depends on #3750, which in turn depends on #3740.
- Contains only the Qwen3.5-VL multimodal embedding-splice optimization and its tests.

## Motivation

The image/video embedding splice used `masked_scatter`. Its source gradient is implemented through `masked_select -> nonzero`; because the selected output has a dynamic size, CUDA must synchronize the stream before allocating it.

In the four-GB200 neat-packing trace, twelve backward `nonzero` calls accounted for 2.101 seconds, or 88.2%, of AutoModel's `cudaStreamSynchronize` time across three profiled optimizer steps.

## Change

The number of image/video feature rows is already known from the encoded feature tensor. Use that fixed size to:

- validate the placeholder count asynchronously;
- find placeholder rows with `torch.nonzero_static`;
- replace rows with `index_copy`.

The backward becomes an asynchronous `index_fill`/`index_select` pair. The helper is shared by the ordinary data-parallel media path and the context-parallel pre-embedding path. The inputs-embeds-only generation fallback remains on the upstream Hugging Face path.

## Correctness

- Forward values match the previous `masked_scatter` implementation.
- Gradients for both token embeddings and multimodal features match the previous implementation.
- Placeholder/feature count mismatches still fail.
- A profiler-backed test asserts `nonzero_static` is present and dynamic `nonzero`/`masked_select` are absent.
- 85 targeted Qwen3.5 tests passed.

## Four-GB200 profile

Exact full-stack profiler head: `fc2c9fce070bb78946d0867f2970e70a6d0e5945`.
The benchmark predates the history split. The current stack has identical
executable source; the only subsequent content change is #3740's validation
Markdown.

- Successful job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/417438959
- `masked_scatter` / backward / `masked_select`: 12 / 12 / 12 -> 0 / 0 / 0
- `cudaStreamSynchronize`: 1,083 calls / 2.382 s -> 1,047 calls / 0.272 s
- Mean CPU step: 15.006 s -> 14.397 s versus the immediately prior AutoModel trace (-4.06%)
- NCCL AG / RS / AR: unchanged at 1,335 / 171 / 18
- Collective dtype and payload: unchanged

The three-step timing is short and the cross-stack Accelerate control came from another allocation. The trace-level removal of the targeted synchronization is the primary evidence; the timing delta should not be treated as a statistically stable throughput claim.
