### PR TITLE
fix(models): declare and honor logits_to_keep on Mistral3 VLM forward

### DIFF
--- a/nemo_automodel/components/models/mistral4/model.py
+++ b/nemo_automodel/components/models/mistral4/model.py
@@ -840,8 +840,9 @@ if _HF_MISTRAL3_AVAILABLE:
             pixel_values: torch.Tensor | None = None,
             image_sizes: torch.Tensor | None = None,
             inputs_embeds: torch.Tensor | None = None,
+            logits_to_keep: Union[int, torch.Tensor] = 0,
             **kwargs: Any,
-        ) -> torch.Tensor:
+        ) -> torch.Tensor | dict[str, torch.Tensor]:
             # PP VLM support: retrieve pixel_values from stored chunks
             if (
                 pixel_values is None
@@ -862,7 +863,8 @@ if _HF_MISTRAL3_AVAILABLE:
                             image_sizes = image_grid_hws
                         self._vlm_chunk_idx = chunk_idx + 1
 
-            if "qkv_format" in kwargs and kwargs["qkv_format"] == "thd":
+            is_thd = kwargs.get("qkv_format") == "thd"
+            if is_thd:
                 input_ids, position_ids, padding_mask, kwargs = squeeze_input_for_thd(
                     input_ids, position_ids, padding_mask, kwargs
                 )
@@ -880,13 +882,23 @@ if _HF_MISTRAL3_AVAILABLE:
             )
 
             hidden_states = outputs.last_hidden_state if hasattr(outputs, "last_hidden_state") else outputs
+
+            # ``0`` is the default "project every position". Anything else is the
+            # fused-loss path: FusedLinearCrossEntropy applies the lm_head itself,
+            # fused with the loss, so hand back hidden states rather than
+            # materialising the [tokens, vocab_size] logits tensor.
+            if not (isinstance(logits_to_keep, int) and logits_to_keep == 0):
+                if is_thd and hidden_states.dim() == 2:
+                    hidden_states = hidden_states.unsqueeze(0)
+                return {"hidden_states": hidden_states}
+
             try:
                 lm = self.lm_head
             except (AttributeError, TypeError):
                 lm = None
             logits = lm(hidden_states) if lm is not None else hidden_states
 
-            if "qkv_format" in kwargs and kwargs["qkv_format"] == "thd":
+            if is_thd:
                 logits = logits.unsqueeze(0)
 
             return logits

