### PR TITLE
fix(kimi-k3): correct MFU accounting (FLOPs formula, config defaults)

### DIFF
--- a/nemo_automodel/components/models/kimi_k3/config.py
+++ b/nemo_automodel/components/models/kimi_k3/config.py
@@ -22,7 +22,13 @@ from transformers.configuration_utils import PretrainedConfig
 
 
 class KimiK3TextConfig(PretrainedConfig):
-    """Configuration for the Kimi K3 hybrid KDA/MLA text backbone."""
+    """Configuration for the Kimi K3 hybrid KDA/MLA text backbone.
+
+    Defaults reproduce the released ``moonshotai/Kimi-K3`` checkpoint (``config.json`` text_config;
+    tech report Table 1): 93 layers (69 KDA + 24 gated MLA), 96 attention heads, dense FFN 33792,
+    896 latent-MoE experts (16 active, 2 shared), so ``from_config`` builds the same shape that
+    ``from_pretrained`` loads.
+    """
 
     model_type = "kimi_linear"
     architectures = ["KimiK3ForCausalLM"]
@@ -33,9 +39,9 @@ class KimiK3TextConfig(PretrainedConfig):
         vocab_size: int = 163840,
         hidden_size: int = 7168,
         head_dim: int | None = None,
-        intermediate_size: int = 18432,
+        intermediate_size: int = 33792,
         num_hidden_layers: int = 93,
-        num_attention_heads: int = 56,
+        num_attention_heads: int = 96,
         num_key_value_heads: int | None = None,
         hidden_act: str = "situ",
         initializer_range: float = 0.02,

--- a/nemo_automodel/components/utils/flops_utils.py
+++ b/nemo_automodel/components/utils/flops_utils.py
@@ -1436,6 +1436,143 @@ def mla_moe_flops(config, gbs=1, seq_len=None):
     )
 
 
