### PR TITLE
feat: support MTP with context and pipeline parallelism

### DIFF
--- a/nemo_automodel/components/loss/mtp.py
+++ b/nemo_automodel/components/loss/mtp.py
@@ -310,6 +310,10 @@ def calculate_mtp_loss(
 class PipelineCausalLMLoss(nn.Module):
     """Pipeline schedule loss that can add MTP auxiliary CE on the last stage.
 
+    Models declaring ``_pp_mtp_targets_in_output`` append globally shifted,
+    CP-local MTP targets after the normal output tuple. The loss strips that
+    tail first and uses it instead of shifting rank-local labels.
+
     Per-microbatch ``seq_idx`` is read from a trailing element of the
     last-stage output tuple — the model appends an ``[B, S] int32`` tail
     when MTP is enabled. This binds each microbatch's seq_idx to its loss
@@ -335,13 +339,33 @@ class PipelineCausalLMLoss(nn.Module):
         # Legacy THD-pack fallback used when the model has no seq_idx tail.
         self.cu_seqlens: torch.Tensor | None = None
 
+    def _extract_mtp_target_tail(self, output) -> tuple[tuple[torch.Tensor, ...] | None, object]:
+        """Strip a model-declared tail of authoritative per-depth targets."""
+        if not getattr(self.model, "_pp_mtp_targets_in_output", False):
+            return None, output
+
+        mtp_config = getattr(self.model, "mtp_config", None)
+        num_depths = int(getattr(mtp_config, "num_layers", 0) or 0)
+        if num_depths == 0:
+            return None, output
+        if not isinstance(output, tuple) or len(output) <= num_depths:
+            raise ValueError(f"Pipeline MTP output must end with {num_depths} precomputed target tensors.")
+
+        targets = output[-num_depths:]
+        if not all(
+            isinstance(target, torch.Tensor) and target.dtype == torch.long and target.dim() == 2 for target in targets
+        ):
+            raise ValueError(f"Pipeline MTP output must end with {num_depths} int64 [batch, sequence] target tensors.")
+        return tuple(targets), output[:-num_depths]
+
     @staticmethod
     def _extract_seq_idx_tail(output) -> tuple[torch.Tensor | None, object]:
         """Detect and strip a trailing per-microbatch seq_idx from output.
 
         Convention: with MTP enabled the last-stage output is
-        ``(logits, *mtp_per_depth_h, seq_idx)`` with an ``[B, S] int32``
-        tail — dtype alone discriminates.
+        ``(primary_output, *mtp_per_depth_h, seq_idx)`` with an ``[B, S] int32``
+        tail — dtype alone discriminates. ``primary_output`` is logits for a
+        logit-based loss and hidden states for a fused linear CE loss.
         """
         if isinstance(output, tuple) and len(output) > 0:
             last = output[-1]
@@ -357,20 +381,29 @@ class PipelineCausalLMLoss(nn.Module):
         Args:
             output: bare hidden states ``[B, S, H]`` (FusedLinearCrossEntropy
                 path), a HF output with logits ``[B, S, V]``, or an MTP tuple
-                ``(logits, *mtp_per_depth_h[, seq_idx])`` with ``seq_idx``
-                ``[B, S]`` int32. A tuple with FusedLinearCrossEntropy raises.
+                ``(primary_output, *mtp_per_depth_h[, seq_idx][, *mtp_targets])``
+                with ``seq_idx`` ``[B, S]`` int32 and authoritative targets
+                ``[B, S]`` int64. For models declaring
+                ``_pp_fused_linear_ce_mtp_supported``, ``primary_output`` is
+                hidden states under FusedLinearCrossEntropy; otherwise it is
+                logits.
             labels: target token ids ``[B, S]`` int64.
 
         Returns:
             Scalar loss tensor.
         """
+        mtp_per_depth_targets, output = self._extract_mtp_target_tail(output)
         seq_idx_mb, output = self._extract_seq_idx_tail(output)
 
         if isinstance(output, tuple):
             if isinstance(self.loss_fn, FusedLinearCrossEntropy):
-                raise ValueError("FusedLinearCrossEntropy is not supported with MTP under pipeline parallelism")
-            logits = output[0]
-            hidden_states = None
+                if not getattr(self.model, "_pp_fused_linear_ce_mtp_supported", False):
+                    raise ValueError("FusedLinearCrossEntropy is not supported with MTP under pipeline parallelism")
+                logits = None
+                hidden_states = output[0]
+            else:
+                logits = output[0]
+                hidden_states = None
             mtp_per_depth_h = None
             mtp_per_depth_logits = None
             if len(output) > 1:
@@ -415,12 +448,13 @@ class PipelineCausalLMLoss(nn.Module):
                 self.loss_fn,
                 mtp_per_depth_h=mtp_per_depth_h,
                 mtp_per_depth_logits=mtp_per_depth_logits,
+                mtp_per_depth_targets=mtp_per_depth_targets,
                 labels=labels,
                 model=self.model,
                 scaling_factor=scaling_factor,
                 ignore_index=self.ignore_index,
-                cu_seqlens=self.cu_seqlens,
-                seq_idx=seq_idx_mb,
+                cu_seqlens=None if mtp_per_depth_targets is not None else self.cu_seqlens,
+                seq_idx=None if mtp_per_depth_targets is not None else seq_idx_mb,
                 lm_weight=shared_lm_weight,
                 grad_reduce_group=self.grad_reduce_group,
             )

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -338,6 +338,10 @@ def _iter_moe_blocks(model_wrapper: nn.Module, backbone: nn.Module):
     mtp_module = getattr(model_wrapper, "mtp", None)
     if mtp_module is not None and hasattr(mtp_module, "layers"):
         yield from mtp_module.layers.children()