--- a/tests/unit_tests/models/mistral4/test_mistral4_logits_to_keep.py
+++ b/tests/unit_tests/models/mistral4/test_mistral4_logits_to_keep.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``logits_to_keep`` on the Mistral 4 VLM forward, the contract the fused losses need.
+
+The recipe decides whether a memory-efficient loss is usable by inspecting the
+forward signature (``_supports_logits_to_keep``), so absorbing the kwarg into
+``**kwargs`` silently downgrades the configured ``loss_fn`` to a default
+``MaskedCrossEntropy`` -- along with its ``fp32_upcast`` setting -- and
+materialises the ``[tokens, vocab_size]`` logits tensor.
+
+These live outside ``test_mistral4_model.py`` because that module is gated on
+``torch.cuda.is_available()``; the contract here is CPU-checkable.
+"""
+
+import pytest
+import torch
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.mistral4.model import _HF_MISTRAL3_AVAILABLE
+from nemo_automodel.components.utils.model_utils import _supports_logits_to_keep
+
+pytestmark = pytest.mark.skipif(not _HF_MISTRAL3_AVAILABLE, reason="transformers mistral3 not available")
+
+HIDDEN_SIZE = 64
+VOCAB_SIZE = 256
+
+
+@pytest.fixture
+def backend():
+    return BackendConfig(
+        attn="sdpa",
+        linear="torch",
+        rms_norm="torch",
+        rope_fusion=False,
+        enable_hf_state_dict_adapter=False,
+    )
+
+
+@pytest.fixture
+def multimodal_config():
+    """Small Mistral3Config wrapping a Mistral4Config text config."""
+    from transformers import AutoConfig
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+
+    from nemo_automodel.components.models.mistral4.configuration import Mistral4Config
+
+    if "mistral4" not in CONFIG_MAPPING:
+        AutoConfig.register("mistral4", Mistral4Config)
+
+    from transformers.models.mistral3.configuration_mistral3 import Mistral3Config
+
+    text_config = Mistral4Config(
+        vocab_size=VOCAB_SIZE,
+        hidden_size=HIDDEN_SIZE,
+        intermediate_size=128,
+        moe_intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        q_lora_rank=32,
+        kv_lora_rank=16,
+        qk_rope_head_dim=8,
+        v_head_dim=16,
+        qk_nope_head_dim=8,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        n_group=1,
+        topk_group=1,
+        first_k_dense_replace=0,
+        norm_topk_prob=True,
+        routed_scaling_factor=1.0,
+        max_position_embeddings=256,
+        rms_norm_eps=1e-6,
+    )
+    return Mistral3Config(
+        text_config=text_config.to_dict(),
+        vision_config={
+            "model_type": "pixtral",
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 4,
+            "num_channels": 3,
+            "image_size": 16,
+            "patch_size": 4,
+        },
+        image_token_index=10,
+        spatial_merge_size=2,
+    )
+
+
+@pytest.fixture
+def model(multimodal_config, backend):
+    from nemo_automodel.components.models.mistral4.model import Mistral3ForConditionalGeneration
+
+    m = Mistral3ForConditionalGeneration(multimodal_config, backend=backend)
+    # Without this the parameters are uninitialised memory, so the finite-value
+    # assertion below passes or fails depending on allocator reuse.
+    m.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
+    return m
+
+
+def test_recipe_detects_logits_to_keep_support(model):
+    """The probe the trainer actually runs before keeping a fused loss."""
+    assert _supports_logits_to_keep(model)
+
+
+def test_logits_to_keep_returns_hidden_states_and_skips_lm_head(model):
+    input_ids = torch.randint(0, VOCAB_SIZE, (1, 8))
+
+    with torch.no_grad():
+        out = model(input_ids, logits_to_keep=1)
+
+    # The recipe raises unless the mapping carries `hidden_states`, and
+    # FusedLinearCrossEntropy reads it via get_final_hidden_states(out).
+    assert "hidden_states" in out
+    hidden = out["hidden_states"]
+    assert hidden.shape == (1, 8, HIDDEN_SIZE)
+    assert hidden.shape[-1] != VOCAB_SIZE, "lm_head was applied; the logits tensor was materialised"
+    assert torch.isfinite(hidden).all()
+
+
+def test_without_logits_to_keep_still_returns_logits(model):
+    """Default path is unchanged: callers that want logits keep getting them."""
+    input_ids = torch.randint(0, VOCAB_SIZE, (1, 8))
+
+    with torch.no_grad():
+        logits = model(input_ids)
+
+    assert isinstance(logits, torch.Tensor)
+    assert logits.shape == (1, 8, VOCAB_SIZE)


### PR DESCRIPTION
# What does this PR do ?

Makes `Mistral3ForConditionalGeneration` declare and honour `logits_to_keep`, so
a configured fused loss is no longer silently replaced.

`forward` absorbed the kwarg into `**kwargs` and never read it.
`_supports_logits_to_keep` inspects the forward signature
(`components/utils/model_utils.py` L76-77), so the check returned `False` and
the recipe swapped the configured loss for a fresh `MaskedCrossEntropy`
(`recipes/llm/train_ft.py` L159, `recipes/vlm/finetune.py` L554,
`_transformers/infrastructure.py` L640). The class is registered
(`_transformers/registry.py` L194-197), so this is user-reachable.

Two consequences, both from #3510:

1. **The full logits tensor is materialised.** `Mistral4Config.vocab_size`
   defaults to 131072, so the head output is `[tokens, 131072]`.
2. **The configured `loss_fn`'s settings are dropped with it** — the replacement
   is a *fresh* `MaskedCrossEntropy()`, so `fp32_upcast: false` is lost.

Same defect and same fix as #3510 (MiniMax-M3). Evidence it was an oversight:
its own text backbone `Mistral4ForCausalLM` declares it (same file, L417), and
its sibling `Mistral3FP8VLMForConditionalGeneration` declares it
(`mistral3_vlm/model.py` L206).

**Contract.** The recipe calls `model(logits_to_keep=1, **batch)` and then
requires `"hidden_states" in out`; `FusedLinearCrossEntropy.forward` takes
`hidden_states` and applies the lm_head itself, fused with the loss. So the
fused path returns the hidden states rather than sliced logits — matching what
#3510 did for M3. The default path (`logits_to_keep=0`) is untouched and still
returns the logits tensor.

# Changelog

- `Mistral3ForConditionalGeneration.forward` declares
  `logits_to_keep: Union[int, torch.Tensor] = 0` and returns
  `{"hidden_states": ...}` when it is set; the default path still returns
  logits, unchanged.
- Hoisted the THD check into a single `is_thd` local (it was computed twice from
  `kwargs`, once before and once after `squeeze_input_for_thd` mutates it) and
  applied the same batch-dim restoration on the hidden-states path.
- New `tests/unit_tests/models/mistral4/test_mistral4_logits_to_keep.py`
  covering the recipe's `_supports_logits_to_keep` probe, the fused path
  returning hidden states without materialising logits, and the unchanged
  default path.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

**On the test file location.** These live in a new file rather than in
`test_mistral4_model.py` because that module carries a module-level
`pytest.mark.skipif(not torch.cuda.is_available())`, so the contract would not
be checked on the CPU tier. The new file is CPU-runnable, mirroring
`tests/unit_tests/models/minimax_m3_vl/test_minimax_m3_logits_to_keep.py`.

**Verification** (CPU, no GPU or checkpoint needed):

- `pytest tests/unit_tests/models/mistral4/test_mistral4_logits_to_keep.py` → 3 passed.
- Reverting only the model change makes `test_recipe_detects_logits_to_keep_support`
  and `test_logits_to_keep_returns_hidden_states_and_skips_lm_head` fail;
  `test_without_logits_to_keep_still_returns_logits` passes either way by design,
  guarding the path this must not change.
- `pytest tests/unit_tests/models/mistral4/ tests/unit_tests/models/mistral3/ tests/unit_tests/models/mistral3_vlm/` → 147 passed, 70 skipped.
- Wider `tests/unit_tests/models/ tests/unit_tests/_transformers/` run: 84 failures
  before and after this change (gemma4 / glm5_next / retrieval), all pre-existing
  on `main` in my environment and unrelated — the only delta is the 2 tests above
  going green. `diffusion_gemma` and `gemma4_unified` were excluded locally: they
  fail to import `transformers.models.diffusion_gemma` on `main` too.
- `ruff format` / `ruff check` clean.

# Additional Information

- Closes #3778
