### PR TITLE
build: bump ffpa-attn to 0.2.4

### DIFF
--- a/docker/common/uv-pytorch.lock
+++ b/docker/common/uv-pytorch.lock
@@ -1844,7 +1844,7 @@ wheels = [
 
 [[package]]
 name = "ffpa-attn"
-version = "0.2.3"
+version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-tvm-ffi" },
@@ -1858,7 +1858,7 @@ dependencies = [
     { name = "torch", marker = "sys_platform == 'never'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/61/6b56635c40fd009b450eeb66c4b5021aaf5e61c055993078fec039845f05/ffpa_attn-0.2.3-py3-none-any.whl", hash = "sha256:d083f772433e9e6fb0f925b03b129d9d2830a310a86c7b5a0e28ecba277a89aa", size = 519417, upload-time = "2026-08-28T18:25:53.975Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/7e/6ed94bf44c3fbbbe43433692ec89cd8d5a99416d9f0a283fe810674ffea9/ffpa_attn-0.2.4-py3-none-any.whl", hash = "sha256:f1df2da0c72f7c9599a72301044be9034ecc75a58c81b01dc53a9c6b74124bde", size = 518958, upload-time = "2026-09-02T03:33:51.237Z" },
 ]
 
 [[package]]
@@ -4268,7 +4268,7 @@ requires-dist = [
     { name = "deep-ep", marker = "extra == 'moe'", git = "https://github.com/deepseek-ai/DeepEP.git?rev=42144303752422ade37f24bca9e2dde12df70e09" },
     { name = "deltalake", marker = "extra == 'delta-databricks'", specifier = ">=1.0.0" },
     { name = "diffusers", marker = "extra == 'diffusion'", specifier = ">=0.39.0" },
-    { name = "ffpa-attn", marker = "extra == 'ffpa'", specifier = ">=0.2.3" },
+    { name = "ffpa-attn", marker = "extra == 'ffpa'", specifier = ">=0.2.4" },
     { name = "flash-attn", marker = "extra == 'fa'", specifier = "<=2.8.3" },
     { name = "flash-linear-attention", marker = "extra == 'fla'", specifier = ">=0.4.2" },
     { name = "flashoptim", specifier = ">=0.1.3" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,10 +141,11 @@ cuda_source = [
 ]
 extra = ["perceptron", "sentencepiece"]
 fa = ["flash-attn<=2.8.3"]
-# ffpa-attn 0.2.3 is the first release that pins nvidia-cutlass-dsl==4.6.2 and
-# quack-kernels==0.6.4, i.e. the same cutlass-dsl flash_attn.cute (FA4) needs. 0.2.2 hard-pinned
-# 4.6.0/0.6.1 and was unsatisfiable alongside FA4, so do not relax this floor.
-ffpa = ["ffpa-attn>=0.2.3", "nvidia-cutlass-dsl==4.6.2"]
+# ffpa-attn 0.2.3 first aligned on nvidia-cutlass-dsl==4.6.2 and quack-kernels==0.6.4,
+# i.e. the same cutlass-dsl flash_attn.cute (FA4) needs. 0.2.4 also fixes the persistent
+# CuTe cache callable ABI. 0.2.2 hard-pinned 4.6.0/0.6.1 and was unsatisfiable alongside
+# FA4, so do not relax this floor.
+ffpa = ["ffpa-attn>=0.2.4", "nvidia-cutlass-dsl==4.6.2"]
 fla = [
     "flash-linear-attention>=0.4.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1814,7 +1814,7 @@ wheels = [
 
 [[package]]
 name = "ffpa-attn"
-version = "0.2.3"
+version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-tvm-ffi" },
@@ -1830,7 +1830,7 @@ dependencies = [
     { name = "torch", version = "2.10.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/61/6b56635c40fd009b450eeb66c4b5021aaf5e61c055993078fec039845f05/ffpa_attn-0.2.3-py3-none-any.whl", hash = "sha256:d083f772433e9e6fb0f925b03b129d9d2830a310a86c7b5a0e28ecba277a89aa", size = 519417, upload-time = "2026-08-28T18:25:53.975Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/7e/6ed94bf44c3fbbbe43433692ec89cd8d5a99416d9f0a283fe810674ffea9/ffpa_attn-0.2.4-py3-none-any.whl", hash = "sha256:f1df2da0c72f7c9599a72301044be9034ecc75a58c81b01dc53a9c6b74124bde", size = 518958, upload-time = "2026-09-02T03:33:51.237Z" },
 ]
 
 [[package]]
@@ -4263,7 +4263,7 @@ requires-dist = [
     { name = "deep-ep", marker = "extra == 'moe'", git = "https://github.com/deepseek-ai/DeepEP.git?rev=42144303752422ade37f24bca9e2dde12df70e09" },
     { name = "deltalake", marker = "extra == 'delta-databricks'", specifier = ">=1.0.0" },
     { name = "diffusers", marker = "extra == 'diffusion'", specifier = ">=0.39.0" },
-    { name = "ffpa-attn", marker = "extra == 'ffpa'", specifier = ">=0.2.3" },
+    { name = "ffpa-attn", marker = "extra == 'ffpa'", specifier = ">=0.2.4" },
     { name = "flash-attn", marker = "extra == 'fa'", specifier = "<=2.8.3" },
     { name = "flash-linear-attention", marker = "extra == 'fla'", specifier = ">=0.4.2" },
     { name = "flashoptim", specifier = ">=0.1.3" },


### PR DESCRIPTION
# What does this PR do ?

Bumps the minimum ffpa-attn version to 0.2.4, which contains the persistent CuTe cache callable ABI fix found during Gemma 4 FFPA validation.

# Changelog

- Require ffpa-attn>=0.2.4 for the ffpa extra.
- Regenerate uv.lock and docker/common/uv-pytorch.lock with CI-pinned uv 0.8.22.

# Validation

- uv 0.8.22: default lock check passes.
- uv 0.8.22: PyTorch-container lock check passes after applying docker/common/update_pyproject_pytorch.sh.
- git diff --check passes.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (Dependency-only update; no code behavior changed in this repository.)
- [x] Did you add or update any necessary documentation? (No documentation changes needed.)

# Additional Information

- Follow-up requested in https://github.com/NVIDIA-NeMo/Automodel/pull/3742#issuecomment-5504342054
- Related to #3742