### PR TITLE
build(deps): verify uv locks for PR #3777

### DIFF
--- a/nemo_automodel/components/loss/kd_loss.py
+++ b/nemo_automodel/components/loss/kd_loss.py
@@ -104,7 +104,11 @@ def _kl_forward_tp(
 
     # --- Per-token KL: local vocabulary contribution then global reduce ---
     kl_local = _forward_kl_from_log_probs(teacher_log_prob, student_log_prob)
-    kl_local = dist_nn_func.all_reduce(kl_local, op=torch.distributed.ReduceOp.SUM, group=tp_group)
+    # Every rank computes the same global KL value, so its backward pass must
+    # retain the local vocabulary gradient instead of reducing that gradient a
+    # second time through the autograd-aware collective.
+    with torch.no_grad():
+        torch.distributed.all_reduce(kl_local, op=torch.distributed.ReduceOp.SUM, group=tp_group)
 
     return kl_local
 

--- a/nemo_automodel/components/loss/kd_loss.py
+++ b/nemo_automodel/components/loss/kd_loss.py
@@ -66,6 +66,42 @@ def _forward_kl_from_log_probs(
     return (teacher_prob * log_ratio).sum(dim=-1)
 
 
+class _AllReduceForwardPassThroughBackward(torch.autograd.Function):
+    """All-reduce a tensor in forward while preserving its local gradient."""
+
+    @staticmethod
+    def forward(ctx, input_tensor: torch.Tensor, group: torch.distributed.ProcessGroup) -> torch.Tensor:
+        """Reduce a clone of the input tensor without mutating its autograd value.
+
+        Args:
+            ctx: Autograd context, unused by this operation.
+            input_tensor: Tensor of shape ``[...]`` containing local per-token KL values.
+            group: Process group over which to sum the local values.
+
+        Returns:
+            Tensor of shape ``[...]`` containing the forward all-reduced values.
+        """
+        output = input_tensor.clone()
+        torch.distributed.all_reduce(output, op=torch.distributed.ReduceOp.SUM, group=group)
+        return output
+
+    @staticmethod
+    def backward(ctx, *grad_outputs: torch.Tensor | None) -> tuple[torch.Tensor | None, None]:
+        """Pass the output gradient through without a second distributed reduction.
+
+        Args:
+            ctx: Autograd context, unused by this operation.
+            grad_outputs: One-element tuple containing a tensor of shape ``[...]``
+                with the gradient of the all-reduced output, or ``None`` when the
+                output is unused.
+
+        Returns:
+            Tuple containing the local input gradient (or ``None`` when the output
+            is unused) and ``None`` for the process group.
+        """
+        return grad_outputs[0], None
+
+
 def _kl_forward_tp(
     t_logits: torch.Tensor,
     s_logits: torch.Tensor,
@@ -107,8 +143,7 @@ def _kl_forward_tp(
     # Every rank computes the same global KL value, so its backward pass must
     # retain the local vocabulary gradient instead of reducing that gradient a
     # second time through the autograd-aware collective.
-    with torch.no_grad():
-        torch.distributed.all_reduce(kl_local, op=torch.distributed.ReduceOp.SUM, group=tp_group)
+    kl_local = _AllReduceForwardPassThroughBackward.apply(kl_local, tp_group)
 
     return kl_local
 

--- a/tests/unit_tests/loss/test_kd_loss.py
+++ b/tests/unit_tests/loss/test_kd_loss.py
@@ -16,6 +16,7 @@ Unit tests for :pyclass:`nemo_automodel.components.loss.kd_loss.KDLoss` and its
 tensor-parallel helpers.
 """
 
+import sys
 from typing import Optional
 
 import pytest
@@ -666,3 +667,45 @@ def _run_two_process_tp_kl(rank: int, init_file: str) -> None:
 
 def test_kl_forward_tp_two_process_matches_full_vocab(tmp_path):
     mp.spawn(_run_two_process_tp_kl, args=(str(tmp_path / "tp_kl"),), nprocs=2, join=True)
+
+
+def _run_two_process_tp_kd_gradient(rank: int, init_file: str) -> None:
+    torch.distributed.init_process_group(
+        backend="gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=2,
+    )
+    try:
+        torch.manual_seed(29)
+        teacher_logits = torch.randn(6, 16)
+        student_logits = torch.randn(6, 16)
+        local_teacher = teacher_logits.chunk(2, dim=-1)[rank].contiguous()
+        local_student = student_logits.chunk(2, dim=-1)[rank].contiguous().requires_grad_()
+        labels = torch.tensor([0, 1, -100, 3, 4, 5])
+
+        actual = KDLoss(tp_group=torch.distributed.group.WORLD)(local_student, local_teacher, labels)
+        actual.backward()
+
+        full_student = student_logits.detach().requires_grad_()
+        teacher_logprob = F.log_softmax(teacher_logits, dim=-1)
+        student_logprob = F.log_softmax(full_student, dim=-1)
+        expected = F.kl_div(student_logprob, teacher_logprob, reduction="none", log_target=True).sum(-1)
+        expected = expected[labels != -100].mean()
+        expected.backward()
+
+        torch.testing.assert_close(
+            local_student.grad,
+            full_student.grad.chunk(2, dim=-1)[rank],
+            atol=1e-6,
+            rtol=1e-5,
+        )
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="the CPU Gloo backend does not support multi-process tests on Windows"
+)
+def test_kd_loss_tp_two_process_matches_full_vocab_gradient(tmp_path):
+    mp.spawn(_run_two_process_tp_kd_gradient, args=(str(tmp_path / "tp_kd_gradient"),), nprocs=2, join=True)

--- a/tests/unit_tests/loss/test_kd_loss.py
+++ b/tests/unit_tests/loss/test_kd_loss.py
@@ -26,6 +26,7 @@ import torch.nn.functional as F
 
 from nemo_automodel.components.loss.kd_loss import (
     KDLoss,
+    _AllReduceForwardPassThroughBackward,
     _infer_tp_group_from_dtensor,
     _kl_forward_chunked,
     _kl_forward_tp,
@@ -639,6 +640,17 @@ def test_kd_loss_tp_path_with_temperature(trivial_pg):
     assert torch.allclose(loss_no_tp, loss_tp, atol=1e-5), (
         f"Non-TP loss {loss_no_tp.item():.6f} != TP loss {loss_tp.item():.6f}"
     )
+
+
+def test_tp_kl_reduction_does_not_mutate_saved_autograd_value(trivial_pg):
+    """The TP reduction must not mutate a tensor saved by an upstream autograd op."""
+    source = torch.randn(6, requires_grad=True)
+    local_kl = source.exp()
+
+    reduced_kl = _AllReduceForwardPassThroughBackward.apply(local_kl, trivial_pg)
+    reduced_kl.sum().backward()
+
+    torch.testing.assert_close(source.grad, local_kl.detach())
 
 
 def _run_two_process_tp_kl(rank: int, init_file: str) -> None:


### PR DESCRIPTION
> [!CAUTION]
> **DO NOT MERGE THIS PR.**
>
> The canonical PR is [#3777](https://github.com/NVIDIA-NeMo/Automodel/pull/3777). Please review and merge that PR instead.

## Purpose

This is a temporary companion PR for the fork-based #3777. It mirrors the current #3777 head and verifies both lock surfaces with the CI-pinned `uv 0.8.22`.

The full default and PyTorch-container lock regeneration produced no file changes, so this branch intentionally carries only an empty, DCO-signed verification commit rather than manufacturing lockfile churn. This PR should be closed without merging.

## Validation

- `uvx --from uv==0.8.22 uv lock`
- regenerated the PyTorch-container lock with `docker/common/update_pyproject_pytorch.sh`
- `uvx --from uv==0.8.22 uv lock --check`
- `git diff --check`
- both lockfiles remained unchanged