+def _kda_attention_per_layer_flops(
+    gbs: int,
+    seq_len: int,
+    hs: int,
+    head_dim: int,
+    num_heads: int,
+    conv_kernel_size: int,
+    use_full_rank_gate: bool,
+    chunk_size: int = 64,
+) -> float:
+    """Per-layer FLOPs for Kimi Delta Attention (KDA, gated delta-rule linear attention).
+
+    Projections follow the KDA layer definition (Kimi Linear, arXiv:2510.26692):
+    q/k/v with short causal convolutions, the low-rank forget gate
+    (``f_a``/``f_b``), the beta projection, the output gate (full-rank ``g_proj``
+    or low-rank ``g_a``/``g_b``) and ``o_proj``. The chunkwise kernel is costed
+    with the paper's own count, ``FLOPs_KDA(T; C, d_h) = 6 T d_h^2 + 3 T C d_h + T C^2``
+    per head (forward, chunk size ``C``), halved to MAC-equivalents so the shared
+    ``6 x`` (forward + backward) factor of this module applies.
+    """
+    proj = num_heads * head_dim
+    gate_params = hs * proj if use_full_rank_gate else hs * head_dim + head_dim * proj
+    linear_params = (
+        3 * hs * proj  # q, k, v projections
+        + hs * head_dim
+        + head_dim * proj  # forget gate f_a / f_b
+        + hs * num_heads  # beta projection
+        + gate_params  # output gate
+        + proj * hs  # o_proj
+    )
+    conv_per_token = 3 * proj * conv_kernel_size
+    kernel_per_token = num_heads * (6 * head_dim**2 + 3 * chunk_size * head_dim + chunk_size**2) / 2
+    return 6 * gbs * seq_len * (linear_params + conv_per_token + kernel_per_token)
+
+
+def kimi_k3_flops(config: Any, gbs: int = 1, seq_len: int | None = None) -> float:
+    """Model FLOPs for Kimi K3 (hybrid KDA / gated-MLA attention + latent MoE with a SiTU shared expert).
+
+    Accepts ``KimiK3TextConfig`` or the multimodal ``KimiK3Config`` wrapper (its
+    ``text_config`` is used; the vision tower is not counted, as for other VL entries).
+
+    The layer pattern is read from the config rather than assumed: 1-based
+    ``linear_attn_config["kda_layers"]`` marks KDA layers and every other layer
+    is MLA (with an extra output-gate projection when ``mla_use_output_gate``);
+    ``first_k_dense_replace`` / ``moe_layer_freq`` mark dense vs MoE MLPs, using
+    the same rule as ``KimiDecoderLayer``. Routed experts run in a latent space
+    of ``routed_expert_hidden_size`` behind shared down/up projections, and the
+    shared expert is one SiTU MLP of ``moe_intermediate_size * num_shared_experts``.
+    The router GEMM (``hidden_size x num_experts``, about 0.6% of the total), norms
+    and the scalar attention-residual projections are omitted, matching the other
+    MoE formulas in this module.
+
+    The router top-k field on this config is ``num_experts_per_token`` (not the
+    ``num_experts_per_tok`` that the generic ``transformer_flops`` fallback probes),
+    which is why K3 was previously costed as a dense 93-layer transformer at well
+    under half of its real FLOPs. For the released checkpoint's configuration
+    (96 attention heads, dense ``intermediate_size`` 33792) the formula counts
+    104.0B active matmul parameters per token and 2.78T total, matching the
+    model card ("104B activated / 2.8T") and the tech report's Table 1 (104.2B /
+    2.78T) to within 0.2%, which is inside the accounting difference for the
+    non-GEMM parameters (router, norms, gate biases). The report's
+    single MTP layer is not shipped in the checkpoint (``num_nextn_predict_layers``
+    is 0) and is not modelled by Automodel, so it is not counted.
+    """
+    if hasattr(config, "text_config") and not hasattr(config, "num_hidden_layers"):
+        config = config.text_config
+
+    if seq_len is None:
+        seq_len = getattr(config, "max_position_embeddings", 2048)
+
+    layers = config.num_hidden_layers
+    hs = config.hidden_size
+    vocab_size = config.vocab_size
+
+    # --- attention layer pattern (1-based kda_layers list) ---
+    linear_attn_config = getattr(config, "linear_attn_config", None) or {}
+    kda_layer_ids = set(linear_attn_config.get("kda_layers", []))
+    num_kda_layers = sum(1 for layer in range(1, layers + 1) if layer in kda_layer_ids)
+    num_mla_layers = layers - num_kda_layers
+
+    attention_heads = config.num_attention_heads
+    mla_per_layer = _mla_attention_per_layer_flops(
+        gbs,
+        seq_len,
+        hs,
+        attention_heads,
+        getattr(config, "q_lora_rank", None),
+        config.kv_lora_rank,
+        config.qk_rope_head_dim,
+        config.qk_nope_head_dim,
+        config.v_head_dim,
+    )
+    if getattr(config, "mla_use_output_gate", False):
+        mla_per_layer += 6 * gbs * seq_len * hs * attention_heads * config.v_head_dim
+
+    kda_per_layer = 0
+    if num_kda_layers:
+        kda_per_layer = _kda_attention_per_layer_flops(
+            gbs,
+            seq_len,
+            hs,
+            linear_attn_config["head_dim"],
+            linear_attn_config["num_heads"],
+            linear_attn_config.get("short_conv_kernel_size", 4),
+            linear_attn_config.get("use_full_rank_gate", False),
+        )
+    attention_flops = num_mla_layers * mla_per_layer + num_kda_layers * kda_per_layer
+
+    # --- MLP layer pattern (same rule as KimiDecoderLayer) ---
+    num_experts = getattr(config, "num_experts", None)
+    is_moe = num_experts is not None and num_experts > 1
+    first_k_dense = getattr(config, "first_k_dense_replace", 0) or 0
+    moe_layer_freq = getattr(config, "moe_layer_freq", 1) or 1
+    num_moe_layers = sum(1 for i in range(layers) if is_moe and i >= first_k_dense and i % moe_layer_freq == 0)
+    num_dense_layers = layers - num_moe_layers
+
+    dense_ffn_params = 3 * hs * config.intermediate_size  # SiTU MLP: gate, up, down
+    moe_ffn_params = 0
+    if is_moe:
+        moe_topk = getattr(config, "num_experts_per_token", None)
+        if moe_topk is None:
+            moe_topk = getattr(config, "num_experts_per_tok", 1)
+        moe_ffn_hs = config.moe_intermediate_size
+        latent = getattr(config, "routed_expert_hidden_size", None)
+        expert_in = latent or hs
+        routed_params = moe_topk * 3 * expert_in * moe_ffn_hs
+        latent_proj_params = 2 * hs * latent if latent else 0
+        shared_params = 3 * hs * moe_ffn_hs * (getattr(config, "num_shared_experts", 0) or 0)
+        moe_ffn_params = routed_params + latent_proj_params + shared_params
+    ffn_flops = 6 * gbs * seq_len * (num_dense_layers * dense_ffn_params + num_moe_layers * moe_ffn_params)
+
+    # --- vocab ---
+    vocab_flops = 6 * gbs * seq_len * hs * vocab_size
+
+    return attention_flops + ffn_flops + vocab_flops
+
+
 def step3_5_flash_flops(config, gbs=1, seq_len=None):
     """Model FLOPs for Step3.5-Flash (GQA + sliding-window / full attention + MoE).
 
@@ -1620,6 +1757,8 @@ def get_flops_formula_for_hf_config(config: Any) -> Callable | None:
         "Mistral3Config": mla_moe_flops,  # Mistral Small 4 (VL wrapper, extracts text_config)
         "KimiK2Config": mla_moe_flops,  # Kimi K2 / K2.5
         "KimiK25Config": mla_moe_flops,
+        "KimiK3TextConfig": kimi_k3_flops,  # Kimi K3 (hybrid KDA/MLA + latent MoE)
+        "KimiK3Config": kimi_k3_flops,  # Kimi K3 multimodal wrapper (text_config)
         # Step3.5-Flash
         "Step3p5Config": step3_5_flash_flops,
         "LongcatFlashConfig": mla_moe_flops,  # MLA + MoE

--- a/tests/unit_tests/models/kimi_k3/test_config_defaults.py
+++ b/tests/unit_tests/models/kimi_k3/test_config_defaults.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""KimiK3TextConfig defaults must describe the released checkpoint, so from_config == from_pretrained shape."""
+
+from nemo_automodel.components.models.kimi_k3.config import KimiK3Config, KimiK3TextConfig
+
+# moonshotai/Kimi-K3 config.json (text_config) at snapshot 9f62e4e9fffbd0a83ddd60e1c209d828994b3569,
+# cross-checked against the safetensors shapes (q_b_proj [18432, 1536] = 96 heads x 192,
+# layers.0.mlp.gate_proj [33792, 7168]) and the tech report's Table 1.
+RELEASED_TEXT_CONFIG = {
+    "vocab_size": 163840,
+    "hidden_size": 7168,
+    "intermediate_size": 33792,
+    "num_hidden_layers": 93,
+    "num_attention_heads": 96,
+    "num_key_value_heads": 96,
+    "moe_intermediate_size": 3072,
+    "num_experts": 896,
+    "num_experts_per_token": 16,
+    "num_shared_experts": 2,
+    "first_k_dense_replace": 1,
+    "moe_layer_freq": 1,
+    "routed_expert_hidden_size": 3584,
+    "latent_moe_use_norm": True,
+    "q_lora_rank": 1536,
+    "kv_lora_rank": 512,
+    "qk_nope_head_dim": 128,
+    "qk_rope_head_dim": 64,
+    "v_head_dim": 128,
+    "mla_use_nope": True,
+    "mla_use_output_gate": True,
+    "attn_res_block_size": 12,
+    "activation_situ_beta": 4.0,
+    "activation_situ_linear_beta": 25.0,
+    "num_nextn_predict_layers": 0,
+    "rms_norm_eps": 1e-5,
+    "max_position_embeddings": 1048576,
+    "tie_word_embeddings": False,
+}
+RELEASED_LINEAR_ATTN = {
+    "head_dim": 128,
+    "num_heads": 96,
+    "short_conv_kernel_size": 4,
+    "use_full_rank_gate": True,
+    "gate_lower_bound": -5.0,
+}
+
+
+def test_text_config_defaults_match_the_released_checkpoint():
+    cfg = KimiK3TextConfig()
+    mismatches = {k: (getattr(cfg, k), v) for k, v in RELEASED_TEXT_CONFIG.items() if getattr(cfg, k) != v}
+    assert not mismatches, f"defaults differ from moonshotai/Kimi-K3 config.json: {mismatches}"
+    for k, v in RELEASED_LINEAR_ATTN.items():
+        assert cfg.linear_attn_config[k] == v, k
+    full = cfg.linear_attn_config["full_attn_layers"]
+    assert full == list(range(4, 93, 4)) + [93]  # every 4th layer plus the final one: 24 gated-MLA layers
+    assert len(cfg.linear_attn_config["kda_layers"]) == 69
+    assert sum(cfg.is_kda_layer(i) for i in range(cfg.num_hidden_layers)) == 69
+
+
+def test_mla_projection_shapes_implied_by_defaults():
+    """The head count shows up in the MLA projection widths; pin them to the checkpoint tensors."""
+    cfg = KimiK3TextConfig()
+    q_head_dim = cfg.qk_nope_head_dim + cfg.qk_rope_head_dim
+    assert cfg.num_attention_heads * q_head_dim == 18432  # q_b_proj.weight: [18432, 1536]
+    assert cfg.num_attention_heads * (cfg.qk_nope_head_dim + cfg.v_head_dim) == 24576  # kv_b_proj.weight: [24576, 512]
+    assert cfg.num_attention_heads * cfg.v_head_dim == 12288  # o_proj / g_proj: [7168, 12288] / [12288, 7168]
+    assert cfg.intermediate_size == 33792  # layers.0.mlp.gate_proj.weight: [33792, 7168]
+
+
+def test_multimodal_wrapper_defaults_follow_the_text_config():
+    assert KimiK3Config().text_config.num_attention_heads == 96
+    assert KimiK3Config().text_config.intermediate_size == 33792

