### PR TITLE
perf(kimi-k3): RMSNorm compile island and benchmark static-routing sync pins

### DIFF
--- a/examples/llm_benchmark/kimi/kimi_k3_gb200.yaml
+++ b/examples/llm_benchmark/kimi/kimi_k3_gb200.yaml
@@ -15,9 +15,11 @@
 # Full-size Kimi-K3 (93 layers / 896 experts, 2.78T total / 104B active)
 # throughput benchmark on 64 nodes x 4 GB200 (256 GPUs): EP32 x PP8, DP32.
 #
-# Measured with this exact configuration: ~441 tok/s/GPU, i.e. ~12.2% MFU on
+# Measured with this exact configuration: ~496 tok/s/GPU, i.e. ~13.7% MFU on
 # the basis  MFU = tok/s/GPU * 6 * 104e9 / 2.25e15  (GB200 bf16 dense peak).
-# Wall-clock cross-check: 4096 rows x 1024 tok = 4.19M tokens/step at ~37 s.
+# Wall-clock cross-check: 4096 rows x 1024 tok = 4.19M tokens/step at ~33 s.
+# (Without compile_norm and benchmark_static_routing this measures ~441-458
+# tok/s/GPU = 12.2-12.7% MFU.)
 #
 # Benchmark regime notes:
 # - Random init + fake_balanced_gate (uniform static routing): the standard
@@ -26,8 +28,12 @@
 #   deterministic and comparable across clusters.
 # - prewarm avoids the step-0 lazy-NCCL-init OOM (pp_microbatch_size=2) and
 #   the fla/cuBLAS cold-start stall; compile_situ fuses the fp32 SiTU and
-#   attention-residual chains; enable_fsdp2_prefetch overlaps FSDP
-#   all-gathers that are otherwise fully exposed.
+#   attention-residual chains; compile_norm fuses the fp32 RMSNorm chain (the
+#   remaining per-token launch tax at this scale); benchmark_static_routing
+#   removes per-microbatch host syncs on routing metadata (only sound with
+#   fake_balanced_gate, enforced at config validation);
+#   enable_fsdp2_prefetch overlaps FSDP all-gathers that are otherwise
+#   fully exposed.
 #
 #   To run on 64 GB200 NVL72 nodes:
 #   automodel examples/llm_benchmark/kimi/kimi_k3_gb200.yaml --nnodes 64 --nproc-per-node 4
@@ -82,6 +88,8 @@ model:
     fake_balanced_gate: true   # benchmark only — see header
     fake_gate_noise: 0.0
     compile_situ: true
+    compile_norm: true
+    benchmark_static_routing: true   # requires fake_balanced_gate, noise 0.0
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true
 
@@ -111,21 +119,15 @@ loss_fn:
   _target_: nemo_automodel.components.loss.linear_ce.FusedLinearCrossEntropy
 
 dataset:
-  _target_: nemo_automodel.components.datasets.llm.mock.MockUnpackedDatasetConfig
-  num_sentences: 49216
-  mean_len: 1024.0
-  std_len: 0.0
-  max_sentence_len: 1024
+  _target_: nemo_automodel.components.datasets.llm.mock_iterable_dataset.MockIterableDataset
   vocab_size: 10000
-  seed: 0
-
-packed_sequence:
-  packed_sequence_size: 0
+  seq_len: 1024
+  num_samples: 1000000
 
 dataloader:
-  _target_: torchdata.stateful_dataloader.StatefulDataLoader
-  collate_fn: nemo_automodel.components.datasets.utils.default_collater
-  shuffle: true
+  _target_: torch.utils.data.DataLoader
+  batch_size: null  # Dataset already yields batches
+  num_workers: 0
 
 optimizer:
   _target_: torch.optim.AdamW

--- a/examples/llm_benchmark/kimi/kimi_k3_gb200.yaml
+++ b/examples/llm_benchmark/kimi/kimi_k3_gb200.yaml
@@ -21,6 +21,16 @@
 # (Without compile_norm and benchmark_static_routing this measures ~441-458
 # tok/s/GPU = 12.2-12.7% MFU.)
 #
+# Measurement provenance: these numbers were taken before #3792 aligned the
+# KimiK3TextConfig defaults with the released checkpoint. from_config then
+# built a 56-head MLA / 18432-wide dense FFN model (~101.5B active matmul
+# params instead of 104.0B), so on the checkpoint-aligned shape this file
+# builds today expect ~2% fewer tok/s at about the same MFU; a re-measurement
+# on the aligned shape will replace the figures above. With #3792 the recipe
+# itself prints MFU on the config-derived basis (run it through
+# nemo_automodel/recipes/llm/benchmark.py --config <this file> to get the
+# per-iteration MFU and the Average MFU summary).
+#
 # Benchmark regime notes:
 # - Random init + fake_balanced_gate (uniform static routing): the standard
 #   upper-bound yardstick; a random-init learned gate routes degenerately.

--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -328,6 +328,18 @@ class BackendConfig:
             activation (currently used by Kimi K3), fusing the elementwise fp32
             chain in both the forward and the backward recompute. Compiled
             numerics are allclose to eager but not bitwise-identical.
