### PR TITLE
packaging: make mlflow and wandb optional extras; switch to mlflow-skinny by default

### DIFF
--- a/nemo_automodel/components/loggers/loggers.py
+++ b/nemo_automodel/components/loggers/loggers.py
@@ -84,8 +84,16 @@ class WandbConfig:
         Returns:
             Initialised ``wandb.Run``.
         """
-        import wandb
-        from wandb import Settings
+        try:
+            import wandb
+            from wandb import Settings
+        except ImportError as e:
+            raise ImportError(
+                "wandb is not installed. To enable W&B experiment tracking, run:\n"
+                "  pip install nemo-automodel[wandb]\n"
+                "or to install all tracking backends:\n"
+                "  pip install nemo-automodel[tracking]"
+            ) from e
 
         named = {k: v for k, v in asdict(self).items() if k != "extra" and v is not None}
         # ``extra`` (e.g. mode/dir) is forwarded verbatim; named fields win on collision.
@@ -157,7 +165,14 @@ class MLflowConfig:
         try:
             import mlflow
         except ImportError as e:
-            raise ImportError("MLflow is not installed. Please install it with: uv add mlflow") from e
+            raise ImportError(
+                "mlflow is not installed. To enable MLflow experiment tracking, run:\n"
+                "  pip install nemo-automodel[mlflow]\n"
+                "For the full MLflow stack (UI, SQL backend, pyarrow):\n"
+                "  pip install nemo-automodel[mlflow-full]\n"
+                "or to install all tracking backends:\n"
+                "  pip install nemo-automodel[tracking]"
+            ) from e
 
         if self.tracking_uri is not None:
             mlflow.set_tracking_uri(self.tracking_uri)

--- a/nemo_automodel/components/loggers/wandb_utils.py
+++ b/nemo_automodel/components/loggers/wandb_utils.py
@@ -31,8 +31,16 @@ def init_wandb_run(wandb_cfg: dict, full_config: dict, default_name: str = ""):
     Returns:
         The initialized ``wandb.Run``.
     """
-    import wandb
-    from wandb import Settings
+    try:
+        import wandb
+        from wandb import Settings
+    except ImportError as e:
+        raise ImportError(
+            "wandb is not installed. To enable W&B experiment tracking, run:\n"
+            "  pip install nemo-automodel[wandb]\n"
+            "or to install all tracking backends:\n"
+            "  pip install nemo-automodel[tracking]"
+        ) from e
 
     kwargs = dict(wandb_cfg)
     if not kwargs.get("name"):

--- a/nemo_automodel/recipes/diffusion/train.py
+++ b/nemo_automodel/recipes/diffusion/train.py
@@ -22,7 +22,10 @@ from typing import Any, Dict
 
 import torch
 import torch.distributed as dist
-import wandb
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore[assignment]
 from torch.distributed.fsdp import CPUOffloadPolicy, MixedPrecisionPolicy
 
 from nemo_automodel._diffusers.auto_diffusion_pipeline import NeMoAutoDiffusionPipeline

--- a/nemo_automodel/recipes/dllm/train_ft.py
+++ b/nemo_automodel/recipes/dllm/train_ft.py
@@ -38,9 +38,15 @@ import logging
 import time
 from contextlib import nullcontext
 
-import mlflow
+try:
+    import mlflow
+except ImportError:
+    mlflow = None  # type: ignore[assignment]
 import torch
-import wandb
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore[assignment]
 from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
 
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config

--- a/nemo_automodel/recipes/llm/kd.py
+++ b/nemo_automodel/recipes/llm/kd.py
@@ -45,7 +45,10 @@ from dataclasses import replace
 from typing import Any, Dict
 
 import torch
-import wandb
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore[assignment]
 from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
 
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -34,10 +34,16 @@ from contextlib import nullcontext
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
-import mlflow
+try:
+    import mlflow
+except ImportError:
+    mlflow = None  # type: ignore[assignment]
 import torch
 import torch.nn as nn
-import wandb
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore[assignment]
 from huggingface_hub import constants as hf_constants
 from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
 from transformers import AutoConfig