+    else:
+        mtp_layers = getattr(backbone, "mtp_layers", None)
+        if mtp_layers is not None:
+            yield from mtp_layers.children()
 
 
 def apply_ep(model: nn.Module, ep_mesh: DeviceMesh, moe_mesh: DeviceMesh | None = None):
@@ -780,9 +784,10 @@ def apply_fsdp(
     # which skips AC on these blocks for the same reason). Bulk backbone experts keep the
     # configured reshard_after_forward.
     mtp_module = getattr(model, "mtp", None)
-    mtp_block_ids = set()
-    if mtp_module is not None and hasattr(mtp_module, "layers"):
-        mtp_block_ids = {id(b) for b in mtp_module.layers.children()}
+    mtp_layers = getattr(mtp_module, "layers", None)
+    if mtp_layers is None:
+        mtp_layers = getattr(_model, "mtp_layers", None)
+    mtp_block_ids = {id(block) for block in mtp_layers.children()} if mtp_layers is not None else set()
 
     for block in _iter_moe_blocks(model, _model):
         moe_module = _get_moe_module(block)

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -1033,13 +1033,25 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             for k, v in batch.items()
         }
         model = self.model_parts[0] if hasattr(self, "model_parts") else None
-        mtp_cp_enabled = not self.pp_enabled and self._get_cp_group_size() > 1 and model.supports.mtp_enabled
+        cp_enabled = self._get_cp_group_size() > 1
+        mtp_enabled = model is not None and model.supports.mtp_enabled
+        # Models that support the combined MTP+CP+PP path use the same global
+        # packed-boundary shift for PP at CP1 as well. Keeping one fixed PP
+        # output/loss contract avoids deriving MTP inputs or targets from a
+        # rank-local CP shard and makes CP1/CP2 directly comparable.
+        mtp_pp_precompute_enabled = self.pp_enabled and mtp_enabled and model.supports.supports_mtp_cp_pp
+        mtp_global_inputs_enabled = mtp_enabled and (cp_enabled or mtp_pp_precompute_enabled)
         mtp_cp_inputs = None