+        compile_norm: torch.compile the fp32 RMSNorm chain of models that opt in
+            (currently Kimi K3), fusing cast/pow/mean/rsqrt/mul into one kernel.
+            Same lazy once-per-process pattern as ``compile_situ``; numerics are
+            allclose to eager but not bitwise-identical.
+        benchmark_static_routing: Benchmark-only. Requires ``fake_balanced_gate=True``
+            with ``fake_gate_noise=0.0``, where routing metadata (tokens per expert,
+            permuted token counts) is identical for every microbatch. Skips the
+            per-microbatch device-to-host reads of that metadata (`.tolist()` /
+            `count_nonzero` / dispatcher size checks) by caching the first
+            microbatch's values, removing recurring host-sync stalls on the hot
+            path. Never enable with a learned gate: cached metadata would go
+            stale and silently corrupt expert dispatch.
         cuda_graph: Scoped partial CUDA-graph configuration.
     """
 
@@ -372,9 +384,27 @@ class BackendConfig:
     # of models using the SiTU expert activation (currently Kimi K3). Fuses the hot fp32
     # elementwise chains; numerics are allclose to eager, not bitwise-identical. Default False.
     compile_situ: bool = False
+    # When True, torch.compile the fp32 RMSNorm chain of opted-in models (currently Kimi K3),
+    # same lazy once-per-process pattern as compile_situ. Numerics are allclose to eager,
+    # not bitwise-identical. Default False.
+    compile_norm: bool = False
+    # Benchmark-only: cache per-microbatch routing metadata (tokens per expert, permuted
+    # token counts) after the first microbatch to remove recurring device-to-host syncs.
+    # Valid ONLY with fake_balanced_gate=True and fake_gate_noise=0.0 (enforced in
+    # __post_init__), where that metadata is constant by construction. Default False.
+    benchmark_static_routing: bool = False
     cuda_graph: CudaGraphConfig = field(default_factory=CudaGraphConfig)
 
     def __post_init__(self) -> None:
+        # benchmark_static_routing caches routing metadata across microbatches, which is
+        # only sound when routing is constant by construction (forced balance, no noise).
+        if self.benchmark_static_routing and not (self.fake_balanced_gate and self.fake_gate_noise == 0.0):
+            raise ValueError(
+                "benchmark_static_routing=True requires fake_balanced_gate=True and "
+                "fake_gate_noise=0.0; with a learned or noisy gate the cached routing "
+                "metadata would go stale and corrupt expert dispatch."
+            )
+
         # QuACK consumes position-gathered cosine/sine tables. TE's fused RoPE path
         # instead assumes contiguous [0, seq_len) positions, so combining the two
         # silently produces incorrect phases for packed, offset, or per-example

--- a/nemo_automodel/components/models/kimi_k3/model.py
+++ b/nemo_automodel/components/models/kimi_k3/model.py
@@ -55,7 +55,9 @@ from nemo_automodel.components.models.kimi_k3.cp import (
 )
 from nemo_automodel.components.models.kimi_k3.situ import (
     _apply_attn_res,
+    _compile_norm_core,
     _compile_situ_cores,
+    _rms_norm,
     _weighted_situ,
 )
 from nemo_automodel.components.models.kimi_k3.state_dict_adapter import KimiK3StateDictAdapter
@@ -228,6 +230,12 @@ def _pad_input(hidden_states: torch.Tensor, indices: torch.Tensor, batch_size: i
     return output.reshape(batch_size, seq_len, *hidden_states.shape[1:])
 
 
+# One cached upper-triangular mask per (dtype, device), grown on demand and
+# sliced per call, so repeated microbatches skip rebuilding the [S, S] mask on
+# the hot path while the cache stays bounded to a single largest-size entry.
+_CAUSAL_MASK_CACHE: dict[tuple[torch.dtype, torch.device], torch.Tensor] = {}
+
+
 def _make_causal_mask(
     inputs_embeds: torch.Tensor,
     packed_context: "KimiPackedContext | None",
@@ -254,10 +262,14 @@ def _make_causal_mask(
             q_global_start=0,
             dtype=dtype,
         )
-    min_value = torch.finfo(dtype).min
-    mask = torch.full((seq_len, seq_len), min_value, device=inputs_embeds.device, dtype=dtype)
-    mask = torch.triu(mask, diagonal=1)
-    return mask[None, None, :, :].expand(batch_size, 1, -1, -1)
+    cache_key = (dtype, inputs_embeds.device)
+    mask = _CAUSAL_MASK_CACHE.get(cache_key)
+    if mask is None or mask.shape[0] < seq_len:
+        min_value = torch.finfo(dtype).min
+        mask = torch.full((seq_len, seq_len), min_value, device=inputs_embeds.device, dtype=dtype)
+        mask = torch.triu(mask, diagonal=1)
+        _CAUSAL_MASK_CACHE[cache_key] = mask
+    return mask[None, None, :seq_len, :seq_len].expand(batch_size, 1, -1, -1)
 
 
 def _packed_context_from_inputs(
@@ -303,11 +315,7 @@ class KimiRMSNorm(nn.Module):
         Returns:
             Tensor of shape [batch, sequence, hidden].
         """
-        input_dtype = hidden_states.dtype
-        hidden_states = hidden_states.to(torch.float32)
-        variance = hidden_states.pow(2).mean(-1, keepdim=True)
-        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
-        return self.weight * hidden_states.to(input_dtype)
+        return _rms_norm(hidden_states, self.weight, self.variance_epsilon)
 
     def reset_parameters(self) -> None:
         nn.init.ones_(self.weight)
@@ -1048,6 +1056,8 @@ class KimiK3MoE(MoE):
             self.gate = KimiK3Gate(moe_config, gate_precision=torch.float32)
         if backend.compile_situ:
             _compile_situ_cores()
