### PR TITLE
fix(training): honor max_steps when num_epochs is unset

### DIFF
--- a/nemo_automodel/components/training/step_scheduler.py
+++ b/nemo_automodel/components/training/step_scheduler.py
@@ -355,8 +355,9 @@ class StepSchedulerConfig:
 
     Attributes:
         global_batch_size: Total samples per optimizer step across all GPUs.
-        num_epochs: Number of training epochs.  When ``None`` the builder
-            derives it from ``max_steps``.  Default: 10.
+        num_epochs: Number of training epochs.  When ``None`` (the default)
+            it is derived from ``max_steps``, or falls back to 10 when
+            ``max_steps`` is also unset.
         max_steps: Hard cap on optimizer steps.  ``None`` means derive from
             ``num_epochs * epoch_len``.
         ckpt_every_steps: Save a checkpoint every N optimizer steps.
@@ -377,7 +378,7 @@ class StepSchedulerConfig:
     """
 
     global_batch_size: int = 32
-    num_epochs: int | None = 10
+    num_epochs: int | None = None
     max_steps: int | None = None
     ckpt_every_steps: int | None = 100
     save_checkpoint_every_epoch: bool = True

--- a/tests/unit_tests/components/training/test_step_scheduler.py
+++ b/tests/unit_tests/components/training/test_step_scheduler.py
@@ -661,3 +661,56 @@ def test_step_scheduler_config_exposes_preemption_signal():
         assert scheduler.sig_handler.sigs == [_signal.SIGUSR2]
     finally:
         scheduler.sig_handler.release()
+
+
+# ---------------------------------------------------------------------------
+# num_epochs / max_steps resolution via the typed config
+# ---------------------------------------------------------------------------
+
+
+def _run_all_steps(scheduler):
+    """Drive the scheduler to exhaustion and return the number of steps executed."""
+    total = 0
+    for epoch in scheduler.epochs:
+        scheduler.set_epoch(epoch)
+        for _ in scheduler:
+            total += 1
+    return total
+
+
+def test_config_max_steps_only_derives_num_epochs():
+    """max_steps alone must be honored; num_epochs is derived, not left at a default."""
+    cfg = StepSchedulerConfig(global_batch_size=1, max_steps=5000, preemption_signal=None)
+    scheduler = cfg.build(SizedDataLoader(num_batches=100), dp_group_size=1, local_batch_size=1)
+
+    assert scheduler.epoch_len == 100
+    assert scheduler.num_epochs == 50  # ceil(5000 / 100)
+    assert _run_all_steps(scheduler) == 5000
+
+
+def test_config_num_epochs_only_derives_max_steps():
+    cfg = StepSchedulerConfig(global_batch_size=1, num_epochs=3, preemption_signal=None)
+    scheduler = cfg.build(SizedDataLoader(num_batches=100), dp_group_size=1, local_batch_size=1)
+
+    assert scheduler.num_epochs == 3
+    assert scheduler.max_steps == 300
+    assert _run_all_steps(scheduler) == 300
+
+
+def test_config_both_set_stops_at_whichever_comes_first():
+    cfg = StepSchedulerConfig(global_batch_size=1, num_epochs=10, max_steps=250, preemption_signal=None)
+    scheduler = cfg.build(SizedDataLoader(num_batches=100), dp_group_size=1, local_batch_size=1)
+
+    assert scheduler.num_epochs == 10
+    assert scheduler.max_steps == 250
+    assert _run_all_steps(scheduler) == 250
+
+
+def test_config_neither_set_keeps_ten_epoch_fallback():
+    """Unchanged behaviour when the config pins neither field."""
+    cfg = StepSchedulerConfig(global_batch_size=1, preemption_signal=None)
+    scheduler = cfg.build(SizedDataLoader(num_batches=100), dp_group_size=1, local_batch_size=1)
+
+    assert scheduler.num_epochs == 10
+    assert scheduler.max_steps == 1000
+    assert _run_all_steps(scheduler) == 1000

--- a/tests/unit_tests/training/test_training_config.py
+++ b/tests/unit_tests/training/test_training_config.py
@@ -21,7 +21,7 @@ class TestStepSchedulerConfig:
     def test_defaults(self):
         cfg = StepSchedulerConfig()
         assert cfg.global_batch_size == 32
-        assert cfg.num_epochs == 10
+        assert cfg.num_epochs is None
         assert cfg.max_steps is None
         assert cfg.ckpt_every_steps == 100
         assert cfg.save_checkpoint_every_epoch is True


### PR DESCRIPTION
# What does this PR do ?

Makes `max_steps` actually cap training when `num_epochs` is left unset.

`StepSchedulerConfig.num_epochs` defaulted to `10` instead of `None`, so the
derivation in `StepScheduler.__init__` never ran on the config path the recipes
use:

```python
if num_epochs is None:
    num_epochs = _calculate_num_epochs(max_steps, self.epoch_len)
```

`asdict(self)` in `StepSchedulerConfig.build()` always passed `num_epochs=10`
unless the user explicitly wrote `num_epochs: null`, leaving that branch dead.
Recipes go through this config — `train_ft.py` line 758 calls
`self.cfg.step_scheduler.build(...)`.

The training loop is bounded by the `epochs` generator as well as by
`max_steps`:

```python
@property
def epochs(self):
    for e in range(epoch, self.num_epochs):
        if self.step >= self.max_steps or self.sigterm_received:
            return
        yield e
```

so with `num_epochs` pinned at 10 the generator ran out before `max_steps` was
reached. A config setting only `max_steps` trained for `10 * epoch_len` steps
and reported success — the symptom is an under-trained model, not an error.

Measured with a 100-step epoch:

| config | `num_epochs` | steps requested | steps executed |
|---|---|---|---|
| `max_steps: 5000` (before) | 10 | 5000 | **1000** |
| `max_steps: 5000` (after) | 50 | 5000 | 5000 |

The field's own docstring already described the intended behaviour ("When
`None` the builder derives it from `max_steps`"), so this makes the code match
the documented contract rather than changing it.

# Changelog

- `StepSchedulerConfig.num_epochs` now defaults to `None` so `max_steps` drives
  the epoch count when `num_epochs` is not pinned.
- Attribute docstring updated to state the resolution order: derived from
  `max_steps`, falling back to 10 when `max_steps` is also unset.
- `tests/unit_tests/training/test_training_config.py::test_defaults` updated for
  the new default.
- Four CPU tests in
  `tests/unit_tests/components/training/test_step_scheduler.py` covering the
  resolution matrix: max-steps-only, num-epochs-only, both set, neither set.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

Behaviour now matches the existing docstring, so no separate doc change was
needed.

**Compatibility.** The both-unset case is deliberately unchanged:
`_calculate_num_epochs` returns its `default_num_epochs=10` when `max_steps is
None`, so a config pinning neither field still resolves to 10 epochs and the
same `max_steps`. `test_config_neither_set_keeps_ten_epoch_fallback` locks that
in. Configs that set `num_epochs` explicitly are unaffected.

**Verification** (CPU, no GPU needed):

- `pytest tests/unit_tests/components/training/test_step_scheduler.py tests/unit_tests/training/test_training_config.py` → 47 passed.
- Reverting only the one-line default makes
  `test_config_max_steps_only_derives_num_epochs` and `test_defaults` fail; the
  other three new tests pass either way, which is intended — they guard the
  paths this must not change.
- `pytest tests/unit_tests/recipes/ tests/unit_tests/training/ tests/unit_tests/components/` → 1379 passed, 19 skipped, no regressions.
  (`tests/unit_tests/recipes/dllm` was excluded locally: it fails to import
  `transformers.models.diffusion_gemma` on `main` too, unrelated to this change.)
- `ruff format` / `ruff check` clean.

# Additional Information

- Related to #3767