--- a/tests/unit_tests/utils/test_flops_utils_new_models.py
+++ b/tests/unit_tests/utils/test_flops_utils_new_models.py
@@ -22,6 +22,7 @@
 - VL composite config text_config fallback in qwen3_flops and qwen3_5_flops
 - _mamba_layer_flops refactored formula
 - _hybrid_model_flops conditional accumulation
+- kimi_k3_flops registration (hybrid KDA / gated-MLA + latent MoE)
 """
 
 from types import SimpleNamespace
@@ -538,6 +539,10 @@ class TestGetFlopsFormula:
     def test_kimi_k2(self):
         cfg = self._make_config("KimiK2Config")
         assert flops_utils.get_flops_formula_for_hf_config(cfg) == flops_utils.mla_moe_flops
+
+    def test_kimi_k3(self):
+        cfg = self._make_config("KimiK3TextConfig")
+        assert flops_utils.get_flops_formula_for_hf_config(cfg) == flops_utils.kimi_k3_flops
 
     def test_unknown_falls_back_to_transformer(self):
         cfg = self._make_config("UnknownModelConfig")

--- a/tests/unit_tests/utils/test_kimi_k3_flops.py
+++ b/tests/unit_tests/utils/test_kimi_k3_flops.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Kimi K3 FLOPs formula (hybrid KDA / gated-MLA attention + latent MoE)."""
+
+import pytest
+
+from nemo_automodel.components.models.kimi_k3.config import KimiK3Config, KimiK3TextConfig
+from nemo_automodel.components.utils import flops_utils
+
+# moonshotai/Kimi-K3 model card: 2.8T total / 104B activated; tech report Table 1: 2.78T / 104.2B.
+# The formula counts matmul weights only (no router GEMM, norms or gate biases) and lands within 0.2% of Table 1.
+K3_TOTAL_PARAMS = 2.78e12
+K3_ACTIVE_PARAMS = 104e9
+
+# Released checkpoint values (config.json text_config), passed explicitly so these tests do not
+# depend on the KimiK3TextConfig defaults.
+CHECKPOINT_OVERRIDES = dict(num_attention_heads=96, num_key_value_heads=96, intermediate_size=33792)
+# The pre-fix from_config shape (56-head MLA, 18432-wide dense FFN) that earlier K3 benchmark
+# numbers were measured with; kept as a second pinned value.
+LEGACY_OVERRIDES = dict(num_attention_heads=56, num_key_value_heads=56, intermediate_size=18432)
+
+
+def _checkpoint_config(**overrides) -> KimiK3TextConfig:
+    return KimiK3TextConfig(**{**CHECKPOINT_OVERRIDES, **overrides})
+
+
+def _kda_layer_counts(config):
+    kda = sum(1 for i in range(config.num_hidden_layers) if config.is_kda_layer(i))
+    return kda, config.num_hidden_layers - kda
+
+
+def _implied_total_params(cfg) -> float:
+    """Total checkpoint parameters implied by the formula: swap top-k experts for all experts, add router + input embedding."""
+    hs, lat = cfg.hidden_size, cfg.routed_expert_hidden_size
+    per_expert = 3 * lat * cfg.moe_intermediate_size
+    moe_layers = cfg.num_hidden_layers - cfg.first_k_dense_replace
+    active = flops_utils.kimi_k3_flops(cfg, gbs=1, seq_len=1) / 6
+    return (
+        active
+        - moe_layers * cfg.num_experts_per_token * per_expert
+        + moe_layers * (cfg.num_experts * per_expert + hs * cfg.num_experts)
+        + cfg.vocab_size * hs
+    )
+
+
+def test_registered_for_text_and_multimodal_configs():
+    assert flops_utils.get_flops_formula_for_hf_config(KimiK3TextConfig()) is flops_utils.kimi_k3_flops
+    assert flops_utils.get_flops_formula_for_hf_config(KimiK3Config()) is flops_utils.kimi_k3_flops
+
+
+def test_multimodal_wrapper_uses_text_config():
+    text = _checkpoint_config()
+    wrapper = KimiK3Config(text_config=text)
+    assert flops_utils.kimi_k3_flops(wrapper, gbs=2, seq_len=512) == flops_utils.kimi_k3_flops(text, gbs=2, seq_len=512)
+
+
+def test_layer_pattern_matches_the_model_card():
+    cfg = _checkpoint_config()
+    assert _kda_layer_counts(cfg) == (69, 24)  # "69 KDA + 24 Gated MLA"
+    assert cfg.first_k_dense_replace == 1 and cfg.moe_layer_freq == 1  # "Number of Dense Layers: 1"
+
+
+def test_active_and_total_params_match_the_model_card():
+    """Per-token FLOPs / 6 at seq_len=1 is the active matmul parameter count."""
+    cfg = _checkpoint_config()
+    active = flops_utils.kimi_k3_flops(cfg, gbs=1, seq_len=1) / 6
+    assert active == pytest.approx(K3_ACTIVE_PARAMS, rel=0.005)
+    assert _implied_total_params(cfg) == pytest.approx(K3_TOTAL_PARAMS, rel=0.005)
+
+
+def test_precomputed_values():
+    assert int(flops_utils.kimi_k3_flops(_checkpoint_config(), gbs=1, seq_len=1024)) == 641380921638912
+    assert int(flops_utils.kimi_k3_flops(KimiK3TextConfig(**LEGACY_OVERRIDES), gbs=1, seq_len=1024)) == 625049308495872
+
+
+def test_linear_in_global_batch_size():
+    cfg = _checkpoint_config()
+    one = flops_utils.kimi_k3_flops(cfg, gbs=1, seq_len=2048)
+    assert flops_utils.kimi_k3_flops(cfg, gbs=4096, seq_len=2048) == pytest.approx(4096 * one)
+
+
+def test_wall_clock_basis_and_dense_fallback():
+    """Published K3 numbers use 6 * 104e9 FLOPs/token; the generic fallback under-counts by >2x."""
+    cfg = _checkpoint_config()
+    for seq_len in (1024, 2048):
+        k3 = flops_utils.kimi_k3_flops(cfg, gbs=1, seq_len=seq_len)
+        assert 1.0 < k3 / (6 * K3_ACTIVE_PARAMS * seq_len) < 1.01  # attention BMM + KDA kernel on top of the params
+        assert flops_utils.transformer_flops(cfg, gbs=1, seq_len=seq_len) < 0.65 * k3
+
+
+def test_attention_split_is_a_convex_combination():
+    """A depth-8 hybrid equals the per-layer mix of the all-KDA and all-MLA variants."""
+    base = _checkpoint_config(num_hidden_layers=8)
+    all_mla = _checkpoint_config(
+        num_hidden_layers=8,
+        linear_attn_config={**base.linear_attn_config, "kda_layers": [], "full_attn_layers": list(range(1, 9))},
+    )
+    all_kda = _checkpoint_config(
+        num_hidden_layers=8,
+        linear_attn_config={**base.linear_attn_config, "kda_layers": list(range(1, 9)), "full_attn_layers": []},
+    )
+    assert _kda_layer_counts(base) == (6, 2)
+    f_base = flops_utils.kimi_k3_flops(base, gbs=1, seq_len=1024)
+    f_mla = flops_utils.kimi_k3_flops(all_mla, gbs=1, seq_len=1024)
+    f_kda = flops_utils.kimi_k3_flops(all_kda, gbs=1, seq_len=1024)
+    assert f_base == pytest.approx((6 * f_kda + 2 * f_mla) / 8)
+    assert f_kda != f_mla
+
+
+def test_active_flops_do_not_depend_on_expert_count():
+    small = _checkpoint_config(num_hidden_layers=24, num_experts=64)
+    big = _checkpoint_config(num_hidden_layers=24, num_experts=896)
+    assert flops_utils.kimi_k3_flops(small, gbs=1, seq_len=1024) == flops_utils.kimi_k3_flops(big, gbs=1, seq_len=1024)
+    assert flops_utils.kimi_k3_flops(small, gbs=1, seq_len=1024) < flops_utils.kimi_k3_flops(
+        _checkpoint_config(), gbs=1, seq_len=1024
+    )
+
+
+def test_optional_blocks_are_costed_exactly():
+    """Latent projections, MLA output gate and shared experts each add their GEMM weights."""
+    ref = _checkpoint_config()
+    hs = ref.hidden_size
+    moe_layers = ref.num_hidden_layers - ref.first_k_dense_replace
+    mla_layers = _kda_layer_counts(ref)[1]
+
+    def params(cfg):
+        return flops_utils.kimi_k3_flops(cfg, gbs=1, seq_len=1) / 6
+
+    no_latent = _checkpoint_config(routed_expert_hidden_size=None)
+    expected = moe_layers * (
+        ref.num_experts_per_token * 3 * ref.routed_expert_hidden_size * ref.moe_intermediate_size
+        + 2 * hs * ref.routed_expert_hidden_size
+        - ref.num_experts_per_token * 3 * hs * ref.moe_intermediate_size
+    )
+    assert params(ref) - params(no_latent) == pytest.approx(expected)
+
+    no_gate = _checkpoint_config(mla_use_output_gate=False)
+    assert params(ref) - params(no_gate) == pytest.approx(mla_layers * hs * ref.num_attention_heads * ref.v_head_dim)
+
+    no_shared = _checkpoint_config(num_shared_experts=0)
+    assert params(ref) - params(no_shared) == pytest.approx(moe_layers * 3 * hs * ref.moe_intermediate_size * 2)