+        if backend.compile_norm:
+            _compile_norm_core()
         expert_activation = partial(
             _weighted_situ,
             beta=config.activation_situ_beta or 1.0,
@@ -1489,7 +1499,11 @@ class KimiK3TextModel(nn.Module):
         Returns:
             Binary padding mask tensor of shape [batch, sequence], or None when no KDA mask is needed.
         """
-        if cache_position[0] > 0 or (attention_mask is not None and torch.all(attention_mask == 1)):
+        if attention_mask is None:
+            # Both branches below return None for this input; returning early skips
+            # a per-microbatch device-to-host sync on cache_position[0].
+            return None
+        if cache_position[0] > 0 or torch.all(attention_mask == 1):
             return None
         return attention_mask
 

--- a/nemo_automodel/components/models/kimi_k3/situ.py
+++ b/nemo_automodel/components/models/kimi_k3/situ.py
@@ -140,6 +140,60 @@ def _compile_situ_cores() -> None:
     _SITU_CORES_COMPILED = True
 
 
+def _rms_norm_core(hidden_states: torch.Tensor, weight: torch.Tensor, variance_epsilon: float) -> torch.Tensor:
+    """fp32 RMSNorm chain shared by every ``KimiRMSNorm`` instance.
+
+    Args:
+        hidden_states: Tensor of shape [..., hidden], with arbitrary leading dimensions.
+        weight: RMSNorm weight of shape [hidden].
+        variance_epsilon: RMSNorm epsilon.
+
+    Returns:
+        Normalized tensor with the same shape and dtype as ``hidden_states``.
+    """
+    input_dtype = hidden_states.dtype
+    hidden_states = hidden_states.to(torch.float32)
+    variance = hidden_states.pow(2).mean(-1, keepdim=True)
+    hidden_states = hidden_states * torch.rsqrt(variance + variance_epsilon)
+    return weight * hidden_states.to(input_dtype)
+
+
+_rms_norm_dispatch = _rms_norm_core
+_RMS_NORM_COMPILED = False
+
+
+def _compile_norm_core() -> None:
+    """Wrap the RMSNorm core with ``torch.compile`` (``BackendConfig.compile_norm``).
+
+    Runs once per process, same lazy pattern as :func:`_compile_situ_cores`:
+    the compiled function replaces the module-level eager core, so every
+    ``KimiRMSNorm`` instance shares one compiled kernel. Compiled numerics are
+    allclose to eager, not bitwise-identical.
+    """
+    global _rms_norm_dispatch, _RMS_NORM_COMPILED
+    if _RMS_NORM_COMPILED:
+        return
+    _rms_norm_dispatch = torch.compile(_rms_norm_core, dynamic=True)
+    _RMS_NORM_COMPILED = True
+
+
+def _rms_norm(hidden_states: torch.Tensor, weight: torch.Tensor, variance_epsilon: float) -> torch.Tensor:
+    """Dispatch RMSNorm through the current (eager or compiled) core.
+
+    Indirection so ``KimiRMSNorm.forward`` picks up the compiled core even when
+    :func:`_compile_norm_core` runs after modules were constructed.
+
+    Args:
+        hidden_states: Tensor of shape [..., hidden], with arbitrary leading dimensions.
+        weight: RMSNorm weight of shape [hidden].
+        variance_epsilon: RMSNorm epsilon.
+
+    Returns:
+        Normalized tensor with the same shape and dtype as ``hidden_states``.
+    """
+    return _rms_norm_dispatch(hidden_states, weight, variance_epsilon)
+
+
 def _situ_rw_is_row_aligned(gate_up: torch.Tensor, routing_weights: torch.Tensor) -> bool:
     """Return True when ``routing_weights`` carries one entry per ``gate_up`` row.
 

--- a/nemo_automodel/components/moe/experts.py
+++ b/nemo_automodel/components/moe/experts.py
@@ -166,6 +166,34 @@ def is_gated_activation(activation: str) -> bool:
     return activation in ("swiglu", "swigluoai", "quick_geglu", "geglu")
 
 
+def _resolve_m_splits(
+    tokens_per_expert: torch.Tensor | list | tuple,
+    static_routing: bool,
+    cached_m_splits: list | None,
+) -> list:
+    """Resolve the per-expert split sizes for TE's grouped GEMM.
+
+    Args:
+        tokens_per_expert: Per-local-expert token counts of shape [num_local_experts]
+            (CUDA tensor from the flex dispatcher, or an already-materialized sequence).
+        static_routing: Benchmark-only static-routing mode (see
+            ``BackendConfig.benchmark_static_routing``) under which the counts are
+            constant for every microbatch.
+        cached_m_splits: The first microbatch's split list, or None before it is known.
+
+    Returns:
+        The split sizes as a Python list. Under static routing with a warm cache the
+        cached list is returned as-is — skipping the per-call device-to-host
+        ``.tolist()`` sync (and its repeat under activation-checkpoint recompute);
+        otherwise the counts are materialized from ``tokens_per_expert``.
+    """
+    if static_routing and cached_m_splits is not None:
+        return cached_m_splits
+    if isinstance(tokens_per_expert, torch.Tensor):
+        return tokens_per_expert.tolist()
+    return list(tokens_per_expert)
+
+
 def _permute_tokens_for_grouped_mm(
     indices: torch.Tensor,
     weights: torch.Tensor,
@@ -923,7 +951,7 @@ class GroupedExpertsDeepEP(nn.Module):
         self.use_mxfp8 = backend is not None and backend.experts == "torch_mm_mxfp8"
         # Benchmark-only (BackendConfig.benchmark_static_routing, validated there): routing
         # metadata is identical per microbatch, so host copies of it can be cached.
-        self.static_routing = backend is not None and getattr(backend, "benchmark_static_routing", False)
+        self.static_routing = backend is not None and backend.benchmark_static_routing
         self._static_tokens_per_expert_cpu: torch.Tensor | None = None
         self.expert_bias = config.expert_bias
         self.is_gated = is_gated_activation(config.expert_activation)
@@ -1220,7 +1248,7 @@ class GroupedExpertsTE(nn.Module):
         # Benchmark-only (BackendConfig.benchmark_static_routing, validated there): the
         # per-microbatch tokens_per_expert.tolist() host sync is replaced by a cached
         # first-microbatch copy, since forced-balanced routing makes it constant.
-        self.static_routing = backend is not None and getattr(backend, "benchmark_static_routing", False)
+        self.static_routing = backend is not None and backend.benchmark_static_routing
         self._static_m_splits: list | None = None
         self.dispatcher_backend = dispatcher_backend
         self.dispatcher_num_sms = dispatcher_num_sms
@@ -1589,14 +1617,7 @@ class GroupedExpertsTE(nn.Module):
         )
         permuted_probs = permuted_probs.unsqueeze(-1)
 
-        if self.static_routing and self._static_m_splits is not None:
-            # Static routing: reuse the first microbatch's split list instead of paying a
-            # device-to-host .tolist() sync per microbatch (and per checkpoint recompute).
-            m_splits = self._static_m_splits
-        elif isinstance(tokens_per_expert, torch.Tensor):
-            m_splits = tokens_per_expert.tolist()
-        else:
-            m_splits = list(tokens_per_expert)
+        m_splits = _resolve_m_splits(tokens_per_expert, self.static_routing, self._static_m_splits)
         if self.static_routing and self._static_m_splits is None:
             self._static_m_splits = m_splits
 

--- a/nemo_automodel/components/moe/experts.py
+++ b/nemo_automodel/components/moe/experts.py
@@ -921,6 +921,10 @@ class GroupedExpertsDeepEP(nn.Module):
         # GEMMs through torchao's MXFP8 kernel (see _torch_mm_experts_fwd).
         self.use_torch_mm = backend is not None and backend.experts in ("torch_mm", "torch_mm_mxfp8")
         self.use_mxfp8 = backend is not None and backend.experts == "torch_mm_mxfp8"
+        # Benchmark-only (BackendConfig.benchmark_static_routing, validated there): routing
+        # metadata is identical per microbatch, so host copies of it can be cached.
+        self.static_routing = backend is not None and getattr(backend, "benchmark_static_routing", False)
+        self._static_tokens_per_expert_cpu: torch.Tensor | None = None
         self.expert_bias = config.expert_bias
         self.is_gated = is_gated_activation(config.expert_activation)
         self.dispatcher_backend = dispatcher_backend
@@ -960,6 +964,7 @@ class GroupedExpertsDeepEP(nn.Module):
             moe_hybridep_num_sms=self.dispatcher_num_sms,
             moe_share_token_dispatcher=self.dispatcher_share_token_dispatcher,
             moe_deepep_async_dispatch=self.dispatcher_async_dispatch,
+            moe_benchmark_static_routing=self.static_routing,
         )
 
         self.n_routed_experts = self.config.n_routed_experts
