### PR TITLE
build(container): bump PyTorch base to 26.08

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG CUDA_IMAGE=nvcr.io/nvidia/cuda-dl-base:26.04-cuda13.2-devel-ubuntu24.04
-ARG PYTORCH_IMAGE=nvcr.io/nvidia/pytorch:26.06-py3
+ARG PYTORCH_IMAGE=nvcr.io/nvidia/pytorch:26.08-py3
 ARG BASE_IMAGE=cuda
 
 FROM ${CUDA_IMAGE} AS cuda


### PR DESCRIPTION
# What does this PR do ?

Update the default PyTorch base container used by NeMo AutoModel builds to the 26.08 release.

# Changelog

- Bump `PYTORCH_IMAGE` from `nvcr.io/nvidia/pytorch:26.06-py3` to `nvcr.io/nvidia/pytorch:26.08-py3`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

- No related issue.