--- a/nemo_automodel/recipes/llm/train_seq_cls.py
+++ b/nemo_automodel/recipes/llm/train_seq_cls.py
@@ -20,7 +20,10 @@ import time
 from contextlib import nullcontext
 
 import torch
-import wandb
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore[assignment]
 
 from nemo_automodel._transformers.utils import apply_cache_compatibility_patches
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config

--- a/nemo_automodel/recipes/multimodal/finetune.py
+++ b/nemo_automodel/recipes/multimodal/finetune.py
@@ -44,7 +44,10 @@ from typing import Any, Dict, List
 import numpy as np
 import torch
 import torch.distributed as dist
-import wandb
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore[assignment]
 
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config  # noqa: E402
 from nemo_automodel.components.loggers.log_utils import setup_logging  # noqa: E402
@@ -981,7 +984,13 @@ class FinetuneRecipeForMultimodal(BaseRecipe):
     # ------------------------------------------------------------------
     def _build_wandb(self):
         assert self.cfg.get("wandb", None) is not None
-        from wandb import Settings
+        try:
+            from wandb import Settings
+        except ImportError as e:
+            raise ImportError(
+                "wandb is not installed. To enable W&B experiment tracking, run:\n"
+                "  pip install nemo-automodel[wandb]"
+            ) from e
 
         kwargs = self.cfg.wandb.to_dict()
         if kwargs.get("name", "") == "":

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -31,10 +31,16 @@ import time
 from contextlib import contextmanager, nullcontext
 from typing import TYPE_CHECKING, Any, Protocol
 
-import mlflow
+try:
+    import mlflow
+except ImportError:
+    mlflow = None  # type: ignore[assignment]
 import torch
 import torch.nn as nn
-import wandb
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore[assignment]
 from torch.utils.data import DataLoader
 from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
 from transformers.processing_utils import ProcessorMixin

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -46,7 +46,10 @@ from contextlib import nullcontext
 from typing import Any
 
 import torch
