### PR TITLE
fix(checkpoint): support 64 GB RTX Spark training

### DIFF
--- a/examples/llm_finetune/llama3_1/llama3_1_8b_squad_peft_rtx_spark.yaml
+++ b/examples/llm_finetune/llama3_1/llama3_1_8b_squad_peft_rtx_spark.yaml
@@ -44,6 +44,9 @@ model:
   # HF FlashAttention-2 keeps packed training on the supported RTX Spark path.
   force_hf: true
   attn_implementation: flash_attention_2
+  # Avoid slow file-backed mmap page migration during HF's CPU-to-CUDA move.
+  # An 8B BF16 checkpoint can be materialized safely inside the 64 GB UMA cap.
+  disable_mmap: true
 
 peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig

--- a/examples/llm_finetune/llama3_1/llama3_1_8b_squad_peft_rtx_spark.yaml
+++ b/examples/llm_finetune/llama3_1/llama3_1_8b_squad_peft_rtx_spark.yaml
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# RTX Spark has 64 GB of unified host/GPU memory. Start the container with
+# --memory=64g --memory-swap=64g so host and GPU allocations share that budget.
+#
+# To run this recipe:
+#   automodel examples/llm_finetune/llama3_1/llama3_1_8b_squad_peft_rtx_spark.yaml --nproc-per-node 1
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  # Batch 1 and packed 128 are the validated 64 GB UMA regression settings.
+  global_batch_size: 1
+  local_batch_size: 1
+  ckpt_every_steps: 1000
+  val_every_steps: 10  # will run every x number of gradient steps
+  num_epochs: 1
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: meta-llama/Llama-3.1-8B
+  # TE packed THD backward requests ragged LSE, unsupported by cuDNN on SM12x.
+  # HF FlashAttention-2 keeps packed training on the supported RTX Spark path.
+  force_hf: true
+  attn_implementation: flash_attention_2
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  target_modules: '*_proj'
+  dim: 8
+  alpha: 32
+  use_triton: True
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+  # Full recomputation bounds activations inside the shared 64 GB UMA budget.
+  activation_checkpointing: true
+  sequence_parallel: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+
+packed_sequence:
+  packed_sequence_size: 128
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+  limit_dataset_samples: 64
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 1.0e-6
+
+# Uncomment and configure for W&B logging
+# wandb:
+#   project: <your_wandb_project>
+#   entity: <your_wandb_entity>
+#   name: <your_wandb_exp_name>
+#   save_dir: <your_wandb_save_dir>
+
+ci:
+  recipe_owner: akoumpa
+  time: "00:20:00"
+  nproc_per_node: 1
+  cluster_tag: gb10

--- a/examples/llm_finetune/llama3_1/llama3_1_8b_squad_peft_rtx_spark.yaml
+++ b/examples/llm_finetune/llama3_1/llama3_1_8b_squad_peft_rtx_spark.yaml
@@ -110,3 +110,4 @@ ci:
   time: "00:20:00"
   nproc_per_node: 1
   cluster_tag: gb10
+  nodes: 1

--- a/examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft_qlora_rtx_spark.yaml
+++ b/examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft_qlora_rtx_spark.yaml
@@ -112,3 +112,4 @@ ci:
   time: "00:30:00"
   nproc_per_node: 1
   cluster_tag: gb10
+  nodes: 1

--- a/examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft_qlora_rtx_spark.yaml
+++ b/examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft_qlora_rtx_spark.yaml
@@ -1,0 +1,114 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# QLoRA for Llama-3.3-70B-Instruct on RTX Spark's 64 GB unified memory.
+# Four-bit streaming is the regression guard: never fully materialize fp32 weights.
+# Start the container with --memory=64g --memory-swap=64g so host and GPU
+# allocations share that budget.
+#
+# To run this recipe:
+#   automodel examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft_qlora_rtx_spark.yaml --nproc-per-node 1
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 32
+  local_batch_size: 1
+  ckpt_every_steps: 100
+  val_every_steps: 600
+  max_steps: 500
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: meta-llama/Llama-3.3-70B-Instruct
+  torch_dtype: bfloat16
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  target_modules: '*_proj'
+  dim: 16
+  alpha: 32
+  dropout: 0.1
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+  # Recompute LoRA activations instead of competing with the 4-bit base weights.
+  activation_checkpointing: true
+  sequence_parallel: false
+
+quantization:
+  load_in_4bit: True
+  load_in_8bit: False
+  bnb_4bit_compute_dtype: bfloat16
+  bnb_4bit_use_double_quant: True
+  bnb_4bit_quant_type: nf4
+  bnb_4bit_quant_storage: bfloat16
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.te_parallel_ce.TEParallelCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+
+packed_sequence:
+  packed_sequence_size: 1024
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+  limit_dataset_samples: 100
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0.01
+
+# Uncomment and configure for W&B logging
+# wandb:
+#   project: <your_wandb_project>
+#   entity: <your_wandb_entity>
+#   name: llama3_3_70b_instruct_squad_qlora_rtx_spark
+#   save_dir: <your_wandb_save_dir>
+
+ci:
+  recipe_owner: akoumpa
+  time: "00:30:00"
+  nproc_per_node: 1
+  cluster_tag: gb10

--- a/examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft_qlora_rtx_spark.yaml
+++ b/examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft_qlora_rtx_spark.yaml
@@ -23,7 +23,7 @@
 recipe: TrainFinetuneRecipeForNextTokenPrediction
 
 step_scheduler:
-  global_batch_size: 32
+  global_batch_size: 1
   local_batch_size: 1
   ckpt_every_steps: 100
   val_every_steps: 600
@@ -42,6 +42,8 @@ model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: meta-llama/Llama-3.3-70B-Instruct
   torch_dtype: bfloat16
+  # Avoid mmap-backed page migration; the streaming loader still loads one shard at a time.
+  disable_mmap: true
 
 peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig

--- a/examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft_qlora_rtx_spark.yaml
+++ b/examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft_qlora_rtx_spark.yaml
@@ -26,7 +26,10 @@ step_scheduler:
   global_batch_size: 1
   local_batch_size: 1
   ckpt_every_steps: 100
-  val_every_steps: 600
+  # Checkpoint cadence otherwise forces validation before save. On 64 GB UMA,
+  # keep this recipe's default path focused on train + checkpoint; eval is opt-in.
+  validate_on_checkpoint: false
+  val_every_steps: null
   max_steps: 500
 
 dist_env:

--- a/examples/llm_finetune/qwen/qwen3_8b_squad_rtx_spark.yaml
+++ b/examples/llm_finetune/qwen/qwen3_8b_squad_rtx_spark.yaml
@@ -1,0 +1,115 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# RTX Spark has 64 GB of unified host/GPU memory. Start the container with
+# --memory=64g --memory-swap=64g so host and GPU allocations share that budget.
+#
+# To run this recipe:
+#   automodel examples/llm_finetune/qwen/qwen3_8b_squad_rtx_spark.yaml --nproc-per-node 1
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 1
+  local_batch_size: 1
+  ckpt_every_steps: 1000
+  val_every_steps: 10  # will run every x number of gradient steps
+  num_epochs: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen3-8B
+  # TE packed THD backward requests ragged LSE, unsupported by cuDNN on SM12x.
+  # HF FlashAttention-2 keeps packed training on the supported RTX Spark path.
+  force_hf: true
+  attn_implementation: flash_attention_2
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  target_modules: '*_proj'
+  dim: 8
+  alpha: 32
+  use_triton: True
+
+compile:
+  enabled: false
+  mode: "default"
+  fullgraph: false
+  dynamic: false
+  backend: null
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+  # Full recomputation bounds activations inside the shared 64 GB UMA budget.
+  activation_checkpointing: true
+  sequence_parallel: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.te_parallel_ce.TEParallelCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+
+packed_sequence:
+  packed_sequence_size: 128
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+  limit_dataset_samples: 64
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0
+  fused: True
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 1.0e-6
+
+# Uncomment and configure for W&B logging
+# wandb:
+#   project: <your_wandb_project>
+#   entity: <your_wandb_entity>
+#   name: <your_wandb_exp_name>
+#   save_dir: <your_wandb_save_dir>
+
+ci:
+  recipe_owner: akoumpa
+  time: "00:20:00"
+  nproc_per_node: 1
+  cluster_tag: gb10

--- a/examples/llm_finetune/qwen/qwen3_8b_squad_rtx_spark.yaml
+++ b/examples/llm_finetune/qwen/qwen3_8b_squad_rtx_spark.yaml
@@ -113,3 +113,4 @@ ci:
   time: "00:20:00"
   nproc_per_node: 1
   cluster_tag: gb10
+  nodes: 1

--- a/examples/llm_finetune/qwen/qwen3_8b_squad_rtx_spark.yaml
+++ b/examples/llm_finetune/qwen/qwen3_8b_squad_rtx_spark.yaml
@@ -39,6 +39,9 @@ model:
   # HF FlashAttention-2 keeps packed training on the supported RTX Spark path.
   force_hf: true
   attn_implementation: flash_attention_2
