### PR TITLE
perf(distributed): ring-pooled PP recv buffers and Kimi-K3 2k benchmark shape

### DIFF
--- a/docs/guides/pipelining.mdx
+++ b/docs/guides/pipelining.mdx
@@ -135,6 +135,32 @@ ap = AutoPipeline(
 ).build(model, loss_fn=loss_fn)
 ```
 
+### Receive Buffer Pooling (`pp_recv_buffer_pool`)
+
+`torch.distributed.pipelining` pre-allocates one receive buffer per microbatch and
+per direction (activations forward, gradients backward). With many microbatches and
+wide stage inputs those buffers can exceed the activations themselves — Kimi-K3 at
+2k-token rows with 64 microbatches needs ~52 GiB of them on middle stages.
+
+Under the 1F1B schedule only `num_stages - stage_index` microbatches are ever in
+flight on a stage, so `pp_recv_buffer_pool: true` rebinds the per-microbatch
+receive slots onto a ring of `(num_stages - stage_index) + pp_recv_buffer_pool_slack`
+real buffer sets (default slack 2). The values flowing through the schedule are
+unchanged; only which buffer object receives each chunk differs.
+
+```yaml
+distributed:
+  pipeline:
+    pp_schedule: 1f1b
+    pp_recv_buffer_pool: true        # default false
+    pp_recv_buffer_pool_slack: 2     # extra buffer sets beyond the in-flight depth
+```
+
+The option applies only to schedules with a bounded in-flight depth (currently
+`1f1b`); other schedules keep the stock allocation with a warning. If the installed
+torch exposes neither of the two known `PipelineStage` layouts, the pool is not
+installed and stock behavior is kept (logged at install time).
+
 ### Model Patching (`patch_inner_model`, `patch_causal_lm_model`)
 
 AutoPipeline splits a model by deep-copying it per stage and pruning away modules that don't belong to that stage. Many Hugging Face models assume the full module tree is present and return `ModelOutput` objects; after pruning, their original `forward()` often breaks (or returns objects that are awkward to pipeline).

--- a/examples/llm_benchmark/kimi/kimi_k3_gb200_2k.yaml
+++ b/examples/llm_benchmark/kimi/kimi_k3_gb200_2k.yaml
@@ -1,0 +1,156 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Full-size Kimi-K3 (93 layers / 896 experts, 2.78T total / 104B active)
+# throughput benchmark at 2k-token rows on 64 nodes x 4 GB200 (256 GPUs):
+# EP32 x PP8, DP32, GBS 4096.
+#
+# Measured with this exact configuration: ~616 tok/s/GPU, i.e. ~17.1% MFU on
+# the basis  MFU = tok/s/GPU * 6 * 104e9 / 2.25e15  (GB200 bf16 dense peak).
+# Wall-clock cross-check: 4096 rows x 2048 tok = 8.39M tokens/step at ~53 s.
+# Peak memory 139.6 GiB per GPU (44 GiB headroom on 184 GiB HBM).
+#
+# Why 2k rows beat the 1k config (13.7% MFU) by 3.4pp: at this scale the
+# workload is launch-bound, so doubling tokens per row halves the per-token
+# kernel-launch tax, and K3's KDA linear attention does not penalize longer
+# rows. The PP bubble at this point is 9.9% (64 microbatches).
+#
+# This shape REQUIRES distributed.pipeline.pp_recv_buffer_pool: without it,
+# torch pre-allocates recv buffers for all 64 microbatches x both directions
+# (~52 GiB on middle stages at 2k) and the run OOMs during step 1. The ring
+# pool sizes buffers to the 1F1B in-flight depth instead, saving ~45 GiB.
+#
+# compile_norm is left off here: this file documents the measured champion
+# configuration; the 2k x compile_norm stack is pending measurement.
+#
+# Other benchmark regime notes match examples/llm_benchmark/kimi/kimi_k3_gb200.yaml.
+#
+#   To run on 64 GB200 NVL72 nodes:
+#   automodel examples/llm_benchmark/kimi/kimi_k3_gb200_2k.yaml --nnodes 64 --nproc-per-node 4
+
+recipe: BenchmarkingRecipeForNextTokenPrediction
+
+benchmark:
+  warmup_steps: 3
+  peak_tflops: 2250   # GB200 bf16 dense peak
+  nsys_start: -1
+  nsys_end: -1
+  nsys_ranks: []
+  num_nodes: 64
+
+step_scheduler:
+  global_batch_size: 4096
+  local_batch_size: 128
+  ckpt_every_steps: 1000
+  val_every_steps: 1000
+  max_steps: 12
+  num_epochs: 1
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 120
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1234
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_config
+  config:
+    _target_: nemo_automodel.components.models.kimi_k3.config.KimiK3TextConfig
+    architectures: [KimiK3ForCausalLM]
+    dtype: bfloat16
+  torch_dtype: bfloat16
+  trust_remote_code: false
+  kda_mode: chunk
+  use_liger_kernel: false
+  use_sdpa_patching: false
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: eager
+    linear: torch
+    rms_norm: torch_fp32
+    experts: te
+    dispatcher: hybridep
+    dispatcher_num_sms: 32
+    rope_fusion: false
+    fake_balanced_gate: true   # benchmark only — see kimi_k3_gb200.yaml header
+    fake_gate_noise: 0.0
+    compile_situ: true
+    compile_norm: false   # champion 2k measurement predates it; stack pending
+    benchmark_static_routing: true   # requires fake_balanced_gate, noise 0.0
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: false
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 8
+  ep_size: 32
+  sequence_parallel: false
+  activation_checkpointing: true
+  enable_fsdp2_prefetch: true
+  pipeline:
+    pp_schedule: 1f1b
+    pp_microbatch_size: 2
+    scale_grads_in_schedule: false
+    patch_inner_model: false
+    patch_causal_lm_model: false
+    pp_recv_buffer_pool: true   # required for this shape — see header
+  moe:
+    reshard_after_forward: false
+    wrap_outer_model: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.linear_ce.FusedLinearCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.mock_iterable_dataset.MockIterableDataset
+  vocab_size: 10000
+  seq_len: 2048
+  num_samples: 1000000
+
+dataloader:
+  _target_: torch.utils.data.DataLoader
+  batch_size: null  # Dataset already yields batches
+  num_workers: 0
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 1.0e-5
+  weight_decay: 0.0
+  betas: [0.9, 0.95]
+  eps: 1.0e-8
+
+prewarm:
+  comm_groups: true
+  fla_gdn_autotune: true
+  cublas_backward: true
+
+wandb:
+  enable: false
+
+clip_grad_norm:
+  max_norm: 1.0
+
+ci:
+  recipe_owner: huiyingl
+  nodes: 64
+  cluster_tag: gb200
+  time: "01:00:00"

--- a/examples/llm_benchmark/kimi/kimi_k3_gb200_2k.yaml
+++ b/examples/llm_benchmark/kimi/kimi_k3_gb200_2k.yaml
@@ -135,6 +135,7 @@ dataset:
   vocab_size: 10000
   seq_len: 2048
   num_samples: 1000000
+  exclude_token_ids: [0]   # KimiK3TextConfig.pad_token_id: the padding row is zero, keep it out of random data
 
 dataloader:
   _target_: torch.utils.data.DataLoader

--- a/examples/llm_benchmark/kimi/kimi_k3_gb200_2k.yaml
+++ b/examples/llm_benchmark/kimi/kimi_k3_gb200_2k.yaml
@@ -21,6 +21,15 @@
 # Wall-clock cross-check: 4096 rows x 2048 tok = 8.39M tokens/step at ~53 s.
 # Peak memory 139.6 GiB per GPU (44 GiB headroom on 184 GiB HBM).
 #
+# Measurement provenance: taken before #3792 aligned the KimiK3TextConfig
+# defaults with the released checkpoint (from_config then built a 56-head MLA
+# / 18432-wide dense FFN model, ~101.5B active matmul params instead of
+# 104.0B). On the checkpoint-aligned shape this file builds today expect ~2%
+# fewer tok/s at about the same MFU and ~1 GiB more per GPU; a re-measurement
+# on the aligned shape will replace the figures above. Run the file through
+# nemo_automodel/recipes/llm/benchmark.py --config <this file> for the
+# recipe's own per-iteration MFU and Average MFU summary.
+#
 # Why 2k rows beat the 1k config (13.7% MFU) by 3.4pp: at this scale the
 # workload is launch-bound, so doubling tokens per row halves the per-token
 # kernel-launch tax, and K3's KDA linear attention does not penalize longer

--- a/examples/llm_benchmark/kimi/kimi_k3_gb200_2k.yaml
+++ b/examples/llm_benchmark/kimi/kimi_k3_gb200_2k.yaml
@@ -16,24 +16,20 @@
 # throughput benchmark at 2k-token rows on 64 nodes x 4 GB200 (256 GPUs):
 # EP32 x PP8, DP32, GBS 4096.
 #
-# Measured with this exact configuration: ~616 tok/s/GPU, i.e. ~17.1% MFU on
-# the basis  MFU = tok/s/GPU * 6 * 104e9 / 2.25e15  (GB200 bf16 dense peak).
-# Wall-clock cross-check: 4096 rows x 2048 tok = 8.39M tokens/step at ~53 s.
-# Peak memory 139.6 GiB per GPU (44 GiB headroom on 184 GiB HBM).
-#
-# Measurement provenance: taken before #3792 aligned the KimiK3TextConfig
-# defaults with the released checkpoint (from_config then built a 56-head MLA
-# / 18432-wide dense FFN model, ~101.5B active matmul params instead of
-# 104.0B). On the checkpoint-aligned shape this file builds today expect ~2%
-# fewer tok/s at about the same MFU and ~1 GiB more per GPU; a re-measurement
-# on the aligned shape will replace the figures above. Run the file through
+# Measured with this exact configuration (64 nodes, 12 iterations, recipe
+# summary = mean over the 9 iterations after 3 warm-up iterations):
+# 538.8 tok/s/GPU at 60.8 s/iteration, Average MFU 15.1% on the recipe's
+# config-derived FLOPs basis (14.9% on tok/s/GPU * 6 * 104e9 / 2.25e15, the
+# GB200 bf16 dense peak). Peak memory 139.8 GiB per GPU (44 GiB headroom on
+# 184 GiB HBM). Run the file through
 # nemo_automodel/recipes/llm/benchmark.py --config <this file> for the
 # recipe's own per-iteration MFU and Average MFU summary.
 #
-# Why 2k rows beat the 1k config (13.7% MFU) by 3.4pp: at this scale the
-# workload is launch-bound, so doubling tokens per row halves the per-token
-# kernel-launch tax, and K3's KDA linear attention does not penalize longer
-# rows. The PP bubble at this point is 9.9% (64 microbatches).
+# Why 2k rows beat the 1k config (kimi_k3_gb200.yaml: 392.4 tok/s/GPU, 10.9%)
+# by 37% / 4.2pp: at this scale the workload is launch-bound, so doubling
+# tokens per row halves the per-token kernel-launch tax, and K3's KDA linear
+# attention does not penalize longer rows. The PP bubble at this point is 9.9%
+# (64 microbatches).
 #
 # This shape REQUIRES distributed.pipeline.pp_recv_buffer_pool: without it,
 # torch pre-allocates recv buffers for all 64 microbatches x both directions
@@ -41,8 +37,7 @@
 # pool sizes buffers to the 1F1B in-flight depth instead, saving ~45 GiB.
 #
 # compile_norm is on: the fp32 RMSNorm chain is the remaining per-token launch
-# tax at this scale (see kimi_k3_gb200.yaml), and the 2k x compile_norm stack is
-# the configuration being re-measured for the figures above.
+# tax at this scale (see kimi_k3_gb200.yaml); the figures above include it.
 #
 # Other benchmark regime notes match examples/llm_benchmark/kimi/kimi_k3_gb200.yaml.
 #

--- a/examples/llm_benchmark/kimi/kimi_k3_gb200_2k.yaml
+++ b/examples/llm_benchmark/kimi/kimi_k3_gb200_2k.yaml
@@ -40,8 +40,9 @@
 # (~52 GiB on middle stages at 2k) and the run OOMs during step 1. The ring
 # pool sizes buffers to the 1F1B in-flight depth instead, saving ~45 GiB.
 #
-# compile_norm is left off here: this file documents the measured champion
-# configuration; the 2k x compile_norm stack is pending measurement.
+# compile_norm is on: the fp32 RMSNorm chain is the remaining per-token launch
+# tax at this scale (see kimi_k3_gb200.yaml), and the 2k x compile_norm stack is
+# the configuration being re-measured for the figures above.
 #
 # Other benchmark regime notes match examples/llm_benchmark/kimi/kimi_k3_gb200.yaml.
 #
@@ -98,7 +99,7 @@ model:
     fake_balanced_gate: true   # benchmark only — see kimi_k3_gb200.yaml header
     fake_gate_noise: 0.0
     compile_situ: true
-    compile_norm: false   # champion 2k measurement predates it; stack pending
+    compile_norm: true
     benchmark_static_routing: true   # requires fake_balanced_gate, noise 0.0
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/nemo_automodel/components/distributed/pipelining/autopipeline.py
+++ b/nemo_automodel/components/distributed/pipelining/autopipeline.py
@@ -82,6 +82,9 @@ class AutoPipeline:
         scale_grads_in_schedule: bool = False,
         # Shape inference optimization
         pp_seq_len: int | None = None,
+        # P2P recv-buffer pooling (see components.distributed.pipelining.recv_buffer_pool)
+        pp_recv_buffer_pool: bool = False,
+        pp_recv_buffer_pool_slack: int = 2,
     ):
         # Validation
         if pp_schedule_csv is None and pp_schedule is None:
@@ -115,6 +118,8 @@ class AutoPipeline:
         self.dtype = dtype
         self.scale_grads_in_schedule = scale_grads_in_schedule
         self.pp_seq_len = pp_seq_len
+        self.pp_recv_buffer_pool = pp_recv_buffer_pool
+        self.pp_recv_buffer_pool_slack = pp_recv_buffer_pool_slack
 
         self.pp_mesh: DeviceMesh = self.world_mesh[pp_axis_name]
 
@@ -142,6 +147,23 @@ class AutoPipeline:
         assert isinstance(model, nn.Module), "model must be a PyTorch module"
 
         validate_hf_model_for_pipeline_support(model)
+
+        if self.pp_recv_buffer_pool:
+            from nemo_automodel.components.distributed.pipelining.recv_buffer_pool import (
+                install_recv_buffer_pool,
+                schedule_supports_recv_pool,
+            )
+
+            # Only 1F1B's bounded in-flight depth makes the ring size proof valid;
+            # schedules with unbounded in-flight microbatches would silently
+            # corrupt gradients through reused recv buffers.
+            if self.pp_schedule_csv is None and schedule_supports_recv_pool(self.pp_schedule):
+                install_recv_buffer_pool(slack=self.pp_recv_buffer_pool_slack)
+            else:
+                logger.warning(
+                    "pp_recv_buffer_pool ignored: schedule %s has no bounded in-flight depth proof",
+                    self.pp_schedule_csv or self.pp_schedule,
+                )
 
         pp_schedule_obj, model_parts, pp_has_first_stage, pp_has_last_stage, stages = pipeline_model(
             model,

--- a/nemo_automodel/components/distributed/pipelining/config.py
+++ b/nemo_automodel/components/distributed/pipelining/config.py
@@ -111,6 +111,11 @@ class PipelineConfig:
     pp_recv_buffer_pool: bool = False
     pp_recv_buffer_pool_slack: int = 2
 
+    def __post_init__(self) -> None:
+        """Validate the recv-buffer-pool knobs."""
+        if self.pp_recv_buffer_pool_slack < 0:
+            raise ValueError(f"pp_recv_buffer_pool_slack must be >= 0, got {self.pp_recv_buffer_pool_slack}")
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert config to dictionary."""
         return {

--- a/nemo_automodel/components/distributed/pipelining/config.py
+++ b/nemo_automodel/components/distributed/pipelining/config.py
@@ -83,6 +83,15 @@ class PipelineConfig:
             compatible with the model's output format.
         pp_seq_len (Optional[int]): Sequence length hint for pipeline parallel
             shape inference. If None, it will be inferred from the dataset config.
+        pp_recv_buffer_pool (bool): Pool the per-microbatch P2P recv buffers into
+            a ring sized to the 1F1B in-flight depth instead of pre-allocating one
+            buffer set per microbatch and direction. Cuts pipeline-stage buffer
+            memory roughly by num_microbatches / (num_stages - stage_index + slack)
+            on early/middle stages. Only applied for schedules with a bounded
+            in-flight depth (currently "1f1b"); ignored with a warning otherwise.
+            Defaults to False.
+        pp_recv_buffer_pool_slack (int): Extra buffer sets beyond the 1F1B
+            in-flight depth when pp_recv_buffer_pool is enabled. Defaults to 2.
     """
 
     pp_schedule: str | None = "1f1b"
@@ -99,6 +108,8 @@ class PipelineConfig:
     scale_grads_in_schedule: bool = False
     loss_fn: Callable | None = None
     pp_seq_len: int | None = None
+    pp_recv_buffer_pool: bool = False
+    pp_recv_buffer_pool_slack: int = 2
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert config to dictionary."""
@@ -117,4 +128,6 @@ class PipelineConfig:
             "scale_grads_in_schedule": self.scale_grads_in_schedule,
             "loss_fn": self.loss_fn,
             "pp_seq_len": self.pp_seq_len,
+            "pp_recv_buffer_pool": self.pp_recv_buffer_pool,
+            "pp_recv_buffer_pool_slack": self.pp_recv_buffer_pool_slack,
         }

--- a/nemo_automodel/components/distributed/pipelining/recv_buffer_pool.py
+++ b/nemo_automodel/components/distributed/pipelining/recv_buffer_pool.py
@@ -46,6 +46,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 _INSTALLED = False
+# Which torch PipelineStage layout the patch bound to ("per-direction-setup" or
+# "prepare-infra"); None until installed. Logged at install time so a run's log
+# states which code path it exercised.
+_INSTALLED_LAYOUT: str | None = None
 
 # Schedules whose in-flight microbatch count per stage is bounded by
 # num_stages - stage_index, making the ring size proof valid. Interleaved /
@@ -73,6 +77,8 @@ def _ring_size(stage, num_microbatches: int, slack: int) -> int:
         slack: Extra buffer sets beyond the 1F1B in-flight depth.
     """
     inflight = max(1, stage.num_stages - stage.stage_index)
+    # Floor of 2: even the last-in-flight stage keeps one buffer set receiving
+    # while the previous chunk's backward still reads its saved input.
     return max(2, min(num_microbatches, inflight + slack))
 
 
@@ -90,8 +96,14 @@ def install_recv_buffer_pool(slack: int = 2) -> bool:
     Returns:
         True if installed (or already installed), False if the torch
         internals do not match any known layout (stock behavior is kept).
+
+    Raises:
+        ValueError: if ``slack`` is negative (a ring smaller than the 1F1B
+            in-flight depth would silently corrupt gradients).
     """
-    global _INSTALLED
+    global _INSTALLED, _INSTALLED_LAYOUT
+    if slack < 0:
+        raise ValueError(f"recv_buffer_pool: slack must be >= 0, got {slack}")
     if _INSTALLED:
         return True
 
@@ -105,9 +117,12 @@ def install_recv_buffer_pool(slack: int = 2) -> bool:
         return False
 
     def _alias_fwd_ring(self, k, num_microbatches):
+        # Forward setup does not touch self.chunks in any known layout; restore
+        # it defensively anyway so a layout that does cannot leave it at k.
+        self.chunks = num_microbatches
         for chunk_id in range(k, num_microbatches):
             self.args_recv_info[chunk_id] = self.args_recv_info[chunk_id % k]
-        logger.info(
+        logger.debug(
             "recv_buffer_pool: stage %d fwd recv ring %d/%d buffer sets",
             self.stage_index,
             k,
@@ -120,7 +135,7 @@ def install_recv_buffer_pool(slack: int = 2) -> bool:
         self.chunks = num_microbatches
         for chunk_id in range(k, num_microbatches):
             self.grad_recv_info[chunk_id] = self.grad_recv_info[chunk_id % k]
-        logger.info(
+        logger.debug(
             "recv_buffer_pool: stage %d bwd recv ring %d/%d buffer sets",
             self.stage_index,
             k,
@@ -128,7 +143,11 @@ def install_recv_buffer_pool(slack: int = 2) -> bool:
         )
 
     if hasattr(manual_cls, "_setup_forward_recv_info"):
-        # torch >= 2.13: per-direction setup helpers.
+        # Layout "per-direction-setup" (torch release/2.12 and later): the
+        # manual PipelineStage allocates in _setup_forward_recv_info(
+        # num_microbatches, has_backward) and the base class in
+        # _setup_backward_recv_info(num_microbatches).
+        layout = "per-direction-setup"
         orig_fwd = manual_cls._setup_forward_recv_info
         orig_bwd = base_cls._setup_backward_recv_info
 
@@ -151,9 +170,11 @@ def install_recv_buffer_pool(slack: int = 2) -> bool:
         manual_cls._setup_forward_recv_info = pooled_setup_forward_recv_info
         base_cls._setup_backward_recv_info = pooled_setup_backward_recv_info
     elif hasattr(manual_cls, "_prepare_forward_infra"):
-        # torch 2.12 line (e.g. the NGC 26.06 container): allocation inside
+        # Layout "prepare-infra" (torch <= 2.11 and the pre-refactor 2.12
+        # nightlies, e.g. the NGC 26.06 container): allocation inside
         # _prepare_forward_infra(num_microbatches, args, kwargs) and the base
         # class's _prepare_backward_infra(num_microbatches).
+        layout = "prepare-infra"
         orig_fwd = manual_cls._prepare_forward_infra
         orig_bwd = base_cls._prepare_backward_infra
 
@@ -181,5 +202,17 @@ def install_recv_buffer_pool(slack: int = 2) -> bool:
         logger.warning("recv_buffer_pool: no known recv-infra entry points on PipelineStage; not installing")
         return False
     _INSTALLED = True
-    logger.info("recv_buffer_pool: installed (slack=%d)", slack)
+    _INSTALLED_LAYOUT = layout
+    if _is_rank_zero():
+        logger.info("recv_buffer_pool: installed (slack=%d, layout=%s)", slack, layout)
     return True
+
+
+def _is_rank_zero() -> bool:
+    """True on rank 0 or when torch.distributed is not initialized (single log line per job)."""
+    try:
+        import torch.distributed as dist
+
+        return not dist.is_initialized() or dist.get_rank() == 0
+    except Exception:  # noqa: BLE001 - logging must never fail install
+        return True

--- a/nemo_automodel/components/distributed/pipelining/recv_buffer_pool.py
+++ b/nemo_automodel/components/distributed/pipelining/recv_buffer_pool.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ring-pooled point-to-point recv buffers for torch pipeline stages.
+
+``torch.distributed.pipelining`` pre-allocates one full-size recv buffer per
+microbatch and per direction (activations forward, gradients backward). At
+large microbatch counts this dominates pipeline-stage memory: e.g. Kimi-K3 at
+2k-token rows x GBS 4096 / mbs 2 / dp32 needs 64 buffer sets per direction,
+~45 GiB on middle stages — more than the activations themselves — which is
+exactly what pushes that shape out of memory on 64 GB200 nodes.
+
+Under the 1F1B schedule only ``num_stages - stage_index`` microbatches are
+ever in flight on a stage: a forward recv buffer is live from irecv-post
+until that chunk's backward consumes the stage input (activation-checkpoint
+recompute reads it), and a grad recv buffer only until the chunk's backward
+returns. This module therefore rebinds the per-chunk recv-info maps onto a
+ring of ``K = (num_stages - stage_index) + slack`` real buffer sets.
+
+Gradient accumulation on reused leaf buffers is already impossible upstream:
+``stage_backward()`` harvests input grads and sets ``val.grad = None`` per
+chunk.
+
+Opt-in via :func:`install_recv_buffer_pool` (wired to
+``PipelineConfig.pp_recv_buffer_pool``); it is a no-op that logs a warning
+and leaves stock behavior when the torch internals it adapts are not
+recognized. Only schedules with bounded in-flight depth are safe — see
+:func:`schedule_supports_recv_pool`; schedules with unbounded in-flight
+microbatches (e.g. GPipe) would silently corrupt gradients (verified by the
+CPU parity harness in the unit tests).
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_INSTALLED = False
+
+# Schedules whose in-flight microbatch count per stage is bounded by
+# num_stages - stage_index, making the ring size proof valid. Interleaved /
+# looped / zero-bubble schedules and CSV schedules have different (or
+# unknown) in-flight envelopes and are intentionally not supported.
+_SUPPORTED_SCHEDULES = frozenset({"1f1b"})
+
+
+def schedule_supports_recv_pool(pp_schedule: str | None) -> bool:
+    """Return True when the schedule's in-flight depth bound makes pooling safe.
+
+    Args:
+        pp_schedule: Schedule name as configured (e.g. ``"1f1b"``, ``"gpipe"``),
+            or None (custom CSV schedule).
+    """
+    return pp_schedule is not None and pp_schedule.lower() in _SUPPORTED_SCHEDULES
+
+
+def _ring_size(stage, num_microbatches: int, slack: int) -> int:
+    """Number of real buffer sets for a stage: in-flight depth plus slack.
+
+    Args:
+        stage: torch ``PipelineStage`` (reads ``num_stages`` / ``stage_index``).
+        num_microbatches: Microbatches per step (upper bound for the ring).
+        slack: Extra buffer sets beyond the 1F1B in-flight depth.
+    """
+    inflight = max(1, stage.num_stages - stage.stage_index)
+    return max(2, min(num_microbatches, inflight + slack))
+
+
+def install_recv_buffer_pool(slack: int = 2) -> bool:
+    """Monkeypatch pipeline-stage recv-buffer setup with ring pooling.
+
+    Must run before pipeline schedule/stage infra preparation. Installs
+    process-wide (class-level) and is idempotent; the first call's ``slack``
+    wins.
+
+    Args:
+        slack: Extra buffer sets beyond the 1F1B in-flight depth, absorbing
+            transient recv-ahead (default 2).
+
+    Returns:
+        True if installed (or already installed), False if the torch
+        internals do not match any known layout (stock behavior is kept).
+    """
+    global _INSTALLED
+    if _INSTALLED:
+        return True
+
+    try:
+        from torch.distributed.pipelining import stage as stage_mod
+
+        base_cls = stage_mod._PipelineStageBase
+        manual_cls = stage_mod.PipelineStage
+    except (ImportError, AttributeError) as exc:
+        logger.warning("recv_buffer_pool: torch internals mismatch, not installing: %s", exc)
+        return False
+
+    def _alias_fwd_ring(self, k, num_microbatches):
+        for chunk_id in range(k, num_microbatches):
+            self.args_recv_info[chunk_id] = self.args_recv_info[chunk_id % k]
+        logger.info(
+            "recv_buffer_pool: stage %d fwd recv ring %d/%d buffer sets",
+            self.stage_index,
+            k,
+            num_microbatches,
+        )
+
+    def _alias_bwd_ring(self, k, num_microbatches):
+        # The callee set self.chunks to the value we passed; the schedule uses
+        # it to detect the final chunk for grad sync — restore the true count.
+        self.chunks = num_microbatches
+        for chunk_id in range(k, num_microbatches):
+            self.grad_recv_info[chunk_id] = self.grad_recv_info[chunk_id % k]
+        logger.info(
+            "recv_buffer_pool: stage %d bwd recv ring %d/%d buffer sets",
+            self.stage_index,
+            k,
+            num_microbatches,
+        )
+
+    if hasattr(manual_cls, "_setup_forward_recv_info"):
+        # torch >= 2.13: per-direction setup helpers.
+        orig_fwd = manual_cls._setup_forward_recv_info
+        orig_bwd = base_cls._setup_backward_recv_info
+
+        def pooled_setup_forward_recv_info(self, num_microbatches, has_backward):
+            k = _ring_size(self, num_microbatches, slack)
+            if self.is_first or k >= num_microbatches:
+                return orig_fwd(self, num_microbatches, has_backward)
+            orig_fwd(self, k, has_backward)
+            _alias_fwd_ring(self, k, num_microbatches)
+
+        def pooled_setup_backward_recv_info(self, num_microbatches):
+            if not isinstance(self, manual_cls) or self.is_last:
+                return orig_bwd(self, num_microbatches)
+            k = _ring_size(self, num_microbatches, slack)
+            if k >= num_microbatches:
+                return orig_bwd(self, num_microbatches)
+            orig_bwd(self, k)
+            _alias_bwd_ring(self, k, num_microbatches)
+
+        manual_cls._setup_forward_recv_info = pooled_setup_forward_recv_info
+        base_cls._setup_backward_recv_info = pooled_setup_backward_recv_info
+    elif hasattr(manual_cls, "_prepare_forward_infra"):
+        # torch 2.12 line (e.g. the NGC 26.06 container): allocation inside
+        # _prepare_forward_infra(num_microbatches, args, kwargs) and the base
+        # class's _prepare_backward_infra(num_microbatches).
+        orig_fwd = manual_cls._prepare_forward_infra
+        orig_bwd = base_cls._prepare_backward_infra
+
+        def pooled_prepare_forward_infra(self, num_microbatches, args, kwargs=None):
+            k = _ring_size(self, num_microbatches, slack)
+            if self.is_first or k >= num_microbatches:
+                return orig_fwd(self, num_microbatches, args, kwargs)
+            outputs = orig_fwd(self, k, args, kwargs)
+            _alias_fwd_ring(self, k, num_microbatches)
+            return outputs
+
+        def pooled_prepare_backward_infra(self, num_microbatches):
+            if not isinstance(self, manual_cls) or self.is_last:
+                return orig_bwd(self, num_microbatches)
+            k = _ring_size(self, num_microbatches, slack)
+            if k >= num_microbatches:
+                return orig_bwd(self, num_microbatches)
+            result = orig_bwd(self, k)
+            _alias_bwd_ring(self, k, num_microbatches)
+            return result
+
+        manual_cls._prepare_forward_infra = pooled_prepare_forward_infra
+        base_cls._prepare_backward_infra = pooled_prepare_backward_infra
+    else:
+        logger.warning("recv_buffer_pool: no known recv-infra entry points on PipelineStage; not installing")
+        return False
+    _INSTALLED = True
+    logger.info("recv_buffer_pool: installed (slack=%d)", slack)
+    return True

--- a/tests/unit_tests/distributed/pipelining/test_recv_buffer_pool.py
+++ b/tests/unit_tests/distributed/pipelining/test_recv_buffer_pool.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit and gloo-parity tests for the pooled pipeline recv buffers.
+
+The parity test trains the same pp4 1F1B pipeline twice inside each spawned
+rank — first with stock recv buffers, then with the ring pool installed —
+using identical seeds and data, and requires bitwise-identical loss
+trajectories and per-stage parameter sums. It catches ring-too-small
+corruption (a prefetch overwriting a buffer still needed by a chunk's
+backward): the linear weight grads read the saved stage input, which IS the
+recv buffer object.
+"""
+
+import faulthandler
+import os
+import socket
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+import torch.nn as nn
+
+from nemo_automodel.components.distributed.pipelining.recv_buffer_pool import (
+    _ring_size,
+    schedule_supports_recv_pool,
+)
+
+_PP = 4
+_HIDDEN = 64
+_MB = 16  # microbatches per step (>> ring K)
+_MBS = 4  # rows per microbatch
+_STEPS = 3
+
+
+class _FakeStage:
+    def __init__(self, num_stages: int, stage_index: int):
+        self.num_stages = num_stages
+        self.stage_index = stage_index
+
+
+def test_ring_size_covers_inflight_plus_slack():
+    # Stage 0 of 8: 8 in flight + 2 slack, capped by the microbatch count.
+    assert _ring_size(_FakeStage(8, 0), num_microbatches=64, slack=2) == 10
+    # Late stage: small in-flight depth, floor of 2.
+    assert _ring_size(_FakeStage(8, 7), num_microbatches=64, slack=0) == 2
+    # Never exceeds the microbatch count.
+    assert _ring_size(_FakeStage(8, 0), num_microbatches=4, slack=2) == 4
+
+
+def test_schedule_gate_only_allows_bounded_inflight_schedules():
+    assert schedule_supports_recv_pool("1f1b")
+    assert schedule_supports_recv_pool("1F1B")
+    assert not schedule_supports_recv_pool("gpipe")
+    assert not schedule_supports_recv_pool("interleaved_1f1b")
+    assert not schedule_supports_recv_pool(None)
+
+
+class _Block(nn.Module):
+    """One pipeline stage: two linears with a residual.
+
+    ``forward`` takes and returns a tensor of shape [rows, hidden].
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.l1 = nn.Linear(_HIDDEN, _HIDDEN)
+        self.l2 = nn.Linear(_HIDDEN, _HIDDEN)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply linear-relu-linear with a residual.
+
+        Args:
+            x: Tensor of shape [rows, hidden].
+
+        Returns:
+            Tensor of shape [rows, hidden].
+        """
+        return self.l2(torch.relu(self.l1(x))) + x
+
+
+def _free_port() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _train_once(rank: int) -> tuple[list[float], float]:
+    """Build a fresh pp4 stage for this rank and train 1F1B for a few steps.
+
+    Returns:
+        (losses, param_sum): per-step mean losses (non-empty on the last rank
+        only) and the double-precision sum of this stage's parameters.
+    """
+    from torch.distributed.pipelining import PipelineStage
+    from torch.distributed.pipelining.schedules import Schedule1F1B
+
+    torch.manual_seed(1234)  # same init on all ranks; each keeps its stage
+    full = nn.Sequential(*[_Block() for _ in range(_PP)])
+    stage_mod = full[rank]
+    stage = PipelineStage(stage_mod, rank, _PP, torch.device("cpu"))
+
+    def loss_fn(out, tgt):
+        return torch.nn.functional.mse_loss(out, tgt)
+
+    sched = Schedule1F1B(stage, n_microbatches=_MB, loss_fn=loss_fn)
+    opt = torch.optim.SGD(stage_mod.parameters(), lr=0.05)
+
+    g = torch.Generator().manual_seed(42)
+    losses: list[float] = []
+    for _ in range(_STEPS):
+        x = torch.randn(_MB * _MBS, _HIDDEN, generator=g)
+        tgt = torch.randn(_MB * _MBS, _HIDDEN, generator=g)
+        opt.zero_grad(set_to_none=True)
+        if rank == 0:
+            sched.step(x)
+        elif rank == _PP - 1:
+            out_losses: list[torch.Tensor] = []
+            sched.step(target=tgt, losses=out_losses)
+            losses.append(torch.stack(out_losses).mean().item())
+        else:
+            sched.step()
+        opt.step()
+
+    param_sum = sum(p.double().sum().item() for p in stage_mod.parameters())
+    return losses, param_sum
+
+
+def _parity_worker(rank: int, world_size: int, port: int) -> None:
+    import torch.distributed as dist
+
+    faulthandler.dump_traceback_later(240, exit=True)
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    try:
+        dist.init_process_group("gloo", rank=rank, world_size=world_size)
+        torch.set_num_threads(1)
+
+        stock_losses, stock_sum = _train_once(rank)
+
+        from nemo_automodel.components.distributed.pipelining.recv_buffer_pool import (
+            install_recv_buffer_pool,
+        )
+
+        assert install_recv_buffer_pool(slack=2)
+        pooled_losses, pooled_sum = _train_once(rank)
+
+        # Bitwise equality: pooling only changes which buffer object receives
+        # each chunk, never the values flowing through the schedule.
+        assert pooled_losses == stock_losses, (rank, stock_losses, pooled_losses)
+        assert pooled_sum == stock_sum, (rank, stock_sum, pooled_sum)
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.mark.run_only_on("GPU")
+def test_pooled_recv_buffers_match_stock_1f1b_exactly():
+    mp.spawn(_parity_worker, args=(_PP, _free_port()), nprocs=_PP, join=True)

--- a/tests/unit_tests/distributed/pipelining/test_recv_buffer_pool.py
+++ b/tests/unit_tests/distributed/pipelining/test_recv_buffer_pool.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit and gloo-parity tests for the pooled pipeline recv buffers.
+"""Unit, layout-simulation and gloo-parity tests for the pooled pipeline recv buffers.
 
 The parity test trains the same pp4 1F1B pipeline twice inside each spawned
 rank — first with stock recv buffers, then with the ring pool installed —
@@ -32,8 +32,10 @@ import torch
 import torch.multiprocessing as mp
 import torch.nn as nn
 
+from nemo_automodel.components.distributed.pipelining import recv_buffer_pool
 from nemo_automodel.components.distributed.pipelining.recv_buffer_pool import (
     _ring_size,
+    install_recv_buffer_pool,
     schedule_supports_recv_pool,
 )
 
@@ -67,6 +69,129 @@ def test_schedule_gate_only_allows_bounded_inflight_schedules():
     assert not schedule_supports_recv_pool(None)
 
 
+def test_negative_slack_is_rejected():
+    from nemo_automodel.components.distributed.pipelining.config import PipelineConfig
+
+    with pytest.raises(ValueError):
+        install_recv_buffer_pool(slack=-1)
+    with pytest.raises(ValueError):
+        PipelineConfig(pp_recv_buffer_pool=True, pp_recv_buffer_pool_slack=-1)
+    assert PipelineConfig(pp_recv_buffer_pool=True).pp_recv_buffer_pool_slack == 2
+
+
+@pytest.fixture
+def fresh_install(monkeypatch):
+    """Reset the process-wide install flag around a test and restore it afterwards."""
+    monkeypatch.setattr(recv_buffer_pool, "_INSTALLED", False)
+    monkeypatch.setattr(recv_buffer_pool, "_INSTALLED_LAYOUT", None)
+    yield
+
+
+def _fake_stage_classes(layout: str):
+    """Minimal stand-ins for torch's _PipelineStageBase / PipelineStage exposing one recv-info layout."""
+
+    class FakeBase:
+        def __init__(self, num_stages, stage_index):
+            self.num_stages = num_stages
+            self.stage_index = stage_index
+            self.is_first = stage_index == 0
+            self.is_last = stage_index == num_stages - 1
+            self.args_recv_info = {}
+            self.grad_recv_info = {}
+            self.chunks = None
+
+    class FakeManual(FakeBase):
+        pass
+
+    if layout == "per-direction-setup":
+
+        def _setup_forward_recv_info(self, num_microbatches, has_backward):
+            for c in range(num_microbatches):
+                self.args_recv_info[c] = (object(),)
+
+        def _setup_backward_recv_info(self, num_microbatches):
+            self.chunks = num_microbatches
+            for c in range(num_microbatches):
+                self.grad_recv_info[c] = (object(),)
+
+        FakeManual._setup_forward_recv_info = _setup_forward_recv_info
+        FakeBase._setup_backward_recv_info = _setup_backward_recv_info
+    elif layout == "prepare-infra":
+
+        def _prepare_forward_infra(self, num_microbatches, args, kwargs=None):
+            for c in range(num_microbatches):
+                self.args_recv_info[c] = (object(),)
+            return ("outputs",)
+
+        def _prepare_backward_infra(self, num_microbatches):
+            self.chunks = num_microbatches
+            for c in range(num_microbatches):
+                self.grad_recv_info[c] = (object(),)
+            return None
+
+        FakeManual._prepare_forward_infra = _prepare_forward_infra
+        FakeBase._prepare_backward_infra = _prepare_backward_infra
+    return FakeBase, FakeManual
+
+
+def _install_on_fakes(monkeypatch, layout):
+    from torch.distributed.pipelining import stage as stage_mod
+
+    base, manual = _fake_stage_classes(layout)
+    monkeypatch.setattr(stage_mod, "_PipelineStageBase", base)
+    monkeypatch.setattr(stage_mod, "PipelineStage", manual)
+    return base, manual
+
+
+def _distinct(d):
+    return len({id(v) for v in d.values()})
+
+
+@pytest.mark.parametrize("layout", ["per-direction-setup", "prepare-infra"])
+def test_both_layouts_pool_to_ring_and_restore_chunks(fresh_install, monkeypatch, layout):
+    """Each known torch layout is bound: middle stage pools both directions to K sets, chunks stays true."""
+    _base, manual = _install_on_fakes(monkeypatch, layout)
+    assert install_recv_buffer_pool(slack=2) is True
+    assert recv_buffer_pool._INSTALLED_LAYOUT == layout
+
+    stage = manual(num_stages=4, stage_index=1)  # in-flight 3 + slack 2 = K 5
+    if layout == "per-direction-setup":
+        stage._setup_forward_recv_info(_MB, True)
+        stage._setup_backward_recv_info(_MB)
+    else:
+        assert stage._prepare_forward_infra(_MB, (), None) == ("outputs",)
+        stage._prepare_backward_infra(_MB)
+    assert len(stage.args_recv_info) == _MB and _distinct(stage.args_recv_info) == 5
+    assert len(stage.grad_recv_info) == _MB and _distinct(stage.grad_recv_info) == 5
+    assert stage.chunks == _MB
+    # the ring wraps: chunk k reuses chunk 0's buffer set
+    assert stage.args_recv_info[5] is stage.args_recv_info[0]
+
+    first = manual(num_stages=4, stage_index=0)
+    last = manual(num_stages=4, stage_index=3)
+    if layout == "per-direction-setup":
+        first._setup_forward_recv_info(_MB, True)
+        last._setup_backward_recv_info(_MB)
+    else:
+        first._prepare_forward_infra(_MB, (), None)
+        last._prepare_backward_infra(_MB)
+    # first stage has no forward recv, last stage no grad recv: both keep stock allocation
+    assert _distinct(first.args_recv_info) == _MB
+    assert _distinct(last.grad_recv_info) == _MB
+
+
+def test_install_fails_open_on_unknown_layout(fresh_install, monkeypatch):
+    from torch.distributed.pipelining import stage as stage_mod
+
+    class Bare:
+        pass
+
+    monkeypatch.setattr(stage_mod, "_PipelineStageBase", Bare)
+    monkeypatch.setattr(stage_mod, "PipelineStage", Bare)
+    assert install_recv_buffer_pool(slack=2) is False
+    assert recv_buffer_pool._INSTALLED is False and recv_buffer_pool._INSTALLED_LAYOUT is None
+
+
 class _Block(nn.Module):
     """One pipeline stage: two linears with a residual.
 
@@ -98,12 +223,13 @@ def _free_port() -> int:
     return port
 
 
-def _train_once(rank: int) -> tuple[list[float], float]:
+def _train_once(rank: int) -> tuple[list[float], float, object]:
     """Build a fresh pp4 stage for this rank and train 1F1B for a few steps.
 
     Returns:
-        (losses, param_sum): per-step mean losses (non-empty on the last rank
-        only) and the double-precision sum of this stage's parameters.
+        (losses, param_sum, stage): per-step mean losses (non-empty on the last
+        rank only), the double-precision sum of this stage's parameters, and the
+        PipelineStage (to inspect its recv-info maps).
     """
     from torch.distributed.pipelining import PipelineStage
     from torch.distributed.pipelining.schedules import Schedule1F1B
@@ -136,7 +262,7 @@ def _train_once(rank: int) -> tuple[list[float], float]:
         opt.step()
 
     param_sum = sum(p.double().sum().item() for p in stage_mod.parameters())
-    return losses, param_sum
+    return losses, param_sum, stage
 
 
 def _parity_worker(rank: int, world_size: int, port: int) -> None:
@@ -149,14 +275,17 @@ def _parity_worker(rank: int, world_size: int, port: int) -> None:
         dist.init_process_group("gloo", rank=rank, world_size=world_size)
         torch.set_num_threads(1)
 
-        stock_losses, stock_sum = _train_once(rank)
-
-        from nemo_automodel.components.distributed.pipelining.recv_buffer_pool import (
-            install_recv_buffer_pool,
-        )
+        stock_losses, stock_sum, _ = _train_once(rank)
 
         assert install_recv_buffer_pool(slack=2)
-        pooled_losses, pooled_sum = _train_once(rank)
+        pooled_losses, pooled_sum, stage = _train_once(rank)
+
+        # The pool really aliased: only K distinct buffer sets remain per direction.
+        k = _ring_size(stage, _MB, 2)
+        if rank != 0:
+            assert len(stage.args_recv_info) == _MB and _distinct(stage.args_recv_info) == k, rank
+        if rank != world_size - 1:
+            assert len(stage.grad_recv_info) == _MB and _distinct(stage.grad_recv_info) == k, rank
 
         # Bitwise equality: pooling only changes which buffer object receives
         # each chunk, never the values flowing through the schedule.
@@ -170,3 +299,39 @@ def _parity_worker(rank: int, world_size: int, port: int) -> None:
 @pytest.mark.run_only_on("GPU")
 def test_pooled_recv_buffers_match_stock_1f1b_exactly():
     mp.spawn(_parity_worker, args=(_PP, _free_port()), nprocs=_PP, join=True)
+
+
+def _too_small_ring_worker(rank: int, world_size: int, port: int) -> None:
+    """Negative control: a ring below the 1F1B in-flight depth must NOT reproduce the stock run."""
+    import torch.distributed as dist
+
+    faulthandler.dump_traceback_later(240, exit=True)
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    try:
+        dist.init_process_group("gloo", rank=rank, world_size=world_size)
+        torch.set_num_threads(1)
+
+        stock_losses, stock_sum, _ = _train_once(rank)
+
+        # stage 1 has 3 chunks in flight; force a 2-set ring so a prefetch lands
+        # on a buffer whose chunk is still waiting for its backward.
+        recv_buffer_pool._ring_size = lambda stage, num_microbatches, slack: 2
+        assert install_recv_buffer_pool(slack=0)
+        diverged = False
+        try:
+            small_losses, small_sum, _ = _train_once(rank)
+            diverged = (rank == world_size - 1 and small_losses != stock_losses) or small_sum != stock_sum
+        except RuntimeError:
+            diverged = True  # autograd may also refuse the overwritten saved input
+        flags = [None] * world_size
+        dist.all_gather_object(flags, diverged)
+        assert any(flags), ("too-small ring reproduced the stock run bitwise", flags)
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.mark.run_only_on("GPU")
+def test_ring_below_inflight_depth_is_detected_by_the_harness():
+    mp.spawn(_too_small_ring_worker, args=(_PP, _free_port()), nprocs=_PP, join=True)


### PR DESCRIPTION
# What does this PR do ?

Opt-in ring pooling of `torch.distributed.pipelining` P2P recv buffers under
1F1B (`distributed.pipeline.pp_recv_buffer_pool`), which removes the
per-microbatch buffer pre-allocation that OOMs Kimi-K3 at 2k rows × GBS 4096
on 64 GB200 nodes, plus the new `kimi_k3_gb200_2k.yaml` benchmark shape it
unlocks.

`torch.distributed.pipelining` pre-allocates one full-size P2P recv buffer
per microbatch and per direction (activations forward, gradients backward).
At large microbatch counts this dominates stage memory: Kimi-K3 at 2k rows x
GBS 4096 / mbs 2 / dp32 means 64 buffer sets per direction, ~52 GiB on middle
stages — more than the activations — and the shape OOMs during step 1 on
64 GB200 nodes (by only 56 MiB, measured).

Under 1F1B only `num_stages - stage_index` microbatches are in flight per
stage: a forward recv buffer is live from irecv-post until that chunk's
backward consumes the stage input (AC recompute reads it); a grad recv buffer
only until the chunk's backward returns. New module
`components/distributed/pipelining/recv_buffer_pool.py` rebinds the per-chunk
recv-info maps onto a ring of `K = inflight + slack` real buffer sets
(~45 GiB saved on middle stages at the shape above).

- **Opt-in**: `distributed.pipeline.pp_recv_buffer_pool: true`
  (+ `pp_recv_buffer_pool_slack`, default 2), threaded
  `PipelineConfig -> AutoPipeline.build()`.
- **Schedule-gated**: only 1F1B (bounded in-flight depth proof). Other
  schedules log a warning and keep stock behavior — GPipe's unbounded
  in-flight depth silently corrupts gradients through reused buffers
  (verified negative on the CPU parity harness during development).
- **torch-version adaptive, fail-open**: adapts both the torch >= 2.13
  layout (`_setup_forward/backward_recv_info`) and the 2.12 line in current
  NGC containers (`_prepare_forward/backward_infra`); anything else logs a
  warning and leaves stock behavior.
- Gradient safety: grad accumulation on reused leaf buffers is impossible
  upstream — `stage_backward()` harvests input grads and sets
  `val.grad = None` per chunk.

# Changelog

- `nemo_automodel/components/distributed/pipelining/recv_buffer_pool.py` (new):
  ring-pooled recv buffers, `schedule_supports_recv_pool()` allowlist
  (`{"1f1b"}`), torch-version probe with fail-open install.
- `nemo_automodel/components/distributed/pipelining/config.py`:
  `PipelineConfig.pp_recv_buffer_pool` (default `False`),
  `pp_recv_buffer_pool_slack` (default 2, validated `>= 0`), documented in the
  class docstring.
- `nemo_automodel/components/distributed/pipelining/autopipeline.py`: thread the
  two fields into `AutoPipeline.build()` and install the pool before stages build.
- `examples/llm_benchmark/kimi/kimi_k3_gb200_2k.yaml` (new): the measured 2k-row
  config with the pool enabled, `compile_norm: true`, and the padding id kept
  out of the mock data (`exclude_token_ids: [0]`, option from #3808 — merge
  #3808 first); the header states the measured shape and figures.
- `tests/unit_tests/distributed/pipelining/test_recv_buffer_pool.py` (new): ring
  size and schedule gate, negative-slack rejection, both torch `PipelineStage`
  layouts on fake stage classes (K buffer sets per direction, `chunks` restored,
  first/last stage untouched), fail-open on an unknown layout, and two spawned
  gloo pp4 harnesses (GPU lane): stock-vs-pooled bitwise parity with the
  aliasing asserted, and a negative control where a ring below the in-flight
  depth must not reproduce the stock run.
- `docs/guides/pipelining.mdx`: a section on `pp_recv_buffer_pool`.
- Depends on #3808 for the `exclude_token_ids` dataset option used by the 2k config.

# Validation

**New benchmark config `kimi_k3_gb200_2k.yaml`** — the pool unlocks 2k rows x
GBS 4096 at 64 nodes, the new best-efficiency K3 shape:

| shape | s/iter | tok/s/GPU | MFU (recipe) | peak mem |
|---|---|---|---|---|
| 1k x GBS4096 (`kimi_k3_gb200.yaml` on main) | 41.76 | 392.4 | 10.9% | 129.3 GiB |
| **2k x GBS4096 + recv pool + compile_norm (this file)** | **60.82** | **538.8** | **15.1%** | 139.8 GiB |

Mechanism: the workload is launch-bound at this scale, so doubling tokens
per row halves the per-token launch tax; K3's KDA linear attention does not
penalize longer rows. PP bubble 9.9% (64 microbatches). The file ships the
exact measured config (compile_norm on, `pp_recv_buffer_pool: true`).

**Measurement provenance:** both rows from one 64-node ladder (job 2912860,
2026-09-04) on main + this PR + #3808, with the recipe's own statistic:
`Average iteration time` / `Average MFU` over the 9 iterations after the 3
warm-up iterations, as printed by `nemo_automodel/recipes/llm/benchmark.py
--config <file>` (MFU on the config-derived FLOPs basis from #3792; the
`6 x 104e9 / 2.25e15` wall-clock basis gives 10.9% / 14.9%). Median-of-steady-
iterations agrees within 1.2%. These replace the pre-#3808 numbers, which were
measured on a model whose weights had not been initialized (see #3808).

**Correctness evidence:**

- **gloo parity harness (in-PR unit test, GPU lane)**: pp4 x 1F1B x 16
  microbatches x 3 steps, stock vs pooled — loss trajectory and per-stage
  parameter sums bitwise identical, and the pooled stages are asserted to hold
  exactly K distinct buffer sets per direction. A negative control with a
  2-set ring on a stage that keeps 3 chunks in flight does not reproduce the
  stock run, so the harness would catch a ring-too-small regression.
- **Both torch layouts covered**: the pool binds to `_setup_forward_recv_info` /
  `_setup_backward_recv_info` (torch release/2.12 and later) or to
  `_prepare_forward_infra` / `_prepare_backward_infra` (torch <= 2.11 and the
  pre-refactor 2.12 nightlies); a unit test drives each layout on fake stage
  classes, and the selected layout is logged at install. The 256-GPU runs below
  used the NGC 26.06 container (prepare-infra layout); CI's pinned torch 2.10
  exercises the same layout.
- **pp2 ring-activation gate at cluster (dev evidence)**: ring active
  (4/8 sets), finite-loss trajectory bitwise-identical over 8 steps,
  throughput neutral at small scale. Re-verified on the current PR tree
  with `BenchmarkingRecipe` (pp2×ep4, seq 2048, 1F1B): 12/12 iterations,
  `recv_buffer_pool: installed (slack=2)`, recipe MFU within 1% of wall-clock.
- **256-GPU evidence**: job 2912860 (this file, 64 nodes) rc=0, 12/12 iterations
  finite, loss 12.4946 → 12.4542, peak 139.8 GiB (44 GiB headroom).

**Review pre-answers:**

1. *Interleaved PP / other schedules?* Gated off by
   `schedule_supports_recv_pool()` — allowlist, currently `{"1f1b"}`.
2. *torch private API drift?* Version-adaptive probe with fail-open: install
   returns False and logs; stock allocation is kept, nothing breaks.
3. *Why monkeypatch instead of subclass?* Stages are constructed inside
   torch's `pipeline_model` flow; class-level rebinding before build is the
   minimal seam that needs no fork of the stage class. Idempotent + opt-in.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (`test_recv_buffer_pool.py`, listed above)
- [x] Did you add or update any necessary documentation? (`PipelineConfig` docstring for both fields; yaml header documents the shape and provenance. No docs page enumerates `PipelineConfig` fields.)

# Additional Information

- Part 2 of 2 of the Kimi-K3 perf series; part 1 (#3779) merged as `ac44d92` and this branch is rebased on top of it, so the diff is only this PR's files. Depends on #3808 (dataset option used by the 2k config).
- Rebased on `main` after #3792 (K3 FLOPs formula + `KimiK3TextConfig`
  defaults aligned with the checkpoint).

