### PR TITLE
feat: support learnable sinks in cuDNN sparse attention

### DIFF
--- a/nemo_automodel/components/models/common/cudnn_sparse_attention.py
+++ b/nemo_automodel/components/models/common/cudnn_sparse_attention.py
@@ -42,6 +42,14 @@ _VALUE_HEAD_DIM = 512
 _FLASH_MLA_TOPK_ALIGNMENT = 512
 
 
+def _sparse_attention_delta_fp32(grad_output: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+    """Compute the FP32 softmax delta without a full-size product tensor."""
+    return (grad_output.float() * out.float()).sum(dim=-1)
+
+
+_sparse_attention_delta_fp32_compiled = torch.compile(_sparse_attention_delta_fp32, dynamic=True)
+
+
 def is_cudnn_sparse_attention_available() -> bool:
     """Return whether the cuDNN backward and FlashMLA forward runtimes import."""
     return bool(_HAS_CUDNN_DSA and _HAS_FLASH_MLA)
@@ -155,6 +163,7 @@ class _CudnnSparseAttention(torch.autograd.Function):
         q: torch.Tensor,
         kv_latent: torch.Tensor,
         topk_indices: torch.Tensor,
+        attn_sink: torch.Tensor,
         softmax_scale: float,
         padded_heads: int,
         topk_length: torch.Tensor | None,
@@ -169,6 +178,8 @@ class _CudnnSparseAttention(torch.autograd.Function):
             kv_latent: CUDA BF16 latent K/V tensor of shape ``[key_tokens, 1, head_dim]``.
             topk_indices: CUDA int32 tensor of shape ``[query_tokens, 1, sparse_width]``
                 containing global K/V coordinates and invalid entries marked ``-1``.
+            attn_sink: FP32 attention-sink logits of shape ``[heads]``. A sink
+                contributes to the softmax denominator and has a zero value.
             softmax_scale: Scale applied to query-key scores.
             padded_heads: FlashMLA-compatible padded head count.
             topk_length: Optional int32 valid-prefix lengths of shape ``[query_tokens]``.
@@ -188,7 +199,6 @@ class _CudnnSparseAttention(torch.autograd.Function):
         if padded_topk != indices.shape[-1]:
             indices = torch.nn.functional.pad(indices, (0, padded_topk - indices.shape[-1]), value=-1)
 
-        attn_sink = torch.full((q.shape[1],), float("-inf"), dtype=torch.float32, device=q.device)
         q_kernel, sink_kernel = _pad_attention_heads(q.contiguous(), attn_sink, padded_heads)
         out_kernel, _max_logits, lse_kernel = _FLASH_MLA_SPARSE_FWD(
             q_kernel,
@@ -224,10 +234,10 @@ class _CudnnSparseAttention(torch.autograd.Function):
                 ``[query_tokens, heads, 512]``.
 
         Returns:
-            Gradients for the eight forward inputs: query tensor of shape
+            Gradients for the nine forward inputs: query tensor of shape
             ``[query_tokens, heads, head_dim]``, latent K/V tensor of shape
-            ``[key_tokens, 1, head_dim]``, then ``None`` for scalar and metadata
-            inputs.
+            ``[key_tokens, 1, head_dim]``, the FP32 attention-sink tensor of
+            shape ``[heads]``, then ``None`` for scalar and metadata inputs.
         """
         q, kv, out, lse, attn_sink, indices, topk_length, cached_valid_rows = ctx.saved_tensors
         valid_row_indices = None
@@ -293,7 +303,17 @@ class _CudnnSparseAttention(torch.autograd.Function):
             grad_q = torch.zeros_like(q)
             grad_q.index_copy_(0, valid_row_indices, grad_q_valid)
         grad_kv = result["dkv"].unsqueeze(1).contiguous()
-        return grad_q, grad_kv, None, None, None, None, None, None
+        # cuDNN's sparse-attention wrapper returns dQ and dKV but not the
+        # learnable sink gradient. FlashMLA's returned LSE excludes the sink
+        # (the kernel applies exp(lse) / (exp(lse) + exp(sink)) only to its
+        # output), so p_sink = sigmoid(sink - lse). For the zero-valued sink,
+        # d_sink = -p_sink * dot(dO, O), summed over queries. This avoids
+        # materializing attention probabilities or selected values.
+        delta_fn = _sparse_attention_delta_fp32_compiled if grad_output.is_cuda else _sparse_attention_delta_fp32
+        delta = delta_fn(grad_output, out)
+        sink_probability = torch.sigmoid(attn_sink.view(1, -1) - lse.float())
+        grad_attn_sink = -(sink_probability * delta).sum(dim=0)
+        return grad_q, grad_kv, None, grad_attn_sink, None, None, None, None, None
 
 
 def cudnn_sparse_attention(
@@ -304,6 +324,7 @@ def cudnn_sparse_attention(
     topk_length: torch.Tensor | None = None,
     all_rows_nonempty: bool = False,
     valid_row_indices: torch.Tensor | None = None,
+    attn_sink: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Run sparse latent attention with FlashMLA forward and cuDNN backward.
 
@@ -322,6 +343,8 @@ def cudnn_sparse_attention(
         all_rows_nonempty: Whether every query has a positive valid-prefix length.
         valid_row_indices: Optional contiguous CUDA int64 indices of nonempty queries
             with shape ``[valid_query_tokens]``.
+        attn_sink: Optional contiguous FP32 tensor of learnable sink logits with
+            shape ``[heads]``. When omitted, attention has no sink.
 
     Returns:
         Contiguous CUDA BF16 latent output tensor of shape
@@ -384,11 +407,26 @@ def cudnn_sparse_attention(
         if valid_row_indices.numel() > q.shape[0]:
             raise ValueError("valid_row_indices cannot contain more entries than query rows.")
 
+    if attn_sink is None:
+        attn_sink = torch.full((q.shape[1],), float("-inf"), dtype=torch.float32, device=q.device)
+    elif (
+        attn_sink.shape != (q.shape[1],)
+        or attn_sink.dtype != torch.float32
+        or attn_sink.device != q.device
+        or not attn_sink.is_contiguous()
+    ):
+        raise ValueError(
+            "attn_sink must be a contiguous float32 tensor on the query device "
+            f"with shape {(q.shape[1],)}, got shape={tuple(attn_sink.shape)}, "
+            f"dtype={attn_sink.dtype}, device={attn_sink.device}."
+        )
+
     padded_heads = _padded_head_count(q.shape[1], major)
     return _CudnnSparseAttention.apply(
         q.contiguous(),
         kv_latent.contiguous(),
         topk_indices.contiguous(),
+        attn_sink,
         float(softmax_scale),
         padded_heads,
         topk_length,

--- a/tests/functional_tests/models/run_cudnn_sparse_attention_sink_parity.py
+++ b/tests/functional_tests/models/run_cudnn_sparse_attention_sink_parity.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real-kernel parity for the shared learnable-sink sparse-attention path."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from importlib.metadata import version
+from pathlib import Path
+
+import torch
+
+from nemo_automodel.components.models.common.cudnn_sparse_attention import (
+    _sparse_attention_delta_fp32,
+    _sparse_attention_delta_fp32_compiled,
+    cudnn_sparse_attention,
+)
+
+FLASH_MLA_REFERENCE_COMMIT = "b7643bd54521f563b839b98289b5cd048c062ba2"
+
+
+def _metrics(actual: torch.Tensor, reference: torch.Tensor) -> dict[str, float]:
+    """Return scalar accuracy metrics for equal-shaped tensors."""
+    if actual.shape != reference.shape:
+        raise AssertionError(f"Shape mismatch: {tuple(actual.shape)} != {tuple(reference.shape)}")
+    actual_flat = actual.detach().double().flatten().cpu()
+    reference_flat = reference.detach().double().flatten().cpu()
+    difference = actual_flat - reference_flat
+    return {
+        "max_abs": difference.abs().max().item(),
+        "mean_abs": difference.abs().mean().item(),
+        "relative_l2": (
+            torch.linalg.vector_norm(difference) / torch.linalg.vector_norm(reference_flat).clamp_min(1e-30)
+        ).item(),
+        "cosine": (
+            torch.dot(actual_flat, reference_flat)
+            / (torch.linalg.vector_norm(actual_flat) * torch.linalg.vector_norm(reference_flat)).clamp_min(1e-30)
+        ).item(),
+    }
+
+
+def _reference_sparse_attention(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sink: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Evaluate sparse MQA plus a zero-valued sink with explicit FP32 math."""
+    keys = kv.squeeze(1)
+    rows = []
+    for query_idx in range(q.shape[0]):
+        selected = indices[query_idx, 0].long()
+        selected_kv = keys.index_select(0, selected[selected >= 0])
+        scores = torch.matmul(q[query_idx].float(), selected_kv.float().T) * scale
+        probabilities = torch.softmax(torch.cat((scores, sink.unsqueeze(-1)), dim=-1), dim=-1)[..., :-1]
+        rows.append(torch.matmul(probabilities, selected_kv[..., :512].float()))
+    return torch.stack(rows).to(torch.bfloat16)
+
+
+def run(output: Path | None = None) -> dict:
+    """Run forward/backward and production-shape sink-delta parity."""
+    import cudnn
+
+    flash_version = version("flash-mla")
+    if FLASH_MLA_REFERENCE_COMMIT[:7] not in flash_version:
+        raise RuntimeError(f"Expected FlashMLA build from {FLASH_MLA_REFERENCE_COMMIT}, got {flash_version!r}.")
+    if str(getattr(cudnn, "__version__", "")) != "1.27.0":
+        raise RuntimeError(f"Expected cuDNN Frontend 1.27.0, got {getattr(cudnn, '__version__', None)!r}.")
+
+    torch.manual_seed(1234)
+    device = torch.device("cuda", torch.cuda.current_device())
+    tokens = 64
+    heads = 64
+    sparse_width = 512
+    scale = 256**-0.5
+    q = torch.randn(tokens, heads, 576, device=device, dtype=torch.bfloat16, requires_grad=True)
+    kv = torch.randn(tokens, 1, 576, device=device, dtype=torch.bfloat16, requires_grad=True)
+    sink = torch.linspace(-0.75, 0.75, heads, device=device, dtype=torch.float32).requires_grad_()
+    indices = torch.full((tokens, 1, sparse_width), -1, device=device, dtype=torch.int32)
+    for query_idx in range(tokens):
+        indices[query_idx, 0, : query_idx + 1] = torch.arange(query_idx + 1, device=device, dtype=torch.int32)
+    topk_length = torch.arange(1, tokens + 1, device=device, dtype=torch.int32)
+    upstream = torch.randn(tokens, heads, 512, device=device, dtype=torch.bfloat16)
+
+    actual = cudnn_sparse_attention(
+        q,
+        kv,
+        indices,
+        scale,
+        topk_length=topk_length,
+        all_rows_nonempty=True,
+        attn_sink=sink,
+    )
+    (actual * upstream).sum().backward()
+    actual_gradients = (q.grad.detach().clone(), kv.grad.detach().clone(), sink.grad.detach().clone())
+
+    q_reference = q.detach().clone().requires_grad_()
+    kv_reference = kv.detach().clone().requires_grad_()
+    sink_reference = sink.detach().clone().requires_grad_()
+    reference = _reference_sparse_attention(q_reference, kv_reference, indices, sink_reference, scale)
+    (reference * upstream).sum().backward()
+    attention_report = {
+        "forward": _metrics(actual, reference),
+        "grad_q": _metrics(actual_gradients[0], q_reference.grad),
+        "grad_kv": _metrics(actual_gradients[1], kv_reference.grad),
+        "grad_sink": _metrics(actual_gradients[2], sink_reference.grad),
+    }
+
+    # At [4096, 64, 512], the eager FP32 product alone is 512 MiB. Verify that
+    # the compiled reduction preserves parity while lowering steady-state peak.
+    full_grad_output = torch.randn(4096, heads, 512, device=device, dtype=torch.bfloat16)
+    full_output = torch.randn_like(full_grad_output)
+    torch.cuda.synchronize()
+    baseline = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    delta_reference = _sparse_attention_delta_fp32(full_grad_output, full_output)
+    torch.cuda.synchronize()
+    reference_peak = torch.cuda.max_memory_allocated() - baseline
+    _sparse_attention_delta_fp32_compiled(full_grad_output[:32], full_output[:32])
+    torch.cuda.synchronize()
+    del delta_reference
+    torch.cuda.empty_cache()
+    baseline = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    delta_actual = _sparse_attention_delta_fp32_compiled(full_grad_output, full_output)
+    torch.cuda.synchronize()
+    compiled_peak = torch.cuda.max_memory_allocated() - baseline
+    delta_reference = _sparse_attention_delta_fp32(full_grad_output, full_output)
+    delta_report = {
+        "parity": _metrics(delta_actual, delta_reference),
+        "reference_incremental_peak_bytes": reference_peak,
+        "compiled_incremental_peak_bytes": compiled_peak,
+    }
+
+    report = {
+        "attention": attention_report,
+        "cudnn_frontend_version": cudnn.__version__,
+        "flash_mla_reference_commit": FLASH_MLA_REFERENCE_COMMIT,
+        "flash_mla_version": flash_version,
+        "sink_delta": delta_report,
+        "torch_version": torch.__version__,
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+    for name, metrics in attention_report.items():
+        relative_l2_limit = 0.025 if name == "forward" else 0.08
+        cosine_limit = 0.999 if name == "forward" else 0.995
+        if metrics["relative_l2"] >= relative_l2_limit or metrics["cosine"] <= cosine_limit:
+            raise AssertionError(f"Sparse-attention {name} parity failed: {metrics}")
+    if delta_report["parity"]["relative_l2"] >= 1.0e-3 or delta_report["parity"]["cosine"] <= 0.999999:
+        raise AssertionError(f"Sparse-attention sink delta parity failed: {delta_report}")
+    if compiled_peak >= reference_peak:
+        raise AssertionError(f"Compiled sink delta did not reduce peak memory: {delta_report}")
+
+    if output is not None:
+        if output.exists():
+            raise FileExistsError(f"Refusing to overwrite parity report: {output}")
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    run(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_cudnn.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_cudnn.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import replace
 
 import pytest
@@ -673,6 +674,65 @@ def test_cudnn_sparse_attention_dispatches_padded_forward_and_exact_backward(
     torch.testing.assert_close(kv_latent.grad, torch.full_like(kv_latent, 5))
     assert fake_flash_mla.called
     assert fake_dsa.called
+
+
+def test_shared_cudnn_sparse_attention_propagates_learnable_sink_gradient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared adapter forwards sink logits and reconstructs their exact gradient."""
+    heads = 2
+    tokens = 2
+    sink = torch.tensor([0.0, math.log(2.0)], dtype=torch.float32, requires_grad=True)
+
+    def fake_flash_mla(
+        q: torch.Tensor,
+        kv_latent: torch.Tensor,
+        indices: torch.Tensor,
+        softmax_scale: float,
+        *,
+        d_v: int,
+        attn_sink: torch.Tensor,
+        topk_length: torch.Tensor,
+        indexer_topk: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        assert q.shape == (tokens, 64, QK_DIM)
+        torch.testing.assert_close(attn_sink[:heads], sink.detach())
+        assert torch.isneginf(attn_sink[heads:]).all()
+        output = torch.zeros(tokens, 64, VALUE_DIM, dtype=torch.bfloat16)
+        output[:, :heads] = 1
+        lse = torch.zeros(tokens, 64, dtype=torch.float32)
+        lse[:, 0] = math.log(4.0)
+        lse[:, 1] = math.log(8.0)
+        return output, torch.zeros_like(lse), lse
+
+    class FakeDsa:
+        def sparse_attention_backward_wrapper(self, q, kv, out, d_out, lse, attn_sink, indices, **kwargs):
+            torch.testing.assert_close(attn_sink[:heads], sink.detach())
+            return {"dq": torch.zeros_like(q), "dkv": torch.zeros_like(kv)}
+
+    monkeypatch.setattr(shared_cudnn, "_HAS_CUDNN_DSA", True)
+    monkeypatch.setattr(shared_cudnn, "_HAS_FLASH_MLA", True)
+    monkeypatch.setattr(shared_cudnn, "_CUDNN_DSA", FakeDsa())
+    monkeypatch.setattr(shared_cudnn, "_FLASH_MLA_SPARSE_FWD", fake_flash_mla)
+    monkeypatch.setattr(shared_cudnn, "_require_cuda_tensors", _accept_cpu_tensors)
+
+    q = torch.ones(tokens, heads, QK_DIM, dtype=torch.bfloat16, requires_grad=True)
+    kv_latent = torch.ones(tokens, 1, QK_DIM, dtype=torch.bfloat16, requires_grad=True)
+    topk_indices = torch.tensor([[[0]], [[0]]], dtype=torch.int32)
+    output = shared_cudnn.cudnn_sparse_attention(
+        q,
+        kv_latent,
+        topk_indices,
+        softmax_scale=0.125,
+        all_rows_nonempty=True,
+        attn_sink=sink,
+    )
+    output.sum().backward()
+
+    # FlashMLA returns LSE without the sink: for both heads
+    # p_sink = exp(sink) / (exp(lse) + exp(sink)) = 1/5. Each of the two
+    # queries contributes dot(dO, O)=512.
+    torch.testing.assert_close(sink.grad, torch.full_like(sink, -204.8))
 
 
 def test_shared_cudnn_sparse_attention_accepts_glm53_dimensions(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
# What does this PR do ?

Add model-independent learnable-sink support to the cuDNN sparse-attention path, including backward parity against FlashMLA.

This is PR 1/3 in the HY4 support stack. The next PR layers generic MTP + CP + PP support on top of this one; the HY4 model itself remains isolated in the final PR.

# Changelog

- Accept an optional FP32 learnable sink in `cudnn_sparse_attention` and forward it through the cuDNN sparse-attention graph.
- Reconstruct the sink gradient from cuDNN LSE output without materializing the eager dense delta tensor.
- Extend the existing GLM DSA coverage for sink forward/backward behavior.
- Add a model-independent GPU parity runner comparing the production cuDNN path with pinned FlashMLA.

# Validation

GPU interactive allocation: Slurm job `16995628`, H100 80GB.

- `ruff check` and `ruff format --check`: passed.
- `pytest tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_cudnn.py`: **27 passed**.
- Real-kernel parity, cuDNN frontend 1.27.0 vs FlashMLA commit `b7643bd54521f563b839b98289b5cd048c062ba2`: passed.
  - forward cosine: `0.9999984564`; relative L2: `0.00175707`
  - query-gradient cosine: `0.9999955054`; relative L2: `0.00299830`
  - KV-gradient cosine: `0.9999732847`; relative L2: `0.00731175`
  - sink-gradient cosine: `0.9999988973`; relative L2: `0.00148600`
  - compiled sink-delta incremental peak: `1 MiB`; eager reference: `1.5 GiB`

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (No user-facing configuration change.)

# Additional Information

Validation log: `logs/hy_v4_prs/pr1-sink-interactive-16995628.log`

