### PR TITLE
fix(config): read YAML config files as UTF-8

### DIFF
--- a/nemo_automodel/cli/utils.py
+++ b/nemo_automodel/cli/utils.py
@@ -67,7 +67,7 @@ def resolve_recipe_name(raw: str) -> str:
 def load_yaml(file_path):
     """Load and return a YAML file as a dict."""
     try:
-        with open(file_path, "r") as file:
+        with open(file_path, "r", encoding="utf-8") as file:
             return yaml.safe_load(file)
     except FileNotFoundError as e:
         logger.error("File '%s' was not found.", file_path)

--- a/nemo_automodel/components/config/loader.py
+++ b/nemo_automodel/components/config/loader.py
@@ -839,6 +839,6 @@ def load_yaml_config(path: str | Path) -> "ConfigNode":
     Returns:
         ConfigNode: A configuration node representing the YAML file.
     """
-    with open(path, "r") as f:
+    with open(path, "r", encoding="utf-8") as f:
         raw = yaml.safe_load(f)
     return ConfigNode(raw)


### PR DESCRIPTION
`load_yaml_config` and the CLI's `load_yaml` open the config as a text stream with no `encoding=`, so it decodes with `locale.getpreferredencoding()`. That is UTF-8 on CI and cp1252 on a Western Windows install, so the same config file produces different values depending on the machine.

This is not hypothetical for this repo. On Windows, loading a shipped example fails outright:

```
load_yaml('examples/llm_finetune/deepseek_v4/deepseek_v4_flash_cp_tulu3.yaml')
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 3578
```

Byte `0x81` is the middle of the U+2581 in a DeepSeek chat template. Configs that happen to decode are worse, because they corrupt template delimiters silently rather than raising.

PyYAML decodes bytes as UTF-8 per the YAML spec; wrapping the file in a locale-encoded text stream bypasses that. Nineteen sites in this package already pass `encoding="utf-8"`, including the YAML reads in `components/models/glm5_next/processing.py`, so this follows the existing convention rather than introducing one.

Two lines. `tests/unit_tests/config` and `tests/unit_tests/_cli`: 91 passed and 3 failed before and after, with identical failing names. Those 3 are pre-existing here, a Windows drive-letter colon case and two `torchao` import errors.
