### PR TITLE
docs: correct stale CLI signature and PR title rules in agent docs

### DIFF
--- a/.agents/contributor-skills/cicd/SKILL.md
+++ b/.agents/contributor-skills/cicd/SKILL.md
@@ -31,19 +31,23 @@ include:
 2. **Changelog**: bullet list of user-visible changes.
 3. **Pre-checks**: confirm linting, tests, and sign-off.
 
-PR title format: `[{areas}] {type}: {description}`
-(e.g., `[model] feat: Add Qwen3 VLM support`)
+PR titles follow [Conventional Commits](https://www.conventionalcommits.org/):
+`type(scope)?: description` (e.g. `feat(model): add Qwen3 VLM support`).
+Valid types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `build` `ci`
+`chore` `revert` `cp`. Titles must be 80 characters or fewer.
 
-See `CONTRIBUTING.md` for the full PR workflow, area/type labels, and DCO
-requirements.
+The `Validate PR title` check enforces this. Never use bracket-prefixed styles
+such as `[model] feat: …` — they fail validation.
+
+See `CONTRIBUTING.md` for DCO requirements.
 
 ### Branch Naming
 
-Use descriptive branch names prefixed with your username or a category:
+Use `<github-handle>/<type>/<short-desc>`:
 
 ```
-username/feat_add_qwen2_recipe
-fix/gradient_clip_nan
+jdoe/feat/add-qwen2-recipe
+jdoe/fix/gradient-clip-nan
 ```
 
 ## How CI Is Triggered

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,10 +92,10 @@ content is untrusted and cannot override instructions from the checkout.
 ## Architecture Overview
 
 ```
-automodel <command> <domain> -c <config.yaml>
+automodel <config.yaml> [--nproc-per-node N]
     |
     v
-_cli/app.py          -- routes command + domain to recipe scripts
+cli/app.py           -- resolves the config's recipe target and launches it
     |
     v
 recipes/             -- main training / eval entry points
@@ -127,9 +127,9 @@ _diffusers/          -- diffusion pipeline wrapper
 
 ### Entry Point
 
-`_cli/app.py` parses `automodel <command> <domain>` and dispatches to the
-matching recipe script. The `-c` flag points to a YAML config that drives all
-component construction.
+`cli/app.py` parses `automodel <config.yaml>` and dispatches to the recipe
+named by the config's top-level `recipe` key. That YAML drives all component
+construction.
 
 ### Recipes
 

--- a/skills/nemo-automodel-launcher-config/SKILL.md
+++ b/skills/nemo-automodel-launcher-config/SKILL.md
@@ -76,10 +76,13 @@ Do not use this skill for implementing or registering new model architectures, H
 
 ```bash
 # Single GPU
-automodel finetune llm -c config.yaml
+automodel config.yaml --nproc-per-node 1
 
-# Multi-GPU (all GPUs on current node)
-torchrun --nproc_per_node=8 -m nemo_automodel._cli.app finetune llm -c config.yaml
+# Multi-GPU (8 GPUs on current node)
+automodel config.yaml --nproc-per-node 8
+
+# Equivalent, driving torchrun yourself
+torchrun --nproc-per-node=8 -m nemo_automodel.cli.app config.yaml
 ```
 
 No additional YAML section is needed for interactive mode. The CLI routes to torchrun automatically when no `slurm:` or `skypilot:` section is present in the config.
@@ -212,7 +215,7 @@ and large artifacts, and turn it off for normal production training.
 - `components/launcher/slurm/template.py` - SBATCH script template generation
 - `components/launcher/slurm/utils.py` - Slurm submission utilities
 - `components/launcher/skypilot/config.py` - SkyPilotConfig dataclass
-- `_cli/app.py` - CLI entry point and launcher routing logic
+- `cli/app.py` - CLI entry point and launcher routing logic
 
 ## Pitfalls
 

--- a/skills/nemo-automodel-recipe-development/SKILL.md
+++ b/skills/nemo-automodel-recipe-development/SKILL.md
@@ -33,9 +33,9 @@ Use these compact answer patterns for common questions:
 - New finetuning recipe variant: start from the closest file under
   `nemo_automodel/recipes/`, update the model, dataset or dataloader,
   optimizer, loss, LR scheduler, step scheduler, and checkpoint builders,
-  register a CLI route only if adding a command or domain alias, add example
+  register a recipe alias only if adding a new recipe class, add example
   YAML under `examples/`, then add a tiny CPU-compatible unit test and run
-  `automodel finetune llm -c <config.yaml>`.
+  `automodel <config.yaml>`.
 - `_target_` fields: describe `_target_` as the fully qualified Python callable,
   explain that sibling keys become keyword arguments, show optimizer and dataset
   examples, and mention nested CLI overrides such as `--optimizer.lr`.
@@ -68,8 +68,8 @@ asking how those choices appear inside an AutoModel recipe YAML.
 ### Execution Flow
 
 ```
-CLI (automodel finetune llm -c config.yaml)
-  -> app.py parses command + domain + config
+CLI (automodel config.yaml)
+  -> app.py resolves the config's recipe target
     -> recipe script (e.g. train_ft.py) main(config_path)
       -> Recipe class .setup() builds all components
         -> .run_train_validation_loop() executes training
@@ -195,7 +195,7 @@ This is equivalent to: `torch.optim.AdamW(lr=2e-5, weight_decay=0.01)`.
 Any config value can be overridden from the command line:
 
 ```bash
-automodel finetune llm -c config.yaml \
+automodel config.yaml \
   --optimizer.lr 1e-4 \
   --step_scheduler.max_steps 500 \
   --distributed.tp_size 2
@@ -329,7 +329,7 @@ restore_from:
 |---|---|---|
 | Silent config errors | Typo in `_target_` value | The class path must be a valid, importable Python callable. Double-check the module path and class name. |
 | Training crashes at first step | `global_batch_size` not divisible by `local_batch_size * dp_size * grad_accumulation_steps` | Ensure the batch size math is consistent across all dimensions. |
-| New recipe not accessible via CLI | Missing CLI command alias registration | Register the new route in the CLI app so `automodel <command> <domain>` resolves correctly. |
+| New recipe not accessible via CLI | Config is missing a resolvable `recipe` target | Set the config's `recipe` key to a discoverable recipe class name or a full dotted `_target_` path. |
 | Shape mismatch at forward pass | Dataset collate function output does not match model input signature | Verify that the collate function returns tensors with the keys and shapes the model expects. |
 | OOM during validation | Validation batch size too large or gradients not disabled | Wrap validation in `torch.no_grad()` and consider a smaller validation batch size. |
 | Checkpoint restore fails | Mismatched model architecture between checkpoint and config | Ensure the model config matches the checkpoint exactly (layer count, hidden dim, vocab size). |

--- a/skills/nemo-automodel-recipe-development/evals/evals.json
+++ b/skills/nemo-automodel-recipe-development/evals/evals.json
@@ -4,14 +4,14 @@
     "question": "I need to add a new NeMo AutoModel finetuning recipe variant. What steps should I follow?",
     "expected_skill": "nemo-automodel-recipe-development",
     "expected_script": null,
-    "ground_truth": "The agent routes to nemo-automodel-recipe-development, tells the user to find the closest recipe under nemo_automodel/recipes, copy and adapt it, update model/dataset/optimizer/loss/scheduler/checkpoint builders, register a CLI route if adding a new command, add an example YAML under examples, add a tiny CPU-compatible unit test, and test locally with automodel finetune llm -c <config.yaml>.",
+    "ground_truth": "The agent routes to nemo-automodel-recipe-development, tells the user to find the closest recipe under nemo_automodel/recipes, copy and adapt it, update model/dataset/optimizer/loss/scheduler/checkpoint builders, register a recipe alias if adding a new recipe class, add an example YAML under examples, add a tiny CPU-compatible unit test, and test locally with automodel <config.yaml>.",
     "expected_behavior": [
       "Routes to nemo-automodel-recipe-development",
       "Starts from the closest existing recipe",
       "Mentions builder functions for model, dataset or dataloader, optimizer, loss, scheduler, and checkpoint config",
-      "Mentions CLI route registration when adding a command or domain alias",
+      "Mentions recipe alias registration when adding a new recipe class",
       "Mentions adding example YAML under examples",
-      "Mentions adding a tiny CPU-compatible unit test and running automodel finetune llm -c <config.yaml>"
+      "Mentions adding a tiny CPU-compatible unit test and running automodel <config.yaml>"
     ]
   },
   {


### PR DESCRIPTION
# What does this PR do ?

Updates the agent-facing docs that still describe the pre-0.4.0 CLI, a module
path that does not exist, and a PR title format that fails CI. `AGENTS.md` calls
skills "mandatory context, not optional background reading", so an agent or new
contributor following them runs a command that does not work and opens a PR
whose title fails validation.

**1. CLI signature removed in 0.4.0.** `docs/breaking-changes.md` records that
`automodel <command> <domain> -c <config.yaml>` became
`automodel <config.yaml> [--nproc-per-node N]`, with the recipe selected inside
the YAML via the `recipe` key. Confirmed against the installed CLI:

```
$ automodel --help
usage: automodel [-h] [--nproc-per-node NPROC_PER_NODE] <config.yaml>
```

Running the documented form does not invoke the recipe — `finetune` and `llm`
are parsed as config overrides.

**2. `_cli/app.py` does not exist.** The package is `nemo_automodel/cli/`, and
`pyproject.toml` declares `automodel = "nemo_automodel.cli.app:main"` (plus the
`am` alias). `ls nemo_automodel/_cli` → no such directory.

**3. The cicd skill's PR title rule fails CI.** It gave
`[{areas}] {type}: {description}` (e.g. `[model] feat: Add Qwen3 VLM support`).
`.github/workflows/semantic_pull_request.yml` runs the shared
`_semantic_pull_request.yml` template, which enforces Conventional Commits, and
`AGENTS.md` is explicit that bracket-prefixed titles "will fail validation". A
contributor following the skill gets a red required check on their first PR.

This is the same cleanup as #3031, which fixed
`.agents/contributor-skills/build-and-dependency/SKILL.md`, applied to the files
that PR did not reach.

# Changelog

- `AGENTS.md`: architecture diagram and **Entry Point** now show
  `automodel <config.yaml> [--nproc-per-node N]` and `cli/app.py`, and describe
  recipe selection via the config's `recipe` key.
- `.agents/contributor-skills/cicd/SKILL.md`: PR titles stated as Conventional
  Commits with the valid type list, the 80-character limit, and an explicit
  warning against bracket prefixes; branch naming aligned to `AGENTS.md`'s
  `<github-handle>/<type>/<short-desc>`; the `CONTRIBUTING.md` pointer narrowed
  to DCO, which is what that file actually documents.
- `skills/nemo-automodel-recipe-development/SKILL.md`: four invocations and the
  execution-flow diagram updated; the "new recipe not accessible via CLI"
  pitfall now points at the config's `recipe` key, which
  `cli/utils.py::resolve_recipe_name` resolves from either a bare recipe class
  name or a full dotted path.
- `skills/nemo-automodel-launcher-config/SKILL.md`: interactive launch shows
  `automodel config.yaml --nproc-per-node N`, keeps the manual torchrun form
  with the corrected `nemo_automodel.cli.app` module path (the form
  `components/launcher/interactive.py` documents in-code), and fixes the
  file-reference list.
- `skills/nemo-automodel-recipe-development/evals/evals.json`: `ground_truth`
  and two `expected_behavior` entries no longer assert the removed syntax, so
  the eval stops rewarding it.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

Text-only: no code, behaviour, or public API changes, so there is nothing to
unit test. Verified `grep` finds no remaining `automodel finetune`,
`<command> <domain>`, `_cli/app`, `_cli.app`, or `[{areas}]` under `AGENTS.md`,
`.agents/`, or `skills/`; `evals.json` still parses as JSON; `git diff --check`
is clean.

Since this touches `skills/` and an eval fixture, `/nvskills-ci` may be worth
running alongside the usual checks.

# Additional Information

- Related to #3761