@@ -1036,7 +1041,10 @@ class GroupedExpertsDeepEP(nn.Module):
         gate_and_up_projs = self.gate_and_up_projs.to_local().to(compute_dtype)
         down_projs = self.down_projs.to_local().to(compute_dtype)
 
-        if torch.count_nonzero(tokens_per_expert) > 0:
+        # With static routing (forced balance, no noise) every expert receives tokens by
+        # construction, so the count_nonzero device-to-host read (one per microbatch, and
+        # again per activation-checkpoint recompute) can be skipped.
+        if self.static_routing or torch.count_nonzero(tokens_per_expert) > 0:
             if self.use_torch_mm:
                 tokens_per_expert_gpu = tokens_per_expert.to(
                     device=permuted_local_hidden_states.device, non_blocking=True
@@ -1077,7 +1085,15 @@ class GroupedExpertsDeepEP(nn.Module):
                         use_mxfp8=self.use_mxfp8,
                     )
             else:
-                tokens_per_expert = tokens_per_expert.to("cpu")
+                # ops.gmm sizes its launches from a CPU copy of tokens_per_expert; under
+                # static routing the first microbatch's copy is reused to avoid the
+                # per-microbatch device-to-host transfer.
+                if self.static_routing and self._static_tokens_per_expert_cpu is not None:
+                    tokens_per_expert = self._static_tokens_per_expert_cpu
+                else:
+                    tokens_per_expert = tokens_per_expert.to("cpu")
+                    if self.static_routing:
+                        self._static_tokens_per_expert_cpu = tokens_per_expert
                 output1 = ops.gmm(
                     permuted_local_hidden_states,
                     gate_and_up_projs,
@@ -1170,7 +1186,8 @@ class GroupedExpertsTE(nn.Module):
 
         Args:
             config: MoE configuration containing expert parameters.
-            backend: Backend configuration (reserved for future use).
+            backend: Backend configuration; reads ``benchmark_static_routing``
+                (cache the per-microbatch split list under forced-balanced routing).
             dispatcher_backend: Backend for the flex token dispatcher ("deepep" or "hybridep").
             dispatcher_num_sms: Number of SMs to use for the dispatcher backend.
             dispatcher_share_token_dispatcher: Whether to share a flex dispatcher communication manager across layers.
@@ -1200,6 +1217,11 @@ class GroupedExpertsTE(nn.Module):
         self.dim = config.dim
         self.moe_inter_dim = config.moe_inter_dim
         self.is_gated = is_gated_activation(config.expert_activation)
+        # Benchmark-only (BackendConfig.benchmark_static_routing, validated there): the
+        # per-microbatch tokens_per_expert.tolist() host sync is replaced by a cached
+        # first-microbatch copy, since forced-balanced routing makes it constant.
+        self.static_routing = backend is not None and getattr(backend, "benchmark_static_routing", False)
+        self._static_m_splits: list | None = None
         self.dispatcher_backend = dispatcher_backend
         self.dispatcher_num_sms = dispatcher_num_sms
         self.dispatcher_share_token_dispatcher = dispatcher_share_token_dispatcher
@@ -1514,6 +1536,7 @@ class GroupedExpertsTE(nn.Module):
             moe_hybridep_num_sms=self.dispatcher_num_sms,
             moe_share_token_dispatcher=self.dispatcher_share_token_dispatcher,
             moe_deepep_async_dispatch=self.dispatcher_async_dispatch,
+            moe_benchmark_static_routing=self.static_routing,
         )
 
         local_expert_indices_offset = self.ep_rank * self.num_local_experts