-        if mtp_cp_enabled:
-            if not model.supports.supports_mtp_cp:
+        if mtp_global_inputs_enabled:
+            if cp_enabled and not model.supports.supports_mtp_cp:
                 raise NotImplementedError(
                     f"{type(model).__name__} declares supports_mtp_cp=False; "
                     "MTP target preparation for context parallelism is unavailable"
+                )
+            if cp_enabled and self.pp_enabled and not model.supports.supports_mtp_cp_pp:
+                raise NotImplementedError(
+                    f"{type(model).__name__} declares supports_mtp_cp_pp=False; "
+                    "MTP target preparation for combined context and pipeline parallelism is unavailable"
                 )
             mtp_cp_inputs = model.prepare_mtp_inputs_for_cp(
                 batch,
@@ -1061,10 +1073,17 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             batch["mtp_per_depth_position_ids"] = tuple(
                 cp_sharder.shard_token_tensor(ids, seq_dim=1, fill=0) for ids in mtp_cp_inputs.position_ids
             )
-            mtp_per_depth_targets = tuple(
+            sharded_mtp_targets = tuple(
                 cp_sharder.shard_token_tensor(targets, seq_dim=1, fill=self.cfg.mtp.ignore_index)
                 for targets in mtp_cp_inputs.targets
             )
+            if self.pp_enabled:
+                # The final PP stage returns these exact per-microbatch targets
+                # alongside its MTP states. PipelineCausalLMLoss strips that
+                # non-differentiable tail before computing the auxiliary loss.
+                batch["mtp_per_depth_targets"] = sharded_mtp_targets
+            else:
+                mtp_per_depth_targets = sharded_mtp_targets
         labels = batch.pop("labels")
         fp8_ctx = self.te_fp8.maybe_te_autocast() if self.te_fp8 is not None else nullcontext()
 

--- a/nemo_automodel/shared/model_utils.py
+++ b/nemo_automodel/shared/model_utils.py
@@ -46,6 +46,10 @@ def iter_transformer_and_mtp_blocks(model: nn.Module) -> Iterator[tuple[nn.Modul
             yield layers, layer_id, block
 
     mtp_layers = getattr(getattr(model, "mtp", None), "layers", None)
+    if mtp_layers is None:
+        # Some native architectures keep checkpoint-compatible MTP blocks
+        # directly on the inner decoder.
+        mtp_layers = getattr(text_model, "mtp_layers", None)
     if mtp_layers is not None:
         for layer_id, block in mtp_layers.named_children():
             yield mtp_layers, layer_id, block

--- a/tests/unit_tests/loss/test_mtp_lm_head_gather.py
+++ b/tests/unit_tests/loss/test_mtp_lm_head_gather.py
@@ -31,6 +31,7 @@ DTensor LM head where the OOM occurred.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -274,6 +275,102 @@ def test_pipeline_loss_fused_ce_with_mtp_tuple_raises():
 
     with pytest.raises(ValueError, match="FusedLinearCrossEntropy is not supported with MTP"):
         loss_mod((logits, mtp_h), labels)
+
+
+def test_pipeline_loss_fused_ce_with_declared_mtp_hidden_tuple():
+    """A model may explicitly declare that its MTP tuple starts with hidden
+    states, allowing the main and auxiliary losses to share fused linear CE."""
+    from nemo_automodel.components.loss.mtp import PipelineCausalLMLoss
+
+    model = _TinyModel()
+    model._pp_fused_linear_ce_mtp_supported = True
+    loss_mod = PipelineCausalLMLoss(FusedLinearCrossEntropy(), model, scaling_factor=SF)
+
+    hidden = torch.randn(B, S, H)
+    mtp_h = torch.randn(B, S, H)
+    seq_idx = torch.arange(S, dtype=torch.int32).unsqueeze(0).expand(B, -1)
+    labels = torch.randint(0, V, (B, S))
+    captured_main = {}
+    captured_mtp = {}
+
+    def fake_main(loss_fn, **kwargs):
+        captured_main.update(kwargs)
+        return hidden.new_tensor(2.0)
+
+    def fake_mtp(loss_fn, **kwargs):
+        captured_mtp.update(kwargs)
+        return hidden.new_tensor(3.0)
+
+    with (
+        mock.patch.object(_mtp, "calculate_loss", side_effect=fake_main),
+        mock.patch.object(_mtp, "calculate_mtp_loss", side_effect=fake_mtp),
+    ):
+        loss = loss_mod((hidden, mtp_h, seq_idx), labels)
+
+    torch.testing.assert_close(loss, hidden.new_tensor(5.0))
+    assert captured_main["hidden_states"] is hidden
+    assert captured_main["logits"] is None
+    assert len(captured_mtp["mtp_per_depth_h"]) == 1
+    assert captured_mtp["mtp_per_depth_h"][0] is mtp_h
+    assert captured_mtp["mtp_per_depth_logits"] is None
+    assert captured_mtp["seq_idx"] is seq_idx
+
+
+def test_pipeline_loss_prefers_precomputed_cp_targets_over_local_label_shift():
+    """An opted-in model's PP tail carries targets shifted before CP split."""
+    from nemo_automodel.components.loss.mtp import PipelineCausalLMLoss
+
+    model = _TinyModel()
+    model._pp_fused_linear_ce_mtp_supported = True
+    model._pp_mtp_targets_in_output = True
+    model.mtp_config = SimpleNamespace(num_layers=1, loss_scaling_factor=SF)
+    loss_mod = PipelineCausalLMLoss(FusedLinearCrossEntropy(), model, scaling_factor=SF)
+
+    hidden = torch.randn(B, S, H)
+    mtp_h = torch.randn(B, S, H)
+    seq_idx = torch.arange(S, dtype=torch.int32).unsqueeze(0).expand(B, -1)
+    labels = torch.randint(0, V, (B, S))
+    mtp_targets = torch.full_like(labels, IGN)
+    mtp_targets[:, :-1] = labels[:, 1:]
+    captured_mtp = {}
+
+    def fake_main(loss_fn, **kwargs):
+        del loss_fn, kwargs
+        return hidden.new_tensor(2.0)
+
+    def fake_mtp(loss_fn, **kwargs):
+        del loss_fn
+        captured_mtp.update(kwargs)
+        return hidden.new_tensor(3.0)
+
+    with (
+        mock.patch.object(_mtp, "calculate_loss", side_effect=fake_main),
+        mock.patch.object(_mtp, "calculate_mtp_loss", side_effect=fake_mtp),
+    ):
+        loss = loss_mod((hidden, mtp_h, seq_idx, mtp_targets), labels)
+
+    torch.testing.assert_close(loss, hidden.new_tensor(5.0))
+    assert len(captured_mtp["mtp_per_depth_targets"]) == 1
+    assert captured_mtp["mtp_per_depth_targets"][0] is mtp_targets
+    assert captured_mtp["seq_idx"] is None
+    assert captured_mtp["cu_seqlens"] is None
+
+
+def test_pipeline_loss_rejects_missing_declared_mtp_target_tail():
+    from nemo_automodel.components.loss.mtp import PipelineCausalLMLoss
+
+    model = _TinyModel()
+    model._pp_fused_linear_ce_mtp_supported = True
+    model._pp_mtp_targets_in_output = True
+    model.mtp_config = SimpleNamespace(num_layers=1, loss_scaling_factor=SF)
+    loss_mod = PipelineCausalLMLoss(FusedLinearCrossEntropy(), model, scaling_factor=SF)
+
+    hidden = torch.randn(B, S, H)
+    mtp_h = torch.randn(B, S, H)
+    seq_idx = torch.arange(S, dtype=torch.int32).unsqueeze(0).expand(B, -1)
+    labels = torch.randint(0, V, (B, S))
+    with pytest.raises(ValueError, match="target tensors"):
+        loss_mod((hidden, mtp_h, seq_idx), labels)
 
 
 def test_non_fused_path_does_not_gather_lm_head():

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -646,6 +646,27 @@ def test_apply_ep_parallelizes_moe_experts(monkeypatch):
     assert isinstance(kwargs["parallelize_plan"], P.ExpertParallel)
 
 
+def test_apply_ep_parallelizes_inner_decoder_mtp_experts(monkeypatch):
+    """Native decoders may register MTP blocks directly beside their layers."""
+    P = _import_parallelizer_with_stubs(monkeypatch)
+    monkeypatch.setattr(P, "MoE", DummyMoE)
+    parallelize_module_mock = MagicMock()
+    monkeypatch.setattr(P, "parallelize_module", parallelize_module_mock)
+
+    backbone_block = DummyBlock(mlp=DummyMoE())
+    mtp_block = DummyBlock(mlp=DummyMoE())
+    model = DummyModel([backbone_block])
+    model.mtp_layers = LayerContainer([mtp_block])
+    ep_mesh = type("Mesh", (), {"size": lambda self: 2})()
+
+    P.apply_ep(model, ep_mesh)
+
+    assert [call.kwargs["module"] for call in parallelize_module_mock.call_args_list] == [
+        backbone_block.mlp.experts,
+        mtp_block.mlp.experts,
+    ]
+
+
 def test_apply_ep_parallelizes_diffusion_style_block_moe(monkeypatch):
     """Diffusion Gemma exposes the MoE branch as block.moe, not block.mlp."""
     P = _import_parallelizer_with_stubs(monkeypatch)

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -2772,3 +2772,170 @@ def test_forward_backward_step_shards_global_mtp_inputs_and_targets(monkeypatch)
     assert captured["cu_seqlens"] is None
     assert model.scale.grad is not None
     assert len(loss_buffer) == 1
+
+
+def test_forward_backward_step_routes_global_mtp_inputs_and_targets_through_cp_pp(monkeypatch):
+    """PP gets embeddings/positions and loss targets from one pre-CP global shift."""
+    from nemo_automodel.components.models.common.mtp import (
+        MTPConfig,
+        prepare_mtp_context_parallel_inputs,
+    )
+
+    captured = {}
+    local_indices = torch.tensor([0, 1, 4, 5])
+
+    class _MTPModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mtp_config = MTPConfig(num_layers=1, layer_pattern="*")
+            self.prepared_before_shard = False
+            self.supports = SimpleNamespace(
+                mtp_enabled=True,
+                supports_mtp_cp=True,
+                supports_mtp_cp_pp=False,
+            )
+
+        def prepare_mtp_inputs_for_cp(self, batch, *, ignore_index=-100):
+            self.prepared_before_shard = True
+            return prepare_mtp_context_parallel_inputs(
+                batch,
+                num_depths=self.mtp_config.num_layers,
+                ignore_index=ignore_index,
+            )
+
+    model = _MTPModel()
+
+    class _FakeContextParallelSharder:
+        def __init__(self, resolved_model, device_mesh, batch, **kwargs):
+            del device_mesh
+            assert resolved_model is model
+            assert model.prepared_before_shard
+            assert kwargs["num_chunks"] == 1
+            assert batch["input_ids"].shape == (1, 6)
+
+        def shard(self, batch):
+            local_batch = dict(batch)
+            for key in ("input_ids", "labels", "position_ids"):
+                local_batch[key] = local_batch[key].index_select(1, local_indices)
+            local_batch.pop("seq_lens")
+            local_batch.pop("seq_lens_padded")
+            return nullcontext, local_batch
+
+        def shard_token_tensor(self, tensor, seq_dim=1, fill=None):
+            del fill
+            return tensor.index_select(seq_dim, local_indices)
+
+    class _FakeSchedule:
+        def __init__(self):
+            self._loss_fn = SimpleNamespace(cu_seqlens=None)
+
+        def step(self, *args, target=None, losses=None, **kwargs):
+            captured["args"] = tuple(t.detach().clone() for t in args)
+            captured["target"] = target.detach().clone()
+            captured["kwargs"] = kwargs
+            losses.append(torch.tensor(1.0))
+
+    schedule = _FakeSchedule()
+    pp = SimpleNamespace(
+        pp_batch_size=1,
+        pp_microbatch_size=1,
+        info=SimpleNamespace(has_first_stage=True, has_last_stage=True, schedule=schedule),
+        update_seq_len=lambda seq_len: captured.__setitem__("seq_len", seq_len),
+    )
+    recipe = TrainFinetuneRecipeForNextTokenPrediction.__new__(TrainFinetuneRecipeForNextTokenPrediction)
+    object.__setattr__(
+        recipe,
+        "cfg",
+        SimpleNamespace(mtp=SimpleNamespace(ignore_index=-100, scaling_factor=1.0)),
+    )
+    object.__setattr__(recipe, "dist_env", SimpleNamespace(device=torch.device("cpu")))
+    object.__setattr__(recipe, "device_mesh", object())
+    object.__setattr__(recipe, "pp_enabled", True)
+    object.__setattr__(recipe, "pp", pp)
+    object.__setattr__(recipe, "tokenizer", SimpleNamespace(pad_token_id=0))
+    object.__setattr__(recipe, "te_fp8", None)
+    object.__setattr__(recipe, "model_parts", [model])
+    object.__setattr__(recipe, "_get_cp_group_size", lambda: 2)
+
+    monkeypatch.setattr("nemo_automodel.recipes.llm.train_ft.ContextParallelSharder", _FakeContextParallelSharder)
+
+    batch = {
+        "input_ids": torch.tensor([[10, 11, 12, 20, 21, 22]]),
+        "labels": torch.tensor([[11, 12, -100, 21, 22, -100]]),
+        "position_ids": torch.tensor([[0, 1, 2, 0, 1, 2]]),
+        "seq_lens": torch.tensor([[3, 3, -1000]]),
+        "seq_lens_padded": torch.tensor([[3, 3, -1000]]),
+    }
+
+    with pytest.raises(NotImplementedError, match="supports_mtp_cp_pp=False"):
+        recipe._forward_backward_step(
+            idx=0,
+            batch=batch,
+            loss_buffer=[],
+            num_label_tokens=4,
+            num_batches=1,
+            is_train=True,
+        )
+
+    model.supports.supports_mtp_cp_pp = True
+    model.prepared_before_shard = False
+    loss_buffer = []
+    recipe._forward_backward_step(
+        idx=0,
+        batch=batch,
+        loss_buffer=loss_buffer,
+        num_label_tokens=4,
+        num_batches=1,
+        is_train=True,
+    )
+
+    assert captured["seq_len"] == 4
+    assert captured["args"][0].tolist() == [[10, 11, 21, 22]]
+    assert captured["target"].tolist() == [[11, 12, 22, -100]]
+    assert captured["kwargs"]["mtp_per_depth_input_ids"][0].tolist() == [[11, 12, 22, 0]]
+    assert captured["kwargs"]["mtp_per_depth_position_ids"][0].tolist() == [[1, 2, 2, 0]]
+    assert captured["kwargs"]["mtp_per_depth_targets"][0].tolist() == [[12, -100, -100, -100]]
+    assert len(loss_buffer) == 1
+
+    class _FakeIdentitySharder:
+        def __init__(self, resolved_model, device_mesh, batch, **kwargs):
+            del device_mesh, batch
+            assert resolved_model is model
+            assert model.prepared_before_shard
+            assert kwargs["num_chunks"] == 1
+
+        def shard(self, unsharded_batch):
+            local_batch = dict(unsharded_batch)
+            local_batch.pop("seq_lens")
+            local_batch.pop("seq_lens_padded")
+            return nullcontext, local_batch
+
+        def shard_token_tensor(self, tensor, seq_dim=1, fill=None):
+            del seq_dim, fill
+            return tensor
+
+    # An opted-in model uses the same precomputed PP contract at CP1. This
+    # keeps CP1 and CP2 target construction identical before only the CP slice
+    # differs.
+    monkeypatch.setattr("nemo_automodel.recipes.llm.train_ft.ContextParallelSharder", _FakeIdentitySharder)
+    object.__setattr__(recipe, "_get_cp_group_size", lambda: 1)
+    model.prepared_before_shard = False
+    captured.clear()
+    loss_buffer = []
+    recipe._forward_backward_step(
+        idx=0,
+        batch=batch,
+        loss_buffer=loss_buffer,
+        num_label_tokens=4,
+        num_batches=1,
+        is_train=True,
+    )
+
+    assert model.prepared_before_shard
+    assert captured["seq_len"] == 6
+    assert captured["args"][0].tolist() == [[10, 11, 12, 20, 21, 22]]
+    assert captured["target"].tolist() == [[11, 12, -100, 21, 22, -100]]
+    assert captured["kwargs"]["mtp_per_depth_input_ids"][0].tolist() == [[11, 12, 0, 21, 22, 0]]
+    assert captured["kwargs"]["mtp_per_depth_position_ids"][0].tolist() == [[1, 2, 0, 1, 2, 0]]
+    assert captured["kwargs"]["mtp_per_depth_targets"][0].tolist() == [[12, -100, -100, 22, -100, -100]]
+    assert len(loss_buffer) == 1

--- a/tests/unit_tests/shared/test_model_utils.py
+++ b/tests/unit_tests/shared/test_model_utils.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from torch import nn
+
+from nemo_automodel.shared.model_utils import iter_transformer_and_mtp_blocks
+
+
+def test_iter_transformer_and_mtp_blocks_finds_inner_decoder_mtp_layers():
+    backbone_block = nn.Linear(2, 2)
+    mtp_block = nn.Linear(2, 2)
+    decoder = nn.Module()
+    decoder.layers = nn.ModuleList([backbone_block])
+    decoder.mtp_layers = nn.ModuleList([mtp_block])
+    model = nn.Module()
+    model.model = decoder
+
+    yielded = list(iter_transformer_and_mtp_blocks(model))
+
+    assert yielded == [
+        (decoder.layers, "0", backbone_block),
+        (decoder.mtp_layers, "0", mtp_block),
+    ]


### PR DESCRIPTION
# What does this PR do ?

Support the generic MTP + context-parallel + pipeline-parallel training combination, including the memory-saving fused linear cross-entropy path.

This is PR 2/3 in the HY4 support stack and depends on #3763. It contains only reusable training/parallelism infrastructure; no HY4 model code is included.

# Changelog

- Prepare MTP inputs and targets from the global packed sequence before CP sharding, including the PP path at CP1 so CP1 and CP2 share one loss contract.
- Carry authoritative CP-local, per-depth MTP targets through the last pipeline stage instead of shifting rank-local labels.
- Allow models that explicitly opt in to combine pipeline MTP with `FusedLinearCrossEntropy`.
- Discover checkpoint-compatible MTP blocks stored directly on an inner decoder for EP/FSDP/activation-checkpointing traversal.
- Add unit coverage for target extraction, packed boundaries, CP+PP capability gating, fused loss, and inner-decoder MTP traversal.

# Validation

GPU interactive allocation: Slurm job `16995628`, H100 80GB.

- `ruff check` and `ruff format --check`: passed.
- Relevant unit suites across loss, recipe, MoE parallelizer, shared traversal, PP+MTP, distributed helpers, and validation: **343 passed, 1 skipped**.
- 2-GPU packed CP + fused-linear-CE + FSDP correctness test: **1 passed**.

The validation command covered:

- `tests/unit_tests/loss/test_mtp_lm_head_gather.py`
- `tests/unit_tests/moe/test_parallelizer.py`
- `tests/unit_tests/recipes/test_train_ft.py`
- `tests/unit_tests/shared/test_model_utils.py`
- `tests/unit_tests/models/nemotron_v3/test_nemotron_v3_pp_mtp.py`
- `tests/unit_tests/distributed/test_parallelizer_utils.py`
- `tests/unit_tests/test_validation.py`
- `tests/functional_tests/training/test_cp_flce_fsdp_correctness.py`

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (No new recipe surface; capability remains model opt-in.)

# Additional Information

Validation logs:

- `logs/hy_v4_prs/pr2-mtp-cp-pp-scoped-interactive-16995628.log`
- `logs/hy_v4_prs/pr2-mtp-cp-pp-interactive-16995628.log`

