### PR TITLE
fix(launcher): honor --nproc-per-node over the local device count

### DIFF
--- a/nemo_automodel/components/launcher/interactive.py
+++ b/nemo_automodel/components/launcher/interactive.py
@@ -121,14 +121,22 @@ class InteractiveLauncher(Launcher):
         repo_root = _get_repo_root()
         script_path = _recipe_module_path(recipe_target, repo_root)
 
-        num_devices = determine_local_world_size(nproc_per_node="gpu")
-        assert num_devices > 0, "Expected num-devices to be > 0"
+        # Only probe the local device count when no worker count was requested.
+        # ``determine_local_world_size(nproc_per_node="gpu")`` raises when no CUDA
+        # device is visible, and an explicit ``--nproc-per-node`` already says how
+        # many workers to start -- including ``1``, which runs in-process here and
+        # never needs a device count.
+        if nproc_per_node is None:
+            num_devices = determine_local_world_size(nproc_per_node="gpu")
+            assert num_devices > 0, "Expected num-devices to be > 0"
+            effective_nproc = num_devices
+        else:
+            effective_nproc = nproc_per_node
 
-        if nproc_per_node == 1 or num_devices == 1:
+        if effective_nproc == 1:
             logger.info("Launching job locally on a single device")
             return self._run_recipe_in_process(recipe_target, config)
         else:
-            effective_nproc = nproc_per_node if nproc_per_node is not None else num_devices
             logger.info("Launching job locally on %d devices", effective_nproc)
 
             torchrun_parser = get_args_parser()

--- a/tests/unit_tests/launcher/test_interactive_launcher.py
+++ b/tests/unit_tests/launcher/test_interactive_launcher.py
@@ -400,3 +400,92 @@ def test_is_torchrun_worker_false_local_rank_only(monkeypatch):
 
 
 import nemo_automodel.components.launcher.interactive
+
+
+# ---------------------------------------------------------------------------
+# InteractiveLauncher.launch – an explicit --nproc-per-node wins over the probe
+# ---------------------------------------------------------------------------
+def test_interactive_launcher_explicit_nproc_beats_single_device(tmp_path):
+    """--nproc-per-node 4 on a one-GPU host must start 4 workers, not silently 1."""
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("")
+
+    mock_dist, mock_args = _make_torch_distributed_mock(world_size=1, run_return=0)
+
+    with (
+        mock.patch.dict("sys.modules", {"torch.distributed.run": mock_dist}),
+        mock.patch(
+            "nemo_automodel.components.launcher.interactive._get_repo_root",
+            return_value=Path("/opt/Automodel"),
+        ),
+    ):
+        launcher = InteractiveLauncher()
+        rc = launcher.launch(
+            config={"key": "val"},
+            config_path=cfg_file,
+            recipe_target="some.module.Recipe",
+            launcher_config=4,
+        )
+    assert rc == 0
+    mock_dist.run.assert_called_once()
+    assert mock_args.nproc_per_node == 4
+
+
+def test_interactive_launcher_explicit_nproc_skips_device_probe(tmp_path):
+    """An explicit worker count must not consult the local device count at all."""
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("")
+
+    mock_dist, _ = _make_torch_distributed_mock(world_size=8, run_return=0)
+
+    with (
+        mock.patch.dict("sys.modules", {"torch.distributed.run": mock_dist}),
+        mock.patch(
+            "nemo_automodel.components.launcher.interactive._get_repo_root",
+            return_value=Path("/opt/Automodel"),
+        ),
+    ):
+        launcher = InteractiveLauncher()
+        launcher.launch(
+            config={"key": "val"},
+            config_path=cfg_file,
+            recipe_target="some.module.Recipe",
+            launcher_config=2,
+        )
+    mock_dist.determine_local_world_size.assert_not_called()
+
+
+def test_interactive_launcher_nproc_1_without_visible_cuda(tmp_path):
+    """--nproc-per-node 1 runs in-process, so a failing GPU probe must not block it."""
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("")
+
+    mock_recipe_instance = mock.MagicMock()
+    mock_recipe_instance.run_train_validation_loop.return_value = 0
+    mock_recipe_cls = mock.MagicMock(return_value=mock_recipe_instance)
+
+    mock_dist, _ = _make_torch_distributed_mock(world_size=1)
+    # torch.distributed.run raises this when torch.cuda.is_available() is False.
+    mock_dist.determine_local_world_size.side_effect = ValueError("Cuda is not available.")
+
+    with (
+        mock.patch.dict("sys.modules", {"torch.distributed.run": mock_dist}),
+        mock.patch(
+            "nemo_automodel.components.launcher.interactive.resolve_recipe_cls",
+            return_value=mock_recipe_cls,
+        ),
+        mock.patch(
+            "nemo_automodel.components.launcher.interactive._get_repo_root",
+            return_value=Path("/opt/Automodel"),
+        ),
+    ):
+        launcher = InteractiveLauncher()
+        rc = launcher.launch(
+            config={"key": "val"},
+            config_path=cfg_file,
+            recipe_target="some.module.Recipe",
+            launcher_config=1,
+        )
+    assert rc == 0
+    mock_recipe_instance.setup.assert_called_once()
+    mock_dist.determine_local_world_size.assert_not_called()