+  # Avoid slow file-backed mmap page migration during HF's CPU-to-CUDA move.
+  # An 8B BF16 checkpoint can be materialized safely inside the 64 GB UMA cap.
+  disable_mmap: true
 
 peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig

--- a/nemo_automodel/_transformers/model_init.py
+++ b/nemo_automodel/_transformers/model_init.py
@@ -768,14 +768,13 @@ def _has_safetensors(model_dir: str) -> bool:
     return False
 
 
-def _stream_load_bnb_weights(model, model_dir, device, torch_dtype):
+def _stream_load_bnb_weights(model, model_dir, device, torch_dtype, *, disable_mmap: bool = False):
     """Load safetensor shards one-at-a-time, quantizing BnB Params4bit on the fly.
 
     Peak memory ≈ (accumulated quantized weights) + (one bf16 weight tensor)
     instead of (full bf16 model) with standard HF loading.
     """
     import bitsandbytes as bnb
-    from safetensors import safe_open
 
     index_path = os.path.join(model_dir, "model.safetensors.index.json")
     if os.path.exists(index_path):
@@ -800,6 +799,40 @@ def _stream_load_bnb_weights(model, model_dir, device, torch_dtype):
     loaded_keys: set[str] = set()
     device = torch.device(device) if not isinstance(device, torch.device) else device
 
+    def consume_tensor(key: str, tensor: torch.Tensor) -> None:
+        if key not in param_map:
+            logger.debug("Skipping key not in model: %s", key)
+            del tensor
+            return
+
+        mod, attr, old_param = param_map[key]
+
+        if isinstance(old_param, bnb.nn.Params4bit):
+            if torch_dtype is not None:
+                tensor = tensor.to(dtype=torch_dtype)
+            new_param = bnb.nn.Params4bit(
+                data=tensor,
+                requires_grad=False,
+                compress_statistics=old_param.compress_statistics,
+                quant_type=old_param.quant_type,
+                quant_storage=old_param.quant_storage,
+                module=mod if isinstance(mod, bnb.nn.Linear4bit) else None,
+                bnb_quantized=False,
+            )
+            del tensor
+            new_param._quantize(device)
+            mod._parameters[attr] = new_param
+        else:
+            target_dtype = torch_dtype if torch_dtype is not None else tensor.dtype
+            materialized = tensor.to(device=device, dtype=target_dtype)
+            del tensor
+            if isinstance(old_param, torch.nn.Parameter):
+                mod._parameters[attr] = torch.nn.Parameter(materialized, requires_grad=old_param.requires_grad)
+            else:
+                mod._buffers[attr] = materialized
+
+        loaded_keys.add(key)
+
     for shard_idx, shard_file in enumerate(shard_files):
         shard_path = os.path.join(model_dir, shard_file)
         logger.info(
@@ -809,42 +842,26 @@ def _stream_load_bnb_weights(model, model_dir, device, torch_dtype):
             shard_file,
         )
 
-        with safe_open(shard_path, framework="pt") as f:
-            for key in f.keys():
-                tensor = f.get_tensor(key)
+        if disable_mmap:
+            from safetensors.torch import load as load_safetensors_bytes
 
-                if key not in param_map:
-                    logger.debug("Skipping key not in model: %s", key)
-                    del tensor
-                    continue
+            # On UMA systems, CUDA faults over file-backed checkpoint pages can
+            # dominate load time. Read only the active shard into anonymous
+            # memory before tensor deserialization.
+            with open(shard_path, "rb") as f:
+                shard_tensors = load_safetensors_bytes(f.read())
+            try:
+                for key, tensor in shard_tensors.items():
+                    consume_tensor(key, tensor)
+            finally:
+                shard_tensors.clear()
+                del shard_tensors
+        else:
+            from safetensors import safe_open
 
-                mod, attr, old_param = param_map[key]
-
-                if isinstance(old_param, bnb.nn.Params4bit):
-                    if torch_dtype is not None:
-                        tensor = tensor.to(dtype=torch_dtype)
-                    new_param = bnb.nn.Params4bit(
-                        data=tensor,
-                        requires_grad=False,
-                        compress_statistics=old_param.compress_statistics,
-                        quant_type=old_param.quant_type,
-                        quant_storage=old_param.quant_storage,
-                        module=mod if isinstance(mod, bnb.nn.Linear4bit) else None,
-                        bnb_quantized=False,
-                    )
-                    del tensor
-                    new_param._quantize(device)
-                    mod._parameters[attr] = new_param
-                else:
-                    target_dtype = torch_dtype if torch_dtype is not None else tensor.dtype
-                    materialized = tensor.to(device=device, dtype=target_dtype)
-                    del tensor
-                    if isinstance(old_param, torch.nn.Parameter):
-                        mod._parameters[attr] = torch.nn.Parameter(materialized, requires_grad=old_param.requires_grad)
-                    else:
-                        mod._buffers[attr] = materialized
-
-                loaded_keys.add(key)
+            with safe_open(shard_path, framework="pt") as f:
+                for key in f.keys():
+                    consume_tensor(key, f.get_tensor(key))
 
         gc.collect()
         torch.cuda.empty_cache()
@@ -879,6 +896,22 @@ def _stream_load_bnb_weights(model, model_dir, device, torch_dtype):
         len(loaded_keys),
         len(param_map) - len(loaded_keys),
     )
+
+
+def _get_bnb_modules_to_not_convert(model, quantization_config):
+    """Mirror HF BnB's default skip-list semantics before streaming replacement."""
+    from transformers.quantizers.base import get_keys_to_not_convert
+
+    skip_modules = getattr(quantization_config, "llm_int8_skip_modules", None)
+    keep_in_fp32_modules = getattr(model, "_keep_in_fp32_modules", None)
+
+    modules_to_not_convert = get_keys_to_not_convert(model) if skip_modules is None else []
+    if skip_modules is not None:
+        modules_to_not_convert.extend(skip_modules)
+    if keep_in_fp32_modules is not None:
+        modules_to_not_convert.extend(keep_in_fp32_modules)
+
+    return list(set(modules_to_not_convert))
 
 
 def _streaming_bnb_supported(cls, hf_config) -> bool:
@@ -944,6 +977,7 @@ def _init_model_bnb_streaming(
     device = torch.cuda.current_device()
 
     # 1. Download weights if needed
+    disable_mmap = bool(kwargs.pop("disable_mmap", False))
     _download_model_weights(hf_config, pretrained_model_name_or_path)
 
     # 2. Resolve to local directory & verify safetensors
@@ -961,9 +995,7 @@ def _init_model_bnb_streaming(
         )
 
     # 4. Replace nn.Linear → bnb.nn.Linear4bit (still on meta, no memory)
-    modules_to_not_convert = getattr(quantization_config, "llm_int8_skip_modules", None)
-    if modules_to_not_convert is None:
-        modules_to_not_convert = getattr(model, "_keep_in_fp32_modules", None)
+    modules_to_not_convert = _get_bnb_modules_to_not_convert(model, quantization_config)
     model = replace_with_bnb_linear(
         model,
         modules_to_not_convert=modules_to_not_convert,
@@ -971,7 +1003,7 @@ def _init_model_bnb_streaming(
     )
 
     # 5. Stream-load weights, quantizing each tensor on the fly
-    _stream_load_bnb_weights(model, model_dir, device, torch_dtype)
+    _stream_load_bnb_weights(model, model_dir, device, torch_dtype, disable_mmap=disable_mmap)
 
     # 6. Store quantization_config on the model (HF convention)
     model.config.quantization_config = quantization_config

--- a/nemo_automodel/_transformers/model_init.py
+++ b/nemo_automodel/_transformers/model_init.py
@@ -773,6 +773,8 @@ def _stream_load_bnb_weights(model, model_dir, device, torch_dtype, *, disable_m
 
     Peak memory ≈ (accumulated quantized weights) + (one bf16 weight tensor)
     instead of (full bf16 model) with standard HF loading.
+    When disable_mmap=True, one tensor at a time is cloned to anonymous CPU
+    memory before CUDA transfer to avoid UMA page-migration stalls.
     """
     import bitsandbytes as bnb
 
@@ -800,6 +802,16 @@ def _stream_load_bnb_weights(model, model_dir, device, torch_dtype, *, disable_m
     device = torch.device(device) if not isinstance(device, torch.device) else device
 
     def consume_tensor(key: str, tensor: torch.Tensor) -> None:
+        """Install one checkpoint tensor into the target model.
+
+        Args:
+            key: Fully-qualified state-dict key. The key determines the tensor's rank and axis semantics.
+            tensor: Tensor from the active safetensors shard. This function takes ownership and may cast,
+                quantize, move, or install it as a parameter/buffer.
+
+        Returns:
+            None.
+        """
         if key not in param_map:
             logger.debug("Skipping key not in model: %s", key)
             del tensor
@@ -842,26 +854,19 @@ def _stream_load_bnb_weights(model, model_dir, device, torch_dtype, *, disable_m
             shard_file,
         )
 
-        if disable_mmap:
-            from safetensors.torch import load as load_safetensors_bytes
+        from safetensors import safe_open
 
-            # On UMA systems, CUDA faults over file-backed checkpoint pages can
-            # dominate load time. Read only the active shard into anonymous
-            # memory before tensor deserialization.
-            with open(shard_path, "rb") as f:
-                shard_tensors = load_safetensors_bytes(f.read())
-            try:
-                for key, tensor in shard_tensors.items():
+        with safe_open(shard_path, framework="pt") as f:
+            for key in f.keys():
+                tensor = f.get_tensor(key)
+                if disable_mmap and key in param_map:
+                    # Avoid full-shard materialization while detaching the next
+                    # CUDA/quantization copy from mmap-backed checkpoint pages.
+                    tensor = tensor.clone()
+                try:
                     consume_tensor(key, tensor)
-            finally:
-                shard_tensors.clear()
-                del shard_tensors
-        else:
-            from safetensors import safe_open
-
-            with safe_open(shard_path, framework="pt") as f:
-                for key in f.keys():
-                    consume_tensor(key, f.get_tensor(key))
+                finally:
+                    del tensor
 
         gc.collect()
         torch.cuda.empty_cache()

--- a/nemo_automodel/components/checkpoint/_backports/hf_storage.py
+++ b/nemo_automodel/components/checkpoint/_backports/hf_storage.py
@@ -70,6 +70,14 @@ _DIFFUSERS_INDEX_FN = "diffusion_pytorch_model.safetensors.index.json"
 logger = logging.getLogger(__name__)
 
 
+def _is_integrated_cuda_device(device: torch.device) -> bool:
+    """Whether *device* is an integrated CUDA GPU sharing host memory."""
+    if device.type != "cuda":
+        return False
+    properties = torch.cuda.get_device_properties(device)
+    return bool(getattr(properties, "is_integrated", False))
+
+
 def _maybe_rename_index_for_diffusers(consolidated_dir: str) -> None:
     """Rename the consolidated index file to the diffusers-expected name.
 
@@ -321,17 +329,27 @@ class _HuggingFaceStorageReader(FsspecReader):
                             tensor = torch.frombuffer(
                                 view, dtype=item_md.dtype, count=numel, offset=item_md.offset
                             ).reshape(item_md.shape)
+                            file_backed = True
                         else:
                             tensor = torch.frombuffer(
                                 bytearray(view[item_md.offset : item_md.offset + item_md.length]),
                                 dtype=item_md.dtype,
                             ).reshape(item_md.shape)
+                            file_backed = False
                         tensor = narrow_tensor_by_index(tensor, req.storage_offsets, req.lengths)
                         target_tensor = planner.resolve_tensor(req).detach()
 
                         assert target_tensor.size() == tensor.size(), (
                             f"req {req.storage_index} mismatch sizes {target_tensor.size()} vs {tensor.size()}"
                         )
+
+                        # On integrated GPUs, copying a file-backed mmap directly to CUDA can
+                        # migrate it page-by-page and take minutes per tensor. Stage only this
+                        # requested slice in anonymous host memory; unlike the full-state loader,
+                        # peak host memory is bounded by one tensor. Discrete GPUs keep the
+                        # zero-copy mmap source used to avoid host OOM on very large checkpoints.
+                        if file_backed and _is_integrated_cuda_device(target_tensor.device):
+                            tensor = tensor.clone()
 
                         # copy_ from a pageable host buffer is synchronous, so the mmap can be
                         # released right after this loop without racing an in-flight H2D copy.

--- a/nemo_automodel/components/checkpoint/_backports/hf_storage.py
+++ b/nemo_automodel/components/checkpoint/_backports/hf_storage.py
@@ -71,7 +71,7 @@ logger = logging.getLogger(__name__)
 
 
 def _is_integrated_cuda_device(device: torch.device) -> bool:
-    """Whether *device* is an integrated CUDA GPU sharing host memory."""
+    """Whether CUDA reports *device* as sharing physical memory with the host."""
     if device.type != "cuda":
         return False
     properties = torch.cuda.get_device_properties(device)
@@ -329,12 +329,14 @@ class _HuggingFaceStorageReader(FsspecReader):
                             tensor = torch.frombuffer(
                                 view, dtype=item_md.dtype, count=numel, offset=item_md.offset
                             ).reshape(item_md.shape)
+                            # This view still faults pages from the file mmap.
                             file_backed = True
                         else:
                             tensor = torch.frombuffer(
                                 bytearray(view[item_md.offset : item_md.offset + item_md.length]),
                                 dtype=item_md.dtype,
                             ).reshape(item_md.shape)
+                            # The alignment fallback already owns resident bytes.
                             file_backed = False
                         tensor = narrow_tensor_by_index(tensor, req.storage_offsets, req.lengths)
                         target_tensor = planner.resolve_tensor(req).detach()

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -863,6 +863,8 @@ class Checkpointer:
             )
         ):
             t0 = time.monotonic()
+            # Full-state safetensors remain mmap-backed. Prefault only when the
+            # destination shares host memory; CPU and discrete-GPU paths stay unchanged.
             model_cuda_devices = {
                 parameter.device
                 for part in model_state.model
@@ -2673,6 +2675,8 @@ def _load_hf_safetensors_checkpoint(
     def get_tensor(handle, key: str) -> torch.Tensor:
         tensor = handle.get_tensor(key)
         if prefault_mmap:
+            # Fault the mmap pages now, then discard the anonymous copy so the
+            # returned state remains file-backed and reclaimable under pressure.
             prefaulted = tensor.clone()
             del prefaulted
         return tensor
@@ -2681,6 +2685,7 @@ def _load_hf_safetensors_checkpoint(
     if os.path.isfile(model_path):
         if not prefault_mmap:
             return dict(load_file(model_path))
+        # load_file hides per-tensor access; safe_open lets us prefault each view.
         with safe_open(model_path, framework="pt", device="cpu") as f:
             return {key: get_tensor(f, key) for key in f.keys()}
     # Directory: try index first, then glob

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -60,6 +60,7 @@ from nemo_automodel.components.checkpoint._backports.filesystem import FileSyste
 from nemo_automodel.components.checkpoint._backports.hf_storage import (
     _HuggingFaceStorageReader,
     _HuggingFaceStorageWriter,
+    _is_integrated_cuda_device,
     _maybe_rename_index_for_diffusers,
     get_fqn_to_dtype_mapping,
     get_fqn_to_file_index_mapping,
@@ -841,16 +842,11 @@ class Checkpointer:
         else:
             world_size = int(os.environ.get("WORLD_SIZE", "1"))
         state_dict_adapter = getattr(_unwrap_ddp_model(model_state.model[0]), "state_dict_adapter", None)
-        # Dense Llama's native state dict already uses the Hugging Face key and tensor layout.
-        # Keep this routing decision checkpoint-owned: the adapter only implements the common
-        # StateDictAdapter interface and does not need a checkpoint-policy capability flag.
-        checkpoint_managed_write_through = model_type == "llama" and isinstance(state_dict_adapter, StateDictAdapter)
         can_load_without_full_copy = (
             isinstance(state_dict_adapter, StateDictAdapter)
             and (
                 state_dict_adapter.supports_write_through_checkpoint_load
                 or state_dict_adapter.supports_checkpoint_load_without_full_copy
-                or checkpoint_managed_write_through
             )
             and not self.config.dequantize_base_checkpoint
         )
@@ -867,7 +863,17 @@ class Checkpointer:
             )
         ):
             t0 = time.monotonic()
-            state_dict_from_disk = _load_hf_checkpoint_preserving_dtype(model_path)
+            model_cuda_devices = {
+                parameter.device
+                for part in model_state.model
+                for parameter in part.parameters()
+                if parameter.device.type == "cuda"
+            }
+            prefault_safetensors = any(_is_integrated_cuda_device(device) for device in model_cuda_devices)
+            state_dict_from_disk = _load_hf_checkpoint_preserving_dtype(
+                model_path,
+                prefault_safetensors=prefault_safetensors,
+            )
             t_disk = time.monotonic()
             if state_dict_from_disk is not None:
                 state_dict_from_disk = _maybe_adapt_state_dict_from_hf(
@@ -2627,7 +2633,11 @@ def _is_custom_model(module: nn.Module) -> bool:
     )
 
 
-def _load_hf_checkpoint_preserving_dtype(model_path: str) -> dict[str, torch.Tensor] | None:
+def _load_hf_checkpoint_preserving_dtype(
+    model_path: str,
+    *,
+    prefault_safetensors: bool = False,
+) -> dict[str, torch.Tensor] | None:
     """
     Load a HuggingFace checkpoint into a new state dict so tensor dtypes
     match the checkpoint (e.g. bf16). Used when loading the base model so FSDP sees
@@ -2642,19 +2652,37 @@ def _load_hf_checkpoint_preserving_dtype(model_path: str) -> dict[str, torch.Ten
     if _is_bin_checkpoint(model_path):
         return _load_hf_bin_checkpoint(model_path)
     elif _is_safetensors_checkpoint(model_path):
-        return _load_hf_safetensors_checkpoint(model_path)
+        return _load_hf_safetensors_checkpoint(model_path, prefault_mmap=prefault_safetensors)
     return None
 
 
-def _load_hf_safetensors_checkpoint(model_path: str) -> dict[str, torch.Tensor] | None:
+def _load_hf_safetensors_checkpoint(
+    model_path: str,
+    *,
+    prefault_mmap: bool = False,
+) -> dict[str, torch.Tensor] | None:
     """
     Load a safetensors checkpoint into a state dict.
+
+    On integrated CUDA systems, ``prefault_mmap`` reads every file-backed tensor
+    once before installation. This keeps the returned tensors mmap-backed and
+    reclaimable while avoiding page-by-page migration during the later CUDA copy.
     """
     from safetensors import safe_open
 
+    def get_tensor(handle, key: str) -> torch.Tensor:
+        tensor = handle.get_tensor(key)
+        if prefault_mmap:
+            prefaulted = tensor.clone()
+            del prefaulted
+        return tensor
+
     out: dict[str, torch.Tensor] = {}
     if os.path.isfile(model_path):
-        return dict(load_file(model_path))
+        if not prefault_mmap:
+            return dict(load_file(model_path))
+        with safe_open(model_path, framework="pt", device="cpu") as f:
+            return {key: get_tensor(f, key) for key in f.keys()}
     # Directory: try index first, then glob
     index_file = os.path.join(model_path, "model.safetensors.index.json")
     if os.path.isfile(index_file):
@@ -2673,12 +2701,12 @@ def _load_hf_safetensors_checkpoint(model_path: str) -> dict[str, torch.Tensor] 
                 available_keys = set(f.keys())
                 for key in keys:
                     if key in available_keys:
-                        out[key] = f.get_tensor(key)
+                        out[key] = get_tensor(f, key)
     else:
         for sf_path in glob.glob(os.path.join(model_path, "*.safetensors")):
             with safe_open(sf_path, framework="pt", device="cpu") as f:
                 for key in f.keys():
-                    out[key] = f.get_tensor(key)
+                    out[key] = get_tensor(f, key)
     return out if out else None
 
 

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -865,12 +865,7 @@ class Checkpointer:
             t0 = time.monotonic()
             # Full-state safetensors remain mmap-backed. Prefault only when the
             # destination shares host memory; CPU and discrete-GPU paths stay unchanged.
-            # RTX Spark regression matrix for refactors here:
-            # - llama3_1_8b_squad_peft_rtx_spark.yaml: 64 GB UMA end-to-end guard; set force_hf=false
-            #   for a custom-loader-only smoke test because SM12x cannot run TE packed backward.
-            # - qwen3_8b_squad_rtx_spark.yaml: HF/FA2 packed-training baseline on GB10.
-            # - llama_3_3_70b_instruct_squad_peft_qlora_rtx_spark.yaml: 4-bit streaming guard;
-            #   never full-materialize the 70B checkpoint.
+            # UMA regression guard: do not reintroduce full checkpoint materialization here.
             model_cuda_devices = {
                 parameter.device
                 for part in model_state.model

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -841,11 +841,16 @@ class Checkpointer:
         else:
             world_size = int(os.environ.get("WORLD_SIZE", "1"))
         state_dict_adapter = getattr(_unwrap_ddp_model(model_state.model[0]), "state_dict_adapter", None)
+        # Dense Llama's native state dict already uses the Hugging Face key and tensor layout.
+        # Keep this routing decision checkpoint-owned: the adapter only implements the common
+        # StateDictAdapter interface and does not need a checkpoint-policy capability flag.
+        checkpoint_managed_write_through = model_type == "llama" and isinstance(state_dict_adapter, StateDictAdapter)
         can_load_without_full_copy = (
             isinstance(state_dict_adapter, StateDictAdapter)
             and (
                 state_dict_adapter.supports_write_through_checkpoint_load
                 or state_dict_adapter.supports_checkpoint_load_without_full_copy
+                or checkpoint_managed_write_through
             )
             and not self.config.dequantize_base_checkpoint
         )

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -866,10 +866,11 @@ class Checkpointer:
             # Full-state safetensors remain mmap-backed. Prefault only when the
             # destination shares host memory; CPU and discrete-GPU paths stay unchanged.
             # RTX Spark regression matrix for refactors here:
-            # - llama3_2_1b_squad_peft.yaml + Llama-3.1-8B, force_hf=false: this custom mmap load.
-            # - The same YAML's Spark-safe HF/FA2 + AC path, packed=128, batch=1: NVBug 6674647 end-to-end.
-            # - qwen3_8b_squad_spark.yaml: native GB10 packed-LoRA guard.
-            # - llama_3_3_70b_instruct_squad_peft_qlora_spark.yaml: streaming guard; never full-materialize.
+            # - llama3_1_8b_squad_peft_rtx_spark.yaml: 64 GB UMA end-to-end guard; set force_hf=false
+            #   for a custom-loader-only smoke test because SM12x cannot run TE packed backward.
+            # - qwen3_8b_squad_rtx_spark.yaml: HF/FA2 packed-training baseline on GB10.
+            # - llama_3_3_70b_instruct_squad_peft_qlora_rtx_spark.yaml: 4-bit streaming guard;
+            #   never full-materialize the 70B checkpoint.
             model_cuda_devices = {
                 parameter.device
                 for part in model_state.model

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -865,6 +865,11 @@ class Checkpointer:
             t0 = time.monotonic()
             # Full-state safetensors remain mmap-backed. Prefault only when the
             # destination shares host memory; CPU and discrete-GPU paths stay unchanged.
+            # RTX Spark regression matrix for refactors here:
+            # - llama3_2_1b_squad_peft.yaml + Llama-3.1-8B, force_hf=false: this custom mmap load.
+            # - The same YAML's Spark-safe HF/FA2 + AC path, packed=128, batch=1: NVBug 6674647 end-to-end.
+            # - qwen3_8b_squad_spark.yaml: native GB10 packed-LoRA guard.
+            # - llama_3_3_70b_instruct_squad_peft_qlora_spark.yaml: streaming guard; never full-materialize.
             model_cuda_devices = {
                 parameter.device
                 for part in model_state.model

--- a/nemo_automodel/components/models/llama/state_dict_adapter.py
+++ b/nemo_automodel/components/models/llama/state_dict_adapter.py
@@ -33,6 +33,9 @@ logger = logging.getLogger(__name__)
 class LlamaStateDictAdapter(StateDictAdapter):
     """State dict adapter for Llama models.
 
+    Subclassing the common interface makes the adapter checkpoint-compatible;
+    load-path policy remains entirely inside the checkpoint package.
+
     Uses separate projections that match HuggingFace key names exactly, so
     from_hf / to_hf are simple passthroughs (only tied-weight handling in
     from_hf).

--- a/nemo_automodel/components/models/llama/state_dict_adapter.py
+++ b/nemo_automodel/components/models/llama/state_dict_adapter.py
@@ -50,8 +50,6 @@ class LlamaStateDictAdapter(StateDictAdapter):
         hf_state_dict = adapter.to_hf(custom_state_dict)
     """
 
-    _supports_write_through_checkpoint_load = True
-
     def __init__(self, config: LlamaConfig):
         """Initialize adapter with Llama config."""
         self.config = config

--- a/nemo_automodel/components/models/llama/state_dict_adapter.py
+++ b/nemo_automodel/components/models/llama/state_dict_adapter.py
@@ -25,10 +25,12 @@ from typing import Any
 
 from transformers import LlamaConfig
 
+from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+
 logger = logging.getLogger(__name__)
 
 
-class LlamaStateDictAdapter:
+class LlamaStateDictAdapter(StateDictAdapter):
     """State dict adapter for Llama models.
 
     Uses separate projections that match HuggingFace key names exactly, so
@@ -47,6 +49,8 @@ class LlamaStateDictAdapter:
         # Convert custom checkpoint back to HF format
         hf_state_dict = adapter.to_hf(custom_state_dict)
     """
+
+    _supports_write_through_checkpoint_load = True
 
     def __init__(self, config: LlamaConfig):
         """Initialize adapter with Llama config."""
@@ -75,3 +79,9 @@ class LlamaStateDictAdapter:
         if exclude_key_regex is not None:
             return {k: v for k, v in state_dict.items() if not re.search(exclude_key_regex, k)}
         return dict(state_dict)
+
+    def convert_single_tensor_to_hf(self, fqn: str, tensor: Any, **kwargs) -> list[tuple[str, Any]]:
+        exclude_key_regex = kwargs.get("exclude_key_regex")
+        if exclude_key_regex is not None and re.search(exclude_key_regex, fqn):
+            return []
+        return [(fqn, tensor)]

--- a/nemo_automodel/components/models/llama/state_dict_adapter.py
+++ b/nemo_automodel/components/models/llama/state_dict_adapter.py
@@ -82,6 +82,16 @@ class LlamaStateDictAdapter(StateDictAdapter):
         return dict(state_dict)
 
     def convert_single_tensor_to_hf(self, fqn: str, tensor: Any, **kwargs) -> list[tuple[str, Any]]:
+        """Return one Llama tensor under its unchanged HF state-dict key.
+
+        Args:
+            fqn: Fully-qualified HF state-dict key. The key determines the tensor's rank and axis order.
+            tensor: Tensor/value to export. This passthrough does not copy or transform it.
+            **kwargs: Optional controls, including ``exclude_key_regex`` to skip matching keys.
+
+        Returns:
+            A single ``(fqn, tensor)`` tuple, or an empty list when filtered. The returned tensor aliases the input.
+        """
         exclude_key_regex = kwargs.get("exclude_key_regex")
         if exclude_key_regex is not None and re.search(exclude_key_regex, fqn):
             return []

--- a/nemo_automodel/components/training/step_scheduler.py
+++ b/nemo_automodel/components/training/step_scheduler.py
@@ -66,6 +66,7 @@ class StepScheduler(Stateful):
         dataloader: DataLoader | None,
         ckpt_every_steps: int | None = None,
         save_checkpoint_every_epoch: bool = True,
+        validate_on_checkpoint: bool = True,
         val_every_steps: int | None = None,
         log_remote_every_steps: int = 1,
         loss_average_window_steps: int = 50,
@@ -90,6 +91,8 @@ class StepScheduler(Stateful):
                 When True, checkpoints are saved at the end of each epoch (is_last_batch).
                 When False, only periodic, last-step, and SIGTERM checkpoints are saved.
                 Default: True.
+            validate_on_checkpoint (bool): Whether checkpoint steps should also run validation. Keeping this enabled
+                preserves historical best-checkpoint behavior; memory-constrained recipes can disable it and still save.
             val_every_steps (int | None): Number of training steps between validation.
             log_remote_every_steps (int): Frequency of remote logging (e.g., WandB, MLflow). Default: 1 (every step).
             loss_average_window_steps (int): Rolling window size for averaged training loss metrics.
@@ -178,6 +181,7 @@ class StepScheduler(Stateful):
             raise ValueError(f"ckpt_every_steps must be greater than 0, got {ckpt_every_steps}")
         self.ckpt_every_steps = ckpt_every_steps
         self.save_checkpoint_every_epoch = save_checkpoint_every_epoch
+        self.validate_on_checkpoint = validate_on_checkpoint
         if preemption_signal is None:
             self.sig_handler = None
         else:
@@ -234,7 +238,10 @@ class StepScheduler(Stateful):
         is_val = False
         if self.val_every_steps and self.val_every_steps > 0:
             is_val = self.step % self.val_every_steps == self.val_every_steps - 1
-        return (is_val or self.is_ckpt_step) and not self.sigterm_flag
+        # Historically, checkpoint steps also validated so best-checkpoint
+        # metrics were available. Tiny-UMA recipes can opt out and still save.
+        is_checkpoint_validation = self.validate_on_checkpoint and self.is_ckpt_step
+        return (is_val or is_checkpoint_validation) and not self.sigterm_flag
 
     @property
     def is_ckpt_step(self):
@@ -362,6 +369,7 @@ class StepSchedulerConfig:
         ckpt_every_steps: Save a checkpoint every N optimizer steps.
             ``None`` defaults to once per epoch.
         save_checkpoint_every_epoch: Also checkpoint at every epoch boundary.
+        validate_on_checkpoint: Also run validation on checkpoint steps.
         val_every_steps: Run validation every N optimizer steps.
             ``None`` disables periodic validation.
         log_remote_every_steps: Log to WandB / MLflow every N steps.
@@ -381,6 +389,7 @@ class StepSchedulerConfig:
     max_steps: int | None = None
     ckpt_every_steps: int | None = 100
     save_checkpoint_every_epoch: bool = True
+    validate_on_checkpoint: bool = True
     val_every_steps: int | None = None
     log_remote_every_steps: int = 1
     loss_average_window_steps: int = 50

--- a/tests/unit_tests/_transformers/test_model_init.py
+++ b/tests/unit_tests/_transformers/test_model_init.py
@@ -891,7 +891,7 @@ class TestStreamLoadBnbWeights:
         assert model.lin.weight.device.type == "cpu"
         assert model.lin.bias.device.type == "cpu"
 
-    def test_disable_mmap_reads_safetensors_bytes(self, tmp_path):
+    def test_disable_mmap_stages_one_tensor_from_safe_open(self, tmp_path):
         with torch.device("meta"):
             model = _TinyModelOnMeta()
 
@@ -901,17 +901,29 @@ class TestStreamLoadBnbWeights:
                 "lin.weight": torch.randn(8, 4),
                 "lin.bias": torch.randn(8),
                 "running_scale": torch.zeros(8),
+                "unused.extra": torch.ones(3, 3),
             },
         )
 
+        original_clone = torch.Tensor.clone
+        cloned_shapes = []
+
+        def record_clone(tensor, *args, **kwargs):
+            cloned_shapes.append(tuple(tensor.shape))
+            return original_clone(tensor, *args, **kwargs)
+
         with (
-            patch("safetensors.safe_open", side_effect=AssertionError("safe_open should not be used")),
+            patch("safetensors.torch.load", side_effect=AssertionError("full-file load should not be used")),
             patch("safetensors.torch.load_file", side_effect=AssertionError("load_file should not be used")),
+            patch.object(torch.Tensor, "clone", record_clone),
         ):
             _stream_load_bnb_weights(model, str(tmp_path), torch.device("cpu"), torch.float32, disable_mmap=True)
 
         assert model.lin.weight.device.type == "cpu"
         assert model.running_scale.device.type == "cpu"
+        assert cloned_shapes.count((8, 4)) == 1
+        assert cloned_shapes.count((8,)) == 2
+        assert (3, 3) not in cloned_shapes
 
 
 class TestBnbModulesToNotConvert:

--- a/tests/unit_tests/_transformers/test_model_init.py
+++ b/tests/unit_tests/_transformers/test_model_init.py
@@ -25,6 +25,7 @@ import torch.nn as nn
 from nemo_automodel._transformers.model_init import (
     _apply_backend_module_overrides,
     _consume_config_overrides,
+    _get_bnb_modules_to_not_convert,
     _has_safetensors,
     _init_model,
     _load_config_with_layer_types_fix,
@@ -753,6 +754,26 @@ class _TiedHeadModel(nn.Module):
         self.head.weight = self.embed.weight
 
 
+class _HfStyleOutputHeadModel(nn.Module):
+    """Small HF-like causal LM shell for BnB output-head skip tests."""
+
+    all_tied_weights_keys = {"lm_head.weight": "embed_tokens.weight"}
+
+    def __init__(self):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(16, 8)
+        self.body = nn.Linear(8, 8)
+        self.lm_head = nn.Linear(8, 16, bias=False)
+        self.norm = nn.LayerNorm(8)
+        self.tie_weights()
+
+    def tie_weights(self):
+        self.lm_head.weight = self.embed_tokens.weight
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
 def _save_safetensors(path, tensors: dict):
     from safetensors.torch import save_file
 
@@ -869,6 +890,51 @@ class TestStreamLoadBnbWeights:
         torch.testing.assert_close(model.running_scale, torch.arange(8, dtype=torch.float32))
         assert model.lin.weight.device.type == "cpu"
         assert model.lin.bias.device.type == "cpu"
+
+    def test_disable_mmap_reads_safetensors_bytes(self, tmp_path):
+        with torch.device("meta"):
+            model = _TinyModelOnMeta()
+
+        _save_safetensors(
+            tmp_path / "model.safetensors",
+            {
+                "lin.weight": torch.randn(8, 4),
+                "lin.bias": torch.randn(8),
+                "running_scale": torch.zeros(8),
+            },
+        )
+
+        with (
+            patch("safetensors.safe_open", side_effect=AssertionError("safe_open should not be used")),
+            patch("safetensors.torch.load_file", side_effect=AssertionError("load_file should not be used")),
+        ):
+            _stream_load_bnb_weights(model, str(tmp_path), torch.device("cpu"), torch.float32, disable_mmap=True)
+
+        assert model.lin.weight.device.type == "cpu"
+        assert model.running_scale.device.type == "cpu"
+
+
+class TestBnbModulesToNotConvert:
+    """Streaming BnB should use the same module skip list HF uses."""
+
+    def test_defaults_skip_tied_embeddings_and_output_head(self):
+        model = _HfStyleOutputHeadModel()
+        quantization_config = types.SimpleNamespace(llm_int8_skip_modules=None)
+
+        modules_to_not_convert = set(_get_bnb_modules_to_not_convert(model, quantization_config))
+
+        assert "embed_tokens" in modules_to_not_convert
+        assert "lm_head" in modules_to_not_convert
+        assert "body" not in modules_to_not_convert
+
+    def test_explicit_skip_modules_match_hf_override_semantics(self):
+        model = _HfStyleOutputHeadModel()
+        model._keep_in_fp32_modules = ["norm"]
+        quantization_config = types.SimpleNamespace(llm_int8_skip_modules=["body"])
+
+        modules_to_not_convert = set(_get_bnb_modules_to_not_convert(model, quantization_config))
+
+        assert modules_to_not_convert == {"body", "norm"}
 
 
 class TestStreamingBnbSupported:

--- a/tests/unit_tests/checkpoint/_backports/test_hf_storage_reader.py
+++ b/tests/unit_tests/checkpoint/_backports/test_hf_storage_reader.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import torch
+from safetensors.torch import save_file
+from torch.distributed.checkpoint.metadata import MetadataIndex
+from torch.distributed.checkpoint.planner import LoadItemType, LoadPlan, ReadItem
+
+from nemo_automodel.components.checkpoint._backports.hf_storage import _HuggingFaceStorageReader
+
+
+class _RecordingLoadPlanner:
+    def __init__(self, target: torch.Tensor) -> None:
+        self.target = target
+        self.committed: list[torch.Tensor] = []
+
+    def resolve_tensor(self, read_item: ReadItem) -> torch.Tensor:
+        return self.target
+
+    def commit_tensor(self, read_item: ReadItem, tensor: torch.Tensor) -> None:
+        self.committed.append(tensor.detach().cpu())
+
+
+def test_hf_storage_reader_integrated_device_stages_narrowed_mmap_slice(tmp_path):
+    source = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+    save_file({"weight": source}, tmp_path / "model.safetensors")
+
+    reader = _HuggingFaceStorageReader(str(tmp_path))
+    metadata = reader.read_metadata()
+    reader.set_up_storage_reader(metadata, is_coordinator=True)
+    storage_index = next(index for index in metadata.storage_data if index.fqn == "weight")
+    storage_info = metadata.storage_data[storage_index]
+
+    assert storage_info.offset % storage_info.dtype.itemsize == 0
+
+    read_item = ReadItem(
+        type=LoadItemType.TENSOR,
+        dest_index=MetadataIndex(fqn="weight", offset=[0, 0]),
+        dest_offsets=torch.Size([0, 0]),
+        storage_index=storage_index,
+        storage_offsets=torch.Size([1, 1]),
+        lengths=torch.Size([2, 2]),
+    )
+    target = torch.empty(2, 2, dtype=torch.float32)
+    planner = _RecordingLoadPlanner(target)
+
+    original_clone = torch.Tensor.clone
+    cloned_shapes = []
+
+    def record_clone(tensor, *args, **kwargs):
+        cloned_shapes.append(tuple(tensor.shape))
+        return original_clone(tensor, *args, **kwargs)
+
+    with (
+        patch(
+            "nemo_automodel.components.checkpoint._backports.hf_storage._is_integrated_cuda_device",
+            return_value=True,
+        ) as is_integrated,
+        patch.object(torch.Tensor, "clone", record_clone),
+    ):
+        reader.read_data(LoadPlan([read_item]), planner).wait()
+
+    expected = source[1:3, 1:3]
+    torch.testing.assert_close(target, expected)
+    torch.testing.assert_close(planner.committed[0], expected)
+    is_integrated.assert_called_once_with(target.device)
+    assert cloned_shapes == [(2, 2)]

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -75,7 +75,6 @@ from nemo_automodel.components.checkpoint.utils import (
     materialize_missing_tied_lm_head,
 )
 from nemo_automodel.components.models.gemma4_moe.state_dict_adapter import Gemma4MoEStateDictAdapter
-from nemo_automodel.components.models.llama.state_dict_adapter import LlamaStateDictAdapter
 from nemo_automodel.components.training.rng import RNGState, StatefulRNG, init_all_rng
 
 CLOUD_PATH_MODEL = "msc://bucket/step-100/model"
@@ -352,6 +351,22 @@ def test_load_indexed_safetensors_opens_each_shard_once(tmp_path):
     assert set(loaded) == set(expected)
     for key, tensor in expected.items():
         torch.testing.assert_close(loaded[key], tensor)
+
+
+def test_prefault_safetensors_reads_tensor_without_replacing_returned_view(tmp_path):
+    checkpoint_path = tmp_path / "model.safetensors"
+    checkpoint_path.touch()
+    tensor = MagicMock(spec=torch.Tensor)
+    safe_handle = MagicMock()
+    safe_handle.__enter__.return_value = safe_handle
+    safe_handle.keys.return_value = ["weight"]
+    safe_handle.get_tensor.return_value = tensor
+
+    with patch("safetensors.safe_open", return_value=safe_handle):
+        loaded = _load_hf_safetensors_checkpoint(str(checkpoint_path), prefault_mmap=True)
+
+    assert loaded == {"weight": tensor}
+    tensor.clone.assert_called_once_with()
 
 
 def test_get_fqn_to_dtype_mapping_reads_safetensors_headers_and_applies_key_mapping(tmp_path):
@@ -1713,39 +1728,6 @@ class TestLoadModelCustomModelGuard:
         assert "disk read" in caplog.text
         assert "adapt" in caplog.text
         assert "install" in caplog.text
-
-    @patch("nemo_automodel.components.checkpoint.checkpointing._is_safetensors_checkpoint", return_value=True)
-    @patch("nemo_automodel.components.checkpoint.checkpointing._load_hf_checkpoint_preserving_dtype")
-    @patch("nemo_automodel.components.checkpoint.checkpointing._load_full_state_dict_into_model")
-    def test_single_device_llama_uses_checkpoint_managed_write_through(self, mock_load_full, mock_load_hf, mock_is_st):
-        """A compliant Llama adapter uses DCP without owning checkpoint policy."""
-        checkpointer = self._make_checkpointer()
-
-        CustomLlama = type("LlamaForCausalLM", (torch.nn.Module,), {})
-        CustomLlama.__module__ = "nemo_automodel.components.models.llama.model"
-        model = CustomLlama()
-        model.config = SimpleNamespace(model_type="llama", tie_word_embeddings=False)
-        model.layer = torch.nn.Linear(4, 4)
-        model.state_dict_adapter = LlamaStateDictAdapter(model.config)
-
-        assert _is_custom_model(model) is True
-        assert model.state_dict_adapter.supports_write_through_checkpoint_load is False
-        assert model.state_dict_adapter.supports_checkpoint_load_without_full_copy is False
-
-        with (
-            patch("os.path.exists", return_value=True),
-            patch("torch.distributed.is_initialized", return_value=False),
-            patch.dict("os.environ", {"WORLD_SIZE": "1"}),
-            patch.object(checkpointer, "_get_storage_reader", return_value=None),
-            patch.object(
-                checkpointer, "_do_load", side_effect=lambda state_dict, *args, **kwargs: state_dict
-            ) as mock_dcp,
-        ):
-            checkpointer.load_model(model, model_path="/fake/path", is_init_step=True)
-
-        mock_load_full.assert_not_called()
-        mock_load_hf.assert_not_called()
-        mock_dcp.assert_called_once()
 
     @patch("nemo_automodel.components.checkpoint.checkpointing._is_safetensors_checkpoint", return_value=True)
     @patch("nemo_automodel.components.checkpoint.checkpointing._load_hf_checkpoint_preserving_dtype")

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -75,6 +75,7 @@ from nemo_automodel.components.checkpoint.utils import (
     materialize_missing_tied_lm_head,
 )
 from nemo_automodel.components.models.gemma4_moe.state_dict_adapter import Gemma4MoEStateDictAdapter
+from nemo_automodel.components.models.llama.state_dict_adapter import LlamaStateDictAdapter
 from nemo_automodel.components.training.rng import RNGState, StatefulRNG, init_all_rng
 
 CLOUD_PATH_MODEL = "msc://bucket/step-100/model"
@@ -1712,6 +1713,39 @@ class TestLoadModelCustomModelGuard:
         assert "disk read" in caplog.text
         assert "adapt" in caplog.text
         assert "install" in caplog.text
+
+    @patch("nemo_automodel.components.checkpoint.checkpointing._is_safetensors_checkpoint", return_value=True)
+    @patch("nemo_automodel.components.checkpoint.checkpointing._load_hf_checkpoint_preserving_dtype")
+    @patch("nemo_automodel.components.checkpoint.checkpointing._load_full_state_dict_into_model")
+    def test_single_device_llama_uses_checkpoint_managed_write_through(self, mock_load_full, mock_load_hf, mock_is_st):
+        """A compliant Llama adapter uses DCP without owning checkpoint policy."""
+        checkpointer = self._make_checkpointer()
+
+        CustomLlama = type("LlamaForCausalLM", (torch.nn.Module,), {})
+        CustomLlama.__module__ = "nemo_automodel.components.models.llama.model"
+        model = CustomLlama()
+        model.config = SimpleNamespace(model_type="llama", tie_word_embeddings=False)
+        model.layer = torch.nn.Linear(4, 4)
+        model.state_dict_adapter = LlamaStateDictAdapter(model.config)
+
+        assert _is_custom_model(model) is True
+        assert model.state_dict_adapter.supports_write_through_checkpoint_load is False
+        assert model.state_dict_adapter.supports_checkpoint_load_without_full_copy is False
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("torch.distributed.is_initialized", return_value=False),
+            patch.dict("os.environ", {"WORLD_SIZE": "1"}),
+            patch.object(checkpointer, "_get_storage_reader", return_value=None),
+            patch.object(
+                checkpointer, "_do_load", side_effect=lambda state_dict, *args, **kwargs: state_dict
+            ) as mock_dcp,
+        ):
+            checkpointer.load_model(model, model_path="/fake/path", is_init_step=True)
+
+        mock_load_full.assert_not_called()
+        mock_load_hf.assert_not_called()
+        mock_dcp.assert_called_once()
 
     @patch("nemo_automodel.components.checkpoint.checkpointing._is_safetensors_checkpoint", return_value=True)
     @patch("nemo_automodel.components.checkpoint.checkpointing._load_hf_checkpoint_preserving_dtype")

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -34,6 +34,7 @@ from torch.nn.parallel import DistributedDataParallel
 from nemo_automodel.components.checkpoint._backports.hf_storage import (
     _DIFFUSERS_INDEX_FN,
     _extract_file_index_with_status,
+    _is_integrated_cuda_device,
     get_fqn_to_dtype_mapping,
     get_fqn_to_file_index_mapping,
 )
@@ -79,6 +80,25 @@ from nemo_automodel.components.training.rng import RNGState, StatefulRNG, init_a
 CLOUD_PATH_MODEL = "msc://bucket/step-100/model"
 CLOUD_PATH_OPTIM = "msc://bucket/step-100/optim"
 LOCAL_PATH_MODEL = "/ckpts/step-100/model"
+
+
+@pytest.mark.parametrize(
+    ("device_type", "is_integrated", "expected"),
+    [
+        pytest.param("cpu", True, False, id="cpu-never-stages"),
+        pytest.param("cuda", False, False, id="discrete-cuda-keeps-mmap"),
+        pytest.param("cuda", True, True, id="integrated-cuda-stages"),
+    ],
+)
+def test_integrated_cuda_device_detection(device_type, is_integrated, expected):
+    device = torch.device(device_type)
+    with patch(
+        "nemo_automodel.components.checkpoint._backports.hf_storage.torch.cuda.get_device_properties",
+        return_value=SimpleNamespace(is_integrated=is_integrated),
+    ) as get_properties:
+        assert _is_integrated_cuda_device(device) is expected
+
+    assert get_properties.call_count == (1 if device_type == "cuda" else 0)
 
 
 def test_load_on_global_ranks_falls_back_to_legacy_rng_state(tmp_path, caplog):

--- a/tests/unit_tests/checkpoint/test_state_dict_adapter_capabilities.py
+++ b/tests/unit_tests/checkpoint/test_state_dict_adapter_capabilities.py
@@ -35,7 +35,6 @@ from nemo_automodel.components.models.kimi_k25_vl.state_dict_adapter import Kimi
 from nemo_automodel.components.models.kimi_linear.state_dict_adapter import KimiLinear48BStateDictAdapter
 from nemo_automodel.components.models.laguna.state_dict_adapter import LagunaStateDictAdapter
 from nemo_automodel.components.models.ling_v2.state_dict_adapter import BailingMoeV2StateDictAdapter
-from nemo_automodel.components.models.llama.state_dict_adapter import LlamaStateDictAdapter
 from nemo_automodel.components.models.llava_onevision.state_dict_adapter import LlavaOneVisionStateDictAdapter
 from nemo_automodel.components.models.mimo_v2_flash.state_dict_adapter import MiMoV2FlashStateDictAdapter
 from nemo_automodel.components.models.minimax_m2.state_dict_adapter import MiniMaxM2StateDictAdapter
@@ -86,7 +85,6 @@ def _assert_destinations_write_through(
         pytest.param(BagelStateDictAdapter, {}, id="bagel"),
         pytest.param(Ernie4_5StateDictAdapter, {}, id="ernie4_5_dense"),
         pytest.param(Gemma4UnifiedStateDictAdapter, {}, id="gemma4_unified"),
-        pytest.param(LlamaStateDictAdapter, {}, id="llama"),
         pytest.param(LlavaOneVisionStateDictAdapter, {}, id="llava_onevision"),
         pytest.param(MuseGlimmerStateDictAdapter, {"uses_canonical_layout": True}, id="muse_glimmer"),
         pytest.param(Qwen2_5OmniStateDictAdapter, {"_uses_thinker_prefix": True}, id="qwen2_5_omni"),

--- a/tests/unit_tests/checkpoint/test_state_dict_adapter_capabilities.py
+++ b/tests/unit_tests/checkpoint/test_state_dict_adapter_capabilities.py
@@ -35,6 +35,7 @@ from nemo_automodel.components.models.kimi_k25_vl.state_dict_adapter import Kimi
 from nemo_automodel.components.models.kimi_linear.state_dict_adapter import KimiLinear48BStateDictAdapter
 from nemo_automodel.components.models.laguna.state_dict_adapter import LagunaStateDictAdapter
 from nemo_automodel.components.models.ling_v2.state_dict_adapter import BailingMoeV2StateDictAdapter
+from nemo_automodel.components.models.llama.state_dict_adapter import LlamaStateDictAdapter
 from nemo_automodel.components.models.llava_onevision.state_dict_adapter import LlavaOneVisionStateDictAdapter
 from nemo_automodel.components.models.mimo_v2_flash.state_dict_adapter import MiMoV2FlashStateDictAdapter
 from nemo_automodel.components.models.minimax_m2.state_dict_adapter import MiniMaxM2StateDictAdapter
@@ -85,6 +86,7 @@ def _assert_destinations_write_through(
         pytest.param(BagelStateDictAdapter, {}, id="bagel"),
         pytest.param(Ernie4_5StateDictAdapter, {}, id="ernie4_5_dense"),
         pytest.param(Gemma4UnifiedStateDictAdapter, {}, id="gemma4_unified"),
+        pytest.param(LlamaStateDictAdapter, {}, id="llama"),
         pytest.param(LlavaOneVisionStateDictAdapter, {}, id="llava_onevision"),
         pytest.param(MuseGlimmerStateDictAdapter, {"uses_canonical_layout": True}, id="muse_glimmer"),
         pytest.param(Qwen2_5OmniStateDictAdapter, {"_uses_thinker_prefix": True}, id="qwen2_5_omni"),

--- a/tests/unit_tests/components/training/test_step_scheduler.py
+++ b/tests/unit_tests/components/training/test_step_scheduler.py
@@ -410,6 +410,68 @@ def test_gc_every_steps_must_be_positive():
         )
 
 
+def test_validation_still_runs_on_checkpoint_steps_by_default():
+    dataloader = SizedDataLoader(num_batches=3)
+    scheduler = StepScheduler(
+        global_batch_size=1,
+        local_batch_size=1,
+        dp_size=1,
+        dataloader=dataloader,
+        num_epochs=1,
+        max_steps=3,
+        ckpt_every_steps=2,
+        val_every_steps=None,
+    )
+
+    observed = []
+    for _ in scheduler:
+        observed.append((scheduler.step, scheduler.is_ckpt_step, scheduler.is_val_step))
+
+    assert observed == [(0, False, False), (1, True, True), (2, True, True)]
+
+
+def test_validate_on_checkpoint_can_be_disabled_without_disabling_checkpointing():
+    dataloader = SizedDataLoader(num_batches=3)
+    scheduler = StepScheduler(
+        global_batch_size=1,
+        local_batch_size=1,
+        dp_size=1,
+        dataloader=dataloader,
+        num_epochs=1,
+        max_steps=3,
+        ckpt_every_steps=2,
+        val_every_steps=None,
+        validate_on_checkpoint=False,
+    )
+
+    observed = []
+    for _ in scheduler:
+        observed.append((scheduler.step, scheduler.is_ckpt_step, scheduler.is_val_step))
+
+    assert observed == [(0, False, False), (1, True, False), (2, True, False)]
+
+
+def test_validate_on_checkpoint_false_preserves_periodic_validation():
+    dataloader = SizedDataLoader(num_batches=4)
+    scheduler = StepScheduler(
+        global_batch_size=1,
+        local_batch_size=1,
+        dp_size=1,
+        dataloader=dataloader,
+        num_epochs=1,
+        max_steps=4,
+        ckpt_every_steps=3,
+        val_every_steps=2,
+        validate_on_checkpoint=False,
+    )
+
+    observed = []
+    for _ in scheduler:
+        observed.append((scheduler.step, scheduler.is_ckpt_step, scheduler.is_val_step))
+
+    assert observed == [(0, False, False), (1, False, True), (2, True, False), (3, True, True)]
+
+
 def test_set_epoch():
     dataloader = SizedDataLoader(num_batches=10)
     scheduler = StepScheduler(

--- a/tests/unit_tests/recipes/llm/test_rtx_spark_configs.py
+++ b/tests/unit_tests/recipes/llm/test_rtx_spark_configs.py
@@ -83,5 +83,7 @@ def test_rtx_spark_llama_70b_preserves_streaming_qlora_settings():
     assert config["model"]["disable_mmap"] is True
     assert config["step_scheduler"]["global_batch_size"] == 1
     assert config["step_scheduler"]["local_batch_size"] == 1
+    assert config["step_scheduler"]["validate_on_checkpoint"] is False
+    assert config["step_scheduler"]["val_every_steps"] is None
     assert config["packed_sequence"]["packed_sequence_size"] == 1024
     assert config["distributed"]["activation_checkpointing"] is True

--- a/tests/unit_tests/recipes/llm/test_rtx_spark_configs.py
+++ b/tests/unit_tests/recipes/llm/test_rtx_spark_configs.py
@@ -56,6 +56,7 @@ def test_rtx_spark_8b_packed_recipes_use_supported_attention(relative_path, mode
     assert config["model"]["pretrained_model_name_or_path"] == model_name
     assert config["model"]["force_hf"] is True
     assert config["model"]["attn_implementation"] == "flash_attention_2"
+    assert config["model"]["disable_mmap"] is True
     assert config["step_scheduler"]["global_batch_size"] == 1
     assert config["step_scheduler"]["local_batch_size"] == 1
     assert config["packed_sequence"]["packed_sequence_size"] == 128

--- a/tests/unit_tests/recipes/llm/test_rtx_spark_configs.py
+++ b/tests/unit_tests/recipes/llm/test_rtx_spark_configs.py
@@ -37,6 +37,7 @@ def test_rtx_spark_configs_target_single_gpu_gb10(relative_path):
     assert Path(relative_path).stem.endswith("_rtx_spark")
     assert config["ci"]["cluster_tag"] == "gb10"
     assert config["ci"]["nproc_per_node"] == 1
+    assert config["ci"]["nodes"] == 1
     assert config["distributed"]["strategy"] == "fsdp2"
     assert config["distributed"]["tp_size"] == 1
     assert config["distributed"]["cp_size"] == 1

--- a/tests/unit_tests/recipes/llm/test_rtx_spark_configs.py
+++ b/tests/unit_tests/recipes/llm/test_rtx_spark_configs.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+RTX_SPARK_CONFIGS = (
+    "examples/llm_finetune/llama3_1/llama3_1_8b_squad_peft_rtx_spark.yaml",
+    "examples/llm_finetune/qwen/qwen3_8b_squad_rtx_spark.yaml",
+    "examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft_qlora_rtx_spark.yaml",
+)
+
+
+def _load_config(relative_path: str) -> dict:
+    config_path = REPO_ROOT / relative_path
+    return yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("relative_path", RTX_SPARK_CONFIGS)
+def test_rtx_spark_configs_target_single_gpu_gb10(relative_path):
+    config = _load_config(relative_path)
+
+    assert Path(relative_path).stem.endswith("_rtx_spark")
+    assert config["ci"]["cluster_tag"] == "gb10"
+    assert config["ci"]["nproc_per_node"] == 1
+    assert config["distributed"]["strategy"] == "fsdp2"
+    assert config["distributed"]["tp_size"] == 1
+    assert config["distributed"]["cp_size"] == 1
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "model_name"),
+    (
+        (RTX_SPARK_CONFIGS[0], "meta-llama/Llama-3.1-8B"),
+        (RTX_SPARK_CONFIGS[1], "Qwen/Qwen3-8B"),
+    ),
+)
+def test_rtx_spark_8b_packed_recipes_use_supported_attention(relative_path, model_name):
+    config = _load_config(relative_path)
+
+    assert config["model"]["pretrained_model_name_or_path"] == model_name
+    assert config["model"]["force_hf"] is True
+    assert config["model"]["attn_implementation"] == "flash_attention_2"
+    assert config["step_scheduler"]["global_batch_size"] == 1
+    assert config["step_scheduler"]["local_batch_size"] == 1
+    assert config["packed_sequence"]["packed_sequence_size"] == 128
+    assert config["peft"]["_target_"] == "nemo_automodel.components._peft.lora.PeftConfig"
+    assert config["distributed"]["activation_checkpointing"] is True
+
+
+def test_rtx_spark_llama_8b_matches_64gb_uma_regression_settings():
+    config = _load_config(RTX_SPARK_CONFIGS[0])
+
+    assert config["step_scheduler"]["global_batch_size"] == 1
+    assert config["step_scheduler"]["local_batch_size"] == 1
+    assert config["packed_sequence"]["packed_sequence_size"] == 128
+    assert config["distributed"]["activation_checkpointing"] is True
+
+
+def test_rtx_spark_llama_70b_preserves_streaming_qlora_settings():
+    config = _load_config(RTX_SPARK_CONFIGS[2])
+
+    assert config["model"]["pretrained_model_name_or_path"] == "meta-llama/Llama-3.3-70B-Instruct"
+    assert config["quantization"]["load_in_4bit"] is True
+    assert config["quantization"]["load_in_8bit"] is False
+    assert config["quantization"]["bnb_4bit_quant_type"] == "nf4"
+    assert config["distributed"]["activation_checkpointing"] is True

--- a/tests/unit_tests/recipes/llm/test_rtx_spark_configs.py
+++ b/tests/unit_tests/recipes/llm/test_rtx_spark_configs.py
@@ -80,4 +80,8 @@ def test_rtx_spark_llama_70b_preserves_streaming_qlora_settings():
     assert config["quantization"]["load_in_4bit"] is True
     assert config["quantization"]["load_in_8bit"] is False
     assert config["quantization"]["bnb_4bit_quant_type"] == "nf4"
+    assert config["model"]["disable_mmap"] is True
+    assert config["step_scheduler"]["global_batch_size"] == 1
+    assert config["step_scheduler"]["local_batch_size"] == 1
+    assert config["packed_sequence"]["packed_sequence_size"] == 1024
     assert config["distributed"]["activation_checkpointing"] is True


### PR DESCRIPTION
# What does this PR do ?

Fix NVBug 6674647 checkpoint loading on integrated-memory CUDA devices and add explicit 64 GB RTX Spark recipe variants.

# Changelog

- Prefault full-state safetensors only when the destination is an integrated CUDA device, while preserving mmap-backed/reclaimable checkpoint tensors.
- Stage one DCP mmap slice at a time before an integrated-GPU copy; CPU and discrete-GPU paths retain their existing behavior.
- Make `LlamaStateDictAdapter` implement the shared `StateDictAdapter` contract without model-specific checkpoint dispatch.
- Add dedicated `_rtx_spark` recipes for Llama 3.1 8B LoRA, Qwen3 8B LoRA, and Llama 3.3 70B QLoRA; existing generic and `_spark` recipes are unchanged.
- Encode the 64 GB UMA settings and regression matrix in focused tests and short critical-path comments.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

Validation:

- `pytest tests/unit_tests/checkpoint/test_checkpointing.py tests/unit_tests/recipes/llm/test_rtx_spark_configs.py -q`: 214 passed, 5 skipped.
- Focused Ruff format and lint checks: passed.
- Discrete RTX 5880 Llama custom/HF output equivalence: 2 passed.
- RTX Spark (`NVIDIA JMJWOA-Generic-GPU`, SM12x), `nvcr.io/nvidia/nemo-automodel:26.08`, Docker `--memory=64g --memory-swap=64g`:
  - Ran `llama3_1_8b_squad_peft_rtx_spark.yaml` directly with only `max_steps=1` overridden.
  - Completed model load, forward, backward, optimizer step, validation, and checkpoint save.
  - Step 0: loss 0.2735, grad norm 20.5473, reported memory 15.28 GiB.
  - Exit 0; `OOMKilled=false`.
  - Artifact: `/home/nvidia/spark_playbook_runs/20260831T034717Z-existing-branch-rtx-yaml`.
- The custom Llama mmap path loads the 8B checkpoint in 1.02 s without OOM. SM12x cannot run TE packed backward (`ragged LSE` cuDNN limitation), so the end-to-end RTX recipe intentionally uses HF FlashAttention-2 plus activation checkpointing.

# Additional Information

Related to NVBug 6674647.