@@ -1566,10 +1589,16 @@ class GroupedExpertsTE(nn.Module):
         )
         permuted_probs = permuted_probs.unsqueeze(-1)
 
-        if isinstance(tokens_per_expert, torch.Tensor):
+        if self.static_routing and self._static_m_splits is not None:
+            # Static routing: reuse the first microbatch's split list instead of paying a
+            # device-to-host .tolist() sync per microbatch (and per checkpoint recompute).
+            m_splits = self._static_m_splits
+        elif isinstance(tokens_per_expert, torch.Tensor):
             m_splits = tokens_per_expert.tolist()
         else:
             m_splits = list(tokens_per_expert)
+        if self.static_routing and self._static_m_splits is None:
+            self._static_m_splits = m_splits
 
         from transformer_engine.pytorch.quantization import FP8GlobalStateManager
 

--- a/nemo_automodel/components/moe/megatron/token_dispatcher.py
+++ b/nemo_automodel/components/moe/megatron/token_dispatcher.py
@@ -380,6 +380,7 @@ class _HybridEPManager(_DispatchManager):
         router_topk: int,
         permute_fusion: bool = False,
         moe_hybridep_num_sms: int = 24,
+        benchmark_static_routing: bool = False,
     ):
         self.group = group
         self.num_local_experts = num_local_experts
@@ -387,6 +388,9 @@ class _HybridEPManager(_DispatchManager):
         self.router_topk = router_topk
         self.permute_fusion = permute_fusion
         self.moe_hybridep_num_sms = moe_hybridep_num_sms
+        # Benchmark-only (TokenDispatcherConfig.moe_benchmark_static_routing):
+        # persist num_permuted_tokens across dispatches, see dispatch()/reset.
+        self.benchmark_static_routing = benchmark_static_routing
         self.num_permuted_tokens = None
 
         # Metadata
@@ -448,7 +452,13 @@ class _HybridEPManager(_DispatchManager):
     ) -> torch.Tensor:
         # Reset num_permuted_tokens to None to avoid reusing cached state from a prior dispatch.
         # This can happen in non-reentrant activation checkpointing mode.
-        self.num_permuted_tokens = None
+        # Benchmark-only exception: with static routing every dispatch permutes the same
+        # count, so reusing the first dispatch's value keeps hybrid_ep_dispatch on its
+        # non-blocking path and removes a per-microbatch host wait on a device-side flag.
+        if self.benchmark_static_routing and getattr(self, "_static_num_permuted_tokens", None) is not None:
+            self.num_permuted_tokens = self._static_num_permuted_tokens
+        else:
+            self.num_permuted_tokens = None
         if self.token_probs.dtype != torch.float32:
             self.token_probs = self.token_probs.float()
 
@@ -486,6 +496,8 @@ class _HybridEPManager(_DispatchManager):
 
         self.tokens_per_expert = tokens_per_expert
         self.num_permuted_tokens = self.tokens_per_expert.sum()
+        if self.benchmark_static_routing and getattr(self, "_static_num_permuted_tokens", None) is None:
+            self._static_num_permuted_tokens = self.num_permuted_tokens
 
         return dispatched_hidden
 
@@ -564,6 +576,12 @@ class TokenDispatcherConfig:
 
     moe_deepep_async_dispatch: bool = False
     """Use asynchronous DeepEP/UCCL-EP dispatch/combine and communication-stream allocations."""
+
+    moe_benchmark_static_routing: bool = False
+    """Benchmark-only (mirrors BackendConfig.benchmark_static_routing, validated there):
+    routing is forced-balanced with no noise, so every dispatch permutes the same token
+    count. Persist num_permuted_tokens across dispatches to keep HybridEP on its
+    non-blocking size path instead of waiting on a device-side count per microbatch."""
 
 
 class MoEFlexTokenDispatcher:
@@ -666,6 +684,7 @@ class MoEFlexTokenDispatcher:
                         router_topk=self.tp_size * self.config.moe_router_topk,
                         permute_fusion=self.config.moe_permute_fusion,
                         moe_hybridep_num_sms=self.config.moe_hybridep_num_sms,
+                        benchmark_static_routing=self.config.moe_benchmark_static_routing,
                     )
                 self._comm_manager = MoEFlexTokenDispatcher.shared_hybridep_manager
             else:
@@ -676,6 +695,7 @@ class MoEFlexTokenDispatcher:
                     router_topk=self.tp_size * self.config.moe_router_topk,
                     permute_fusion=self.config.moe_permute_fusion,
                     moe_hybridep_num_sms=self.config.moe_hybridep_num_sms,
+                    benchmark_static_routing=self.config.moe_benchmark_static_routing,
                 )
             self.hybridep_metadata_processor = _HybridEPMetadataProcessor(
                 num_experts=self.tp_size * self.config.num_moe_experts,

--- a/tests/unit_tests/models/kimi_k3/test_causal_mask_cache.py
+++ b/tests/unit_tests/models/kimi_k3/test_causal_mask_cache.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import nemo_automodel.components.models.kimi_k3.model as kimi_k3_model
+from nemo_automodel.components.models.kimi_k3.model import _make_causal_mask
+
+
+def _reference_mask(batch_size: int, seq_len: int, dtype: torch.dtype) -> torch.Tensor:
+    min_value = torch.finfo(dtype).min
+    mask = torch.full((seq_len, seq_len), min_value, dtype=dtype)
+    mask = torch.triu(mask, diagonal=1)
+    return mask[None, None, :, :].expand(batch_size, 1, -1, -1)
+
+
+@pytest.fixture(autouse=True)
+def clear_mask_cache():
+    kimi_k3_model._CAUSAL_MASK_CACHE.clear()
+    yield
+    kimi_k3_model._CAUSAL_MASK_CACHE.clear()
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_cached_mask_matches_reference(dtype):
+    embeds = torch.zeros(2, 5, 8)
+    out = _make_causal_mask(embeds, None, dtype=dtype)
+    torch.testing.assert_close(out, _reference_mask(2, 5, dtype))
+
+
+def test_cache_reused_and_sliced_for_shorter_sequences():
+    long_embeds = torch.zeros(1, 9, 8)
+    _make_causal_mask(long_embeds, None, dtype=torch.float32)
+    cached = kimi_k3_model._CAUSAL_MASK_CACHE[(torch.float32, long_embeds.device)]
+
+    short_embeds = torch.zeros(3, 4, 8)
+    out = _make_causal_mask(short_embeds, None, dtype=torch.float32)
+
+    # Shorter request slices the existing entry instead of rebuilding it.
+    assert kimi_k3_model._CAUSAL_MASK_CACHE[(torch.float32, short_embeds.device)] is cached
+    torch.testing.assert_close(out, _reference_mask(3, 4, torch.float32))
+
+
+def test_cache_grows_for_longer_sequences_and_stays_single_entry():
+    _make_causal_mask(torch.zeros(1, 4, 8), None, dtype=torch.float32)
+    out = _make_causal_mask(torch.zeros(1, 6, 8), None, dtype=torch.float32)
+
+    torch.testing.assert_close(out, _reference_mask(1, 6, torch.float32))
+    cache = kimi_k3_model._CAUSAL_MASK_CACHE
+    assert len(cache) == 1
+    assert cache[(torch.float32, torch.zeros(1).device)].shape == (6, 6)

--- a/tests/unit_tests/models/kimi_k3/test_compile_norm.py
+++ b/tests/unit_tests/models/kimi_k3/test_compile_norm.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import nemo_automodel.components.models.kimi_k3.situ as kimi_k3_situ
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.kimi_k3.config import KimiK3TextConfig
+from nemo_automodel.components.models.kimi_k3.model import KimiK3MoE, KimiRMSNorm, _build_moe_config
+
+
+def _tiny_config() -> KimiK3TextConfig:
+    return KimiK3TextConfig(
+        vocab_size=64,
+        hidden_size=32,
+        head_dim=8,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        torch_dtype="float32",
+        num_experts=4,
+        num_experts_per_token=2,
+        num_shared_experts=0,
+        first_k_dense_replace=0,
+        moe_intermediate_size=16,
+        routed_expert_hidden_size=16,
+        q_lora_rank=16,
+        kv_lora_rank=16,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=4,
+        v_head_dim=8,
+        linear_attn_config={
+            "head_dim": 8,
+            "num_heads": 4,
+            "short_conv_kernel_size": 4,
+            "kda_layers": [],
+            "full_attn_layers": [1],
+            "use_full_rank_gate": True,
+            "gate_lower_bound": -5.0,
+        },
+        attn_res_block_size=1,
+    )
+
+
+def _build_moe(backend: BackendConfig) -> KimiK3MoE:
+    config = _tiny_config()
+    moe_config = _build_moe_config(config, torch.float32, None)
+    return KimiK3MoE(config, moe_config, backend)
+
+
+def _torch_backend(**overrides) -> BackendConfig:
+    return BackendConfig(
+        attn="eager",
+        linear="torch",
+        experts="torch",
+        dispatcher="torch",
+        enable_hf_state_dict_adapter=False,
+        **overrides,
+    )
+
+
+@pytest.fixture
+def restore_norm_core():
+    """Snapshot and restore the module-level RMSNorm core around a test."""
+    orig_dispatch = kimi_k3_situ._rms_norm_dispatch
+    orig_flag = kimi_k3_situ._RMS_NORM_COMPILED
+    yield
+    kimi_k3_situ._rms_norm_dispatch = orig_dispatch
+    kimi_k3_situ._RMS_NORM_COMPILED = orig_flag
+
+
+def test_compile_norm_defaults_to_false():
+    assert BackendConfig().compile_norm is False
+
+
+def test_default_backend_leaves_norm_eager(restore_norm_core):
+    orig_dispatch = kimi_k3_situ._rms_norm_dispatch
+
+    _build_moe(_torch_backend())
+
+    assert kimi_k3_situ._rms_norm_dispatch is orig_dispatch
+    assert kimi_k3_situ._RMS_NORM_COMPILED is False
+
+
+def test_compile_norm_wraps_core_once(restore_norm_core):
+    orig_dispatch = kimi_k3_situ._rms_norm_dispatch
+
+    _build_moe(_torch_backend(compile_norm=True))
+
+    assert kimi_k3_situ._RMS_NORM_COMPILED is True
+    assert kimi_k3_situ._rms_norm_dispatch is not orig_dispatch
+
+    wrapped = kimi_k3_situ._rms_norm_dispatch
+    _build_moe(_torch_backend(compile_norm=True))
+    assert kimi_k3_situ._rms_norm_dispatch is wrapped
+
+
+def test_compiled_norm_matches_eager(restore_norm_core):
+    torch.manual_seed(0)
+    module = KimiRMSNorm(hidden_size=32, eps=1e-6, dtype=torch.float32)
+    with torch.no_grad():
+        module.weight.mul_(0.0).add_(torch.rand_like(module.weight) + 0.5)
+    x = torch.randn(4, 7, 32, dtype=torch.float32, requires_grad=True)
+
+    eager_out = module(x)
+    eager_out.sum().backward()
+    eager_grad = x.grad.detach().clone()
+    x.grad = None
+
+    # Modules built before the hook runs must still pick up the compiled core.
+    kimi_k3_situ._compile_norm_core()
+    compiled_out = module(x)
+    compiled_out.sum().backward()
+
+    torch.testing.assert_close(compiled_out, eager_out, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(x.grad, eager_grad, rtol=1e-5, atol=1e-6)
+
+
+def test_benchmark_static_routing_requires_forced_balance():
+    with pytest.raises(ValueError, match="benchmark_static_routing"):
+        BackendConfig(benchmark_static_routing=True)
+
+    with pytest.raises(ValueError, match="benchmark_static_routing"):
+        BackendConfig(benchmark_static_routing=True, fake_balanced_gate=True, fake_gate_noise=0.1)
+
+    cfg = BackendConfig(benchmark_static_routing=True, fake_balanced_gate=True, fake_gate_noise=0.0)
+    assert cfg.benchmark_static_routing is True

--- a/tests/unit_tests/moe/test_static_routing_m_splits.py
+++ b/tests/unit_tests/moe/test_static_routing_m_splits.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral coverage for the static-routing m_splits cache used by GroupedExpertsTE."""
+
+import torch
+
+from nemo_automodel.components.moe.experts import _resolve_m_splits
+
+
+def test_without_static_routing_every_call_materializes():
+    first = _resolve_m_splits(torch.tensor([3, 1, 0, 4]), static_routing=False, cached_m_splits=None)
+    assert first == [3, 1, 0, 4]
+    # A later microbatch with different counts must be re-materialized, never cached.
+    second = _resolve_m_splits(torch.tensor([2, 2, 2, 2]), static_routing=False, cached_m_splits=first)
+    assert second == [2, 2, 2, 2]
+
+
+def test_static_routing_reuses_first_microbatch_splits():
+    counts = torch.tensor([4, 4, 4, 4])
+    first = _resolve_m_splits(counts, static_routing=True, cached_m_splits=None)
+    assert first == [4, 4, 4, 4]
+
+    # Warm cache: the cached list object is returned as-is and the tensor is not
+    # consulted (this is the device-to-host sync being skipped). Passing different
+    # counts documents the contract: static routing asserts the counts are constant,
+    # so the cache — not the tensor — is authoritative.
+    later = _resolve_m_splits(torch.tensor([9, 9, 9, 9]), static_routing=True, cached_m_splits=first)
+    assert later is first
+
+
+def test_sequence_inputs_pass_through_as_lists():
+    assert _resolve_m_splits((5, 6), static_routing=False, cached_m_splits=None) == [5, 6]
+    assert _resolve_m_splits([7], static_routing=True, cached_m_splits=None) == [7]


### PR DESCRIPTION
# What does this PR do ?

Two opt-in launch-tax reductions for the Kimi-K3 GB200 benchmark
(`BackendConfig.compile_norm`, `BackendConfig.benchmark_static_routing`), two
unconditional hot-path fixes in the K3 attention-mask path, and the
`MockIterableDataset` pairing fix that makes `kimi_k3_gb200.yaml` runnable.

1. **`BackendConfig.compile_norm`** (default `False`) — `torch.compile` the
   fp32 RMSNorm chain once per process, the same lazy pattern as the merged
   `compile_situ`. The core moved to `situ.py` next to the other compile
   hooks; `KimiRMSNorm.forward` dispatches through it, so modules built
   before the hook still pick up the compiled kernel.
2. **`BackendConfig.benchmark_static_routing`** (default `False`) — under
   forced-balanced routing (`fake_balanced_gate` + zero noise, enforced in
   `__post_init__`) the per-microbatch routing metadata is constant, so its
   recurring device-to-host syncs are skipped after the first microbatch:
   - `GroupedExpertsTE`: the per-call `tokens_per_expert.tolist()`
   - `GroupedExpertsDeepEP`: `count_nonzero` gate + the CPU
     `tokens_per_expert` copy for `ops.gmm`
   - flex dispatcher: persist `num_permuted_tokens`
     (`TokenDispatcherConfig.moe_benchmark_static_routing`) so HybridEP
     stays on its non-blocking size path
3. Unconditional: `_update_linear_attn_mask` early-return for
   `attention_mask=None` (skips a per-microbatch D2H on
   `cache_position[0]`); `_make_causal_mask` caches one `[S, S]` mask per
   (dtype, device), grown on demand and sliced (bounded cache).
4. `examples/llm_benchmark/kimi/kimi_k3_gb200.yaml`: `BenchmarkingRecipe`
   was paired with `MockUnpackedDatasetConfig` and raised `KeyError: 'seq_len'`
   at startup; switched to `MockIterableDataset` and enabled the two flags.

# Changelog

- `nemo_automodel/components/models/common/utils.py`: `BackendConfig.compile_norm`,
  `BackendConfig.benchmark_static_routing` (+ `__post_init__` validation, docstrings).
- `nemo_automodel/components/models/kimi_k3/situ.py`: lazy once-per-process RMSNorm
  compile hook (`compile_norm`), sibling of `compile_situ`.
- `nemo_automodel/components/models/kimi_k3/model.py`: `KimiRMSNorm` dispatch through
  the hook; `attention_mask=None` early return; bounded `_make_causal_mask` cache.
- `nemo_automodel/components/moe/experts.py`: static-routing `m_splits` cache for
  `GroupedExpertsTE` / `GroupedExpertsDeepEP`.
- `nemo_automodel/components/moe/megatron/token_dispatcher.py`:
  `TokenDispatcherConfig.moe_benchmark_static_routing`, persisted `num_permuted_tokens`.
- `examples/llm_benchmark/kimi/kimi_k3_gb200.yaml`: dataset pairing fix, flags on,
  header states the measured shape and provenance.
- Tests: `tests/unit_tests/models/kimi_k3/test_compile_norm.py`,
  `tests/unit_tests/models/kimi_k3/test_causal_mask_cache.py`,
  `tests/unit_tests/moe/test_static_routing_m_splits.py`.

# Validation

**Measured (256 GPUs, 64×GB200 NVL72, pp8×EP32, 1k rows × GBS 4096, mock):**

| config | tok/s/GPU | MFU |
|---|---|---|
| merged main, shipped YAML | 441–458 | 12.2–12.7% |
| + static-routing pins | 446.6–451.6 (+2.4% isolated) | 12.4–12.5% |
| + compile_norm | **495.7** | **13.7%** |

MFU basis `tok/s/GPU × 6 × 104e9 / 2.25e15`. Same-job back-to-back rungs;
loss parity across all steps with flags on/off at mini scale; RMSNorm compile
parity covered by unit tests (allclose fwd+bwd). Scale effect: compile_norm
gains +5.3% on a 2-node mini but +11% at 256 GPUs — at the launch-bound
operating point, fusing the per-token norm chain pays in both busy time and
inter-kernel gaps.

**Measurement provenance:** the 13.7% figure was measured before #3792, when
`from_config` built a 56-head MLA / 18432-wide dense FFN model (~101.5B active
matmul parameters instead of 104.0B). The yaml header says so. On the
checkpoint-aligned shape this file builds today expect ~2% fewer tok/s at about
the same MFU; a 64-node re-run on the aligned shape is queued (`w51p` rung =
this exact file) and the numbers here and in the header will be replaced when
it lands.

**Tests:**

- `test_compile_norm.py` — default-off, wrap-once/idempotent, late-binding
  dispatch, fwd+bwd allclose parity, `benchmark_static_routing` validation
  (raises without forced balance).
- `test_causal_mask_cache.py` — cached mask equals reference, slice-reuse for
  shorter sequences, grow-and-replace for longer, single-entry bound.
- `test_static_routing_m_splits.py` — behavioral coverage for the cache
  (review-bot follow-up).
- Full kimi_k3 suite: 84 passed (1 pre-existing env failure on clean main).
- `ruff check` + `ruff format --check` (0.12.12, CI version): clean.
- With #3792 the recipe prints MFU on the config-derived basis; run the file
  through `nemo_automodel/recipes/llm/benchmark.py --config …` for the
  per-iteration `MFU:` lines and the `Average MFU` summary (the
  `automodel <yaml>` launcher uses the generic loop and prints only the
  setup-time `TFLOPs/GPU`).

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (three new unit-test files, listed above)
- [x] Did you add or update any necessary documentation? (`BackendConfig` docstrings for both flags; yaml header documents the measured shape. No docs page enumerates `BackendConfig` fields.)

# Additional Information

- Part 1 of 2. The PP recv-buffer pool and the 2k-row benchmark shape
  (17.1% MFU) are in #3780, which is stacked on this PR — infra-level change
  with a different review audience. Merge order: this PR first.
- `preserve_rng_state` gating in the AC wrappers was measured as part of the
  pins bundle but is deferred with it (shared-infra plumbing, unknown
  isolated gain).
- Rebased on `main` after #3792 (K3 FLOPs formula + `KimiK3TextConfig`
  defaults aligned with the checkpoint).