-import wandb
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore[assignment]
 from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
 
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,9 +87,7 @@ dependencies = [
     "torch>=2.6.0",
     "torchdata",
     "transformers==5.12.1",
-    "wandb>=0.28.0",
     "torchao",
-    "mlflow",
     "flashoptim>=0.1.3",
     # 0.6.4 pins nvidia-cutlass-dsl==4.6.2, matching what flash_attn.cute requires at the
     # pinned FLASH_ATTN_REF. Both import `cutlass`, so they have to agree. (0.6.1 pinned 4.6.0.)
@@ -104,7 +102,7 @@ diffusion = [
     "torchvision",
 ]
 diffusion_kernels = [
-    "nemo_automodel[diffusion]",
+    "nemo-automodel[diffusion]",
     "kernels",
 ]
 # nvidia-cudnn-cu12 pin: This is required for GPTOSS TE support + faster cudnn attention (only on Linux where CUDA is available)
@@ -153,8 +151,8 @@ delta-databricks = [
     "databricks-sql-connector>=4.4.0",  # Minimum connector compatible with patched Thrift 0.24.0
 ]
 moe = [
-    "nemo_automodel[cuda]",
-    "nemo_automodel[fla]",
+    "nemo-automodel[cuda]",
+    "nemo-automodel[fla]",
     "deep_ep",
 ]
 vlm = [
@@ -190,18 +188,36 @@ diffusion-media = [
     "opencv-python-headless==4.10.0.84",  # cv2: diffusion preprocessing entry point (also in vlm-media)
 ]
 media = [
-    "nemo_automodel[vlm-media]",
-    "nemo_automodel[diffusion-media]",
+    "nemo-automodel[vlm-media]",
+    "nemo-automodel[diffusion-media]",
+]
+mlflow = [
+    # mlflow-skinny: same Python tracking API, no server/UI/pyarrow/scipy/etc.
+    # Avoids the mlflow vs mlflow-skinny mutual-exclusion conflict that breaks
+    # environments using sagemaker-mlflow, kedro-mlflow, and managed ML platforms.
+    "mlflow-skinny",
+]
+mlflow-full = [
+    # Full mlflow stack: tracking server, UI, SQL backend, pyarrow, etc.
+    # Use when you need the MLflow UI or sql:// artifact stores.
+    "mlflow",
+]
+wandb = ["wandb>=0.28.0"]
+tracking = [
+    # Convenience meta-extra: installs both experiment-tracking backends.
+    "nemo-automodel[mlflow]",
+    "nemo-automodel[wandb]",
 ]
 all = [
-    "nemo_automodel[cli]",
-    "nemo_automodel[cuda]",
-    "nemo_automodel[delta-databricks]",
-    "nemo_automodel[diffusion]",
-    "nemo_automodel[extra]",
-    "nemo_automodel[fla]",
-    "nemo_automodel[s3]",
-    "nemo_automodel[vlm]",
+    "nemo-automodel[cli]",
+    "nemo-automodel[cuda]",
+    "nemo-automodel[delta-databricks]",
+    "nemo-automodel[diffusion]",
+    "nemo-automodel[extra]",
+    "nemo-automodel[fla]",
+    "nemo-automodel[s3]",
+    "nemo-automodel[tracking]",
+    "nemo-automodel[vlm]",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Closes #3783

`mlflow` and `wandb` are experiment-tracking backends that are opt-in via YAML config. Listing them as hard core dependencies causes two problems:

1. **`mlflow` conflicts with `mlflow-skinny`** — mutually exclusive PyPI packages. Environments shipping `mlflow-skinny` (sagemaker-mlflow, kedro-mlflow, managed ML platforms like SageMaker/Vertex) hard-block on install.
2. **Heavy unused transitive deps** — `mlflow` (full) pulls in pyarrow, scipy, scikit-learn, flask, sqlalchemy, etc. Users who never configure a logger pay this cost unconditionally.

## Changes

### `pyproject.toml`
- Remove `wandb>=0.28.0` and `mlflow` from `dependencies[]`
- Add new optional extras:
  - `[mlflow]` → `mlflow-skinny` (full tracking API, no UI/server/pyarrow — no conflict)
  - `[mlflow-full]` → `mlflow` (UI, SQL backend, pyarrow, etc.)
  - `[wandb]` → `wandb>=0.28.0`
  - `[tracking]` → meta-extra pulling in both `[mlflow]` + `[wandb]`
- Wire `[tracking]` into `[all]`
- Fix all composite extras to use canonical distribution name `nemo-automodel` (hyphens) not `nemo_automodel` (underscores) per PEP 508

### Logger modules (`loggers.py`, `wandb_utils.py`)
- Upgrade `ImportError` messages to point to the new extras (`pip install nemo-automodel[mlflow]`, `[wandb]`, `[tracking]`)

### Recipe files (8 files)
Replace top-level hard `import mlflow` / `import wandb` with `try/except` sentinels that set the module to `None` on `ImportError`. All call-sites already guard via `wandb.run is not None` and `mlflow.active_run() is not None`, so runtime behaviour is unchanged when extras are installed.

Files updated:
- `nemo_automodel/recipes/llm/train_ft.py`
- `nemo_automodel/recipes/llm/kd.py`
- `nemo_automodel/recipes/llm/train_seq_cls.py`
- `nemo_automodel/recipes/dllm/train_ft.py`
- `nemo_automodel/recipes/diffusion/train.py`
- `nemo_automodel/recipes/vlm/finetune.py`
- `nemo_automodel/recipes/vlm/kd.py`
- `nemo_automodel/recipes/multimodal/finetune.py`

## Install patterns after this change

```bash
pip install nemo-automodel                  # lean — no logger overhead
pip install nemo-automodel[mlflow]          # MLflow skinny (no conflict with mlflow-skinny envs)
pip install nemo-automodel[mlflow-full]     # MLflow full stack (UI, SQL, pyarrow)
pip install nemo-automodel[wandb]           # W&B only
pip install nemo-automodel[tracking]        # both backends
pip install nemo-automodel[all]             # everything (includes tracking)
```

## Precedent

[sagemaker-mlflow PR #22](https://github.com/aws/sagemaker-mlflow/pull/22) applied the identical fix (mlflow → mlflow-skinny + [full] escape hatch). Same pattern used by kedro-mlflow, bentoml, lightning.