### PR DESCRIPTION
# What does this PR do ?

Makes Automodel's Kimi K3 MFU accounting correct. Two independent defects made the reported MFU wrong for K3:

1. **No FLOPs formula for K3.** `get_flops_formula_for_hf_config` had no entry for `KimiK3TextConfig`, so K3 fell through to the generic dense `transformer_flops`, whose MoE branch probes `num_experts_per_tok` while the K3 config spells it `num_experts_per_token`. The 2.78T hybrid MoE was costed as a dense 93-layer transformer at ~0.44× of its real FLOPs (a 64-node run that measures 13.7% MFU wall-clock printed ~6.0%).
2. **`from_config` built a lighter model than the checkpoint.** `KimiK3TextConfig` defaulted to `num_attention_heads=56` and `intermediate_size=18432`; the released `moonshotai/Kimi-K3` has 96 heads and a 33792-wide dense FFN (config.json, safetensors shapes, tech report Table 1). `from_pretrained` was unaffected (config.json overrides), but the benchmark recipes and random-init smoke configs built ~101.5B instead of ~104B active matmul parameters per token, so their throughput numbers were not numbers for Kimi K3.

Two commits, one per defect; they are independent (the formula's tests pass explicit config values).

# Changelog

- `flops_utils.kimi_k3_flops`: hybrid KDA / gated-MLA attention (layer pattern read from `linear_attn_config`, MLA output gate), latent MoE (`routed_expert_hidden_size` down/up projections around the top-k experts) + SiTU shared expert, dense layer(s) per `first_k_dense_replace`, LM head. KDA chunked kernel costed with the Kimi Linear paper's count (`6 T d_h² + 3 T C d_h + T C²` per head, arXiv:2510.26692). `_kda_attention_per_layer_flops` helper mirrors `_gdn_attention_per_layer_flops`.
- Registry entries for `KimiK3TextConfig` and the multimodal `KimiK3Config` wrapper (`text_config` is used; the vision tower is not counted, as for the other VL entries).
- `KimiK3TextConfig` defaults: `num_attention_heads` 56 → 96, `intermediate_size` 18432 → 33792; docstring states the defaults reproduce the released checkpoint.
- Tests: `tests/unit_tests/utils/test_kimi_k3_flops.py` (layer pattern, model-card parameter counts, precomputed values for the checkpoint and the pre-fix shapes, batch linearity, >2× correction over the dense fallback, exact cost of each optional block); `tests/unit_tests/models/kimi_k3/test_config_defaults.py` (pins the released text config, the linear-attention block, the 69 KDA / 24 MLA pattern, the MLA projection widths implied by the head count, the multimodal wrapper); a registration case in `test_flops_utils_new_models.py`.

# Verification

Cross-checked against the released checkpoint (`moonshotai/Kimi-K3` `config.json` + `modeling_kimi_linear.py` + safetensors headers: `q_b_proj [18432, 1536]` = 96 × 192, `kv_b_proj [24576, 512]`, `layers.0.mlp.gate_proj [33792, 7168]`), the model card, and the K3 tech report (Table 1: 96 heads, 104.2B activated / 2.78T total):

- With the corrected defaults `from_config` builds the checkpoint's shape, and the formula counts **104.0B active matmul parameters per token, 2.78T total** (within 0.2% of Table 1; the formula counts GEMM weights only — no router, norms or gate biases). Layer pattern 69 KDA + 24 gated MLA, 1 dense layer, 16/896 experts, 2 shared — all read from the config.
- FLOPs/token at seq 1024 / 2048 = 1.004× / 1.007× of the wall-clock basis `6 × 104e9` used for every published K3 number (the excess is the MLA attention BMMs and the KDA kernel).
- The report's single MTP layer is not in the released checkpoint (`num_nextn_predict_layers: 0`) and not modelled by Automodel, so it is not counted.
- Tests run locally (CPU, torch 2.14 / transformers 5.16): `tests/unit_tests/utils/` 247 passed (1 pre-existing environment failure in `test_yaml_utils.py`: needs `/home/TestData`); `tests/unit_tests/models/kimi_k3/` 65 passed (1 environment failure: FLA kernels not installed); `tests/unit_tests/recipes/llm/test_benchmark.py` 33 passed. `ruff format --check` / `ruff check` clean on the changed files.
- End-to-end (2 nodes × 4 GB200, `nemo_automodel/recipes/llm/benchmark.py --config …`, Kimi-K3 reduced to 24 layers / 64 experts, seq 4096, GBS 32, random init, the formula commit applied on upstream `main`): `TFLOPs/GPU: 21323.249904` printed at setup = `kimi_k3_flops(cfg, gbs=32, seq_len=4096)` exactly (the dense fallback would have given 0.485× of that). Steady iterations 4.95 s → printed `MFU: 23.93%`; the wall-clock basis at the same iteration time (`tokens/s/GPU × 6 × active params / 2.25e15`) gives 23.74%, ratio 1.008. `Average MFU: 23.17%` over the 9 post-warmup iterations (two GC-slowed).

# Additional Information

- Review order: please review this PR before #3779 / #3780 — both will be rebased on this change (their benchmark yamls now build the real K3 shape) and their measured numbers re-stamped.
- Orthogonal to #3731 (throughput accounting in `train_ft.py`); this fixes the FLOPs-per-token estimate and the `from_config` model shape.
- Reproducing the printout: the per-iteration `MFU:` lines and `Average MFU` come from `run_benchmark()`, which only the `recipes/llm/benchmark.py --config <yaml>` entry (used by the L2 benchmark tests) runs; the `automodel <yaml>` launcher in the yaml headers goes through the generic `run_train_validation_loop()` and prints only the setup-time `TFLOPs/GPU`.
- Impact of the defaults change on `from_config` users: the K3 benchmark recipes (`examples/llm_benchmark/kimi/kimi_k3_gb200*.yaml`) and random-init smoke configs now build the real K3 shape — 24 MLA layers gain ~90M parameters each and the dense layer doubles, ≈ +2.5% FLOPs/token, ≈ +1 GiB/GPU at EP32×PP8 on 256 GPUs. Throughput numbers in those yaml headers were measured with the old shape and will be re-stamped in #3779 / #3780 after a re-run.
- Not changed here: the generic fallback still probes only `num_experts_per_tok`, so other unregistered MoE configs with a different spelling are still under-costed — worth its own tiny fix.
