### PR TITLE
docs: repair links left dangling by the Fern docs migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,7 @@ After installing the git hooks, `git commit` will automatically run incremental 
 
 ## Adding Documentation
 
-If your contribution involves documentation changes, please refer to the [Documentation Development](docs/documentation.md) guide for detailed instructions on building and serving the documentation.
+If your contribution involves documentation changes, please refer to the [Fern docs maintenance guide](.agents/contributor-skills/fern-docs/SKILL.md) guide for detailed instructions on building and serving the documentation.
 
 ## Signing Your Work
 

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ NeMo AutoModel achieves great training performance on NVIDIA GPUs. Below are hig
 | GPT-OSS 20B | 8 | 4096 | 279 | 13,058 | TE + DeepEP + FlexAttn |
 | Qwen3 MoE 30B | 8 | 4096 | 212 | 11,842 | TE + DeepEP |
 
-For complete benchmark results including configuration details, see the [Performance Summary](docs/performance-summary.md).
+For complete benchmark results including configuration details, see the [Performance Summary](docs/performance-summary.mdx).
 
 <!--
 ## Mesh‑Aware Checkpointing


### PR DESCRIPTION
Two links in the top-level docs point at files that no longer exist. Both look like fallout from the move to Fern/MDX.

**`README.md`** links the Performance Summary at `docs/performance-summary.md`. The file is now `docs/performance-summary.mdx`.

```
gh api repos/NVIDIA-NeMo/Automodel/contents/docs/performance-summary.md   -> 404
gh api repos/NVIDIA-NeMo/Automodel/contents/docs/performance-summary.mdx  -> exists
```

**`CONTRIBUTING.md`** sends documentation contributors to `docs/documentation.md` for "building and serving the documentation". Neither `.md` nor `.mdx` exists at that path. The guide that actually covers that ground is `.agents/contributor-skills/fern-docs/SKILL.md`, whose own description is "add, update, move, or remove pages; manage redirects, slugs, navigation, and version aliases; run validation and previews", so I pointed the sentence there.

That second one is a judgement call and yours to overrule. If you would rather that sentence point at the hosted contributor docs, or be dropped until a human-facing guide exists, say so and I will change it. I picked the destination that exists and covers the described task.

Two notes on the first one: `README.md` line 19 already links the hosted page for the same document (`docs.nvidia.com/nemo/automodel/latest/performance-summary.html`), so if you prefer consistency there over an in-repo relative link, that is a one-word change. I kept the relative link because that is what the line was already doing.

I checked the remaining in-repo links in both files against the repo; these two were the only ones that do not resolve.
