### PR TITLE
perf(magi): avoid TE padding for magi

### DIFF
--- a/examples/llm_finetune/qwen/qwen3_moe_2layer_magi_packed_cp8_32k.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_2layer_magi_packed_cp8_32k.yaml
@@ -1,0 +1,132 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Single-node gate for long-context Qwen3-MoE Magi CP benchmarking. The model
+# keeps Qwen3-30B-A3B's production attention, router, expert, and vocabulary
+# dimensions, but uses two transformer layers so CP8 forward/backward/optimizer
+# tests finish quickly. DeepEP, TE experts, THD packing, and activation
+# checkpointing stay enabled. Compare the identical recipe with:
+#
+#   automodel <this-file> --nproc-per-node 8 --model.backend.attn=te
+#
+# Sweep 64K with --packed_sequence.packed_sequence_size=65536 and
+# --model.config.max_position_embeddings=65536 after the 32K gate passes.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 1
+  local_batch_size: 1
+  max_steps: 5
+  num_epochs: 1
+  ckpt_every_steps: 1000
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 20
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1234
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_config
+  config:
+    _target_: transformers.models.qwen3_moe.configuration_qwen3_moe.Qwen3MoeConfig
+    architectures: [Qwen3MoeForCausalLM]
+    vocab_size: 151936
+    hidden_size: 2048
+    intermediate_size: 6144
+    moe_intermediate_size: 768
+    num_hidden_layers: 2
+    num_attention_heads: 32
+    num_key_value_heads: 4
+    head_dim: 128
+    max_position_embeddings: 32768
+    hidden_act: silu
+    rms_norm_eps: 1.0e-6
+    rope_theta: 1000000.0
+    num_experts: 128
+    num_experts_per_tok: 8
+    decoder_sparse_step: 1
+    mlp_only_layers: []
+    router_aux_loss_coef: 0.001
+    norm_topk_prob: true
+    initializer_range: 0.02
+    bos_token_id: 151643
+    eos_token_id: 151645
+    pad_token_id: 151643
+    use_cache: false
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: magi
+    linear: te
+    rms_norm: torch_fp32
+    experts: te
+    dispatcher: deepep
+    rope_fusion: false
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: false
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: /tmp/qwen3_magi_cp_smoke/
+  model_save_format: safetensors
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 8
+  pp_size: 1
+  ep_size: 8
+  sequence_parallel: false
+  activation_checkpointing: true
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: train
+  num_samples_limit: 8192
+  pad_to_max_length: false
+  tokenizer:
+    pretrained_model_name_or_path: Qwen/Qwen3-30B-A3B
+
+packed_sequence:
+  packed_sequence_size: 32768
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.packed_sequence_thd_collater
+  shuffle: false
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas: [0.9, 0.999]
+  eps: 1.0e-7
+  lr: 1.0e-4
+  weight_decay: 0
+  foreach: false
+
+wandb:
+  enable: false
+
+ci:
+  recipe_owner: huiyingl
+  time: "00:20:00"
+  nodes: 1

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -719,12 +719,14 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                     dp_world_size=self._get_dp_group_size(),
                     pp_enabled=self.pp_enabled,
                     supports_seq_lens=_supports_seq_lens(self.model_parts[0]),
-                    # Models that own their CP shard the packed row contiguously;
-                    # per-document CP padding is a TE blockdiag concern and would
-                    # make pack composition depend on the topology.
+                    # Models and backends that own their CP dispatch do not need
+                    # TE's per-document ``2 * cp_size`` packing alignment.
                     cp_size=(
                         1
-                        if getattr(self.model_parts[0], "_owns_cp_attention", False)
+                        if (
+                            getattr(self.model_parts[0], "_owns_cp_attention", False)
+                            or (self.magi.enabled and self.magi.custom)
+                        )
                         else self.cfg.get("distributed.cp_size", 1)
                     ),
                     attn_implementation=attn_implementation,


### PR DESCRIPTION
# What does this PR do ?

Avoid Transformer Engine-specific per-document CP padding when the attention backend owns context-parallel dispatch, including the custom Magi backend. Add a two-layer Qwen3-MoE exact-geometry recipe that exercises packed THD CP with the production attention, router, expert, and dispatcher dimensions.

TE block-diagonal THD CP requires each packed document to be aligned to `2 * cp_size`. Magi builds and dispatches its own arbitrary-mask layout, so retaining that TE-only alignment wastes attention work and reduces the useful label tokens that fit in a pack.

`packing_cp_size=1` changes only dataset packing alignment. Runtime `distributed.cp_size` remains CP8 or CP16.

# Changelog

- Select packer CP alignment from attention ownership: model-owned CP and custom Magi use the baseline CP1 alignment; TE continues using the configured CP size.
- Add `qwen3_moe_2layer_magi_packed_cp8_32k.yaml`, preserving Qwen3-30B-A3B head, expert, router, vocabulary, DeepEP, TE-expert, activation-checkpointing, backward, and optimizer paths while reducing depth to two layers for a practical gate.
- Add parameterized unit coverage for TE, model-owned CP, custom Magi, and non-custom Magi behavior.

# Validation

- [x] `ruff format --check nemo_automodel/recipes/llm/train_ft.py tests/unit_tests/recipes/test_train_ft.py`
- [x] `ruff check nemo_automodel/recipes/llm/train_ft.py tests/unit_tests/recipes/test_train_ft.py`
- [x] `python tools/lint_example_yamls.py examples/llm_finetune/qwen/qwen3_moe_2layer_magi_packed_cp8_32k.yaml`
- [x] `python -m pytest tests/unit_tests/recipes/test_train_ft.py -q` — 96 passed, 7 skipped
- [x] Single-node CP8 forward/backward/optimizer gate before multi-node CP16
- [x] Fresh W&B runs, 30 optimizer steps each; steady window is steps 10–29

| Qwen3-MoE case | Magi physical vs TE | Magi effective-label vs TE |
|---|---:|---:|
| 2-layer exact geometry, CP8 / 64K | +9.81% | +18.29% |
| Actual 48-layer Qwen3-30B-A3B, CP8 / 32K | +63.17% | +88.27% |
| 2-layer exact geometry, CP16 / 64K | -29.35% | -16.11% |

W&B workspace: https://wandb.ai/Nemo-automodel/magi

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused unit coverage and an end-to-end benchmark recipe.
- [x] Added the example recipe needed to document and reproduce the path.

# Additional Information

- Base: `main` at `3ddef9b1`.
- Head commit is DCO signed off.
- This custom-model path does not depend on HF Magi PR #2622; that change is intentionally absent from this diff.