### PR DESCRIPTION
# What does this PR do ?

Makes `InteractiveLauncher` act on an explicit `--nproc-per-node` instead of
letting the local GPU probe override it. The probe ran first, so the flag lost
to it in two ways:

```python
num_devices = determine_local_world_size(nproc_per_node="gpu")
assert num_devices > 0, "Expected num-devices to be > 0"

if nproc_per_node == 1 or num_devices == 1:
    return self._run_recipe_in_process(recipe_target, config)
else:
    effective_nproc = nproc_per_node if nproc_per_node is not None else num_devices
```

**1. `--nproc-per-node N` was silently downgraded on a one-GPU host.**
`num_devices == 1` short-circuits to the in-process path whatever the user
asked for, so `automodel config.yaml --nproc-per-node 4` started **one** worker
and logged "Launching job locally on a single device" without saying the
requested value was dropped. Running several ranks on one device is a normal way
to exercise FSDP/DDP or PP code paths on a dev box, and `torchrun` supports it.

**2. `--nproc-per-node 1` failed with no visible CUDA device.**
`determine_local_world_size(nproc_per_node="gpu")` raises when
`torch.cuda.is_available()` is false, and it ran before the `nproc_per_node == 1`
branch — the one path that needs no device count, since it runs the recipe
in-process:

```
ValueError: Cuda is not available.
```

Also fires under `CUDA_VISIBLE_DEVICES=""`. The error comes from inside
`torch.distributed.run`, so it names neither the flag nor an AutoModel
requirement.

**Scope, to be explicit:** this does not make CPU training work — the recipe
still requires CUDA further down. It makes the documented flag behave as
documented and lets the failure come from the framework rather than from a
device probe the requested single-process path never needed.

# Changelog

- `InteractiveLauncher.launch` probes `determine_local_world_size` only when
  `nproc_per_node is None`; an explicit value is used as-is.
- The single-process branch keys off the resolved worker count rather than
  `nproc_per_node == 1 or num_devices == 1`, so an explicit `N > 1` reaches
  torchrun even when one device is visible.
- Three CPU tests in `tests/unit_tests/launcher/test_interactive_launcher.py`:
  explicit `4` on a one-device host reaches torchrun with 4 workers; an explicit
  count never calls the probe; and `--nproc-per-node 1` still runs in-process
  when the probe would raise `ValueError("Cuda is not available.")`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

`--help` already documents the flag as "Number of workers per node for
local/interactive jobs" with no mention of clamping to the device count, so the
code now matches it and no doc change was needed.

**Compatibility.** Without the flag the behaviour is byte-for-byte the same: the
probe still runs, still asserts `> 0`, and still picks in-process for one device
or torchrun for more. All 21 pre-existing tests in the file pass unmodified,
including `test_interactive_launcher_single_device`,
`test_interactive_launcher_multi_device`, and
`test_interactive_launcher_multi_device_explicit_nproc`.

**Verification** (CPU, no GPU needed):

- `pytest tests/unit_tests/launcher/` → 103 passed.
- Reverting only `interactive.py` makes all three new tests fail, so they are
  not vacuous.
- `pytest tests/unit_tests/launcher/ tests/unit_tests/_cli/ tests/unit_tests/recipes/` → 1291 passed, 12 skipped.
  (`tests/unit_tests/recipes/dllm` excluded locally: it fails to import
  `transformers.models.diffusion_gemma` on `main` too, unrelated to this change.)
- `ruff format` / `ruff check` clean.

# Additional Information

- Related to #3774
