### PR TITLE
refactor(components): enforce public imports in ci

### DIFF
--- a/.agents/contributor-skills/linting-and-formatting/SKILL.md
+++ b/.agents/contributor-skills/linting-and-formatting/SKILL.md
@@ -109,8 +109,10 @@ modify it. Use the current year (2026).
 - **Optional dependencies** must be guarded with `safe_import()` from
   `nemo_automodel.shared.import_utils`. Never let an optional import crash
   module loading.
-- **Components must not import each other** — enforced by `import-linter`
-  (see `pyproject.toml`).
+- **Component imports use exported symbols only** — every consumer outside a
+  component, including recipes and other components, imports from the component
+  package; the imported symbol must be declared in its `__all__`. This is
+  enforced by `import-linter` (see `pyproject.toml`).
 
 ## Code Review Checklist
 
@@ -121,7 +123,7 @@ modify it. Use the current year (2026).
 5. **No bare `print()`** — use `logging.getLogger(__name__)`
 6. **No commented-out code** without explanation
 7. **Optional imports** guarded with `safe_import()`
-8. **No cross-component imports** between `components/` subdirectories
+8. **Public component imports only** from recipes, framework code, and other components
 
 ## Automated Review
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -94,8 +94,9 @@ jobs:
           - optional dependencies imported without `safe_import()` from
             `nemo_automodel.shared.import_utils`, including raw
             `try/except ImportError` or mock/stub fallbacks in production code;
-          - new cross-component imports between directories under
-            `nemo_automodel/components/`;
+          - new imports of a component from any code outside that component that
+            bypass the target component's package-level exports (`__all__`),
+            including imports from recipes and framework code;
           - new component config fields without a backward-compatible default, or
             component code that converts typed configs into untyped dictionaries
             instead of preserving the typed config boundary;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,9 +139,10 @@ then runs the training loop.
 
 ### Components
 
-Everything under `components/` is a self-contained building block. Components
-are composed by recipes, never by each other (no hidden cross-component
-imports).
+Everything under `components/` is a self-contained building block. Recipes and
+other packages consume components through the symbols exported by each
+component package; components use the same public interfaces when they depend
+on one another.
 
 ### Transformers Bridge
 

--- a/docs/about/key-features.mdx
+++ b/docs/about/key-features.mdx
@@ -131,7 +131,7 @@ Components are modular, self-contained building blocks that recipes assemble:
 | `loss/` | Cross-entropy, linear cross-entropy, KD loss |
 | `launcher/` | Interactive, SkyPilot, and NeMo-Run job launch; Slurm uses the root-level `slurm.sub` script |
 
-Each component can be used independently and has no cross-module imports.
+Every component consumer—including recipes and other components—imports symbols from the target component's package API. The package's `__all__` defines that public interface.
 
 ### The `automodel` CLI
 

--- a/docs/about/key-features.mdx
+++ b/docs/about/key-features.mdx
@@ -7,9 +7,9 @@ NeMo AutoModel provides GPU-accelerated, `transformers`-compatible training for 
 
 ## Why NeMo AutoModel?
 
-- **Hugging Face native**: Train any model from the Hub with no checkpoint conversion -- day-0 support for new releases.
+- **Hugging Face native**: Train any model from the Hub with no checkpoint conversion. Day-0 support for new releases.
 - **High performance**: Custom CUDA kernels (TransformerEngine, DeepEP, FlexAttn) deliver up to 279 TFLOPs/sec/GPU.
-- **Any scale**: The same recipe runs on 1 GPU or across hundreds of nodes -- parallelism is configuration, not code.
+- **Any scale**: The same recipe runs on 1 GPU or across hundreds of nodes. Parallelism is configuration, not code.
 - **Hackable**: Linear training scripts with YAML config. No hidden trainer abstractions.
 - **Open source**: Apache 2.0 licensed, NVIDIA-supported, and actively maintained.
 
@@ -76,7 +76,7 @@ FP8 training via torchao for reduced memory and higher throughput on supported m
 </Card>
 
 <Card title="Multi-Node with SLURM">
-Copy the checked-in `slurm.sub` or download it from Github (available [here](https://github.com/NVIDIA-NeMo/Automodel/blob/main/slurm.sub)), edit its `CONFIG` and `#SBATCH` directives for your cluster, and submit it with `sbatch`. See the [Cluster guide](/job-launchers/slurm-cluster).
+Copy the checked-in `slurm.sub` or download it from GitHub (available in the [repository root `slurm.sub` file](https://github.com/NVIDIA-NeMo/Automodel/blob/main/slurm.sub)), edit its `CONFIG` and `#SBATCH` directives for your cluster, and submit it with `sbatch`. See the [Cluster guide](/job-launchers/slurm-cluster).
 </Card>
 
 </Cards>
@@ -126,12 +126,12 @@ Components are modular, self-contained building blocks that recipes assemble:
 | `_peft/` | LoRA and QLoRA implementations |
 | `attention/` | Fused attention, rotary embeddings, FlexAttn |
 | `checkpoint/` | DCP save/load with SafeTensors output |
-| `moe/` | Mixture of Experts routing and DeepEP integration |
+| `moe/` | Mixture-of-Experts routing and DeepEP integration |
 | `optim/` | Optimizers and LR schedulers |
 | `loss/` | Cross-entropy, linear cross-entropy, KD loss |
 | `launcher/` | Interactive, SkyPilot, and NeMo-Run job launch; Slurm uses the root-level `slurm.sub` script |
 
-Every component consumer—including recipes and other components—imports symbols from the target component's package API. The package's `__all__` defines that public interface.
+Consumers of the component packages covered by the import contract, including recipes and other components, import symbols from the target component's package API. The package's `__all__` defines that public interface.
 
 ### The `automodel` CLI
 

--- a/docs/repository-structure.mdx
+++ b/docs/repository-structure.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Repository Structure"
-description: ""
+description: "Overview of the NeMo AutoModel repository layout, including components, recipes, and the CLI."
 position: 6
 ---
 This introductory guide presents the structure of the NeMo AutoModel repository, provides a brief overview of its parts, introduces concepts such as components and recipes, and explains how everything fits together.
@@ -14,10 +14,10 @@ NeMo AutoModel is a PyTorch library for fine-tuning and pretraining large-scale 
 - **End-to-end workflows** with recipes for data preparation, training, and evaluation.
 
 ## Repository Structure
-The AutoModel source code is available under the [`nemo_automodel`](https://github.com/NVIDIA-NeMo/Automodel/tree/main/nemo_automodel) directory. It is organized into three directories:
-- [`components/`](https://github.com/NVIDIA-NeMo/Automodel/tree/main/nemo_automodel/components)  - Self-contained modules
+The NeMo AutoModel source code is available under the [`nemo_automodel`](https://github.com/NVIDIA-NeMo/Automodel/tree/main/nemo_automodel) directory. This guide focuses on three primary directories:
+- [`components/`](https://github.com/NVIDIA-NeMo/Automodel/tree/main/nemo_automodel/components) - Self-contained modules
 - [`recipes/`](https://github.com/NVIDIA-NeMo/Automodel/tree/main/nemo_automodel/recipes) - End-to-end training workflows
-- [`cli/`](https://github.com/NVIDIA-NeMo/Automodel/tree/main/nemo_automodel/cli) - CLI entry-point and job launcher dispatch.
+- [`cli/`](https://github.com/NVIDIA-NeMo/Automodel/tree/main/nemo_automodel/cli) - CLI entry-point and job launcher dispatch
 
 ### Components Directory
 The `components/` directory contains isolated modules used in training loops.
@@ -100,7 +100,7 @@ Recipes are launched via the `automodel` CLI:
 automodel --nproc-per-node 2 examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml
 ```
 
-The above command will fine-tune the Llama3.2-1B model on the SQuAD dataset with two GPUs using the [`llama3_2_1b_squad.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml) config.
+The command fine-tunes the Llama3.2-1B model on the SQuAD dataset with two GPUs using the [`llama3_2_1b_squad.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml) config.
 For a single-GPU run, omit `--nproc-per-node`:
 ```bash
 automodel examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml
@@ -114,7 +114,7 @@ The recipe/components structure enables you to:
 {/* For an in-depth explanation of the LLM recipe please also see the [LLM recipe deep-dive guide](https://github.com/NVIDIA-NeMo/Automodel/blob/main/docs/llm_recipe_deep_dive). */}
 
 #### Configure a Recipe
-An example YAML configuration is shown below. The complete config is available [here](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml):
+An example YAML configuration is shown below. The complete config is available in the [Llama 3.2 SQuAD example config](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml):
 ```yaml
 recipe: TrainFinetuneRecipeForNextTokenPrediction
 

--- a/docs/repository-structure.mdx
+++ b/docs/repository-structure.mdx
@@ -21,7 +21,7 @@ The AutoModel source code is available under the [`nemo_automodel`](https://gith
 
 ### Components Directory
 The `components/` directory contains isolated modules used in training loops.
-Each component is designed to be dependency-light and reusable without cross-module imports.
+Each component is designed to be dependency-light and reusable. Every consumer, including recipes and other components, uses the target component's exported package API.
 
 #### Directory Structure
 The following directory listing shows all components along with explanations of their contents.
@@ -50,7 +50,7 @@ $ tree -L 1 nemo_automodel/components/
 
 #### Key Features
 - Each component can be used independently in other projects.
-- Each component has its own dependencies, without cross-module imports.
+- Recipes, framework code, and other components import only symbols exported by the target component's package API.
 - Unit tests are colocated with the component they cover.
 
 ### Recipes Directory

--- a/nemo_automodel/_diffusers/auto_diffusion_pipeline.py
+++ b/nemo_automodel/_diffusers/auto_diffusion_pipeline.py
@@ -49,12 +49,15 @@ import torch
 import torch.nn as nn
 
 from nemo_automodel._diffusers._hf_cache import resolve_diffusion_model_dir
-from nemo_automodel.components.distributed import DistributedSetup, ParallelismSizes, parallelizer
-from nemo_automodel.components.distributed.config import DDPConfig, FSDP2Config
-from nemo_automodel.components.distributed.ddp import DDPManager
-from nemo_automodel.components.distributed.fsdp2 import FSDP2Manager
-from nemo_automodel.components.distributed.parallelizer import (
+from nemo_automodel.components.distributed import (
+    PARALLELIZATION_STRATEGIES,
+    DDPConfig,
+    DDPManager,
+    DistributedSetup,
+    FSDP2Config,
+    FSDP2Manager,
     HunyuanParallelizationStrategy,
+    ParallelismSizes,
     WanParallelizationStrategy,
 )
 from nemo_automodel.shared.import_utils import safe_import_te
@@ -141,8 +144,8 @@ def _import_diffusers_class(class_name: str):
 
 def _init_parallelizer():
     """Register custom parallelization strategies."""
-    parallelizer.PARALLELIZATION_STRATEGIES["WanTransformer3DModel"] = WanParallelizationStrategy()
-    parallelizer.PARALLELIZATION_STRATEGIES["HunyuanVideo15Transformer3DModel"] = HunyuanParallelizationStrategy()
+    PARALLELIZATION_STRATEGIES["WanTransformer3DModel"] = WanParallelizationStrategy()
+    PARALLELIZATION_STRATEGIES["HunyuanVideo15Transformer3DModel"] = HunyuanParallelizationStrategy()
 
 
 def _choose_device(device: torch.device | None) -> torch.device:
@@ -506,7 +509,7 @@ def _enable_context_parallel(
         apply_cudnn_attention_patch,
         apply_native_flash_backward_patch,
     )
-    from nemo_automodel.components.distributed.mesh_utils import create_ring_ulysses_mesh
+    from nemo_automodel.components.distributed import create_ring_ulysses_mesh
 
     # Interim fixes for the diffusers<=0.39 _native_flash/_native_cudnn backward
     # bugs on the CP path; feature-detected, no-ops once upstream ships the fix.

--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -53,13 +53,15 @@ from transformers.initialization import no_init_weights  # noqa: E402
 from transformers.models.auto.auto_factory import _BaseAutoModelClass  # noqa: E402
 from transformers.utils import ContextManagers  # noqa: E402
 
-from nemo_automodel.components.distributed.config import DistributedSetup  # noqa: E402
-from nemo_automodel.components.distributed.ddp import DDPManager  # noqa: E402
-from nemo_automodel.components.distributed.init_utils import get_world_size_safe  # noqa: E402
-from nemo_automodel.components.distributed.megatron_fsdp import MegatronFSDPManager  # noqa: E402
-from nemo_automodel.components.distributed.pipelining.autopipeline import AutoPipeline  # noqa: E402, F401
+from nemo_automodel.components.distributed import (
+    AutoPipeline,  # noqa: E402, F401
+    DDPManager,  # noqa: E402
+    DistributedSetup,  # noqa: E402
+    MegatronFSDPManager,  # noqa: E402
+    get_world_size_safe,  # noqa: E402
+)
 from nemo_automodel.components.quantization.qat import QATConfig  # noqa: E402
-from nemo_automodel.components.utils.model_utils import (  # noqa: E402
+from nemo_automodel.components.utils import (  # noqa: E402
     init_empty_weights,
     resolve_trust_remote_code,
 )

--- a/nemo_automodel/_transformers/capabilities.py
+++ b/nemo_automodel/_transformers/capabilities.py
@@ -44,9 +44,11 @@ logger = logging.getLogger(__name__)
 
 def _has_optimized_tp_plan(model_cls: type) -> bool:
     """Check if *model_cls* has an entry in ``PARALLELIZE_FUNCTIONS``."""
-    from nemo_automodel.components.distributed.optimized_tp_plans import (
+    from nemo_automodel.components.distributed import (
         PARALLELIZE_FUNCTIONS,
-        _get_class_qualname,
+    )
+    from nemo_automodel.components.distributed import (
+        get_class_qualname as _get_class_qualname,
     )
 
     return _get_class_qualname(model_cls) in PARALLELIZE_FUNCTIONS

--- a/nemo_automodel/_transformers/infrastructure.py
+++ b/nemo_automodel/_transformers/infrastructure.py
@@ -39,38 +39,37 @@ from nemo_automodel._transformers.v4_patches.kv_sharing import (
 )
 from nemo_automodel._transformers.v4_patches.rotary import fix_rotary_embeddings, should_fix_rotary_embeddings
 from nemo_automodel.components._peft.lora import apply_lora_to_linear_modules
-from nemo_automodel.components.checkpoint.checkpointing import (
+from nemo_automodel.components.checkpoint import (
     Checkpointer,
     CheckpointingConfig,
-    _maybe_adapt_state_dict_to_hf,
 )
-from nemo_automodel.components.distributed.config import (
+from nemo_automodel.components.checkpoint import (
+    maybe_adapt_state_dict_to_hf as _maybe_adapt_state_dict_to_hf,
+)
+from nemo_automodel.components.distributed import (
+    AutoPipeline,
     DDPConfig,
+    DDPManager,
     DistributedStrategyConfig,
     FSDP2Config,
+    FSDP2Manager,
     MegatronFSDPConfig,
-    MoEParallelizerConfig,
-)
-from nemo_automodel.components.distributed.ddp import DDPManager
-from nemo_automodel.components.distributed.fsdp2 import FSDP2Manager
-from nemo_automodel.components.distributed.init_utils import get_world_size_safe
-from nemo_automodel.components.distributed.megatron_fsdp import (
     MegatronFSDPManager,
+    MeshContext,
+    MoEParallelizerConfig,
+    PipelineConfig,
+    get_world_size_safe,
     restore_distributed_param_attrs,
     snapshot_distributed_param_attrs,
 )
-from nemo_automodel.components.distributed.mesh import MeshContext
-from nemo_automodel.components.distributed.pipelining.autopipeline import AutoPipeline
-from nemo_automodel.components.distributed.pipelining.config import PipelineConfig
-from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
+from nemo_automodel.components.loss import MaskedCrossEntropy
 from nemo_automodel.components.models.common.utils import cast_frozen_modules_to_compute_dtype
 from nemo_automodel.components.quantization.fp8 import apply_fp8_to_model
 from nemo_automodel.components.quantization.qat import QATConfig
-from nemo_automodel.components.utils.compile_utils import compile_model
-from nemo_automodel.components.utils.model_utils import (
+from nemo_automodel.components.utils import (
     FreezeConfig,
-    _supports_logits_to_keep,
     apply_parameter_freezing,
+    compile_model,
     count_model_parameters,
     enable_radio_vit_fused_attn,
     freeze_deepseek_v4_indexer_params,
@@ -79,6 +78,9 @@ from nemo_automodel.components.utils.model_utils import (
     init_empty_weights,
     parse_freeze_config,
     print_trainable_parameters,
+)
+from nemo_automodel.components.utils import (
+    supports_logits_to_keep as _supports_logits_to_keep,
 )
 from nemo_automodel.shared.tied_weights import ensure_tied_lm_head
 
@@ -836,7 +838,7 @@ def apply_model_infrastructure(
     uses_te_attention = _uses_te_attention(model) if mesh.cp_size > 1 or mesh.tp_size > 1 else False
     uses_thd_only_te_attention = _uses_thd_only_te_attention(model) if uses_te_attention else False
     if mesh.ep_size <= 1 and (mesh.cp_size > 1 or (mesh.tp_size > 1 and uses_thd_only_te_attention)):
-        from nemo_automodel.components.distributed.context_parallel.utils import (
+        from nemo_automodel.components.distributed import (
             attach_context_parallel_hooks,
             attach_cp_sdpa_hooks,
             attach_te_context_parallel,

--- a/nemo_automodel/_transformers/mfu.py
+++ b/nemo_automodel/_transformers/mfu.py
@@ -31,7 +31,7 @@ import torch
 if TYPE_CHECKING:
     from transformers import PretrainedConfig
 
-from nemo_automodel.components.utils.flops_utils import (
+from nemo_automodel.components.utils import (
     calculate_mfu,
     get_flops_formula_for_hf_config,
 )

--- a/nemo_automodel/_transformers/model_init.py
+++ b/nemo_automodel/_transformers/model_init.py
@@ -58,10 +58,9 @@ from nemo_automodel._transformers.utils import apply_qwen3_omni_config_patch
 
 apply_qwen3_omni_config_patch()
 
-import nemo_automodel.components.checkpoint.utils as checkpoint_utils
-import nemo_automodel.components.distributed.utils as dist_utils
 from nemo_automodel._transformers.registry import ModelRegistry, resolve_custom_config_cls
-from nemo_automodel.components.distributed.init_utils import get_local_world_size_preinit, get_world_size_safe
+from nemo_automodel.components.checkpoint import get_checkpoint_tensor_dtypes
+from nemo_automodel.components.distributed import FirstRankPerNode, get_local_world_size_preinit, get_world_size_safe
 from nemo_automodel.components.models.common.gated_delta_net_fp32 import (
     has_gated_delta_net_fp32_checkpoint_contract,
     is_gated_delta_net_fp32_param_key,
@@ -72,7 +71,8 @@ from nemo_automodel.components.models.common.utils import (
     initialize_linear_module,
     initialize_rms_norm_module,
 )
-from nemo_automodel.components.utils.model_utils import resolve_trust_remote_code, skip_random_init
+from nemo_automodel.components.utils import resolve_trust_remote_code, skip_random_init
+from nemo_automodel.shared.tied_weights import is_tied_word_embeddings
 from nemo_automodel.shared.utils import dtype_from_str
 
 logger = logging.getLogger(__name__)
@@ -406,9 +406,7 @@ def _download_model_weights(hf_config, pretrained_model_name_or_path, process_gr
                 "downloaded path to the `pretrained_model_name_or_path` argument.",
                 num_nodes,
             )
-        # Import via module reference (vs bound name) so unit tests can patch
-        # `nemo_automodel.components.distributed.utils.FirstRankPerNode`.
-        with dist_utils.FirstRankPerNode(group=process_group):
+        with FirstRankPerNode(group=process_group):
             snapshot_download(pretrained_model_name_or_path)
 
 
@@ -441,7 +439,7 @@ def _prepopulate_remote_code_cache(hf_config, pretrained_model_name_or_path, kwa
             if isinstance(ref, str) and "." in ref:
                 module_files.add(ref.rsplit(".", 1)[0] + ".py")
     src_py = glob.glob(os.path.join(src_dir, "*.py"))
-    with dist_utils.FirstRankPerNode(group=process_group):
+    with FirstRankPerNode(group=process_group):
         for module_file in module_files:
             try:
                 cached = get_cached_module_file(src_dir, module_file)
@@ -970,7 +968,7 @@ def _init_model_bnb_streaming(
     from transformers.initialization import no_init_weights
     from transformers.integrations.bitsandbytes import replace_with_bnb_linear
 
-    from nemo_automodel.components.utils.model_utils import init_empty_weights
+    from nemo_automodel.components.utils import init_empty_weights
 
     if isinstance(torch_dtype, str) and torch_dtype != "auto":
         torch_dtype = dtype_from_str(torch_dtype)
@@ -1065,9 +1063,7 @@ def _restore_loaded_model_dtype(
         return
 
     try:
-        checkpoint_dtypes = checkpoint_utils._get_checkpoint_tensor_dtypes(
-            pretrained_model_name_or_path, hf_config, load_kwargs
-        )
+        checkpoint_dtypes = get_checkpoint_tensor_dtypes(pretrained_model_name_or_path, hf_config, load_kwargs)
     except Exception as exc:
         logger.warning(
             "Failed to inspect checkpoint tensor dtypes for %s; leaving loaded dtypes unchanged: %s",
@@ -1390,7 +1386,7 @@ def _tie_weights_nemo(model):
     # model is tied. Re-tying an untied model here would alias away the trained
     # ``lm_head.weight`` that ``from_pretrained`` just loaded (see #2941).
     config = getattr(model, "config", None)
-    if config is not None and not checkpoint_utils.is_tied_word_embeddings(model):
+    if config is not None and not is_tied_word_embeddings(model):
         return
 
     def get_module_by_fqn(model, fqn):

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -43,7 +43,7 @@ from nemo_automodel._transformers.sentence_transformer_export import (
     _SentenceTransformerMetadataExporter,
     _supports_standard_sentence_transformer_export,
 )
-from nemo_automodel.components.loss.intermediate_distill import LayerCapture
+from nemo_automodel.components.loss import LayerCapture
 from nemo_automodel.components.models.common.bidirectional import EncoderStateDictAdapter
 
 logger = logging.get_logger(__name__)

--- a/nemo_automodel/_transformers/sentence_transformer_export.py
+++ b/nemo_automodel/_transformers/sentence_transformer_export.py
@@ -620,7 +620,7 @@ class _SentenceTransformerMetadataExporter:
         original_model_path: str | None,
     ) -> None:
         """Write deployable Hugging Face metadata plus standard Sentence Transformers assets."""
-        from nemo_automodel.components.checkpoint.addons import _save_generated_hf_assets
+        from nemo_automodel.components.checkpoint import save_generated_hf_assets as _save_generated_hf_assets
 
         deploy_config = self.model_part.get_hf_export_config()
         source_model_path = self._source_model_path(original_model_path)

--- a/nemo_automodel/cli/app.py
+++ b/nemo_automodel/cli/app.py
@@ -52,7 +52,7 @@ import sys
 from pathlib import Path
 
 from nemo_automodel.cli.utils import load_yaml, resolve_recipe_name
-from nemo_automodel.components.config.loader import resolve_yaml_env_vars
+from nemo_automodel.components.config import resolve_yaml_env_vars
 
 # When launched via external torchrun each worker imports this module.
 # Suppress non-rank-0 CLI output before setup_logging installs RankFilter.
@@ -134,7 +134,7 @@ def main():
 
     if skypilot_config := config.pop("skypilot", None):
         logger.info("Launching job via SkyPilot")
-        from nemo_automodel.components.launcher.skypilot.launcher import SkyPilotLauncher
+        from nemo_automodel.components.launcher import SkyPilotLauncher
 
         return SkyPilotLauncher().launch(
             config,
@@ -146,14 +146,14 @@ def main():
 
     elif nemo_run_config := config.pop("nemo_run", None):
         logger.info("Launching job via NeMo-Run")
-        from nemo_automodel.components.launcher.nemo_run.launcher import NemoRunLauncher
+        from nemo_automodel.components.launcher import NemoRunLauncher
 
         return NemoRunLauncher().launch(config, config_path, recipe_target, nemo_run_config, extra)
 
     else:
         logger.info("Launching job interactively (local)")
-        from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-        from nemo_automodel.components.launcher.interactive import InteractiveLauncher
+        from nemo_automodel.components.config import parse_args_and_load_config
+        from nemo_automodel.components.launcher import InteractiveLauncher
 
         cfg = parse_args_and_load_config(str(config_path), argv=extra)
         return InteractiveLauncher().launch(cfg, config_path, recipe_target, args.nproc_per_node, extra)

--- a/nemo_automodel/components/attention/utils.py
+++ b/nemo_automodel/components/attention/utils.py
@@ -108,7 +108,7 @@ def initialize_attn_module_and_func(
             )
         # requires magi_attention; the guards above are exercised on CPU but the
         # kernel build is not, so exclude it from coverage.
-        from nemo_automodel.components.distributed.context_parallel.magi import (  # pragma: no cover - requires magi_attention
+        from nemo_automodel.components.distributed import (  # pragma: no cover - requires magi_attention
             make_magi_attn_func,
         )
 

--- a/nemo_automodel/components/checkpoint/__init__.py
+++ b/nemo_automodel/components/checkpoint/__init__.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import importlib as _importlib
+
 from ._torch_backports import apply_async_checkpoint_patch as _nemo__apply_async_patch
 from ._torch_backports import apply_patches as _nemo__apply_patches
 from .config import CheckpointingConfig, _is_geq_torch_2_9, _is_leq_torch_2_7_1
@@ -22,3 +24,37 @@ if _is_leq_torch_2_7_1():
 
 if _is_geq_torch_2_9():
     _nemo__apply_async_patch()
+
+_LAZY_ATTRS = {
+    "Checkpointer": (".checkpointing", "Checkpointer"),
+    "StateDictAdapter": (".state_dict_adapter", "StateDictAdapter"),
+    "find_latest_checkpoint": (".utils", "find_latest_checkpoint"),
+    "get_checkpoint_tensor_dtypes": (".utils", "_get_checkpoint_tensor_dtypes"),
+    "load_full_state_dict_into_model": (".checkpointing", "_load_full_state_dict_into_model"),
+    "load_hf_checkpoint_preserving_dtype": (".checkpointing", "_load_hf_checkpoint_preserving_dtype"),
+    "load_hf_safetensors_state_dict": (".checkpointing", "load_hf_safetensors_state_dict"),
+    "load_torch_ckpt": (".checkpointing", "load_torch_ckpt"),
+    "maybe_adapt_state_dict_to_hf": (".checkpointing", "_maybe_adapt_state_dict_to_hf"),
+    "resolve_restore_from_to_checkpoint_dir": (".utils", "resolve_restore_from_to_checkpoint_dir"),
+    "save_config": (".checkpointing", "save_config"),
+    "save_generated_hf_assets": (".addons", "_save_generated_hf_assets"),
+    "save_losses": (".checkpointing", "save_losses"),
+}
+
+__all__ += sorted(_LAZY_ATTRS.keys())
+
+
+def __getattr__(name: str) -> object:
+    """Load an exported component symbol on first access."""
+    if name in _LAZY_ATTRS:
+        module_path, attr_name = _LAZY_ATTRS[name]
+        module = _importlib.import_module(module_path, __name__)
+        attr = getattr(module, attr_name)
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return the component's exported symbols."""
+    return sorted(__all__)

--- a/nemo_automodel/components/config/__init__.py
+++ b/nemo_automodel/components/config/__init__.py
@@ -11,3 +11,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import importlib as _importlib
+
+_LAZY_ATTRS = {
+    "ConfigNode": (".loader", "ConfigNode"),
+    "config_to_yaml_str": (".loader", "config_to_yaml_str"),
+    "parse_args_and_load_config": ("._arg_parser", "parse_args_and_load_config"),
+    "resolve_yaml_env_vars": (".loader", "resolve_yaml_env_vars"),
+}
+
+__all__ = sorted(_LAZY_ATTRS.keys())
+
+
+def __getattr__(name: str) -> object:
+    """Load an exported component symbol on first access."""
+    if name in _LAZY_ATTRS:
+        module_path, attr_name = _LAZY_ATTRS[name]
+        module = _importlib.import_module(module_path, __name__)
+        attr = getattr(module, attr_name)
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return the component's exported symbols."""
+    return sorted(__all__)

--- a/nemo_automodel/components/datasets/__init__.py
+++ b/nemo_automodel/components/datasets/__init__.py
@@ -11,3 +11,93 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import importlib as _importlib
+
+_LAZY_ATTRS = {
+    "BagelDataloaderConfig": (".multimodal.loader", "BagelDataloaderConfig"),
+    "BagelDatasetConfig": (".multimodal.datasets", "BagelDatasetConfig"),
+    "DLLMCollator": (".dllm.collate", "DLLMCollator"),
+    "DSPARK_DTYPE_MAP": (".llm.dspark_cache", "DTYPE_MAP"),
+    "DataloaderConfig": (".loader", "DataloaderConfig"),
+    "DatasetBuildSchedule": (".loader", "DatasetBuildSchedule"),
+    "EAGLE3_DTYPE_MAP": (".llm.eagle3_cache", "DTYPE_MAP"),
+    "MegatronSamplerConfig": (".llm.megatron.sampler", "MegatronSamplerConfig"),
+    "MetaFilesDataloaderConfig": (".diffusion.meta_files_dataset", "MetaFilesDataloaderConfig"),
+    "MockWanDataloaderConfig": (".diffusion.mock_dataloader", "MockWanDataloaderConfig"),
+    "NeatPackConfig": (".vlm.neat_packing_vlm", "NeatPackConfig"),
+    "PreTokenizedDatasetWrapperConfig": (".vlm.datasets", "PreTokenizedDatasetWrapperConfig"),
+    "ScheduledDatasetConfig": (".loader", "ScheduledDatasetConfig"),
+    "TextToImageDataloaderConfig": (".diffusion.collate_fns", "TextToImageDataloaderConfig"),
+    "TextToVideoDataloaderConfig": (".diffusion.collate_fns", "TextToVideoDataloaderConfig"),
+    "VlmCollatorConfig": (".vlm.loader", "VlmCollatorConfig"),
+    "VlmDataloaderConfig": (".vlm.loader", "VlmDataloaderConfig"),
+    "VlmProcessorConfig": (".vlm.loader", "VlmProcessorConfig"),
+    "VlmVideoProcessorConfig": (".vlm.loader", "VlmVideoProcessorConfig"),
+    "add_causal_masks_to_batch": (".utils", "add_causal_masks_to_batch"),
+    "build_block_causal_additive_mask": (".llm.packed_sequence", "build_block_causal_additive_mask"),
+    "build_cache_manifest": (".llm.dspark_cache", "build_cache_manifest"),
+    "build_cached_dspark_dataloader": (".llm.dspark_cache", "build_cached_dspark_dataloader"),
+    "build_cached_eagle3_dataloader": (".llm.eagle3_cache", "build_cached_eagle3_dataloader"),
+    "build_dspark_vlm_dataloader": (".vlm.dspark_collate", "build_dspark_vlm_dataloader"),
+    "build_eagle3_dataloader": (".llm.eagle3", "build_eagle3_dataloader"),
+    "build_eagle3_token_mapping": (".llm.eagle3", "build_eagle3_token_mapping"),
+    "compress_target_probs": (".llm.eagle3_cache", "compress_target_probs"),
+    "compute_batch_cache": (".llm.dspark_cache", "compute_batch_cache"),
+    "convert_sharegpt_to_conversation": (".vlm.datasets", "convert_sharegpt_to_conversation"),
+    "corrupt_all_masked": (".dllm.corruption", "corrupt_all_masked"),
+    "corrupt_blockwise": (".dllm.corruption", "corrupt_blockwise"),
+    "corrupt_mix": (".dllm.corruption", "corrupt_mix"),
+    "corrupt_uniform": (".dllm.corruption", "corrupt_uniform"),
+    "corrupt_uniform_random": (".dllm.corruption", "corrupt_uniform_random"),
+    "dataloader_from_sample": (".llm.offline_cache", "dataloader_from_sample"),
+    "dspark_existing_shard_indices": (".llm.dspark_cache", "existing_shard_indices"),
+    "dspark_manifest_path": (".llm.dspark_cache", "manifest_path"),
+    "dspark_read_manifest": (".llm.dspark_cache", "read_manifest"),
+    "dspark_write_manifest": (".llm.dspark_cache", "write_manifest"),
+    "dspark_write_shard": (".llm.dspark_cache", "write_shard"),
+    "eagle3_existing_shard_indices": (".llm.eagle3_cache", "existing_shard_indices"),
+    "eagle3_manifest_path": (".llm.eagle3_cache", "manifest_path"),
+    "eagle3_read_manifest": (".llm.eagle3_cache", "read_manifest"),
+    "eagle3_write_manifest": (".llm.eagle3_cache", "write_manifest"),
+    "eagle3_write_shard": (".llm.eagle3_cache", "write_shard"),
+    "has_chat_template": (".llm.formatting_utils", "_has_chat_template"),
+    "is_compressed": (".llm.eagle3_cache", "is_compressed"),
+    "load_datasets": (".llm.retrieval_dataset", "load_datasets"),
+    "load_openai_messages": (".llm.chat_dataset", "_load_openai_messages"),
+    "load_or_build_eagle3_token_mapping": (".llm.eagle3", "load_or_build_eagle3_token_mapping"),
+    "make_agent_chat_eval_samples": (".llm.agent_chat", "make_agent_chat_eval_samples"),
+    "make_collate_fn": (".loader", "make_collate_fn"),
+    "make_dataset_config": (".loader", "make_dataset_config"),
+    "make_packing_config": (".loader", "make_packing_config"),
+    "manifest_mismatch_fields": (".llm.dspark_cache", "manifest_mismatch_fields"),
+    "read_target_embeddings": (".llm.eagle3_cache", "read_target_embeddings"),
+    "read_target_weight_modules": (".llm.dspark_cache", "read_target_weight_modules"),
+    "resolve_chat_template": (".llm.formatting_utils", "_resolve_chat_template"),
+    "resume_start_sample": (".llm.offline_cache", "resume_start_sample"),
+    "set_image_pixel_bounds": (".vlm.utils", "set_image_pixel_bounds"),
+    "stage_vlm_media_for_pp": (".vlm.pp_media", "stage_vlm_media_for_pp"),
+    "tokenizer_chat_template_sha256": (".llm.dspark_cache", "tokenizer_chat_template_sha256"),
+    "write_cache_shards": (".llm.offline_cache", "write_cache_shards"),
+    "write_cache_shards_distributed": (".llm.offline_cache", "write_cache_shards_distributed"),
+    "write_target_embeddings": (".llm.eagle3_cache", "write_target_embeddings"),
+    "write_target_weights": (".llm.dspark_cache", "write_target_weights"),
+}
+
+__all__ = sorted(_LAZY_ATTRS.keys())
+
+
+def __getattr__(name: str) -> object:
+    """Load an exported component symbol on first access."""
+    if name in _LAZY_ATTRS:
+        module_path, attr_name = _LAZY_ATTRS[name]
+        module = _importlib.import_module(module_path, __name__)
+        attr = getattr(module, attr_name)
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return the component's exported symbols."""
+    return sorted(__all__)

--- a/nemo_automodel/components/distributed/__init__.py
+++ b/nemo_automodel/components/distributed/__init__.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib as _importlib
+from typing import TYPE_CHECKING
+
 from nemo_automodel.components.distributed.config import (
     DDPConfig,
     DistributedSetup,
@@ -22,7 +25,11 @@ from nemo_automodel.components.distributed.config import (
 )
 from nemo_automodel.components.distributed.init_utils import DistInfo, initialize_distributed
 from nemo_automodel.components.distributed.mesh import MeshContext, ParallelismSizes
+from nemo_automodel.components.distributed.mesh_utils import get_fsdp_dp_mesh
 from nemo_automodel.components.distributed.pipelining.config import PipelineConfig
+
+if TYPE_CHECKING:
+    from nemo_automodel.components.distributed.context_parallel.magi import make_magi_attn_func
 
 __all__ = [
     "DDPConfig",
@@ -35,5 +42,106 @@ __all__ = [
     "MultimodalDistributedConfig",
     "ParallelismSizes",
     "PipelineConfig",
+    "get_fsdp_dp_mesh",
     "initialize_distributed",
 ]
+
+_LAZY_ATTRS = {
+    "AutoPipeline": (".pipelining.autopipeline", "AutoPipeline"),
+    "BlockdiagCpModelState": (".blockdiag_cp", "BlockdiagCpModelState"),
+    "ContextParallelSharder": (".context_parallel.sharder", "ContextParallelSharder"),
+    "CpVisionFrameShardingConfig": (".cp_vision_frame_shard", "CpVisionFrameShardingConfig"),
+    "DDPManager": (".ddp", "DDPManager"),
+    "DefaultParallelizationStrategy": (".parallelizer", "DefaultParallelizationStrategy"),
+    "DistributedStrategyConfig": (".config", "DistributedStrategyConfig"),
+    "FSDP2Manager": (".fsdp2", "FSDP2Manager"),
+    "FirstRankPerNode": (".utils", "FirstRankPerNode"),
+    "HunyuanParallelizationStrategy": (".parallelizer", "HunyuanParallelizationStrategy"),
+    "MULTIMODAL_SUFFIXES": (".pipelining.hf_utils", "MULTIMODAL_SUFFIXES"),
+    "MagiState": (".context_parallel.magi", "MagiState"),
+    "MambaContextParallel": (".context_parallel.mamba", "MambaContextParallel"),
+    "MegatronFSDPManager": (".megatron_fsdp", "MegatronFSDPManager"),
+    "MultimodalVisionConfig": (".config", "MultimodalVisionConfig"),
+    "PARALLELIZATION_STRATEGIES": (".parallelizer", "PARALLELIZATION_STRATEGIES"),
+    "PARALLELIZE_FUNCTIONS": (".optimized_tp_plans", "PARALLELIZE_FUNCTIONS"),
+    "SELECTIVE_AC_WRAPPER_FLAG": (".activation_checkpointing", "SELECTIVE_AC_WRAPPER_FLAG"),
+    "ShardLayout": (".context_parallel.sharder", "ShardLayout"),
+    "WanParallelizationStrategy": (".parallelizer", "WanParallelizationStrategy"),
+    "apply_selective_checkpointing_to_layers": (".activation_checkpointing", "apply_selective_checkpointing_to_layers"),
+    "apply_submodule_checkpointing": (".activation_checkpointing", "apply_submodule_checkpointing"),
+    "attach_context_parallel_hooks": (".context_parallel.utils", "attach_context_parallel_hooks"),
+    "attach_cp_sdpa_hooks": (".context_parallel.utils", "attach_cp_sdpa_hooks"),
+    "attach_te_context_parallel": (".context_parallel.utils", "attach_te_context_parallel"),
+    "configure_fsdp_unused_param_reduction": (".parallelizer_utils", "configure_fsdp_unused_param_reduction"),
+    "contiguous_local_indices": (".context_parallel.sharder", "contiguous_local_indices"),
+    "convert_attention_mask_to_padding_mask": (".context_parallel.sharder", "convert_attention_mask_to_padding_mask"),
+    "cp_blockdiag_sdpa": (".blockdiag_cp", "cp_blockdiag_sdpa"),
+    "cp_dispatcher_suspended": (".context_parallel.utils", "cp_dispatcher_suspended"),
+    "cp_vision_frame_sharding_active": (".cp_vision_frame_shard", "cp_vision_frame_sharding_active"),
+    "create_ring_ulysses_mesh": (".mesh_utils", "create_ring_ulysses_mesh"),
+    "current_blockdiag_cp_state": (".blockdiag_cp", "current_blockdiag_cp_state"),
+    "dp_eval_sample_shard": (".utils", "dp_eval_sample_shard"),
+    "ensure_fsdp_ops_sac_ignored": (".activation_checkpointing", "ensure_fsdp_ops_sac_ignored"),
+    "ensure_profiler_ops_sac_ignored": (".activation_checkpointing", "ensure_profiler_ops_sac_ignored"),
+    "fsdp2_sharding_enabled": (".fsdp2", "fsdp2_sharding_enabled"),
+    "fully_shard_by_dtype": (".parallelizer_utils", "fully_shard_by_dtype"),
+    "get_class_qualname": (".optimized_tp_plans", "_get_class_qualname"),
+    "get_flat_mesh": (".mesh_utils", "get_flat_mesh"),
+    "get_internal_fsdp_mp_policy": (".parallelizer_utils", "get_internal_fsdp_mp_policy"),
+    "get_local_world_size_preinit": (".init_utils", "get_local_world_size_preinit"),
+    "get_model_layer_groups": (".parallelizer", "get_model_layer_groups"),
+    "get_parallel_plan": (".parallelizer", "_get_parallel_plan"),
+    "get_submesh": (".mesh_utils", "get_submesh"),
+    "get_sync_ctx": (".utils", "get_sync_ctx"),
+    "get_text_module": (".pipelining.hf_utils", "get_text_module"),
+    "get_world_size_safe": (".init_utils", "get_world_size_safe"),
+    "is_selective_activation_checkpointing": (".activation_checkpointing", "is_selective_activation_checkpointing"),
+    "make_cp_blockdiag_batch_and_ctx": (".blockdiag_cp", "make_cp_blockdiag_batch_and_ctx"),
+    "make_magi_attn_func": (".context_parallel.magi", "make_magi_attn_func"),
+    "make_selective_checkpoint_context_fn": (".activation_checkpointing", "make_selective_checkpoint_context_fn"),
+    "maybe_distribute_visual": (".cp_vision_frame_shard", "maybe_distribute_visual"),
+    "maybe_shard_optimizer": (".megatron_fsdp", "maybe_shard_optimizer"),
+    "normalize_activation_checkpointing_scope": (".config", "normalize_activation_checkpointing_scope"),
+    "register_parallel_strategy": (".parallelizer", "register_parallel_strategy"),
+    "reject_unsupported_mtp_cp": (".parallelizer_utils", "reject_unsupported_mtp_cp"),
+    "reject_unsupported_mtp_cp_pp": (".parallelizer_utils", "reject_unsupported_mtp_cp_pp"),
+    "reset_cp_vision_group": (".cp_vision_frame_shard", "reset_cp_vision_group"),
+    "resolve_strategy_config": (".config", "_resolve_strategy_config"),
+    "restore_distributed_param_attrs": (".megatron_fsdp", "restore_distributed_param_attrs"),
+    "round_robin_local_indices": (".context_parallel.sharder", "round_robin_local_indices"),
+    "sdpa_backend_snapshot_context_fn": (".activation_checkpointing", "sdpa_backend_snapshot_context_fn"),
+    "set_cp_vision_group": (".cp_vision_frame_shard", "set_cp_vision_group"),
+    "setup_magi": (".context_parallel.magi", "setup_magi"),
+    "shard_batch_aux_only": (".context_parallel.sharder", "shard_batch_aux_only"),
+    "shard_batch_contiguous": (".context_parallel.sharder", "shard_batch_contiguous"),
+    "shard_sequence_for_cp_contiguous": (".context_parallel.sharder", "shard_sequence_for_cp_contiguous"),
+    "shard_sequence_for_cp_round_robin": (".context_parallel.sharder", "shard_sequence_for_cp_round_robin"),
+    "snapshot_distributed_param_attrs": (".megatron_fsdp", "snapshot_distributed_param_attrs"),
+    "split_batch_into_thd_chunks": (".thd_utils", "split_batch_into_thd_chunks"),
+    "thd_padding_mask_from_token_ids": (".thd_utils", "thd_padding_mask_from_token_ids"),
+    "transformer_engine_attention_backend_snapshot_context_fn": (
+        ".activation_checkpointing",
+        "transformer_engine_attention_backend_snapshot_context_fn",
+    ),
+    "translate_to_lora": (".parallel_styles", "translate_to_lora"),
+    "unshard_context_parallel_tensor": (".context_parallel.utils", "unshard_context_parallel_tensor"),
+    "unwrap_checkpoint_wrapper": (".activation_checkpointing", "unwrap_checkpoint_wrapper"),
+}
+
+__all__ += sorted(_LAZY_ATTRS.keys())
+
+
+def __getattr__(name: str) -> object:
+    """Load an exported component symbol on first access."""
+    if name in _LAZY_ATTRS:
+        module_path, attr_name = _LAZY_ATTRS[name]
+        module = _importlib.import_module(module_path, __name__)
+        attr = getattr(module, attr_name)
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return the component's exported symbols."""
+    return sorted(__all__)

--- a/nemo_automodel/components/eval/tool_call_evaluator.py
+++ b/nemo_automodel/components/eval/tool_call_evaluator.py
@@ -35,7 +35,7 @@ from typing import Any, Dict, List, Union
 
 import torch
 
-from nemo_automodel.components.datasets.llm.agent_chat import (
+from nemo_automodel.components.datasets import (
     make_agent_chat_eval_samples,
 )
 from nemo_automodel.components.eval.tool_call_parser import (

--- a/nemo_automodel/components/flow_matching/__init__.py
+++ b/nemo_automodel/components/flow_matching/__init__.py
@@ -30,6 +30,10 @@ _LAZY_ATTRS = {
     "FluxAdapter": (".adapters", "FluxAdapter"),
     "HunyuanAdapter": (".adapters", "HunyuanAdapter"),
     "SimpleAdapter": (".adapters", "SimpleAdapter"),
+    "enable_hunyuan_flash_varlen_mask_optimization": (
+        ".adapters.hunyuan",
+        "enable_hunyuan_flash_varlen_mask_optimization",
+    ),
 }
 
 __all__ = sorted(_LAZY_ATTRS.keys())

--- a/nemo_automodel/components/launcher/__init__.py
+++ b/nemo_automodel/components/launcher/__init__.py
@@ -11,3 +11,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import importlib as _importlib
+
+_LAZY_ATTRS = {
+    "InteractiveLauncher": (".interactive", "InteractiveLauncher"),
+    "NemoRunLauncher": (".nemo_run.launcher", "NemoRunLauncher"),
+    "SkyPilotLauncher": (".skypilot.launcher", "SkyPilotLauncher"),
+}
+
+__all__ = sorted(_LAZY_ATTRS.keys())
+
+
+def __getattr__(name: str) -> object:
+    """Load an exported component symbol on first access."""
+    if name in _LAZY_ATTRS:
+        module_path, attr_name = _LAZY_ATTRS[name]
+        module = _importlib.import_module(module_path, __name__)
+        attr = getattr(module, attr_name)
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return the component's exported symbols."""
+    return sorted(__all__)

--- a/nemo_automodel/components/loggers/__init__.py
+++ b/nemo_automodel/components/loggers/__init__.py
@@ -12,6 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib as _importlib
+
 from nemo_automodel.components.loggers.loggers import CometConfig, MLflowConfig, WandbConfig
 
 __all__ = ["CometConfig", "MLflowConfig", "WandbConfig"]
+
+_LAZY_ATTRS = {
+    "DEFAULT_BUFFER_SIZE": (".metric_logger", "DEFAULT_BUFFER_SIZE"),
+    "MetricsSample": (".metric_logger", "MetricsSample"),
+    "build_metric_logger": (".metric_logger", "build_metric_logger"),
+    "end_mlflow_active_run_as_killed": (".mlflow_utils", "end_mlflow_active_run_as_killed"),
+    "init_wandb_run": (".wandb_utils", "init_wandb_run"),
+    "setup_logging": (".log_utils", "setup_logging"),
+    "suppress_wandb_log_messages": (".wandb_utils", "suppress_wandb_log_messages"),
+    "to_float_metrics": (".mlflow_utils", "to_float_metrics"),
+}
+
+__all__ += sorted(_LAZY_ATTRS.keys())
+
+
+def __getattr__(name: str) -> object:
+    """Load an exported component symbol on first access."""
+    if name in _LAZY_ATTRS:
+        module_path, attr_name = _LAZY_ATTRS[name]
+        module = _importlib.import_module(module_path, __name__)
+        attr = getattr(module, attr_name)
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return the component's exported symbols."""
+    return sorted(__all__)

--- a/nemo_automodel/components/loss/__init__.py
+++ b/nemo_automodel/components/loss/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib as _importlib
+
 from nemo_automodel.components.loss.loss import (
     LOSS_CONFIG_REGISTRY,
     FusedLinearCEConfig,
@@ -35,3 +37,48 @@ __all__ = [
     "build_loss_config",
     "build_loss_module",
 ]
+
+_LAZY_ATTRS = {
+    "BlockDiffusionCrossEntropyLoss": (".dllm_loss", "BlockDiffusionCrossEntropyLoss"),
+    "DFlashDecayLoss": (".dllm_loss", "DFlashDecayLoss"),
+    "EmbeddingDistillLoss": (".embedding_distill", "EmbeddingDistillLoss"),
+    "EmbeddingMSELoss": (".embedding_distill", "EmbeddingMSELoss"),
+    "FusedLinearCrossEntropy": (".linear_ce", "FusedLinearCrossEntropy"),
+    "HybridDiffusionLLMLoss": (".dllm_loss", "HybridDiffusionLLMLoss"),
+    "IDLMLoss": (".dllm_loss", "IDLMLoss"),
+    "InfoNCEDistillLoss": (".infonce", "InfoNCEDistillLoss"),
+    "InfoNCELoss": (".infonce", "InfoNCELoss"),
+    "IntermediateDistillLoss": (".intermediate_distill", "IntermediateDistillLoss"),
+    "KDLoss": (".kd_loss", "KDLoss"),
+    "LayerCapture": (".intermediate_distill", "LayerCapture"),
+    "MDLMCrossEntropyLoss": (".dllm_loss", "MDLMCrossEntropyLoss"),
+    "MTPLossConfig": (".mtp", "MTPLossConfig"),
+    "MaskedCrossEntropy": (".masked_ce", "MaskedCrossEntropy"),
+    "SCDDLoss": (".dllm_loss", "SCDDLoss"),
+    "ScoreDistillLoss": (".embedding_distill", "ScoreDistillLoss"),
+    "calculate_loss": (".utils", "calculate_loss"),
+    "calculate_mtp_loss": (".mtp", "calculate_mtp_loss"),
+    "encoder_ar_loss": (".dllm_loss", "encoder_ar_loss"),
+    "get_lm_head_weight": (".utils", "_get_lm_head_weight"),
+    "listmle_loss": (".listmle", "listmle_loss"),
+    "masked_soft_cross_entropy": (".soft_ce", "masked_soft_cross_entropy"),
+    "scdd_schedule": (".dllm_loss", "scdd_schedule"),
+}
+
+__all__ += sorted(_LAZY_ATTRS.keys())
+
+
+def __getattr__(name: str) -> object:
+    """Load an exported component symbol on first access."""
+    if name in _LAZY_ATTRS:
+        module_path, attr_name = _LAZY_ATTRS[name]
+        module = _importlib.import_module(module_path, __name__)
+        attr = getattr(module, attr_name)
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return the component's exported symbols."""
+    return sorted(__all__)

--- a/nemo_automodel/components/models/bagel/hf_backbone_loader.py
+++ b/nemo_automodel/components/models/bagel/hf_backbone_loader.py
@@ -90,7 +90,9 @@ def _resolve_hf_weight_path(model_path: str) -> str:
 
 def _load_hf_state_dict(model_path: str) -> dict[str, torch.Tensor]:
     """Load a HF safetensors/bin checkpoint as a full CPU state dict."""
-    from nemo_automodel.components.checkpoint.checkpointing import _load_hf_checkpoint_preserving_dtype
+    from nemo_automodel.components.checkpoint import (
+        load_hf_checkpoint_preserving_dtype as _load_hf_checkpoint_preserving_dtype,
+    )
 
     resolved_path = _resolve_hf_weight_path(model_path)
     state_dict = _load_hf_checkpoint_preserving_dtype(resolved_path)
@@ -120,7 +122,7 @@ def _copy_qwen_mot_weights_from_und(language_model) -> int:
 
 def _load_qwen_backbone_into_bagel(model, llm_path: str, *, copy_init_moe: bool) -> None:
     """Load vanilla Qwen weights into BAGEL's language model after AM sharding."""
-    from nemo_automodel.components.checkpoint.checkpointing import _load_full_state_dict_into_model
+    from nemo_automodel.components.checkpoint import load_full_state_dict_into_model as _load_full_state_dict_into_model
 
     logger.info("Loading Qwen backbone from %s", llm_path)
     state_dict = _load_hf_state_dict(llm_path)
@@ -140,7 +142,7 @@ def _load_qwen_backbone_into_bagel(model, llm_path: str, *, copy_init_moe: bool)
 
 def _load_siglip_backbone_into_bagel(model, vit_path: str) -> None:
     """Load SigLIP weights into BAGEL's packed-NaViT vision model after AM sharding."""
-    from nemo_automodel.components.checkpoint.checkpointing import _load_full_state_dict_into_model
+    from nemo_automodel.components.checkpoint import load_full_state_dict_into_model as _load_full_state_dict_into_model
 
     logger.info("Loading SigLIP vision backbone from %s", vit_path)
     state_dict = _load_hf_state_dict(vit_path)
@@ -294,7 +296,7 @@ def build_bagel_from_hf_backbones(
         if meta_init:
             from transformers.initialization import no_init_weights
 
-            from nemo_automodel.components.utils.model_utils import init_empty_weights
+            from nemo_automodel.components.utils import init_empty_weights
 
             with no_init_weights(), init_empty_weights():
                 model = BagelForUnifiedMultimodal(bagel_config, backend=backend)

--- a/nemo_automodel/components/models/bagel/state_dict_adapter.py
+++ b/nemo_automodel/components/models/bagel/state_dict_adapter.py
@@ -53,7 +53,7 @@ import pathlib
 import re
 from typing import TYPE_CHECKING, Any
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 
 if TYPE_CHECKING:
     import torch

--- a/nemo_automodel/components/models/common/bidirectional.py
+++ b/nemo_automodel/components/models/common/bidirectional.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 
 
 class EncoderStateDictAdapter(StateDictAdapter):

--- a/nemo_automodel/components/models/deepseek_v3/model.py
+++ b/nemo_automodel/components/models/deepseek_v3/model.py
@@ -38,7 +38,7 @@ from nemo_automodel.components.models.deepseek_v3.state_dict_adapter import Deep
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MLP, MoE
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 

--- a/nemo_automodel/components/models/deepseek_v3/state_dict_adapter.py
+++ b/nemo_automodel/components/models/deepseek_v3/state_dict_adapter.py
@@ -20,7 +20,7 @@ import torch
 from torch.distributed.device_mesh import DeviceMesh
 from transformers import DeepseekV3Config
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin

--- a/nemo_automodel/components/models/deepseek_v32/model.py
+++ b/nemo_automodel/components/models/deepseek_v32/model.py
@@ -46,7 +46,7 @@ from nemo_automodel.components.models.deepseek_v32.config import DeepseekV32Conf
 from nemo_automodel.components.models.deepseek_v32.layers import DeepseekV32MLA
 from nemo_automodel.components.models.deepseek_v32.state_dict_adapter import DeepSeekV32StateDictAdapter
 from nemo_automodel.components.moe.config import MoEConfig
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 

--- a/nemo_automodel/components/models/deepseek_v4/cp.py
+++ b/nemo_automodel/components/models/deepseek_v4/cp.py
@@ -447,7 +447,7 @@ def make_dsv4_contiguous_shard_cp_batch_and_ctx(
     """
     import contextlib
 
-    from nemo_automodel.components.distributed.context_parallel.sharder import (  # noqa: PLC0415
+    from nemo_automodel.components.distributed import (  # noqa: PLC0415
         ShardLayout,
         convert_attention_mask_to_padding_mask,
         shard_batch_contiguous,

--- a/nemo_automodel/components/models/deepseek_v4/model.py
+++ b/nemo_automodel/components/models/deepseek_v4/model.py
@@ -884,7 +884,7 @@ class DeepseekV4ForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         """
         from functools import partial  # noqa: PLC0415
 
-        from nemo_automodel.components.distributed.context_parallel.sharder import (  # noqa: PLC0415
+        from nemo_automodel.components.distributed import (  # noqa: PLC0415
             ContextParallelSharder,
             contiguous_local_indices,
         )

--- a/nemo_automodel/components/models/deepseek_v4/state_dict_adapter.py
+++ b/nemo_automodel/components/models/deepseek_v4/state_dict_adapter.py
@@ -53,7 +53,7 @@ import torch
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.deepseek_v3.state_dict_adapter import (
     BLOCK_SIZE,

--- a/nemo_automodel/components/models/diffusion_gemma/fsdp.py
+++ b/nemo_automodel/components/models/diffusion_gemma/fsdp.py
@@ -123,7 +123,7 @@ def register_diffusion_gemma_parallel_strategy() -> None:
     Invoked at import of ``model.py`` (a torch-enabled context), which always
     runs before the model is parallelized.
     """
-    from nemo_automodel.components.distributed.parallelizer import (
+    from nemo_automodel.components.distributed import (
         PARALLELIZATION_STRATEGIES,
         DefaultParallelizationStrategy,
         register_parallel_strategy,

--- a/nemo_automodel/components/models/diffusion_gemma/state_dict_adapter.py
+++ b/nemo_automodel/components/models/diffusion_gemma/state_dict_adapter.py
@@ -48,7 +48,7 @@ import torch
 import torch.distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe import state_dict_utils
 from nemo_automodel.components.moe.layers import MoEConfig

--- a/nemo_automodel/components/models/ernie4_5/model.py
+++ b/nemo_automodel/components/models/ernie4_5/model.py
@@ -49,7 +49,7 @@ from nemo_automodel.components.models.ernie4_5.state_dict_adapter import (
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MLP, MoE
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 

--- a/nemo_automodel/components/models/ernie4_5/state_dict_adapter.py
+++ b/nemo_automodel/components/models/ernie4_5/state_dict_adapter.py
@@ -21,7 +21,7 @@ from typing import Any
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin

--- a/nemo_automodel/components/models/gemma4_moe/cp_batch.py
+++ b/nemo_automodel/components/models/gemma4_moe/cp_batch.py
@@ -35,7 +35,7 @@ from typing import Any
 
 import torch
 
-from nemo_automodel.components.distributed.context_parallel.sharder import (
+from nemo_automodel.components.distributed import (
     convert_attention_mask_to_padding_mask,
     shard_batch_contiguous,
 )

--- a/nemo_automodel/components/models/gemma4_moe/loss.py
+++ b/nemo_automodel/components/models/gemma4_moe/loss.py
@@ -20,7 +20,7 @@ import torch
 import torch.distributed as dist
 from torch.distributed.tensor import Partial, Replicate
 
-from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
+from nemo_automodel.components.loss import FusedLinearCrossEntropy
 
 
 class Gemma4TensorParallelFusedLinearCrossEntropy(FusedLinearCrossEntropy):

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -80,7 +80,7 @@ except (ModuleNotFoundError, ImportError, AttributeError):
     CausalLMOutputWithPast = _make_missing("CausalLMOutputWithPast")
 
 from nemo_automodel._transformers.model_capabilities import ModelCapabilities
-from nemo_automodel.components.distributed.context_parallel.sharder import (
+from nemo_automodel.components.distributed import (
     ContextParallelSharder,
     contiguous_local_indices,
     shard_sequence_for_cp_contiguous,

--- a/nemo_automodel/components/models/gemma4_moe/parallelization.py
+++ b/nemo_automodel/components/models/gemma4_moe/parallelization.py
@@ -245,7 +245,7 @@ def _gemma4_tp_plan(model: nn.Module, sequence_parallel: bool = False) -> dict[s
 
 def register_gemma4_parallel_strategy() -> None:
     """Register Gemma4's model-owned FSDP2 strategy once."""
-    from nemo_automodel.components.distributed.parallelizer import (
+    from nemo_automodel.components.distributed import (
         PARALLELIZATION_STRATEGIES,
         DefaultParallelizationStrategy,
         register_parallel_strategy,

--- a/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
@@ -45,7 +45,7 @@ from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Replicate, Shard
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe import state_dict_utils
 from nemo_automodel.components.moe.layers import MoEConfig

--- a/nemo_automodel/components/models/gemma4_unified/state_dict_adapter.py
+++ b/nemo_automodel/components/models/gemma4_unified/state_dict_adapter.py
@@ -17,7 +17,7 @@
 import re
 from typing import TYPE_CHECKING, Any
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 
 if TYPE_CHECKING:
     from torch.distributed.device_mesh import DeviceMesh

--- a/nemo_automodel/components/models/glm4_moe/model.py
+++ b/nemo_automodel/components/models/glm4_moe/model.py
@@ -38,7 +38,7 @@ from nemo_automodel.components.models.gpt_oss.rope_utils import RotaryEmbedding,
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MLP, MoE
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 

--- a/nemo_automodel/components/models/glm4_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/glm4_moe/state_dict_adapter.py
@@ -18,7 +18,7 @@ from typing import Any, Optional
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin

--- a/nemo_automodel/components/models/glm4_moe_lite/model.py
+++ b/nemo_automodel/components/models/glm4_moe_lite/model.py
@@ -40,7 +40,7 @@ from nemo_automodel.components.models.deepseek_v3.rope_utils import (
 from nemo_automodel.components.models.glm4_moe.state_dict_adapter import Glm4MoeStateDictAdapter
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MLP, MoE, MoEConfig
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 

--- a/nemo_automodel/components/models/glm5_next/cp.py
+++ b/nemo_automodel/components/models/glm5_next/cp.py
@@ -18,7 +18,7 @@ from typing import Any
 import torch
 import torch.distributed as dist
 
-from nemo_automodel.components.distributed.context_parallel.sharder import ShardLayout
+from nemo_automodel.components.distributed import ShardLayout
 from nemo_automodel.shared.import_utils import safe_import_from
 
 _PAD_DOC_ID = 0

--- a/nemo_automodel/components/models/glm5_next/layers.py
+++ b/nemo_automodel/components/models/glm5_next/layers.py
@@ -18,7 +18,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from nemo_automodel.components.distributed.activation_checkpointing import unwrap_checkpoint_wrapper
+from nemo_automodel.components.distributed import unwrap_checkpoint_wrapper
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.common.cudnn_sparse_attention import (
     cudnn_sparse_attention,

--- a/nemo_automodel/components/models/glm5_next/model.py
+++ b/nemo_automodel/components/models/glm5_next/model.py
@@ -14,7 +14,7 @@ import torch
 from torch import nn
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
-from nemo_automodel.components.distributed.context_parallel.sharder import (
+from nemo_automodel.components.distributed import (
     ContextParallelSharder,
     contiguous_local_indices,
 )

--- a/nemo_automodel/components/models/glm5_next/state_dict_adapter.py
+++ b/nemo_automodel/components/models/glm5_next/state_dict_adapter.py
@@ -16,7 +16,7 @@ from typing import Any
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.glm5_next.config import Glm5NextConfig
 from nemo_automodel.components.moe.config import MoEConfig

--- a/nemo_automodel/components/models/glm_moe_dsa/cp.py
+++ b/nemo_automodel/components/models/glm_moe_dsa/cp.py
@@ -21,11 +21,9 @@ import contextlib
 import torch
 import torch.distributed as dist
 
-from nemo_automodel.components.distributed.context_parallel.sharder import (
+from nemo_automodel.components.distributed import (
     ShardLayout,
     contiguous_local_indices,
-)
-from nemo_automodel.components.distributed.thd_utils import (
     split_batch_into_thd_chunks,
     thd_padding_mask_from_token_ids,
 )

--- a/nemo_automodel/components/models/glm_moe_dsa/model.py
+++ b/nemo_automodel/components/models/glm_moe_dsa/model.py
@@ -41,7 +41,7 @@ from nemo_automodel.components.models.glm_moe_dsa.optimized_kernels import prepa
 from nemo_automodel.components.models.glm_moe_dsa.state_dict_adapter import GlmMoeDsaStateDictAdapter
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MLP, MoE, MoEConfig
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 
@@ -429,7 +429,7 @@ class GlmMoeDsaForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         """
         from functools import partial  # noqa: PLC0415
 
-        from nemo_automodel.components.distributed.context_parallel.sharder import (  # noqa: PLC0415
+        from nemo_automodel.components.distributed import (  # noqa: PLC0415
             ContextParallelSharder,
             contiguous_local_indices,
         )

--- a/nemo_automodel/components/models/gpt_oss/model.py
+++ b/nemo_automodel/components/models/gpt_oss/model.py
@@ -39,7 +39,7 @@ from nemo_automodel.components.models.gpt_oss.state_dict_adapter import GPTOSSSt
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MoE
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 logger = logging.getLogger(__name__)

--- a/nemo_automodel/components/models/gpt_oss/state_dict_adapter.py
+++ b/nemo_automodel/components/models/gpt_oss/state_dict_adapter.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import torch
 from transformers import GptOssConfig
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe.config import MoEConfig
 

--- a/nemo_automodel/components/models/hy_mt2/model.py
+++ b/nemo_automodel/components/models/hy_mt2/model.py
@@ -61,7 +61,7 @@ from nemo_automodel.components.models.hy_mt2.state_dict_adapter import HyMT2Stat
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MLP, MoE
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 

--- a/nemo_automodel/components/models/hy_mt2/state_dict_adapter.py
+++ b/nemo_automodel/components/models/hy_mt2/state_dict_adapter.py
@@ -47,7 +47,7 @@ from typing import Any
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin

--- a/nemo_automodel/components/models/hy_v3/model.py
+++ b/nemo_automodel/components/models/hy_v3/model.py
@@ -48,7 +48,7 @@ from nemo_automodel.components.models.hy_v3.state_dict_adapter import HYV3StateD
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MLP, MoE
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 

--- a/nemo_automodel/components/models/hy_v3/state_dict_adapter.py
+++ b/nemo_automodel/components/models/hy_v3/state_dict_adapter.py
@@ -50,7 +50,7 @@ from typing import Any
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin

--- a/nemo_automodel/components/models/inkling/state_dict_adapter.py
+++ b/nemo_automodel/components/models/inkling/state_dict_adapter.py
@@ -20,7 +20,7 @@ from typing import Any
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe import state_dict_utils
 from nemo_automodel.components.moe.config import MoEConfig

--- a/nemo_automodel/components/models/kimi_k25_vl/model.py
+++ b/nemo_automodel/components/models/kimi_k25_vl/model.py
@@ -159,7 +159,7 @@ from nemo_automodel.components.models.deepseek_v3.rope_utils import freqs_cis_fr
 from nemo_automodel.components.models.kimi_k25_vl.state_dict_adapter import KimiK25VLStateDictAdapter
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 # Check for flash attention

--- a/nemo_automodel/components/models/kimi_k25_vl/state_dict_adapter.py
+++ b/nemo_automodel/components/models/kimi_k25_vl/state_dict_adapter.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import torch
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.deepseek_v3.state_dict_adapter import DeepSeekV3StateDictAdapter
 from nemo_automodel.components.moe.config import MoEConfig

--- a/nemo_automodel/components/models/kimi_k3/cp.py
+++ b/nemo_automodel/components/models/kimi_k3/cp.py
@@ -44,7 +44,7 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 
-from nemo_automodel.components.distributed.context_parallel.sharder import ShardLayout
+from nemo_automodel.components.distributed import ShardLayout
 
 _PAD_DOC_ID = 0
 

--- a/nemo_automodel/components/models/kimi_k3/model.py
+++ b/nemo_automodel/components/models/kimi_k3/model.py
@@ -33,7 +33,7 @@ from nemo_automodel.components.attention.utils import (
     postprocess_output_for_attn,
     preprocess_args_and_kwargs_for_attn,
 )
-from nemo_automodel.components.distributed.init_utils import get_world_size_safe
+from nemo_automodel.components.distributed import get_world_size_safe
 from nemo_automodel.components.models.common import BackendConfig, initialize_linear_module
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
 from nemo_automodel.components.models.common.packing import get_unpad_data, is_indexed_packed_mask
@@ -63,7 +63,7 @@ from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.experts import GroupedExperts, GroupedExpertsDeepEP
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import FakeBalancedGate, Gate, MoE
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.import_utils import UnavailableError, safe_import_from
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
@@ -1968,7 +1968,7 @@ class KimiK3ForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         Returns:
             Batch updates carrying the model-owned context-parallel sharder.
         """
-        from nemo_automodel.components.distributed.context_parallel.sharder import (  # noqa: PLC0415
+        from nemo_automodel.components.distributed import (  # noqa: PLC0415
             ContextParallelSharder,
             contiguous_local_indices,
         )

--- a/nemo_automodel/components/models/kimi_k3/state_dict_adapter.py
+++ b/nemo_automodel/components/models/kimi_k3/state_dict_adapter.py
@@ -22,7 +22,7 @@ from typing import Any
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin

--- a/nemo_automodel/components/models/kimi_linear/cp.py
+++ b/nemo_automodel/components/models/kimi_linear/cp.py
@@ -45,7 +45,7 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 
-from nemo_automodel.components.distributed.context_parallel.sharder import ShardLayout
+from nemo_automodel.components.distributed import ShardLayout
 
 _PAD_DOC_ID = 0
 

--- a/nemo_automodel/components/models/kimi_linear/model.py
+++ b/nemo_automodel/components/models/kimi_linear/model.py
@@ -27,10 +27,10 @@ import torch.nn.functional as F
 from torch import nn
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
-from nemo_automodel.components.distributed.activation_checkpointing import unwrap_checkpoint_wrapper
-from nemo_automodel.components.distributed.context_parallel.sharder import (
+from nemo_automodel.components.distributed import (
     ContextParallelSharder,
     contiguous_local_indices,
+    unwrap_checkpoint_wrapper,
 )
 from nemo_automodel.components.models.common import BackendConfig, initialize_linear_module
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
@@ -56,7 +56,7 @@ from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.experts import GroupedExperts
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MLP, MoE
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.import_utils import UnavailableError, safe_import_from
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 

--- a/nemo_automodel/components/models/kimi_linear/state_dict_adapter.py
+++ b/nemo_automodel/components/models/kimi_linear/state_dict_adapter.py
@@ -22,7 +22,7 @@ from typing import Any
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin

--- a/nemo_automodel/components/models/kimivl/model.py
+++ b/nemo_automodel/components/models/kimivl/model.py
@@ -118,7 +118,7 @@ from nemo_automodel.components.models.deepseek_v3.rope_utils import freqs_cis_fr
 from nemo_automodel.components.models.deepseek_v3.state_dict_adapter import DeepSeekV3StateDictAdapter
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 # Check for flash attention

--- a/nemo_automodel/components/models/laguna/state_dict_adapter.py
+++ b/nemo_automodel/components/models/laguna/state_dict_adapter.py
@@ -20,7 +20,7 @@ from typing import Any
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin

--- a/nemo_automodel/components/models/ling_v2/model.py
+++ b/nemo_automodel/components/models/ling_v2/model.py
@@ -60,7 +60,7 @@ from nemo_automodel.components.models.ling_v2.state_dict_adapter import BailingM
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MLP, MoE
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 

--- a/nemo_automodel/components/models/ling_v2/state_dict_adapter.py
+++ b/nemo_automodel/components/models/ling_v2/state_dict_adapter.py
@@ -46,7 +46,7 @@ from typing import Any, Optional
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.ling_v2.config import BailingMoeV2Config
 from nemo_automodel.components.moe.config import MoEConfig

--- a/nemo_automodel/components/models/llama/state_dict_adapter.py
+++ b/nemo_automodel/components/models/llama/state_dict_adapter.py
@@ -25,7 +25,7 @@ from typing import Any
 
 from transformers import LlamaConfig
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 
 logger = logging.getLogger(__name__)
 

--- a/nemo_automodel/components/models/llava_onevision/state_dict_adapter.py
+++ b/nemo_automodel/components/models/llava_onevision/state_dict_adapter.py
@@ -31,7 +31,7 @@ Applies the same regex rename HF does via ``_checkpoint_conversion_mapping``:
 import re
 from typing import Any
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 
 _HF_TO_NEMO_RULES = [
     (re.compile(r"^visual\."), "model.visual."),

--- a/nemo_automodel/components/models/mimo_v2_flash/state_dict_adapter.py
+++ b/nemo_automodel/components/models/mimo_v2_flash/state_dict_adapter.py
@@ -21,7 +21,7 @@ from typing import Any
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.deepseek_v3.state_dict_adapter import (
     create_scale_inv_for_weight,

--- a/nemo_automodel/components/models/minimax_m2/model.py
+++ b/nemo_automodel/components/models/minimax_m2/model.py
@@ -36,7 +36,7 @@ from nemo_automodel.components.models.minimax_m2.layers import MiniMaxM2Attentio
 from nemo_automodel.components.models.minimax_m2.state_dict_adapter import MiniMaxM2StateDictAdapter
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MoE, MoEConfig
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 

--- a/nemo_automodel/components/models/minimax_m2/state_dict_adapter.py
+++ b/nemo_automodel/components/models/minimax_m2/state_dict_adapter.py
@@ -18,7 +18,7 @@ from typing import Any, Optional
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.deepseek_v3.state_dict_adapter import (
     BLOCK_SIZE,

--- a/nemo_automodel/components/models/minimax_m3_vl/model.py
+++ b/nemo_automodel/components/models/minimax_m3_vl/model.py
@@ -26,7 +26,7 @@ from typing import Any
 import torch
 import torch.nn as nn
 
-from nemo_automodel.components.distributed.context_parallel.sharder import (
+from nemo_automodel.components.distributed import (
     ContextParallelSharder,
     round_robin_local_indices,
     shard_batch_aux_only,
@@ -54,7 +54,7 @@ from nemo_automodel.components.models.minimax_m3_vl.state_dict_adapter import (
 from nemo_automodel.components.models.minimax_m3_vl.vision_encoder import MiniMaxM3VisionModel
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MoEConfig
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 
@@ -513,7 +513,7 @@ class MiniMaxM3SparseForConditionalGeneration(HFCheckpointingMixin, nn.Module, M
                 "MiniMax M3 VL does not support MTP modules under pipeline parallelism yet; "
                 "set text_config.num_mtp_modules=0 for pp_size>1 runs."
             )
-        from nemo_automodel.components.distributed.pipelining.hf_utils import MULTIMODAL_SUFFIXES
+        from nemo_automodel.components.distributed import MULTIMODAL_SUFFIXES
 
         text_prefix = "model."  # M3's text stack lives directly under self.model
         fixed: list[list[str]] = []
@@ -609,7 +609,7 @@ class MiniMaxM3SparseForConditionalGeneration(HFCheckpointingMixin, nn.Module, M
         # this embed+splice runs in-forward under an active CP ring context it must
         # suspend the ring dispatcher, or torch's load-balanced ring SDPA rejects
         # the non-causal attention. No-op when CP is inactive.
-        from nemo_automodel.components.distributed.context_parallel.utils import (
+        from nemo_automodel.components.distributed import (
             cp_dispatcher_suspended,  # noqa: PLC0415
         )
 

--- a/nemo_automodel/components/models/minimax_m3_vl/state_dict_adapter.py
+++ b/nemo_automodel/components/models/minimax_m3_vl/state_dict_adapter.py
@@ -36,7 +36,7 @@ from typing import Any, Optional
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe.layers import MoEConfig
 from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin

--- a/nemo_automodel/components/models/mistral3/state_dict_adapter.py
+++ b/nemo_automodel/components/models/mistral3/state_dict_adapter.py
@@ -42,7 +42,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 import torch
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 
 if TYPE_CHECKING:
     from torch.distributed.device_mesh import DeviceMesh

--- a/nemo_automodel/components/models/mistral4/model.py
+++ b/nemo_automodel/components/models/mistral4/model.py
@@ -46,7 +46,7 @@ from nemo_automodel.components.models.mistral4.state_dict_adapter import (
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MoE
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 

--- a/nemo_automodel/components/models/mistral4/state_dict_adapter.py
+++ b/nemo_automodel/components/models/mistral4/state_dict_adapter.py
@@ -19,7 +19,7 @@ from typing import Any
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.deepseek_v3.state_dict_adapter import dequantize_from_fp8
 from nemo_automodel.components.moe.config import MoEConfig

--- a/nemo_automodel/components/models/muse_glimmer/model.py
+++ b/nemo_automodel/components/models/muse_glimmer/model.py
@@ -40,13 +40,13 @@ from nemo_automodel.components.attention.utils import (
     postprocess_output_for_attn,
     preprocess_args_and_kwargs_for_attn,
 )
-from nemo_automodel.components.distributed.context_parallel.sharder import (
+from nemo_automodel.components.distributed import (
     ContextParallelSharder,
+    cp_dispatcher_suspended,
     round_robin_local_indices,
     shard_batch_aux_only,
     shard_sequence_for_cp_round_robin,
 )
-from nemo_automodel.components.distributed.context_parallel.utils import cp_dispatcher_suspended
 from nemo_automodel.components.models.common import BackendConfig, compute_lm_head_logits
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
 from nemo_automodel.components.models.common.tie_word_embeddings import (

--- a/nemo_automodel/components/models/muse_glimmer/parallelization.py
+++ b/nemo_automodel/components/models/muse_glimmer/parallelization.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 def register_muse_glimmer_parallel_strategy() -> None:
     """Register the MuseGlimmer strategy and expose its CP mesh to model-owned embedding."""
-    from nemo_automodel.components.distributed.parallelizer import (
+    from nemo_automodel.components.distributed import (
         PARALLELIZATION_STRATEGIES,
         DefaultParallelizationStrategy,
         register_parallel_strategy,
@@ -50,7 +50,7 @@ def register_muse_glimmer_parallel_strategy() -> None:
             # MuseGlimmer is BSHD-capable (not THD-only), so keep that model-specific
             # setup here rather than broadening the generic infrastructure gate.
             if tp_size > 1 and cp_size <= 1 and model.backend.attn == "te":
-                from nemo_automodel.components.distributed.context_parallel.utils import (
+                from nemo_automodel.components.distributed import (
                     attach_te_context_parallel,
                 )
 

--- a/nemo_automodel/components/models/muse_glimmer/state_dict_adapter.py
+++ b/nemo_automodel/components/models/muse_glimmer/state_dict_adapter.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import torch
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.muse_glimmer.config import MuseGlimmerConfig
 
 

--- a/nemo_automodel/components/models/nemotron_omni/model.py
+++ b/nemo_automodel/components/models/nemotron_omni/model.py
@@ -34,13 +34,13 @@ from transformers import AutoConfig, AutoModel
 from transformers.configuration_utils import PretrainedConfig
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
-from nemo_automodel.components.distributed.context_parallel.sharder import (
+from nemo_automodel.components.distributed import (
     ContextParallelSharder,
+    cp_dispatcher_suspended,
     round_robin_local_indices,
     shard_batch_aux_only,
     shard_sequence_for_cp_round_robin,
 )
-from nemo_automodel.components.distributed.context_parallel.utils import cp_dispatcher_suspended
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
 from nemo_automodel.components.models.common.tie_word_embeddings import (

--- a/nemo_automodel/components/models/nemotron_omni/state_dict_adapter.py
+++ b/nemo_automodel/components/models/nemotron_omni/state_dict_adapter.py
@@ -67,7 +67,7 @@ from typing import Any, Optional
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.nemotron_v3.state_dict_adapter import NemotronV3StateDictAdapter
 from nemo_automodel.components.moe.config import MoEConfig

--- a/nemo_automodel/components/models/nemotron_v3/model.py
+++ b/nemo_automodel/components/models/nemotron_v3/model.py
@@ -47,7 +47,7 @@ from nemo_automodel.components.models.nemotron_v3.mtp import (
 from nemo_automodel.components.models.nemotron_v3.state_dict_adapter import NemotronV3StateDictAdapter
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 

--- a/nemo_automodel/components/models/nemotron_v3/state_dict_adapter.py
+++ b/nemo_automodel/components/models/nemotron_v3/state_dict_adapter.py
@@ -19,7 +19,7 @@ from typing import Any, Optional
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin

--- a/nemo_automodel/components/models/qwen2_5_omni/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen2_5_omni/state_dict_adapter.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import torch
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 
 logger = logging.getLogger(__name__)

--- a/nemo_automodel/components/models/qwen3_5/model.py
+++ b/nemo_automodel/components/models/qwen3_5/model.py
@@ -38,15 +38,13 @@ from transformers.models.qwen3_5.modeling_qwen3_5 import (
     Qwen3_5Model as HFQwen3_5Model,
 )
 
-from nemo_automodel.components.distributed.context_parallel.sharder import (
+from nemo_automodel.components.distributed import (
     ContextParallelSharder,
+    cp_vision_frame_sharding_active,
+    maybe_distribute_visual,
     round_robin_local_indices,
     shard_batch_aux_only,
     shard_sequence_for_cp_round_robin,
-)
-from nemo_automodel.components.distributed.cp_vision_frame_shard import (
-    cp_vision_frame_sharding_active,
-    maybe_distribute_visual,
 )
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
@@ -65,7 +63,7 @@ from nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn import CPAwareG
 from nemo_automodel.components.models.qwen3_next.layers import Qwen3NextRMSNorm
 from nemo_automodel.components.models.qwen3_next.model import Block
 from nemo_automodel.components.moe.layers import MoEConfig
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 from .state_dict_adapter import Qwen3_5DenseStateDictAdapter
@@ -381,7 +379,7 @@ class Qwen3_5DenseBlock(Block):
             )
 
         linear_attn_mask = attention_mask
-        from nemo_automodel.components.distributed.blockdiag_cp import current_blockdiag_cp_state
+        from nemo_automodel.components.distributed import current_blockdiag_cp_state
 
         if current_blockdiag_cp_state() is not None:
             packed_gdn_metadata = None
@@ -1188,7 +1186,7 @@ class Qwen3_5ForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5ForConditio
         # splice runs in-forward under an active CP ring context it must suspend the
         # ring dispatcher, or torch's load-balanced ring SDPA all-gathers the vision
         # Q/K/V and rejects the non-causal attention. No-op when CP is inactive.
-        from nemo_automodel.components.distributed.context_parallel.utils import (
+        from nemo_automodel.components.distributed import (
             cp_dispatcher_suspended,  # noqa: PLC0415
         )
 

--- a/nemo_automodel/components/models/qwen3_5/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen3_5/state_dict_adapter.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common.gated_delta_net_fp32 import (
     forced_gated_delta_net_fp32_dtype_mapping,
     upcast_gated_delta_net_fp32_state_tensor,

--- a/nemo_automodel/components/models/qwen3_5_moe/cp_linear_attn.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/cp_linear_attn.py
@@ -373,7 +373,7 @@ class CPAwareGatedDeltaNet(Qwen3_5MoeGatedDeltaNet):
                 indices=indices,
             )
 
-        from nemo_automodel.components.distributed.blockdiag_cp import current_blockdiag_cp_state
+        from nemo_automodel.components.distributed import current_blockdiag_cp_state
 
         return self._forward_with_cp(
             hidden_states,

--- a/nemo_automodel/components/models/qwen3_5_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/model.py
@@ -61,17 +61,15 @@ except ModuleNotFoundError:
     Qwen3_5MoeVisionRotaryEmbedding = _make_missing("Qwen3_5MoeVisionRotaryEmbedding")
     HFQwen3_5MoeModel = _make_missing("Qwen3_5MoeModel")
 
-from nemo_automodel.components.distributed.context_parallel.sharder import (
+from nemo_automodel.components.distributed import (
     ContextParallelSharder,
     contiguous_local_indices,
+    cp_vision_frame_sharding_active,
+    maybe_distribute_visual,
     round_robin_local_indices,
     shard_batch_aux_only,
     shard_sequence_for_cp_contiguous,
     shard_sequence_for_cp_round_robin,
-)
-from nemo_automodel.components.distributed.cp_vision_frame_shard import (
-    cp_vision_frame_sharding_active,
-    maybe_distribute_visual,
 )
 from nemo_automodel.components.models.common import BackendConfig, initialize_linear_module
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
@@ -95,7 +93,7 @@ from nemo_automodel.components.models.qwen3_next.layers import Qwen3NextAttentio
 from nemo_automodel.components.models.qwen3_next.model import Block
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MoEConfig
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 from .cp_linear_attn import CPAwareGatedDeltaNet
@@ -138,7 +136,7 @@ class _Qwen3_5MoeAttention(Qwen3NextAttention):
             Attention output of shape
             ``[batch, heads, local_sequence, head_dim]``.
         """
-        from nemo_automodel.components.distributed.blockdiag_cp import (
+        from nemo_automodel.components.distributed import (
             cp_blockdiag_sdpa,
             current_blockdiag_cp_state,
         )
@@ -204,7 +202,7 @@ class Qwen3_5MoeBlock(Block):
             )
 
         linear_attn_mask = attention_mask
-        from nemo_automodel.components.distributed.blockdiag_cp import current_blockdiag_cp_state
+        from nemo_automodel.components.distributed import current_blockdiag_cp_state
 
         if current_blockdiag_cp_state() is not None:
             packed_gdn_metadata = None
@@ -746,7 +744,7 @@ class Qwen3_5MoeTextModelBackend(nn.Module):
         # do not support padding masks, so we null them out.
         if getattr(self, "_cp_enabled", False):
             attention_mask = None
-            from nemo_automodel.components.distributed.blockdiag_cp import current_blockdiag_cp_state
+            from nemo_automodel.components.distributed import current_blockdiag_cp_state
 
             if current_blockdiag_cp_state() is None:
                 padding_mask = None
@@ -1422,7 +1420,7 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
         if uses_blockdiag_cp and self.backend.attn != "sdpa":
             raise ValueError("Qwen3.5-MoE packed context parallelism requires model.backend.attn='sdpa'")
         if uses_blockdiag_cp:
-            from nemo_automodel.components.distributed.blockdiag_cp import make_cp_blockdiag_batch_and_ctx
+            from nemo_automodel.components.distributed import make_cp_blockdiag_batch_and_ctx
 
             cp_sharder = ContextParallelSharder(
                 shard_batch=partial(make_cp_blockdiag_batch_and_ctx, shard_primary=False),
@@ -1497,7 +1495,7 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
         # splice runs in-forward under an active CP ring context it must suspend the
         # ring dispatcher, or torch's load-balanced ring SDPA all-gathers the vision
         # Q/K/V and rejects the non-causal attention. No-op when CP is inactive.
-        from nemo_automodel.components.distributed.context_parallel.utils import (
+        from nemo_automodel.components.distributed import (
             cp_dispatcher_suspended,  # noqa: PLC0415
         )
 
@@ -1735,7 +1733,7 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
                     image_grid_thw=image_grid_thw,
                     video_grid_thw=video_grid_thw,
                 )
-                from nemo_automodel.components.distributed.blockdiag_cp import current_blockdiag_cp_state
+                from nemo_automodel.components.distributed import current_blockdiag_cp_state
 
                 uses_blockdiag_cp = current_blockdiag_cp_state() is not None
                 if self.mtp is not None and self.training:

--- a/nemo_automodel/components/models/qwen3_5_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/state_dict_adapter.py
@@ -46,7 +46,7 @@ import torch
 from safetensors import SafetensorError, safe_open
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.common.gated_delta_net_fp32 import (
     forced_gated_delta_net_fp32_dtype_mapping,

--- a/nemo_automodel/components/models/qwen3_8_flash_next/cp.py
+++ b/nemo_automodel/components/models/qwen3_8_flash_next/cp.py
@@ -26,7 +26,7 @@ import torch.distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.nn.functional import all_gather as differentiable_all_gather
 
-from nemo_automodel.components.distributed.context_parallel.sharder import (
+from nemo_automodel.components.distributed import (
     ShardLayout,
     shard_batch_contiguous,
 )

--- a/nemo_automodel/components/models/qwen3_8_flash_next/layers.py
+++ b/nemo_automodel/components/models/qwen3_8_flash_next/layers.py
@@ -29,8 +29,7 @@ import torch.nn.functional as F
 from torch import nn
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.distributed.activation_checkpointing import unwrap_checkpoint_wrapper
-from nemo_automodel.components.distributed.blockdiag_cp import BlockdiagCpModelState
+from nemo_automodel.components.distributed import BlockdiagCpModelState, unwrap_checkpoint_wrapper
 from nemo_automodel.components.models.common import BackendConfig, initialize_linear_module
 from nemo_automodel.components.models.gpt_oss.rope_utils import apply_rotary_emb_qk
 from nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn import CPAwareGatedDeltaNet

--- a/nemo_automodel/components/models/qwen3_8_flash_next/model.py
+++ b/nemo_automodel/components/models/qwen3_8_flash_next/model.py
@@ -34,7 +34,7 @@ from torch import nn
 from torch.distributed.device_mesh import DeviceMesh
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 
-from nemo_automodel.components.distributed.context_parallel.sharder import (
+from nemo_automodel.components.distributed import (
     ContextParallelSharder,
     contiguous_local_indices,
 )

--- a/nemo_automodel/components/models/qwen3_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_moe/model.py
@@ -20,7 +20,7 @@ import torch.nn as nn
 from transformers.modeling_outputs import CausalLMOutputWithPast
 from transformers.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
 
-from nemo_automodel.components.distributed.activation_checkpointing import unwrap_checkpoint_wrapper
+from nemo_automodel.components.distributed import unwrap_checkpoint_wrapper
 from nemo_automodel.components.models.common import (
     BackendConfig,
     get_rope_config,
@@ -39,7 +39,7 @@ from nemo_automodel.components.models.qwen3_moe.state_dict_adapter import Qwen3M
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MLP, MoE
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 

--- a/nemo_automodel/components/models/qwen3_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen3_moe/state_dict_adapter.py
@@ -19,7 +19,7 @@ from typing import Any, Optional
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin

--- a/nemo_automodel/components/models/qwen3_next/model.py
+++ b/nemo_automodel/components/models/qwen3_next/model.py
@@ -20,7 +20,7 @@ import torch.nn as nn
 from transformers.modeling_outputs import CausalLMOutputWithPast
 from transformers.models.qwen3_next.configuration_qwen3_next import Qwen3NextConfig
 
-from nemo_automodel.components.distributed.activation_checkpointing import unwrap_checkpoint_wrapper
+from nemo_automodel.components.distributed import unwrap_checkpoint_wrapper
 from nemo_automodel.components.models.common import (
     BackendConfig,
     get_rope_config,
@@ -43,7 +43,7 @@ from nemo_automodel.components.models.qwen3_next.state_dict_adapter import Qwen3
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MLP, MoE
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 

--- a/nemo_automodel/components/models/qwen3_next/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen3_next/state_dict_adapter.py
@@ -18,7 +18,7 @@ from typing import Any, Optional
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.common.gated_delta_net_fp32 import (
     forced_gated_delta_net_fp32_dtype_mapping,

--- a/nemo_automodel/components/models/qwen3_omni_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_omni_moe/model.py
@@ -40,7 +40,7 @@ from nemo_automodel.components.models.qwen3_moe.model import Block
 from nemo_automodel.components.models.qwen3_omni_moe.state_dict_adapter import Qwen3OmniMoeStateDictAdapter
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 

--- a/nemo_automodel/components/models/qwen3_omni_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen3_omni_moe/state_dict_adapter.py
@@ -18,7 +18,7 @@ from typing import Any, Optional
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin

--- a/nemo_automodel/components/models/qwen3_vl/model.py
+++ b/nemo_automodel/components/models/qwen3_vl/model.py
@@ -28,14 +28,14 @@ from transformers.models.qwen3_vl.modeling_qwen3_vl import (
     Qwen3VLForConditionalGeneration as HFQwen3VLForConditionalGeneration,
 )
 
-from nemo_automodel.components.distributed.context_parallel.sharder import (
+from nemo_automodel.components.distributed import (
     ContextParallelSharder,
+    cp_dispatcher_suspended,
+    maybe_distribute_visual,
     round_robin_local_indices,
     shard_batch_aux_only,
     shard_sequence_for_cp_round_robin,
 )
-from nemo_automodel.components.distributed.context_parallel.utils import cp_dispatcher_suspended
-from nemo_automodel.components.distributed.cp_vision_frame_shard import maybe_distribute_visual
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
 from nemo_automodel.components.models.common.tie_word_embeddings import (
     TieSupport,

--- a/nemo_automodel/components/models/qwen3_vl/parallelization.py
+++ b/nemo_automodel/components/models/qwen3_vl/parallelization.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 def register_qwen3_vl_parallel_strategy() -> None:
     """Register the dense Qwen3-VL FSDP2 strategy once."""
-    from nemo_automodel.components.distributed.parallelizer import (
+    from nemo_automodel.components.distributed import (
         PARALLELIZATION_STRATEGIES,
         DefaultParallelizationStrategy,
         register_parallel_strategy,

--- a/nemo_automodel/components/models/qwen3_vl_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_vl_moe/model.py
@@ -40,7 +40,7 @@ from nemo_automodel.components.models.common.utils import cast_model_to_dtype, c
 from nemo_automodel.components.models.qwen3_moe.model import Block
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 from .state_dict_adapter import Qwen3VLMoeStateDictAdapter

--- a/nemo_automodel/components/models/qwen3_vl_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen3_vl_moe/state_dict_adapter.py
@@ -18,7 +18,7 @@ from typing import Any, Optional
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe import state_dict_utils
 from nemo_automodel.components.moe.config import MoEConfig

--- a/nemo_automodel/components/models/qwen_image_edit/adapter.py
+++ b/nemo_automodel/components/models/qwen_image_edit/adapter.py
@@ -21,7 +21,7 @@ from typing import Any
 import torch
 import torch.nn as nn
 
-from nemo_automodel.components.flow_matching.adapters.base import FlowMatchingContext, ModelAdapter
+from nemo_automodel.components.flow_matching import FlowMatchingContext, ModelAdapter
 
 
 class QwenImageEditAdapter(ModelAdapter):

--- a/nemo_automodel/components/models/step3p5/model.py
+++ b/nemo_automodel/components/models/step3p5/model.py
@@ -36,7 +36,7 @@ from nemo_automodel.components.models.step3p5.state_dict_adapter import Step3p5S
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MoE
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 

--- a/nemo_automodel/components/models/step3p5/state_dict_adapter.py
+++ b/nemo_automodel/components/models/step3p5/state_dict_adapter.py
@@ -43,7 +43,7 @@ from typing import Any, Optional
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.state_dict_utils import (

--- a/nemo_automodel/components/models/step3p7/model.py
+++ b/nemo_automodel/components/models/step3p7/model.py
@@ -23,7 +23,7 @@ import torch
 import torch.nn as nn
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
-from nemo_automodel.components.distributed.context_parallel.sharder import (
+from nemo_automodel.components.distributed import (
     ContextParallelSharder,
     round_robin_local_indices,
     shard_batch_aux_only,
@@ -45,7 +45,7 @@ from nemo_automodel.components.models.step3p7.state_dict_adapter import Step3p7S
 from nemo_automodel.components.models.step3p7.vision_encoder import StepRoboticsVisionEncoder
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.components.utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 logger = logging.getLogger(__name__)

--- a/nemo_automodel/components/models/step3p7/state_dict_adapter.py
+++ b/nemo_automodel/components/models/step3p7/state_dict_adapter.py
@@ -20,7 +20,7 @@ from typing import Any
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
-from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.checkpoint import StateDictAdapter
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.step3p5.state_dict_adapter import Step3p5StateDictAdapter
 from nemo_automodel.components.moe.config import MoEConfig

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -20,7 +20,7 @@ import torch.nn.functional as F
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor, Partial, Replicate
 
-from nemo_automodel.components.distributed.init_utils import get_world_size_safe
+from nemo_automodel.components.distributed import get_world_size_safe
 from nemo_automodel.components.models.common import BackendConfig, initialize_linear_module
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.experts import (

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -32,8 +32,14 @@ from torch.distributed.tensor import Replicate, Shard, distribute_module, distri
 from torch.distributed.tensor.parallel import ParallelStyle, parallelize_module
 from torch.utils.checkpoint import CheckpointPolicy, create_selective_checkpoint_contexts
 
-from nemo_automodel.components.distributed import parallelizer_utils
-from nemo_automodel.components.distributed.pipelining.hf_utils import get_text_module
+from nemo_automodel.components.distributed import (
+    configure_fsdp_unused_param_reduction,
+    fully_shard_by_dtype,
+    get_internal_fsdp_mp_policy,
+    get_text_module,
+    reject_unsupported_mtp_cp,
+    reject_unsupported_mtp_cp_pp,
+)
 from nemo_automodel.components.moe.experts import GroupedExpertsDeepEP, GroupedExpertsTE
 from nemo_automodel.components.moe.layers import (
     Gate,
@@ -258,7 +264,7 @@ def _resolve_moe_tp_plan(
     if tp_shard_plan is not None:
         # Reuse the standard parser for explicit dictionaries, named plans and
         # import paths, then apply the stricter MoE ownership validation below.
-        from nemo_automodel.components.distributed.parallelizer import _get_parallel_plan
+        from nemo_automodel.components.distributed import get_parallel_plan as _get_parallel_plan
 
         plan = _get_parallel_plan(
             model,
@@ -267,9 +273,11 @@ def _resolve_moe_tp_plan(
             tp_size=tp_size,
         )
     else:
-        from nemo_automodel.components.distributed.optimized_tp_plans import (
+        from nemo_automodel.components.distributed import (
             PARALLELIZE_FUNCTIONS,
-            _get_class_qualname,
+        )
+        from nemo_automodel.components.distributed import (
+            get_class_qualname as _get_class_qualname,
         )
 
         model_cls = type(model)
@@ -434,11 +442,11 @@ def _apply_multimodal_tower_ac(model: nn.Module, scopes: tuple[str, ...]) -> Non
 
     # Lazy imports keep the heavy, transformers-aware dense parallelizer module
     # off the text-only MoE call path.
-    from nemo_automodel.components.distributed.activation_checkpointing import (
+    from nemo_automodel.components.distributed import (
         apply_submodule_checkpointing,
+        get_model_layer_groups,
         sdpa_backend_snapshot_context_fn,
     )
-    from nemo_automodel.components.distributed.parallelizer import get_model_layer_groups
 
     layer_groups = get_model_layer_groups(model)
     tower_layers = [
@@ -497,7 +505,7 @@ def apply_ac(
     # Lazy import: keeps the scope normalization single-sourced with the strategy
     # configs without importing distributed.config on the (torch-stub-friendly)
     # module import path.
-    from nemo_automodel.components.distributed.config import normalize_activation_checkpointing_scope
+    from nemo_automodel.components.distributed import normalize_activation_checkpointing_scope
 
     scopes = normalize_activation_checkpointing_scope(activation_checkpointing_scope)
     checkpoint_decoder = "all" in scopes or "language" in scopes
@@ -521,7 +529,7 @@ def apply_ac(
         if checkpoint_decoder:
             # Reuse the dense FSDP2 selective policy so the save-op set (attention,
             # matmuls, comm collectives, topk, D2H copies) stays single-sourced.
-            from nemo_automodel.components.distributed.activation_checkpointing import (
+            from nemo_automodel.components.distributed import (
                 SELECTIVE_AC_WRAPPER_FLAG,
                 make_selective_checkpoint_context_fn,
                 transformer_engine_attention_backend_snapshot_context_fn,
@@ -608,7 +616,7 @@ def apply_ac(
     def selective_checkpointing_context_fn():
         return create_selective_checkpoint_contexts(_custom_policy)
 
-    from nemo_automodel.components.distributed.activation_checkpointing import (
+    from nemo_automodel.components.distributed import (
         ensure_fsdp_ops_sac_ignored,
         ensure_profiler_ops_sac_ignored,
         transformer_engine_attention_backend_snapshot_context_fn,
@@ -686,7 +694,7 @@ def apply_fsdp(
             output_dtype=torch.bfloat16,
             cast_forward_inputs=True,
         )
-    experts_mp_policy = parallelizer_utils.get_internal_fsdp_mp_policy(mp_policy)
+    experts_mp_policy = get_internal_fsdp_mp_policy(mp_policy)
     fp32_compute_module_names = tuple(getattr(model, "_keep_in_fp32_modules_strict", None) or ())
 
     fully_shard_impl = fully_shard
@@ -827,7 +835,7 @@ def apply_fsdp(
 
         # Reuse the dense dtype-aware path for model-owned fp32 contracts while
         # leaving EP-owned experts out of the block's dtype and FSDP ownership.
-        parallelizer_utils.fully_shard_by_dtype(
+        fully_shard_by_dtype(
             block,
             mesh=fsdp_mesh,
             mp_policy=mp_policy,
@@ -999,7 +1007,7 @@ def apply_cp(model: torch.nn.Module, cp_mesh: DeviceMesh, cp_comm_type: str = "p
                     type(attn_module).__name__ if attn_module is not None else type(self_attn).__name__,
                 )
         elif layer_type == "mamba":
-            from nemo_automodel.components.distributed.context_parallel.mamba import MambaContextParallel
+            from nemo_automodel.components.distributed import MambaContextParallel
 
             mixer = block.self_attn  # NemotronV3Block.self_attn aliases mixer
             mixer.cp = MambaContextParallel(
@@ -1088,7 +1096,7 @@ def parallelize_model(
         model._nemo_moe_tp_requires_pretrained_weights = True
         # PEFT is applied before distributed sharding. Translate each style so
         # LoRA-wrapped shared-expert/lm-head modules keep the same TP semantics.
-        from nemo_automodel.components.distributed.parallel_styles import translate_to_lora
+        from nemo_automodel.components.distributed import translate_to_lora
 
         model_parallel_plan = {path: translate_to_lora(style) for path, style in model_parallel_plan.items()}
         logger.info(
@@ -1102,8 +1110,8 @@ def parallelize_model(
 
     cp_enabled = cp_axis_name is not None and world_mesh[cp_axis_name].size() > 1
     if cp_enabled:
-        parallelizer_utils.reject_unsupported_mtp_cp_pp(model)
-        parallelizer_utils.reject_unsupported_mtp_cp(model)
+        reject_unsupported_mtp_cp_pp(model)
+        reject_unsupported_mtp_cp(model)
         apply_cp(model, world_mesh[cp_axis_name])
 
     ep_enabled = ep_axis_name is not None and moe_mesh is not None and moe_mesh[ep_axis_name].size() > 1
@@ -1132,7 +1140,7 @@ def parallelize_model(
     else:
         ep_shard_mesh = None
 
-    from nemo_automodel.components.distributed.mesh_utils import get_fsdp_dp_mesh, get_submesh
+    from nemo_automodel.components.distributed import get_fsdp_dp_mesh, get_submesh
 
     axis_names = tuple(dp_axis_names or ())
     # HSDP combines a native replica axis with a flattened shard/CP axis.
@@ -1157,7 +1165,7 @@ def parallelize_model(
             frozen_multimodal_sharding=frozen_multimodal_sharding,
         )
         if cp_enabled:
-            configured_units = parallelizer_utils.configure_fsdp_unused_param_reduction(model)
+            configured_units = configure_fsdp_unused_param_reduction(model)
             logger.info(
                 "Enabled unused-parameter reduce-scatter on %d MoE FSDP units for context parallelism",
                 configured_units,

--- a/nemo_automodel/components/optim/__init__.py
+++ b/nemo_automodel/components/optim/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib as _importlib
+
 from .dion import build_dion_optimizer, is_dion_optimizer
 from .optimizer import (
     OPTIMIZER_CONFIG_REGISTRY,
@@ -52,3 +54,26 @@ __all__ = [
     "build_dion_optimizer",
     "is_dion_optimizer",
 ]
+
+_LAZY_ATTRS = {
+    "resolve_storage_dtype": (".precision_warnings", "resolve_storage_dtype"),
+    "warn_if_torch_adam_with_bf16_params": (".precision_warnings", "warn_if_torch_adam_with_bf16_params"),
+}
+
+__all__ += sorted(_LAZY_ATTRS.keys())
+
+
+def __getattr__(name: str) -> object:
+    """Load an exported component symbol on first access."""
+    if name in _LAZY_ATTRS:
+        module_path, attr_name = _LAZY_ATTRS[name]
+        module = _importlib.import_module(module_path, __name__)
+        attr = getattr(module, attr_name)
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return the component's exported symbols."""
+    return sorted(__all__)

--- a/nemo_automodel/components/optim/dion.py
+++ b/nemo_automodel/components/optim/dion.py
@@ -20,7 +20,7 @@ from typing import Any, Protocol
 
 import torch.nn as nn
 
-from nemo_automodel.components.distributed.mesh_utils import get_fsdp_dp_mesh
+from nemo_automodel.components.distributed import get_fsdp_dp_mesh
 
 
 class _DionFamilyConfig(Protocol):

--- a/nemo_automodel/components/speculative/bench_common.py
+++ b/nemo_automodel/components/speculative/bench_common.py
@@ -187,7 +187,7 @@ def _load_prompts(args: argparse.Namespace) -> list[list[dict[str, Any]]]:
     an optional attribute -- callers that only ever use ``messages_column``
     (the two single-dataset benchmarks' own ``argparse.Namespace``) need not set it.
     """
-    from nemo_automodel.components.datasets.llm.chat_dataset import _load_openai_messages
+    from nemo_automodel.components.datasets import load_openai_messages as _load_openai_messages
 
     dataset = _load_openai_messages(
         args.input_data,

--- a/nemo_automodel/components/speculative/dflash/core.py
+++ b/nemo_automodel/components/speculative/dflash/core.py
@@ -51,7 +51,7 @@ from nemo_automodel.components.attention.dflash_mask import (
     create_dflash_block_mask,
     create_dflash_sdpa_mask,
 )
-from nemo_automodel.components.loss.dllm_loss import DFlashDecayLoss
+from nemo_automodel.components.loss import DFlashDecayLoss
 from nemo_automodel.components.speculative.dflash.draft_qwen3 import Qwen3DFlashDraftModel
 
 

--- a/nemo_automodel/components/speculative/dflash/jetspec_core.py
+++ b/nemo_automodel/components/speculative/dflash/jetspec_core.py
@@ -47,7 +47,7 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 
-from nemo_automodel.components.loss.kd_loss import KDLoss
+from nemo_automodel.components.loss import KDLoss
 from nemo_automodel.components.speculative.dflash.core import (
     DFlashTrainerModule,
     NoValidAnchorsError,

--- a/nemo_automodel/components/speculative/dflash/target.py
+++ b/nemo_automodel/components/speculative/dflash/target.py
@@ -29,7 +29,7 @@ from typing import Any, Sequence
 import torch
 import torch.nn as nn
 
-from nemo_automodel.components.datasets.llm.packed_sequence import build_block_causal_additive_mask
+from nemo_automodel.components.datasets import build_block_causal_additive_mask
 
 
 @dataclass
@@ -99,7 +99,7 @@ class HFDFlashTargetModel:
         self.cp_mesh = cp_mesh
         self._cp_size = cp_mesh.size() if cp_mesh is not None else 1
         if self._cp_size > 1:
-            from nemo_automodel.components.distributed.context_parallel.utils import attach_context_parallel_hooks
+            from nemo_automodel.components.distributed import attach_context_parallel_hooks
             from nemo_automodel.components.speculative.target_cp import attach_cp_kv_gather_hooks
 
             # Strip the 4D mask, and all-gather K/V so each rank attends its local Q

--- a/nemo_automodel/components/speculative/dspark/target.py
+++ b/nemo_automodel/components/speculative/dspark/target.py
@@ -30,9 +30,9 @@ from typing import Sequence
 import torch
 import torch.nn as nn
 
-from nemo_automodel.components.datasets.llm.packed_sequence import build_block_causal_additive_mask
+from nemo_automodel.components.datasets import build_block_causal_additive_mask
 from nemo_automodel.components.speculative.dspark.common import validate_target_layer_ids
-from nemo_automodel.components.utils.model_utils import filter_forward_kwargs
+from nemo_automodel.components.utils import filter_forward_kwargs
 
 
 @dataclass
@@ -74,7 +74,7 @@ class HFDSparkTargetModel:
         self.cp_mesh = cp_mesh
         self._cp_size = cp_mesh.size() if cp_mesh is not None else 1
         if self._cp_size > 1:
-            from nemo_automodel.components.distributed.context_parallel.utils import attach_context_parallel_hooks
+            from nemo_automodel.components.distributed import attach_context_parallel_hooks
             from nemo_automodel.components.speculative.target_cp import attach_cp_kv_gather_hooks
 
             # Strip the 4D mask (self_attn then calls SDPA on the local shard), and

--- a/nemo_automodel/components/speculative/dspark/target_utils.py
+++ b/nemo_automodel/components/speculative/dspark/target_utils.py
@@ -18,7 +18,12 @@ from __future__ import annotations
 
 from transformers import AutoConfig, PretrainedConfig
 
-from nemo_automodel.components.datasets.llm.formatting_utils import _has_chat_template, _resolve_chat_template
+from nemo_automodel.components.datasets import (
+    has_chat_template as _has_chat_template,
+)
+from nemo_automodel.components.datasets import (
+    resolve_chat_template as _resolve_chat_template,
+)
 
 GEMMA4_MODEL_TYPES = ("gemma4", "gemma4_unified")
 DEEPSEEK_V4_MODEL_TYPE = "deepseek_v4"

--- a/nemo_automodel/components/speculative/eagle/core.py
+++ b/nemo_automodel/components/speculative/eagle/core.py
@@ -22,7 +22,7 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
-from nemo_automodel.components.loss.soft_ce import masked_soft_cross_entropy
+from nemo_automodel.components.loss import masked_soft_cross_entropy
 
 
 def _shift_left_with_zero(tensor: torch.Tensor) -> torch.Tensor:

--- a/nemo_automodel/components/speculative/eagle/core_v12.py
+++ b/nemo_automodel/components/speculative/eagle/core_v12.py
@@ -22,8 +22,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from nemo_automodel.components.loss.listmle import listmle_loss
-from nemo_automodel.components.loss.soft_ce import masked_soft_cross_entropy
+from nemo_automodel.components.loss import listmle_loss, masked_soft_cross_entropy
 
 
 @dataclass

--- a/nemo_automodel/components/speculative/eagle/draft_deepseek.py
+++ b/nemo_automodel/components/speculative/eagle/draft_deepseek.py
@@ -47,7 +47,7 @@ import torch
 import torch.nn as nn
 from transformers import PretrainedConfig, PreTrainedModel
 
-from nemo_automodel.components.datasets.llm.packed_sequence import build_block_causal_additive_mask
+from nemo_automodel.components.datasets import build_block_causal_additive_mask
 from nemo_automodel.components.models.common import initialize_rms_norm_module
 from nemo_automodel.components.models.deepseek_v3.rope_utils import (
     apply_rotary_emb,

--- a/nemo_automodel/components/speculative/eagle/draft_llama.py
+++ b/nemo_automodel/components/speculative/eagle/draft_llama.py
@@ -99,7 +99,7 @@ import torch
 import torch.nn as nn
 from transformers import PretrainedConfig, PreTrainedModel
 
-from nemo_automodel.components.datasets.llm.packed_sequence import build_block_causal_additive_mask
+from nemo_automodel.components.datasets import build_block_causal_additive_mask
 from nemo_automodel.components.models.common import initialize_rms_norm_module
 from nemo_automodel.components.models.llama.rope_utils import (
     LlamaRotaryEmbedding,

--- a/nemo_automodel/components/speculative/eagle/draft_llama_v12.py
+++ b/nemo_automodel/components/speculative/eagle/draft_llama_v12.py
@@ -26,7 +26,7 @@ import torch
 import torch.nn as nn
 from transformers import PretrainedConfig, PreTrainedModel
 
-from nemo_automodel.components.datasets.llm.packed_sequence import build_block_causal_additive_mask
+from nemo_automodel.components.datasets import build_block_causal_additive_mask
 from nemo_automodel.components.models.common import initialize_rms_norm_module
 from nemo_automodel.components.models.llama.rope_utils import (
     LlamaRotaryEmbedding,

--- a/nemo_automodel/components/speculative/eagle/msd.py
+++ b/nemo_automodel/components/speculative/eagle/msd.py
@@ -30,7 +30,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from transformers import PretrainedConfig
 
-from nemo_automodel.components.loss.soft_ce import masked_soft_cross_entropy
+from nemo_automodel.components.loss import masked_soft_cross_entropy
 from nemo_automodel.components.speculative.eagle.draft_llama_v12 import (
     LlamaEagleDraftModel,
     _build_causal_mask,

--- a/nemo_automodel/components/speculative/eagle/target.py
+++ b/nemo_automodel/components/speculative/eagle/target.py
@@ -23,7 +23,7 @@ from typing import Sequence
 import torch
 import torch.nn as nn
 
-from nemo_automodel.components.datasets.llm.packed_sequence import build_block_causal_additive_mask
+from nemo_automodel.components.datasets import build_block_causal_additive_mask
 from nemo_automodel.components.speculative.eagle.backend import Eagle3TargetBackend
 
 
@@ -168,7 +168,7 @@ class HFEagle3TargetModel(Eagle3TargetBackend):
         self.cp_mesh = cp_mesh
         self._cp_size = cp_mesh.size() if cp_mesh is not None else 1
         if self._cp_size > 1:
-            from nemo_automodel.components.distributed.context_parallel.utils import attach_context_parallel_hooks
+            from nemo_automodel.components.distributed import attach_context_parallel_hooks
             from nemo_automodel.components.speculative.target_cp import attach_cp_kv_gather_hooks
 
             attach_context_parallel_hooks(self.model)

--- a/nemo_automodel/components/speculative/eagle/target_v12.py
+++ b/nemo_automodel/components/speculative/eagle/target_v12.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 
-from nemo_automodel.components.datasets.llm.packed_sequence import build_block_causal_additive_mask
+from nemo_automodel.components.datasets import build_block_causal_additive_mask
 
 
 def _shift_left_with_zero(tensor: torch.Tensor) -> torch.Tensor:

--- a/nemo_automodel/components/speculative/eagle/vispec_core.py
+++ b/nemo_automodel/components/speculative/eagle/vispec_core.py
@@ -39,7 +39,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from nemo_automodel.components.loss.listmle import listmle_loss
+from nemo_automodel.components.loss import listmle_loss
 from nemo_automodel.components.speculative.eagle.core_v12 import FeatureNoiseConfig
 
 

--- a/nemo_automodel/components/speculative/precompute_dspark.py
+++ b/nemo_automodel/components/speculative/precompute_dspark.py
@@ -43,24 +43,34 @@ from transformers import AutoConfig
 
 from nemo_automodel._transformers import NeMoAutoModelForCausalLM
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
-from nemo_automodel.components.datasets.llm.dspark_cache import (
-    DTYPE_MAP,
+from nemo_automodel.components.datasets import (
+    DSPARK_DTYPE_MAP as DTYPE_MAP,
+)
+from nemo_automodel.components.datasets import (
     build_cache_manifest,
+    build_eagle3_dataloader,
     compute_batch_cache,
-    existing_shard_indices,
+    dataloader_from_sample,
     manifest_mismatch_fields,
-    manifest_path,
-    read_manifest,
+    resume_start_sample,
     tokenizer_chat_template_sha256,
-    write_manifest,
-    write_shard,
+    write_cache_shards,
     write_target_weights,
 )
-from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
-from nemo_automodel.components.datasets.llm.offline_cache import (
-    dataloader_from_sample,
-    resume_start_sample,
-    write_cache_shards,
+from nemo_automodel.components.datasets import (
+    dspark_existing_shard_indices as existing_shard_indices,
+)
+from nemo_automodel.components.datasets import (
+    dspark_manifest_path as manifest_path,
+)
+from nemo_automodel.components.datasets import (
+    dspark_read_manifest as read_manifest,
+)
+from nemo_automodel.components.datasets import (
+    dspark_write_manifest as write_manifest,
+)
+from nemo_automodel.components.datasets import (
+    dspark_write_shard as write_shard,
 )
 from nemo_automodel.components.speculative.dspark.registry import build_target_layer_ids
 from nemo_automodel.components.speculative.dspark.target import HFDSparkTargetModel

--- a/nemo_automodel/components/speculative/precompute_eagle3.py
+++ b/nemo_automodel/components/speculative/precompute_eagle3.py
@@ -61,22 +61,33 @@ import torch
 
 from nemo_automodel._transformers import NeMoAutoModelForCausalLM
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
-from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader, build_eagle3_token_mapping
-from nemo_automodel.components.datasets.llm.eagle3_cache import (
-    DTYPE_MAP,
-    compress_target_probs,
-    existing_shard_indices,
-    is_compressed,
-    manifest_path,
-    read_manifest,
-    write_manifest,
-    write_shard,
-    write_target_embeddings,
+from nemo_automodel.components.datasets import (
+    EAGLE3_DTYPE_MAP as DTYPE_MAP,
 )
-from nemo_automodel.components.datasets.llm.offline_cache import (
+from nemo_automodel.components.datasets import (
+    build_eagle3_dataloader,
+    build_eagle3_token_mapping,
+    compress_target_probs,
     dataloader_from_sample,
+    is_compressed,
     resume_start_sample,
     write_cache_shards,
+    write_target_embeddings,
+)
+from nemo_automodel.components.datasets import (
+    eagle3_existing_shard_indices as existing_shard_indices,
+)
+from nemo_automodel.components.datasets import (
+    eagle3_manifest_path as manifest_path,
+)
+from nemo_automodel.components.datasets import (
+    eagle3_read_manifest as read_manifest,
+)
+from nemo_automodel.components.datasets import (
+    eagle3_write_manifest as write_manifest,
+)
+from nemo_automodel.components.datasets import (
+    eagle3_write_shard as write_shard,
 )
 from nemo_automodel.components.speculative.eagle import HFEagle3TargetModel
 from nemo_automodel.components.speculative.eagle.core import _compute_target_distribution

--- a/nemo_automodel/components/speculative/regenerate.py
+++ b/nemo_automodel/components/speculative/regenerate.py
@@ -376,7 +376,7 @@ def _iter_samples(
 async def _run(args: argparse.Namespace) -> int:
     """Async driver: load dataset, regenerate, write shards. Returns a process exit code."""
     aiohttp = _import_aiohttp()
-    from nemo_automodel.components.datasets.llm.chat_dataset import _load_openai_messages
+    from nemo_automodel.components.datasets import load_openai_messages as _load_openai_messages
 
     _validate_args(args)
     output_dir = Path(args.output_dir)

--- a/nemo_automodel/components/speculative/regenerate_vlm.py
+++ b/nemo_automodel/components/speculative/regenerate_vlm.py
@@ -53,8 +53,7 @@ import torch
 from datasets import load_dataset
 from transformers import AutoModelForImageTextToText, AutoProcessor
 
-from nemo_automodel.components.datasets.vlm.datasets import convert_sharegpt_to_conversation
-from nemo_automodel.components.datasets.vlm.utils import set_image_pixel_bounds
+from nemo_automodel.components.datasets import convert_sharegpt_to_conversation, set_image_pixel_bounds
 from nemo_automodel.shared.import_utils import safe_import
 
 logger = logging.getLogger(__name__)

--- a/nemo_automodel/components/speculative/target_cp.py
+++ b/nemo_automodel/components/speculative/target_cp.py
@@ -172,7 +172,7 @@ def run_target_cp_forward_and_gather(
         **forward_kwargs,
     }
     if filter_kwargs:
-        from nemo_automodel.components.utils.model_utils import filter_forward_kwargs
+        from nemo_automodel.components.utils import filter_forward_kwargs
 
         call_kwargs = filter_forward_kwargs(model, call_kwargs)
     with cp_ctx:

--- a/nemo_automodel/components/training/__init__.py
+++ b/nemo_automodel/components/training/__init__.py
@@ -14,6 +14,50 @@
 
 """Training utilities shared across recipes."""
 
+import importlib as _importlib
+
 from nemo_automodel.components.training.step_scheduler import StepSchedulerConfig
 
 __all__ = ["StepSchedulerConfig"]
+
+_LAZY_ATTRS = {
+    "DistributedSignalHandler": (".signal_handler", "DistributedSignalHandler"),
+    "EMAManager": (".ema", "EMAManager"),
+    "EmbeddingRowRepairConfig": (".embedding_row_repair", "EmbeddingRowRepairConfig"),
+    "GarbageCollection": (".garbage_collection", "GarbageCollection"),
+    "NEFTune": (".neftune", "NEFTune"),
+    "PrewarmConfig": (".prewarm", "PrewarmConfig"),
+    "ScopedModuleOffloading": (".utils", "ScopedModuleOffloading"),
+    "ScopedRNG": (".rng", "ScopedRNG"),
+    "ShardedModelEMAManager": (".ema", "ShardedModelEMAManager"),
+    "StatefulRNG": (".rng", "StatefulRNG"),
+    "StepScheduler": (".step_scheduler", "StepScheduler"),
+    "Timers": (".timers", "Timers"),
+    "clip_grad_norm": (".utils", "clip_grad_norm"),
+    "count_tail_padding": (".utils", "count_tail_padding"),
+    "get_expert_tp_replication_factor": (".utils", "get_expert_tp_replication_factor"),
+    "get_final_hidden_states": (".model_output_utils", "get_final_hidden_states"),
+    "init_all_rng": (".rng", "init_all_rng"),
+    "prepare_after_first_microbatch": (".utils", "prepare_after_first_microbatch"),
+    "prepare_for_final_backward": (".utils", "prepare_for_final_backward"),
+    "prepare_for_grad_accumulation": (".utils", "prepare_for_grad_accumulation"),
+    "scale_grads_and_clip_grad_norm": (".utils", "scale_grads_and_clip_grad_norm"),
+}
+
+__all__ += sorted(_LAZY_ATTRS.keys())
+
+
+def __getattr__(name: str) -> object:
+    """Load an exported component symbol on first access."""
+    if name in _LAZY_ATTRS:
+        module_path, attr_name = _LAZY_ATTRS[name]
+        module = _importlib.import_module(module_path, __name__)
+        attr = getattr(module, attr_name)
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return the component's exported symbols."""
+    return sorted(__all__)

--- a/nemo_automodel/components/utils/__init__.py
+++ b/nemo_automodel/components/utils/__init__.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib as _importlib
+
+_LAZY_ATTRS = {
+    "FreezeConfig": (".model_utils", "FreezeConfig"),
+    "ModuleSelector": (".model_utils", "ModuleSelector"),
+    "VLM_INPUT_KEYS": (".model_utils", "VLM_INPUT_KEYS"),
+    "apply_parameter_freezing": (".model_utils", "apply_parameter_freezing"),
+    "build_compile_config": (".compile_utils", "build_compile_config"),
+    "calculate_mfu": (".flops_utils", "calculate_mfu"),
+    "compile_model": (".compile_utils", "compile_model"),
+    "compile_module_inplace": (".compile_utils", "compile_module_inplace"),
+    "count_model_parameters": (".model_utils", "count_model_parameters"),
+    "enable_radio_vit_fused_attn": (".model_utils", "enable_radio_vit_fused_attn"),
+    "filter_forward_kwargs": (".model_utils", "filter_forward_kwargs"),
+    "freeze_deepseek_v4_indexer_params": (".model_utils", "freeze_deepseek_v4_indexer_params"),
+    "freeze_minimax_m3_indexer_params": (".model_utils", "freeze_minimax_m3_indexer_params"),
+    "freeze_unused_kv_sharing_params": (".model_utils", "freeze_unused_kv_sharing_params"),
+    "get_flops_formula_for_hf_config": (".flops_utils", "get_flops_formula_for_hf_config"),
+    "init_empty_weights": (".model_utils", "init_empty_weights"),
+    "nemotronh_mtp_flops": (".flops_utils", "_nemotronh_mtp_flops"),
+    "parse_freeze_config": (".model_utils", "parse_freeze_config"),
+    "print_trainable_parameters": (".model_utils", "print_trainable_parameters"),
+    "resolve_trust_remote_code": (".model_utils", "resolve_trust_remote_code"),
+    "skip_random_init": (".model_utils", "skip_random_init"),
+    "squeeze_input_for_thd": (".model_utils", "squeeze_input_for_thd"),
+    "supports_logits_to_keep": (".model_utils", "_supports_logits_to_keep"),
+    "supports_seq_lens": (".model_utils", "_supports_seq_lens"),
+}
+
+__all__ = sorted(_LAZY_ATTRS.keys())
+
+
+def __getattr__(name: str) -> object:
+    """Load an exported component symbol on first access."""
+    if name in _LAZY_ATTRS:
+        module_path, attr_name = _LAZY_ATTRS[name]
+        module = _importlib.import_module(module_path, __name__)
+        attr = getattr(module, attr_name)
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return the component's exported symbols."""
+    return sorted(__all__)

--- a/nemo_automodel/recipes/_dist_utils.py
+++ b/nemo_automodel/recipes/_dist_utils.py
@@ -24,16 +24,18 @@ first, then pass the resulting world size here.
 import logging
 from typing import Any, Dict
 
-from nemo_automodel.components.distributed.config import (
+from nemo_automodel.components.distributed import (
+    CpVisionFrameShardingConfig,
     DistributedSetup,
     MoEParallelizerConfig,
     MultimodalDistributedConfig,
     MultimodalVisionConfig,
-    _resolve_strategy_config,
+    ParallelismSizes,
+    PipelineConfig,
 )
-from nemo_automodel.components.distributed.cp_vision_frame_shard import CpVisionFrameShardingConfig
-from nemo_automodel.components.distributed.mesh import ParallelismSizes
-from nemo_automodel.components.distributed.pipelining.config import PipelineConfig
+from nemo_automodel.components.distributed import (
+    resolve_strategy_config as _resolve_strategy_config,
+)
 from nemo_automodel.shared.utils import dtype_from_str
 
 logger = logging.getLogger(__name__)
@@ -353,7 +355,7 @@ def create_distributed_setup_from_config(
     Returns:
         A :class:`DistributedSetup` with device meshes and policy configs attached.
     """
-    from nemo_automodel.components.distributed.init_utils import get_world_size_safe
+    from nemo_automodel.components.distributed import get_world_size_safe
 
     if world_size is None:
         world_size = get_world_size_safe()
@@ -401,7 +403,7 @@ def shard_optimizers_for_megatron_fsdp(model, optimizers, distributed_config, *,
     ``maybe_shard_optimizer`` assert rather than silently skip under Megatron-FSDP.
     No-op unless ``distributed_config`` is a MegatronFSDPConfig running distributed.
     """
-    from nemo_automodel.components.distributed.megatron_fsdp import maybe_shard_optimizer
+    from nemo_automodel.components.distributed import maybe_shard_optimizer
 
     parts = list(getattr(model, "parts", [model]))
     return [maybe_shard_optimizer(part, opt, distributed_config, allow=allow) for part, opt in zip(parts, optimizers)]

--- a/nemo_automodel/recipes/_typed_config.py
+++ b/nemo_automodel/recipes/_typed_config.py
@@ -46,9 +46,9 @@ from dataclasses import fields, is_dataclass
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
-from nemo_automodel.components.loggers.loggers import CometConfig, MLflowConfig, WandbConfig
-from nemo_automodel.components.optim.optimizer import LRSchedulerConfig
-from nemo_automodel.components.training.step_scheduler import StepSchedulerConfig
+from nemo_automodel.components.loggers import CometConfig, MLflowConfig, WandbConfig
+from nemo_automodel.components.optim import LRSchedulerConfig
+from nemo_automodel.components.training import StepSchedulerConfig
 
 if TYPE_CHECKING:
     from nemo_automodel._transformers.mfu import MFUConfig
@@ -172,7 +172,7 @@ class RecipeConfig:
 
     @cached_property
     def optimizer(self) -> "OptimizerConfig" | None:
-        from nemo_automodel.components.optim.optimizer import build_optimizer_config
+        from nemo_automodel.components.optim import build_optimizer_config
 
         node = self._raw.get("optimizer", None)
         if node is None:
@@ -209,7 +209,7 @@ class RecipeConfig:
 
     def _packing_config(self):
         """Resolve the recipe's optional sequence-packing strategy config."""
-        from nemo_automodel.components.datasets.loader import make_packing_config
+        from nemo_automodel.components.datasets import make_packing_config
 
         ps = _as_dict(self._raw.get("packed_sequence", None))
         if ps.get("packed_sequence_size", 0) > 0:
@@ -221,10 +221,10 @@ class RecipeConfig:
         from torch.utils.data import DataLoader
         from torchdata.stateful_dataloader import StatefulDataLoader
 
-        from nemo_automodel.components.datasets.llm.megatron.sampler import MegatronSamplerConfig
-        from nemo_automodel.components.datasets.loader import (
+        from nemo_automodel.components.datasets import (
             DataloaderConfig,
             DatasetBuildSchedule,
+            MegatronSamplerConfig,
             ScheduledDatasetConfig,
             make_collate_fn,
             make_dataset_config,
@@ -328,7 +328,7 @@ class RecipeConfig:
     @staticmethod
     def _resolve_vlm_processor(node: Any) -> "VlmProcessorConfig":
         """Resolve an optional processor section into its typed component config."""
-        from nemo_automodel.components.datasets.vlm.loader import VlmProcessorConfig, VlmVideoProcessorConfig
+        from nemo_automodel.components.datasets import VlmProcessorConfig, VlmVideoProcessorConfig
 
         if node is None:
             return VlmProcessorConfig()
@@ -370,10 +370,13 @@ class RecipeConfig:
         """
         from torchdata.stateful_dataloader import StatefulDataLoader
 
-        from nemo_automodel.components.datasets.loader import make_dataset_config
-        from nemo_automodel.components.datasets.vlm.datasets import PreTokenizedDatasetWrapperConfig
-        from nemo_automodel.components.datasets.vlm.loader import VlmCollatorConfig, VlmDataloaderConfig
-        from nemo_automodel.components.datasets.vlm.neat_packing_vlm import NeatPackConfig
+        from nemo_automodel.components.datasets import (
+            NeatPackConfig,
+            PreTokenizedDatasetWrapperConfig,
+            VlmCollatorConfig,
+            VlmDataloaderConfig,
+            make_dataset_config,
+        )
 
         target, dataset_kwargs = _callable_and_kwargs(dataset_node)
         # `tokenizer`/`processor` are runtime build args, not declarative dataset fields.
@@ -517,12 +520,12 @@ class RecipeConfig:
         Returns:
             Typed dataloader config whose ``build`` accepts runtime rank and batch-size values.
         """
-        from nemo_automodel.components.datasets.diffusion.collate_fns import (
+        from nemo_automodel.components.datasets import (
+            MetaFilesDataloaderConfig,
+            MockWanDataloaderConfig,
             TextToImageDataloaderConfig,
             TextToVideoDataloaderConfig,
         )
-        from nemo_automodel.components.datasets.diffusion.meta_files_dataset import MetaFilesDataloaderConfig
-        from nemo_automodel.components.datasets.diffusion.mock_dataloader import MockWanDataloaderConfig
 
         target, kwargs = _callable_and_kwargs(node)
         module = getattr(target, "__module__", None)
@@ -568,8 +571,7 @@ class RecipeConfig:
     @cached_property
     def bagel_dataloader(self) -> "BagelDataloaderConfig" | None:
         """Typed packed-dataset and dataloader config for BAGEL recipes."""
-        from nemo_automodel.components.datasets.multimodal.datasets import BagelDatasetConfig
-        from nemo_automodel.components.datasets.multimodal.loader import BagelDataloaderConfig
+        from nemo_automodel.components.datasets import BagelDataloaderConfig, BagelDatasetConfig
 
         dataset_node = self._raw.get("dataset", None)
         if dataset_node is None:
@@ -615,13 +617,13 @@ class RecipeConfig:
         # output / get_mtp_loss_scaling_factor; ignore_index is fixed) and are not
         # exposed via YAML.  This typed accessor just lets recipes build MTP through
         # the typed-config boundary like the other sections.
-        from nemo_automodel.components.loss.mtp import MTPLossConfig
+        from nemo_automodel.components.loss import MTPLossConfig
 
         return MTPLossConfig()
 
     @cached_property
     def prewarm(self) -> "PrewarmConfig | None":
-        from nemo_automodel.components.training.prewarm import PrewarmConfig
+        from nemo_automodel.components.training import PrewarmConfig
 
         node = self._raw.get("prewarm", None)
         return PrewarmConfig(**_section_kwargs(node)) if node else None
@@ -635,14 +637,14 @@ class RecipeConfig:
 
     @cached_property
     def embedding_row_repair(self) -> "EmbeddingRowRepairConfig | None":
-        from nemo_automodel.components.training.embedding_row_repair import EmbeddingRowRepairConfig
+        from nemo_automodel.components.training import EmbeddingRowRepairConfig
 
         node = self._raw.get("embedding_row_repair", None)
         return EmbeddingRowRepairConfig(**_section_kwargs(node)) if node else None
 
     @cached_property
     def checkpoint(self) -> "CheckpointingConfig":
-        from nemo_automodel.components.checkpoint.config import CheckpointingConfig
+        from nemo_automodel.components.checkpoint import CheckpointingConfig
 
         node = self._raw.get("checkpoint", None)
         kwargs = _as_dict(node) if node is not None else {}

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -40,22 +40,18 @@ except ImportError:
     # < v5
     from transformers.tokenization_utils import PreTrainedTokenizerBase
 
-from nemo_automodel.components.checkpoint.checkpointing import (
+from nemo_automodel.components.checkpoint import (
+    find_latest_checkpoint,
     load_torch_ckpt,
+    resolve_restore_from_to_checkpoint_dir,
     save_config,
     save_losses,
 )
-from nemo_automodel.components.checkpoint.utils import (
-    find_latest_checkpoint,
-    resolve_restore_from_to_checkpoint_dir,
-)
-from nemo_automodel.components.config.loader import ConfigNode, config_to_yaml_str
-from nemo_automodel.components.distributed.mesh_utils import get_flat_mesh
+from nemo_automodel.components.config import ConfigNode, config_to_yaml_str
+from nemo_automodel.components.distributed import get_flat_mesh
 from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
-from nemo_automodel.components.optim.scheduler import OptimizerParamScheduler
-from nemo_automodel.components.training.garbage_collection import GarbageCollection
-from nemo_automodel.components.training.rng import StatefulRNG
-from nemo_automodel.components.training.step_scheduler import StepScheduler
+from nemo_automodel.components.optim import OptimizerParamScheduler
+from nemo_automodel.components.training import GarbageCollection, StatefulRNG, StepScheduler
 from nemo_automodel.recipes._typed_config import RecipeConfig
 
 logger = logging.getLogger(__name__)

--- a/nemo_automodel/recipes/diffusion/train.py
+++ b/nemo_automodel/recipes/diffusion/train.py
@@ -26,15 +26,14 @@ import wandb
 from torch.distributed.fsdp import CPUOffloadPolicy, MixedPrecisionPolicy
 
 from nemo_automodel._diffusers.auto_diffusion_pipeline import NeMoAutoDiffusionPipeline
-from nemo_automodel.components.distributed.fsdp2 import fsdp2_sharding_enabled
-from nemo_automodel.components.distributed.init_utils import initialize_distributed
-from nemo_automodel.components.distributed.utils import get_sync_ctx
-from nemo_automodel.components.flow_matching.pipeline import FlowMatchingPipeline, create_adapter
-from nemo_automodel.components.loggers.log_utils import setup_logging
-from nemo_automodel.components.loggers.wandb_utils import suppress_wandb_log_messages
-from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG, init_all_rng
-from nemo_automodel.components.training.utils import (
+from nemo_automodel.components.distributed import fsdp2_sharding_enabled, get_sync_ctx, initialize_distributed
+from nemo_automodel.components.flow_matching import FlowMatchingPipeline, create_adapter
+from nemo_automodel.components.loggers import setup_logging, suppress_wandb_log_messages
+from nemo_automodel.components.training import (
+    ScopedRNG,
+    StatefulRNG,
     clip_grad_norm,
+    init_all_rng,
     prepare_after_first_microbatch,
     prepare_for_final_backward,
     prepare_for_grad_accumulation,
@@ -727,7 +726,7 @@ class TrainDiffusionRecipe(BaseRecipe):
             )
 
         if self.optimize_hunyuan_flash_varlen_mask:
-            from nemo_automodel.components.flow_matching.adapters.hunyuan import (
+            from nemo_automodel.components.flow_matching import (
                 enable_hunyuan_flash_varlen_mask_optimization,
             )
 

--- a/nemo_automodel/recipes/dllm/strategy.py
+++ b/nemo_automodel/recipes/dllm/strategy.py
@@ -41,16 +41,15 @@ from nemo_automodel.components.attention.idlm_mask import (
     create_idlm_block_mask,
     create_idlm_sdpa_mask,
 )
-from nemo_automodel.components.datasets.dllm.corruption import (
+from nemo_automodel.components.datasets import (
     corrupt_all_masked,
     corrupt_blockwise,
     corrupt_mix,
     corrupt_uniform,
     corrupt_uniform_random,
 )
-from nemo_automodel.components.distributed.context_parallel import ContextParallelSharder
-from nemo_automodel.components.distributed.utils import get_sync_ctx
-from nemo_automodel.components.loss.dllm_loss import (
+from nemo_automodel.components.distributed import ContextParallelSharder, get_sync_ctx
+from nemo_automodel.components.loss import (
     BlockDiffusionCrossEntropyLoss,
     HybridDiffusionLLMLoss,
     IDLMLoss,
@@ -599,7 +598,7 @@ class DFlashStrategy(DLLMStrategy):
         """Load and freeze the target LM; resolve block_size, layer_ids, decay loss."""
         from transformers import AutoModelForCausalLM, AutoTokenizer
 
-        from nemo_automodel.components.loss.dllm_loss import DFlashDecayLoss
+        from nemo_automodel.components.loss import DFlashDecayLoss
 
         dflash_cfg = recipe.cfg.get("dflash", None) or {}
 

--- a/nemo_automodel/recipes/dllm/train_ft.py
+++ b/nemo_automodel/recipes/dllm/train_ft.py
@@ -43,23 +43,20 @@ import torch
 import wandb
 from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
 
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.datasets.dllm.collate import DLLMCollator
-from nemo_automodel.components.distributed.context_parallel import ContextParallelSharder
-from nemo_automodel.components.distributed.utils import get_sync_ctx
-from nemo_automodel.components.loggers.metric_logger import MetricsSample
-from nemo_automodel.components.loggers.mlflow_utils import to_float_metrics
-from nemo_automodel.components.loss.dllm_loss import encoder_ar_loss
+from nemo_automodel.components.config import parse_args_and_load_config
+from nemo_automodel.components.datasets import DLLMCollator
+from nemo_automodel.components.distributed import ContextParallelSharder, get_sync_ctx
+from nemo_automodel.components.loggers import MetricsSample, to_float_metrics
+from nemo_automodel.components.loss import encoder_ar_loss
 from nemo_automodel.components.models.diffusion_gemma.attention_mask import build_block_diffusion_training_mask
-from nemo_automodel.components.training.rng import ScopedRNG
-from nemo_automodel.components.training.utils import (
+from nemo_automodel.components.training import (
+    ScopedRNG,
     prepare_after_first_microbatch,
     prepare_for_final_backward,
     prepare_for_grad_accumulation,
     scale_grads_and_clip_grad_norm,
 )
-from nemo_automodel.components.utils.flops_utils import calculate_mfu
-from nemo_automodel.components.utils.model_utils import filter_forward_kwargs
+from nemo_automodel.components.utils import calculate_mfu, filter_forward_kwargs
 from nemo_automodel.recipes.dllm.strategy import BlockDiffusionStrategy, get_dllm_strategy
 from nemo_automodel.recipes.llm.train_ft import TrainFinetuneRecipeForNextTokenPrediction
 

--- a/nemo_automodel/recipes/kd_utils.py
+++ b/nemo_automodel/recipes/kd_utils.py
@@ -24,8 +24,7 @@ import torch
 import torch.distributed as dist
 from torch.distributed.tensor import DTensor, Shard
 
-from nemo_automodel.components.distributed.config import DDPConfig, DistributedSetup
-from nemo_automodel.components.distributed.context_parallel.utils import unshard_context_parallel_tensor
+from nemo_automodel.components.distributed import DDPConfig, DistributedSetup, unshard_context_parallel_tensor
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config, parse_distributed_section
 
 if TYPE_CHECKING:

--- a/nemo_automodel/recipes/llm/_spec_train_utils.py
+++ b/nemo_automodel/recipes/llm/_spec_train_utils.py
@@ -29,7 +29,7 @@ from typing import Any
 import torch.nn as nn
 
 from nemo_automodel.components.quantization.fp8 import apply_fp8_to_model, build_fp8_config
-from nemo_automodel.components.utils.compile_utils import build_compile_config, compile_module_inplace
+from nemo_automodel.components.utils import build_compile_config, compile_module_inplace
 
 
 def apply_draft_fp8(draft_model: nn.Module, cfg_fp8: Any) -> None:

--- a/nemo_automodel/recipes/llm/benchmark.py
+++ b/nemo_automodel/recipes/llm/benchmark.py
@@ -18,14 +18,14 @@ import pathlib
 
 import torch
 
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.training.timers import Timers
-from nemo_automodel.components.training.utils import (
+from nemo_automodel.components.config import parse_args_and_load_config
+from nemo_automodel.components.training import (
+    Timers,
     prepare_after_first_microbatch,
     prepare_for_final_backward,
     prepare_for_grad_accumulation,
 )
-from nemo_automodel.components.utils.flops_utils import calculate_mfu, get_flops_formula_for_hf_config
+from nemo_automodel.components.utils import calculate_mfu, get_flops_formula_for_hf_config
 from nemo_automodel.recipes.llm.train_ft import TrainFinetuneRecipeForNextTokenPrediction
 
 logger = logging.getLogger(__name__)
@@ -193,7 +193,7 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
                 total_params = self.pp.total_params_before_pp
             else:
                 # No PP - model is not sharded, calculate directly
-                from nemo_automodel.components.utils.model_utils import print_trainable_parameters
+                from nemo_automodel.components.utils import print_trainable_parameters
 
                 lora_params, total_params = print_trainable_parameters(self.model_parts[0])
             frozen_params = total_params - lora_params
@@ -246,7 +246,7 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
         ``mtp_config.use_repeated_layer``, and the per-sublayer ``block_type`` from
         ``mtp.layers``. Returns 0.0 when the model has no enabled MTP head.
         """
-        from nemo_automodel.components.utils.flops_utils import _nemotronh_mtp_flops
+        from nemo_automodel.components.utils import nemotronh_mtp_flops as _nemotronh_mtp_flops
 
         for mp in self.model_parts:
             mtp_cfg = getattr(mp, "mtp_config", None)

--- a/nemo_automodel/recipes/llm/kd.py
+++ b/nemo_automodel/recipes/llm/kd.py
@@ -49,28 +49,24 @@ import wandb
 from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
 
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.distributed.config import DistributedSetup
-from nemo_automodel.components.distributed.context_parallel import ContextParallelSharder
-from nemo_automodel.components.distributed.pipelining.config import PipelineConfig
-from nemo_automodel.components.distributed.utils import get_sync_ctx
-from nemo_automodel.components.loggers.metric_logger import MetricsSample
-from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
-from nemo_automodel.components.loss.utils import calculate_loss
-from nemo_automodel.components.optim.precision_warnings import resolve_storage_dtype
-from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
-from nemo_automodel.components.training.rng import ScopedRNG
-from nemo_automodel.components.training.signal_handler import DistributedSignalHandler
-from nemo_automodel.components.training.utils import (
+from nemo_automodel.components.config import parse_args_and_load_config
+from nemo_automodel.components.distributed import ContextParallelSharder, DistributedSetup, PipelineConfig, get_sync_ctx
+from nemo_automodel.components.loggers import MetricsSample
+from nemo_automodel.components.loss import FusedLinearCrossEntropy, calculate_loss
+from nemo_automodel.components.optim import resolve_storage_dtype
+from nemo_automodel.components.training import (
+    DistributedSignalHandler,
     ScopedModuleOffloading,
+    ScopedRNG,
     count_tail_padding,
     get_expert_tp_replication_factor,
+    get_final_hidden_states,
     prepare_after_first_microbatch,
     prepare_for_final_backward,
     prepare_for_grad_accumulation,
     scale_grads_and_clip_grad_norm,
 )
-from nemo_automodel.components.utils.model_utils import filter_forward_kwargs
+from nemo_automodel.components.utils import filter_forward_kwargs
 from nemo_automodel.recipes.kd_utils import (
     RUN_TEACHER,
     STOP_TEACHER,

--- a/nemo_automodel/recipes/llm/precompute_dspark_dist.py
+++ b/nemo_automodel/recipes/llm/precompute_dspark_dist.py
@@ -49,23 +49,35 @@ import torch.distributed as dist
 
 from nemo_automodel._transformers import NeMoAutoModelForCausalLM
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.datasets.llm.dspark_cache import (
-    DTYPE_MAP,
+from nemo_automodel.components.config import parse_args_and_load_config
+from nemo_automodel.components.datasets import (
+    DSPARK_DTYPE_MAP as DTYPE_MAP,
+)
+from nemo_automodel.components.datasets import (
     build_cache_manifest,
+    build_eagle3_dataloader,
     compute_batch_cache,
-    existing_shard_indices,
     manifest_mismatch_fields,
-    manifest_path,
-    read_manifest,
     tokenizer_chat_template_sha256,
-    write_manifest,
-    write_shard,
+    write_cache_shards_distributed,
     write_target_weights,
 )
-from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
-from nemo_automodel.components.datasets.llm.offline_cache import write_cache_shards_distributed
-from nemo_automodel.components.distributed.init_utils import initialize_distributed
+from nemo_automodel.components.datasets import (
+    dspark_existing_shard_indices as existing_shard_indices,
+)
+from nemo_automodel.components.datasets import (
+    dspark_manifest_path as manifest_path,
+)
+from nemo_automodel.components.datasets import (
+    dspark_read_manifest as read_manifest,
+)
+from nemo_automodel.components.datasets import (
+    dspark_write_manifest as write_manifest,
+)
+from nemo_automodel.components.datasets import (
+    dspark_write_shard as write_shard,
+)
+from nemo_automodel.components.distributed import initialize_distributed
 from nemo_automodel.components.speculative.dspark.common import validate_target_layer_ids
 from nemo_automodel.components.speculative.dspark.registry import build_target_layer_ids
 from nemo_automodel.components.speculative.dspark.target import HFDSparkTargetModel

--- a/nemo_automodel/recipes/llm/train_dflash.py
+++ b/nemo_automodel/recipes/llm/train_dflash.py
@@ -39,25 +39,24 @@ from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
 
 from nemo_automodel._transformers import NeMoAutoModelForCausalLM
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
-from nemo_automodel.components.checkpoint.checkpointing import (
+from nemo_automodel.components.checkpoint import (
     Checkpointer,
     CheckpointingConfig,
+    find_latest_checkpoint,
     load_torch_ckpt,
+    resolve_restore_from_to_checkpoint_dir,
     save_config,
     save_losses,
 )
-from nemo_automodel.components.checkpoint.utils import find_latest_checkpoint, resolve_restore_from_to_checkpoint_dir
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
-from nemo_automodel.components.distributed.init_utils import initialize_distributed
-from nemo_automodel.components.distributed.mesh_utils import get_flat_mesh
-from nemo_automodel.components.loggers.log_utils import setup_logging
-from nemo_automodel.components.loggers.wandb_utils import init_wandb_run, suppress_wandb_log_messages
+from nemo_automodel.components.config import parse_args_and_load_config
+from nemo_automodel.components.datasets import build_eagle3_dataloader
+from nemo_automodel.components.distributed import get_flat_mesh, initialize_distributed
+from nemo_automodel.components.loggers import init_wandb_run, setup_logging, suppress_wandb_log_messages
 from nemo_automodel.components.speculative.dflash.core import DFlashTrainerModule, NoValidAnchorsError
 from nemo_automodel.components.speculative.dflash.draft_qwen3 import build_target_layer_ids
 from nemo_automodel.components.speculative.dflash.registry import DFlashDraftSpec, resolve_dflash_draft_spec
 from nemo_automodel.components.speculative.dflash.target import HFDFlashTargetModel, resolve_text_config
-from nemo_automodel.components.training.rng import StatefulRNG
+from nemo_automodel.components.training import StatefulRNG
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config
 from nemo_automodel.recipes.base_recipe import BaseRecipe, _is_checkpoint_model_config_compatible
 from nemo_automodel.recipes.llm._spec_train_utils import (

--- a/nemo_automodel/recipes/llm/train_dflash2.py
+++ b/nemo_automodel/recipes/llm/train_dflash2.py
@@ -38,7 +38,7 @@ import logging
 
 import torch
 
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
+from nemo_automodel.components.config import parse_args_and_load_config
 from nemo_automodel.components.speculative.dflash.dflash2_core import DFlash2TrainerModule
 from nemo_automodel.components.speculative.dflash.registry import DFlashDraftSpec
 from nemo_automodel.recipes.llm.train_dflash import TrainDFlashRecipe

--- a/nemo_automodel/recipes/llm/train_domino.py
+++ b/nemo_automodel/recipes/llm/train_domino.py
@@ -30,7 +30,7 @@ import logging
 
 import torch
 
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
+from nemo_automodel.components.config import parse_args_and_load_config
 from nemo_automodel.components.speculative.dflash.domino_core import DominoTrainerModule, get_lambda_base
 from nemo_automodel.recipes.llm.train_dflash import TrainDFlashRecipe
 

--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -40,39 +40,48 @@ from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
 
 from nemo_automodel._transformers import NeMoAutoModelForCausalLM, NeMoAutoModelForImageTextToText
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
-from nemo_automodel.components.checkpoint.checkpointing import (
+from nemo_automodel.components.checkpoint import (
     Checkpointer,
     CheckpointingConfig,
+    find_latest_checkpoint,
     load_torch_ckpt,
+    resolve_restore_from_to_checkpoint_dir,
     save_config,
     save_losses,
 )
-from nemo_automodel.components.checkpoint.utils import find_latest_checkpoint, resolve_restore_from_to_checkpoint_dir
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.datasets.llm.dspark_cache import (
-    DTYPE_MAP,
+from nemo_automodel.components.config import parse_args_and_load_config
+from nemo_automodel.components.datasets import (
+    DSPARK_DTYPE_MAP as DTYPE_MAP,
+)
+from nemo_automodel.components.datasets import (
     build_cached_dspark_dataloader,
-    read_manifest,
+    build_dspark_vlm_dataloader,
+    build_eagle3_dataloader,
     read_target_weight_modules,
 )
-from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
-from nemo_automodel.components.datasets.vlm.dspark_collate import build_dspark_vlm_dataloader
-from nemo_automodel.components.distributed.activation_checkpointing import (
+from nemo_automodel.components.datasets import (
+    dspark_read_manifest as read_manifest,
+)
+from nemo_automodel.components.distributed import (
+    FSDP2Config,
     apply_selective_checkpointing_to_layers,
     apply_submodule_checkpointing,
+    get_flat_mesh,
+    get_sync_ctx,
+    initialize_distributed,
     is_selective_activation_checkpointing,
 )
-from nemo_automodel.components.distributed.config import FSDP2Config
-from nemo_automodel.components.distributed.init_utils import initialize_distributed
-from nemo_automodel.components.distributed.mesh_utils import get_flat_mesh
-from nemo_automodel.components.distributed.utils import get_sync_ctx
-from nemo_automodel.components.loggers.log_utils import setup_logging
-from nemo_automodel.components.loggers.metric_logger import MetricsSample, build_metric_logger
-from nemo_automodel.components.loggers.wandb_utils import init_wandb_run, suppress_wandb_log_messages
+from nemo_automodel.components.loggers import (
+    MetricsSample,
+    build_metric_logger,
+    init_wandb_run,
+    setup_logging,
+    suppress_wandb_log_messages,
+)
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.deepseek_v4.config import DeepseekV4Config
 from nemo_automodel.components.models.minimax_m3_vl.processing import build_minimax_m3_vl_processor
-from nemo_automodel.components.optim.optimizer import build_optimizer
+from nemo_automodel.components.optim import build_optimizer
 from nemo_automodel.components.speculative.dspark.common import validate_target_layer_ids
 from nemo_automodel.components.speculative.dspark.config import (
     build_deepseek_v4_draft_config,
@@ -108,8 +117,8 @@ from nemo_automodel.components.speculative.dspark.target_utils import (
 from nemo_automodel.components.speculative.dspark.target_utils import (
     read_target_model_type as _read_target_model_type,
 )
-from nemo_automodel.components.training.rng import StatefulRNG
-from nemo_automodel.components.utils.model_utils import VLM_INPUT_KEYS
+from nemo_automodel.components.training import StatefulRNG
+from nemo_automodel.components.utils import VLM_INPUT_KEYS
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config, parse_distributed_section
 from nemo_automodel.recipes.base_recipe import (
     BaseRecipe,

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -30,24 +30,23 @@ from transformers import AutoConfig
 
 from nemo_automodel._transformers import NeMoAutoModelForCausalLM
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
-from nemo_automodel.components.checkpoint.checkpointing import (
+from nemo_automodel.components.checkpoint import (
     CheckpointingConfig,
+    find_latest_checkpoint,
     load_torch_ckpt,
+    resolve_restore_from_to_checkpoint_dir,
     save_config,
     save_losses,
 )
-from nemo_automodel.components.checkpoint.utils import find_latest_checkpoint, resolve_restore_from_to_checkpoint_dir
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
-from nemo_automodel.components.distributed.init_utils import initialize_distributed
-from nemo_automodel.components.distributed.mesh_utils import get_flat_mesh
-from nemo_automodel.components.loggers.log_utils import setup_logging
-from nemo_automodel.components.loggers.wandb_utils import init_wandb_run, suppress_wandb_log_messages
+from nemo_automodel.components.config import parse_args_and_load_config
+from nemo_automodel.components.datasets import build_eagle3_dataloader
+from nemo_automodel.components.distributed import get_flat_mesh, initialize_distributed
+from nemo_automodel.components.loggers import init_wandb_run, setup_logging, suppress_wandb_log_messages
 from nemo_automodel.components.speculative.eagle.core_v12 import EagleTrainerModule, FeatureNoiseConfig
 from nemo_automodel.components.speculative.eagle.registry import resolve_eagle1_draft_spec
 from nemo_automodel.components.speculative.eagle.target_v12 import HFEagleTargetModel
-from nemo_automodel.components.training.rng import StatefulRNG
-from nemo_automodel.components.utils.model_utils import print_trainable_parameters
+from nemo_automodel.components.training import StatefulRNG
+from nemo_automodel.components.utils import print_trainable_parameters
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config
 from nemo_automodel.recipes.base_recipe import BaseRecipe, _is_checkpoint_model_config_compatible
 from nemo_automodel.recipes.llm._spec_train_utils import (

--- a/nemo_automodel/recipes/llm/train_eagle2.py
+++ b/nemo_automodel/recipes/llm/train_eagle2.py
@@ -23,7 +23,7 @@ remember that the underlying optimization is identical to EAGLE-1.
 
 from __future__ import annotations
 
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
+from nemo_automodel.components.config import parse_args_and_load_config
 from nemo_automodel.recipes.llm.train_eagle1 import TrainEagle1Recipe
 
 

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -33,27 +33,26 @@ from transformers import AutoConfig
 from nemo_automodel._transformers import NeMoAutoModelForCausalLM
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
 from nemo_automodel.components._peft.lora import apply_lora_to_linear_modules
-from nemo_automodel.components.checkpoint.checkpointing import (
+from nemo_automodel.components.checkpoint import (
     CheckpointingConfig,
+    find_latest_checkpoint,
     load_hf_safetensors_state_dict,
     load_torch_ckpt,
+    resolve_restore_from_to_checkpoint_dir,
     save_config,
     save_losses,
 )
-from nemo_automodel.components.checkpoint.utils import find_latest_checkpoint, resolve_restore_from_to_checkpoint_dir
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.datasets.llm.eagle3 import (
+from nemo_automodel.components.config import parse_args_and_load_config
+from nemo_automodel.components.datasets import (
+    build_cached_eagle3_dataloader,
     build_eagle3_dataloader,
     load_or_build_eagle3_token_mapping,
 )
-from nemo_automodel.components.datasets.llm.eagle3_cache import (
-    build_cached_eagle3_dataloader,
-    read_manifest,
+from nemo_automodel.components.datasets import (
+    eagle3_read_manifest as read_manifest,
 )
-from nemo_automodel.components.distributed.init_utils import initialize_distributed
-from nemo_automodel.components.distributed.mesh_utils import get_flat_mesh
-from nemo_automodel.components.loggers.log_utils import setup_logging
-from nemo_automodel.components.loggers.wandb_utils import init_wandb_run, suppress_wandb_log_messages
+from nemo_automodel.components.distributed import get_flat_mesh, initialize_distributed
+from nemo_automodel.components.loggers import init_wandb_run, setup_logging, suppress_wandb_log_messages
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.kimi_k3.config import KimiK3TextConfig
 from nemo_automodel.components.speculative.decode_eval import DecodeEvalRunner, resolve_decode_eval_config
@@ -65,8 +64,8 @@ from nemo_automodel.components.speculative.eagle import (
 from nemo_automodel.components.speculative.eagle.registry import resolve_eagle3_draft_spec
 from nemo_automodel.components.speculative.eagle.remote import RemoteEagle3TargetModel
 from nemo_automodel.components.speculative.regen_loop import RegenRunner, resolve_regen_config
-from nemo_automodel.components.training.rng import StatefulRNG
-from nemo_automodel.components.utils.model_utils import print_trainable_parameters
+from nemo_automodel.components.training import StatefulRNG
+from nemo_automodel.components.utils import print_trainable_parameters
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config
 from nemo_automodel.recipes.base_recipe import BaseRecipe, _is_checkpoint_model_config_compatible
 from nemo_automodel.recipes.llm._spec_train_utils import (
@@ -1314,7 +1313,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         ``self.target_model`` / ``self.target_wrapper`` to ``None`` and builds the
         cache-backed dataloader.
         """
-        from nemo_automodel.components.datasets.llm.eagle3_cache import read_target_embeddings
+        from nemo_automodel.components.datasets import read_target_embeddings
 
         self.target_model = None
         self.target_wrapper = None

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -53,49 +53,62 @@ from nemo_automodel._transformers.infrastructure import (
     instantiate_infrastructure,
 )
 from nemo_automodel._transformers.utils import apply_cache_compatibility_patches
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.config.loader import ConfigNode
+from nemo_automodel.components.config import ConfigNode, parse_args_and_load_config
 from nemo_automodel.components.cuda_graphs import PartialCudaGraphManager
-from nemo_automodel.components.datasets.loader import DataloaderConfig
-from nemo_automodel.components.distributed.config import DistributedSetup, FSDP2Config, MegatronFSDPConfig
-from nemo_automodel.components.distributed.context_parallel import ContextParallelSharder
-from nemo_automodel.components.distributed.context_parallel.magi import MagiState, setup_magi
-from nemo_automodel.components.distributed.init_utils import initialize_distributed
-from nemo_automodel.components.distributed.mesh import MeshContext
-from nemo_automodel.components.distributed.pipelining import AutoPipeline
-from nemo_automodel.components.distributed.utils import FirstRankPerNode, dp_eval_sample_shard, get_sync_ctx
-from nemo_automodel.components.loggers.log_utils import setup_logging
-from nemo_automodel.components.loggers.metric_logger import MetricsSample, build_metric_logger
-from nemo_automodel.components.loggers.mlflow_utils import (
+from nemo_automodel.components.datasets import DataloaderConfig
+from nemo_automodel.components.distributed import (
+    AutoPipeline,
+    ContextParallelSharder,
+    DistributedSetup,
+    FirstRankPerNode,
+    FSDP2Config,
+    MagiState,
+    MegatronFSDPConfig,
+    MeshContext,
+    dp_eval_sample_shard,
+    get_sync_ctx,
+    initialize_distributed,
+    setup_magi,
+)
+from nemo_automodel.components.loggers import (
+    MetricsSample,
+    build_metric_logger,
     end_mlflow_active_run_as_killed,
+    setup_logging,
+    suppress_wandb_log_messages,
     to_float_metrics,
 )
-from nemo_automodel.components.loggers.wandb_utils import suppress_wandb_log_messages
-from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
-from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
-from nemo_automodel.components.loss.mtp import calculate_mtp_loss
-from nemo_automodel.components.loss.utils import _get_lm_head_weight, calculate_loss
+from nemo_automodel.components.loss import (
+    FusedLinearCrossEntropy,
+    MaskedCrossEntropy,
+    calculate_loss,
+    calculate_mtp_loss,
+)
+from nemo_automodel.components.loss import get_lm_head_weight as _get_lm_head_weight
 from nemo_automodel.components.quantization.fp8 import build_fp8_config
-from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
-from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG
-from nemo_automodel.components.training.utils import (
+from nemo_automodel.components.training import (
+    ScopedRNG,
+    StatefulRNG,
     count_tail_padding,
     get_expert_tp_replication_factor,
+    get_final_hidden_states,
     prepare_after_first_microbatch,
     prepare_for_final_backward,
     prepare_for_grad_accumulation,
     scale_grads_and_clip_grad_norm,
 )
-from nemo_automodel.components.utils.compile_utils import (
-    build_compile_config,
-)
-from nemo_automodel.components.utils.flops_utils import calculate_mfu
-from nemo_automodel.components.utils.model_utils import (
+from nemo_automodel.components.utils import (
     FreezeConfig,
-    _supports_logits_to_keep,
-    _supports_seq_lens,
+    build_compile_config,
+    calculate_mfu,
     filter_forward_kwargs,
     resolve_trust_remote_code,
+)
+from nemo_automodel.components.utils import (
+    supports_logits_to_keep as _supports_logits_to_keep,
+)
+from nemo_automodel.components.utils import (
+    supports_seq_lens as _supports_seq_lens,
 )
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config, shard_optimizers_for_megatron_fsdp
 from nemo_automodel.recipes._typed_config import RecipeConfig
@@ -375,7 +388,7 @@ def _build_pp_collate_wrapper(cfg_model, pp_enabled: bool):
         )
         return None
 
-    from nemo_automodel.components.datasets.utils import add_causal_masks_to_batch
+    from nemo_automodel.components.datasets import add_causal_masks_to_batch
 
     def wrapper(base_collate_fn):
         def chained_collate_fn(batch, base_fn=base_collate_fn, config=hf_model_config):
@@ -793,7 +806,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         neftune_cfg = self.cfg.get("neftune", None)
         self.neftune = None
         if neftune_cfg is not None:
-            from nemo_automodel.components.training.neftune import NEFTune
+            from nemo_automodel.components.training import NEFTune
 
             noise_alpha = neftune_cfg.get("noise_alpha", 5.0) if hasattr(neftune_cfg, "get") else neftune_cfg
             self.neftune = NEFTune(noise_alpha=float(noise_alpha))

--- a/nemo_automodel/recipes/llm/train_jetspec.py
+++ b/nemo_automodel/recipes/llm/train_jetspec.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 import logging
 
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
+from nemo_automodel.components.config import parse_args_and_load_config
 from nemo_automodel.components.speculative.dflash.jetspec_core import JetSpecTrainerModule
 from nemo_automodel.components.speculative.dflash.target import HFDFlashTargetModel
 from nemo_automodel.recipes.llm.train_dflash import TrainDFlashRecipe

--- a/nemo_automodel/recipes/llm/train_seq_cls.py
+++ b/nemo_automodel/recipes/llm/train_seq_cls.py
@@ -23,16 +23,16 @@ import torch
 import wandb
 
 from nemo_automodel._transformers.utils import apply_cache_compatibility_patches
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.distributed.init_utils import initialize_distributed
-from nemo_automodel.components.distributed.utils import FirstRankPerNode
-from nemo_automodel.components.loggers.log_utils import setup_logging
-from nemo_automodel.components.loggers.metric_logger import MetricsSample, build_metric_logger
-from nemo_automodel.components.loggers.wandb_utils import suppress_wandb_log_messages
-from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG
-from nemo_automodel.components.training.utils import clip_grad_norm
-from nemo_automodel.components.utils.flops_utils import calculate_mfu
-from nemo_automodel.components.utils.model_utils import FreezeConfig, ModuleSelector, filter_forward_kwargs
+from nemo_automodel.components.config import parse_args_and_load_config
+from nemo_automodel.components.distributed import FirstRankPerNode, initialize_distributed
+from nemo_automodel.components.loggers import (
+    MetricsSample,
+    build_metric_logger,
+    setup_logging,
+    suppress_wandb_log_messages,
+)
+from nemo_automodel.components.training import ScopedRNG, StatefulRNG, clip_grad_norm
+from nemo_automodel.components.utils import FreezeConfig, ModuleSelector, calculate_mfu, filter_forward_kwargs
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config, shard_optimizers_for_megatron_fsdp
 from nemo_automodel.recipes._typed_config import RecipeConfig
 from nemo_automodel.recipes.base_recipe import BaseRecipe

--- a/nemo_automodel/recipes/llm/train_vispec.py
+++ b/nemo_automodel/recipes/llm/train_vispec.py
@@ -41,13 +41,15 @@ from torch.nn.parallel import DistributedDataParallel
 from transformers import AutoConfig, AutoModelForImageTextToText, AutoProcessor
 
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
-from nemo_automodel.components.checkpoint.checkpointing import load_hf_safetensors_state_dict
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
-from nemo_automodel.components.datasets.vlm.dspark_collate import build_dspark_vlm_dataloader
-from nemo_automodel.components.datasets.vlm.utils import set_image_pixel_bounds
-from nemo_automodel.components.distributed.init_utils import initialize_distributed
-from nemo_automodel.components.loggers.log_utils import setup_logging
+from nemo_automodel.components.checkpoint import load_hf_safetensors_state_dict
+from nemo_automodel.components.config import parse_args_and_load_config
+from nemo_automodel.components.datasets import (
+    build_dspark_vlm_dataloader,
+    build_eagle3_dataloader,
+    set_image_pixel_bounds,
+)
+from nemo_automodel.components.distributed import initialize_distributed
+from nemo_automodel.components.loggers import setup_logging
 from nemo_automodel.components.speculative.eagle.core_v12 import EagleTrainerModule, FeatureNoiseConfig
 from nemo_automodel.components.speculative.eagle.registry import (
     resolve_vispec_draft_spec,
@@ -57,7 +59,7 @@ from nemo_automodel.components.speculative.eagle.target_v12 import HFEagleTarget
 from nemo_automodel.components.speculative.eagle.vispec_core import VispecTrainerModule
 from nemo_automodel.components.speculative.eagle.vispec_draft import apply_vispec_draft_architecture
 from nemo_automodel.components.speculative.eagle.vispec_target import HFVispecTargetModel
-from nemo_automodel.components.utils.model_utils import print_trainable_parameters
+from nemo_automodel.components.utils import print_trainable_parameters
 from nemo_automodel.recipes.llm._spec_train_utils import (
     apply_draft_compile,
     apply_draft_fp8,

--- a/nemo_automodel/recipes/multimodal/finetune.py
+++ b/nemo_automodel/recipes/multimodal/finetune.py
@@ -46,18 +46,24 @@ import torch
 import torch.distributed as dist
 import wandb
 
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config  # noqa: E402
-from nemo_automodel.components.loggers.log_utils import setup_logging  # noqa: E402
-from nemo_automodel.components.loggers.metric_logger import MetricsSample, build_metric_logger  # noqa: E402
-from nemo_automodel.components.loggers.wandb_utils import suppress_wandb_log_messages  # noqa: E402
+from nemo_automodel.components.config import parse_args_and_load_config  # noqa: E402
+from nemo_automodel.components.loggers import (  # noqa: E402
+    MetricsSample,
+    build_metric_logger,
+    setup_logging,  # noqa: E402
+    suppress_wandb_log_messages,  # noqa: E402
+)
 from nemo_automodel.components.models.bagel.configuration import resolve_bagel_backend  # noqa: E402
 from nemo_automodel.components.models.bagel.hf_backbone_loader import (  # noqa: E402
     build_bagel_from_hf_backbones,
     initialize_bagel_non_backbone_weights,
     load_bagel_hf_backbone_weights,
 )
-from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG  # noqa: E402
-from nemo_automodel.components.training.step_scheduler import StepScheduler  # noqa: E402
+from nemo_automodel.components.training import (  # noqa: E402
+    ScopedRNG,
+    StatefulRNG,
+    StepScheduler,  # noqa: E402
+)
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config  # noqa: E402
 from nemo_automodel.recipes._typed_config import RecipeConfig  # noqa: E402
 from nemo_automodel.recipes.base_recipe import BaseRecipe  # noqa: E402
@@ -317,7 +323,7 @@ class FinetuneRecipeForMultimodal(BaseRecipe):
                 instantiate_infrastructure,
             )
             from nemo_automodel.components.quantization.fp8 import build_fp8_config
-            from nemo_automodel.components.utils.compile_utils import build_compile_config
+            from nemo_automodel.components.utils import build_compile_config
 
             model_wrapper, autopipeline, parallelize_fn, qat_quantizer = instantiate_infrastructure(
                 distributed_config=self.distributed_config,
@@ -371,7 +377,7 @@ class FinetuneRecipeForMultimodal(BaseRecipe):
         torch.cuda.reset_peak_memory_stats()
 
         # -- distributed bringup ------------------------------------------
-        from nemo_automodel.components.distributed.init_utils import initialize_distributed
+        from nemo_automodel.components.distributed import initialize_distributed
 
         cfg_dist_env = self.cfg.get("dist_env", {})
         backend = cfg_dist_env.get("backend", "nccl")
@@ -505,7 +511,7 @@ class FinetuneRecipeForMultimodal(BaseRecipe):
                     raise ValueError(
                         "ema.implementation='sharded_model' currently requires model.init_mode='hf_backbones'."
                     )
-                from nemo_automodel.components.training.ema import ShardedModelEMAManager
+                from nemo_automodel.components.training import ShardedModelEMAManager
 
                 ema_model = self._build_hf_backbone_bagel_model(
                     artifact_path=artifact_path,
@@ -526,7 +532,7 @@ class FinetuneRecipeForMultimodal(BaseRecipe):
                     len(self.ema),
                 )
             else:
-                from nemo_automodel.components.training.ema import EMAManager
+                from nemo_automodel.components.training import EMAManager
 
                 self.ema = EMAManager(self.model, decay=float(ema_decay))
                 logger.info(
@@ -616,7 +622,7 @@ class FinetuneRecipeForMultimodal(BaseRecipe):
         # enabled in the YAML.
         self.checkpointer = None
         if ckpt_enabled:
-            from nemo_automodel.components.checkpoint.checkpointing import (
+            from nemo_automodel.components.checkpoint import (
                 Checkpointer,
                 CheckpointingConfig,
             )

--- a/nemo_automodel/recipes/retrieval/distill_bi_encoder.py
+++ b/nemo_automodel/recipes/retrieval/distill_bi_encoder.py
@@ -14,13 +14,18 @@ import torch
 import torch.distributed
 from torch.nn.parallel import DistributedDataParallel
 
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.distributed.utils import get_sync_ctx
-from nemo_automodel.components.loggers.metric_logger import MetricsSample
-from nemo_automodel.components.loss.embedding_distill import EmbeddingDistillLoss, EmbeddingMSELoss, ScoreDistillLoss
-from nemo_automodel.components.loss.infonce import InfoNCEDistillLoss, InfoNCELoss
-from nemo_automodel.components.loss.intermediate_distill import IntermediateDistillLoss
-from nemo_automodel.components.training.utils import scale_grads_and_clip_grad_norm
+from nemo_automodel.components.config import parse_args_and_load_config
+from nemo_automodel.components.distributed import get_sync_ctx
+from nemo_automodel.components.loggers import MetricsSample
+from nemo_automodel.components.loss import (
+    EmbeddingDistillLoss,
+    EmbeddingMSELoss,
+    InfoNCEDistillLoss,
+    InfoNCELoss,
+    IntermediateDistillLoss,
+    ScoreDistillLoss,
+)
+from nemo_automodel.components.training import scale_grads_and_clip_grad_norm
 from nemo_automodel.recipes.retrieval.train_bi_encoder import TrainBiEncoderRecipe
 
 logger = logging.getLogger(__name__)

--- a/nemo_automodel/recipes/retrieval/mine_hard_negatives.py
+++ b/nemo_automodel/recipes/retrieval/mine_hard_negatives.py
@@ -26,8 +26,8 @@ from tqdm import tqdm
 
 from nemo_automodel._transformers.auto_model import NeMoAutoModelBiEncoder
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
-from nemo_automodel.components.datasets.llm.retrieval_dataset import load_datasets
-from nemo_automodel.components.distributed.init_utils import DistInfo, initialize_distributed
+from nemo_automodel.components.datasets import load_datasets
+from nemo_automodel.components.distributed import DistInfo, initialize_distributed
 
 logger = logging.getLogger(__name__)
 

--- a/nemo_automodel/recipes/retrieval/train_bi_encoder.py
+++ b/nemo_automodel/recipes/retrieval/train_bi_encoder.py
@@ -26,21 +26,18 @@ import torch.nn.functional as F
 from transformers import ProcessorMixin
 
 from nemo_automodel._transformers.utils import apply_cache_compatibility_patches
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.distributed.config import DDPConfig
-from nemo_automodel.components.distributed.init_utils import initialize_distributed
-from nemo_automodel.components.distributed.utils import FirstRankPerNode, get_sync_ctx
-from nemo_automodel.components.loggers.log_utils import setup_logging
-from nemo_automodel.components.loggers.metric_logger import (
+from nemo_automodel.components.config import parse_args_and_load_config
+from nemo_automodel.components.distributed import DDPConfig, FirstRankPerNode, get_sync_ctx, initialize_distributed
+from nemo_automodel.components.loggers import (
     DEFAULT_BUFFER_SIZE,
     MetricsSample,
     build_metric_logger,
+    setup_logging,
+    suppress_wandb_log_messages,
 )
-from nemo_automodel.components.loggers.wandb_utils import suppress_wandb_log_messages
-from nemo_automodel.components.optim.precision_warnings import warn_if_torch_adam_with_bf16_params
-from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG
-from nemo_automodel.components.training.utils import scale_grads_and_clip_grad_norm
-from nemo_automodel.components.utils.compile_utils import build_compile_config
+from nemo_automodel.components.optim import warn_if_torch_adam_with_bf16_params
+from nemo_automodel.components.training import ScopedRNG, StatefulRNG, scale_grads_and_clip_grad_norm
+from nemo_automodel.components.utils import build_compile_config
 from nemo_automodel.recipes._dist_utils import (
     create_distributed_setup_from_config,
     shard_optimizers_for_megatron_fsdp,

--- a/nemo_automodel/recipes/retrieval/train_cross_encoder.py
+++ b/nemo_automodel/recipes/retrieval/train_cross_encoder.py
@@ -18,10 +18,10 @@ from contextlib import nullcontext
 import torch
 import torch.nn.functional as F
 
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.distributed.utils import get_sync_ctx
-from nemo_automodel.components.loggers.metric_logger import MetricsSample
-from nemo_automodel.components.training.rng import ScopedRNG
+from nemo_automodel.components.config import parse_args_and_load_config
+from nemo_automodel.components.distributed import get_sync_ctx
+from nemo_automodel.components.loggers import MetricsSample
+from nemo_automodel.components.training import ScopedRNG
 from nemo_automodel.recipes.retrieval.train_bi_encoder import TrainBiEncoderRecipe, _get_autocast_ctx
 from nemo_automodel.shared.import_utils import safe_import
 

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -45,43 +45,58 @@ from nemo_automodel._transformers import (
     NeMoAutoModelForMultimodalLM,
 )
 from nemo_automodel._transformers.utils import apply_cache_compatibility_patches, resolve_get_rope_index
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.datasets.vlm.pp_media import stage_vlm_media_for_pp
-from nemo_automodel.components.distributed.config import DistributedSetup, FSDP2Config, MegatronFSDPConfig
-from nemo_automodel.components.distributed.context_parallel import ContextParallelSharder
-from nemo_automodel.components.distributed.context_parallel.magi import MagiState, setup_magi
-from nemo_automodel.components.distributed.cp_vision_frame_shard import (
+from nemo_automodel.components.config import parse_args_and_load_config
+from nemo_automodel.components.datasets import stage_vlm_media_for_pp
+from nemo_automodel.components.distributed import (
+    AutoPipeline,
+    ContextParallelSharder,
     CpVisionFrameShardingConfig,
+    DistributedSetup,
+    FirstRankPerNode,
+    FSDP2Config,
+    MagiState,
+    MegatronFSDPConfig,
+    get_sync_ctx,
+    initialize_distributed,
     reset_cp_vision_group,
     set_cp_vision_group,
+    setup_magi,
 )
-from nemo_automodel.components.distributed.init_utils import initialize_distributed
-from nemo_automodel.components.distributed.pipelining import AutoPipeline
-from nemo_automodel.components.distributed.utils import FirstRankPerNode, get_sync_ctx
-from nemo_automodel.components.loggers.log_utils import setup_logging
-from nemo_automodel.components.loggers.metric_logger import MetricsSample, build_metric_logger
-from nemo_automodel.components.loggers.mlflow_utils import (
+from nemo_automodel.components.loggers import (
+    MetricsSample,
+    build_metric_logger,
     end_mlflow_active_run_as_killed,
+    setup_logging,
+    suppress_wandb_log_messages,
     to_float_metrics,
 )
-from nemo_automodel.components.loggers.wandb_utils import suppress_wandb_log_messages
-from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
-from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
-from nemo_automodel.components.loss.mtp import calculate_mtp_loss
-from nemo_automodel.components.loss.utils import _get_lm_head_weight, calculate_loss
+from nemo_automodel.components.loss import (
+    FusedLinearCrossEntropy,
+    MaskedCrossEntropy,
+    calculate_loss,
+    calculate_mtp_loss,
+)
+from nemo_automodel.components.loss import get_lm_head_weight as _get_lm_head_weight
 from nemo_automodel.components.quantization.fp8 import build_fp8_config
-from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
-from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG
-from nemo_automodel.components.training.utils import (
+from nemo_automodel.components.training import (
+    ScopedRNG,
+    StatefulRNG,
     count_tail_padding,
     get_expert_tp_replication_factor,
+    get_final_hidden_states,
     prepare_after_first_microbatch,
     prepare_for_final_backward,
     prepare_for_grad_accumulation,
     scale_grads_and_clip_grad_norm,
 )
-from nemo_automodel.components.utils.compile_utils import build_compile_config
-from nemo_automodel.components.utils.model_utils import VLM_INPUT_KEYS, _supports_logits_to_keep, filter_forward_kwargs
+from nemo_automodel.components.utils import (
+    VLM_INPUT_KEYS,
+    build_compile_config,
+    filter_forward_kwargs,
+)
+from nemo_automodel.components.utils import (
+    supports_logits_to_keep as _supports_logits_to_keep,
+)
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config, shard_optimizers_for_megatron_fsdp
 from nemo_automodel.recipes._typed_config import RecipeConfig
 from nemo_automodel.recipes.base_recipe import BaseRecipe
@@ -357,7 +372,7 @@ def build_dataloader(
     dp_world_size = 1
     cp_size = 1
     if device_mesh is not None:
-        from nemo_automodel.components.distributed.mesh_utils import get_flat_mesh
+        from nemo_automodel.components.distributed import get_flat_mesh
 
         dp_mesh = get_flat_mesh(device_mesh, "dp")
         dp_rank = dp_mesh.get_local_rank()

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -50,24 +50,22 @@ import wandb
 from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
 
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
-from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.components.distributed.config import DistributedSetup
-from nemo_automodel.components.distributed.context_parallel import ContextParallelSharder
-from nemo_automodel.components.distributed.utils import get_sync_ctx
-from nemo_automodel.components.loggers.metric_logger import MetricsSample
-from nemo_automodel.components.optim.precision_warnings import resolve_storage_dtype
-from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
-from nemo_automodel.components.training.rng import ScopedRNG
-from nemo_automodel.components.training.signal_handler import DistributedSignalHandler
-from nemo_automodel.components.training.utils import (
+from nemo_automodel.components.config import parse_args_and_load_config
+from nemo_automodel.components.distributed import ContextParallelSharder, DistributedSetup, get_sync_ctx
+from nemo_automodel.components.loggers import MetricsSample
+from nemo_automodel.components.optim import resolve_storage_dtype
+from nemo_automodel.components.training import (
+    DistributedSignalHandler,
     ScopedModuleOffloading,
+    ScopedRNG,
     count_tail_padding,
+    get_final_hidden_states,
     prepare_after_first_microbatch,
     prepare_for_final_backward,
     prepare_for_grad_accumulation,
     scale_grads_and_clip_grad_norm,
 )
-from nemo_automodel.components.utils.model_utils import filter_forward_kwargs
+from nemo_automodel.components.utils import filter_forward_kwargs
 from nemo_automodel.recipes.kd_utils import (
     RUN_TEACHER,
     STOP_TEACHER,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -508,10 +508,13 @@ known-third-party = ["datasets", "transformers", "wandb"]
 [tool.importlinter]
 root_package = "nemo_automodel"
 exclude_type_checking_imports = true
+contract_types = [
+    "component_interface: tools.import_linter_contracts.ComponentInterfaceContract",
+]
 
 [[tool.importlinter.contracts]]
-name = "Components must not import each other"
-type = "independence"
+name = "Component imports use exported symbols"
+type = "component_interface"
 modules = [
     "nemo_automodel.components.checkpoint",
     "nemo_automodel.components.config",
@@ -526,8 +529,6 @@ modules = [
     "nemo_automodel.components.utils",
 ]
 ignore_imports = [
-    # Dion needs the FSDP DP mesh resolver so its optimizer mesh matches parameter sharding.
-    "nemo_automodel.components.optim.dion -> nemo_automodel.components.distributed.mesh_utils",
     "nemo_automodel.components.distributed.optimized_tp_plans -> nemo_automodel.components.models.llama.model",
     "nemo_automodel.components.distributed.optimized_tp_plans -> nemo_automodel.components.models.mistral3_vlm.model",
 ]

--- a/tests/unit_tests/_cli/test_app.py
+++ b/tests/unit_tests/_cli/test_app.py
@@ -230,7 +230,7 @@ def test_main_dispatches_to_interactive(monkeypatch, recipe_yaml):
             return 0
 
     monkeypatch.setattr(
-        "nemo_automodel.components.launcher.interactive.InteractiveLauncher",
+        "nemo_automodel.components.launcher.InteractiveLauncher",
         FakeInteractiveLauncher,
     )
     result = module.main()
@@ -250,7 +250,7 @@ def test_main_dispatches_to_nemo_run(monkeypatch, nemo_run_yaml):
             return 0
 
     monkeypatch.setattr(
-        "nemo_automodel.components.launcher.nemo_run.launcher.NemoRunLauncher",
+        "nemo_automodel.components.launcher.NemoRunLauncher",
         FakeNemoRunLauncher,
     )
     result = module.main()
@@ -286,7 +286,7 @@ def test_main_resolves_skypilot_env_vars(monkeypatch, tmp_path):
             return 0
 
     monkeypatch.setattr(
-        "nemo_automodel.components.launcher.skypilot.launcher.SkyPilotLauncher",
+        "nemo_automodel.components.launcher.SkyPilotLauncher",
         FakeSkyPilotLauncher,
     )
     result = module.main()
@@ -310,7 +310,7 @@ def test_main_passes_extra_args(monkeypatch, recipe_yaml):
             return 0
 
     monkeypatch.setattr(
-        "nemo_automodel.components.launcher.interactive.InteractiveLauncher",
+        "nemo_automodel.components.launcher.InteractiveLauncher",
         FakeInteractiveLauncher,
     )
     module.main()

--- a/tests/unit_tests/_transformers/test_auto_model.py
+++ b/tests/unit_tests/_transformers/test_auto_model.py
@@ -1105,7 +1105,7 @@ class TestModelMappingKeyErrorFallback:
         with (
             patch("nemo_automodel._transformers.model_init.get_hf_config", return_value=fake_config),
             patch(
-                "nemo_automodel.components.checkpoint.utils._get_checkpoint_tensor_dtypes",
+                "nemo_automodel._transformers.model_init.get_checkpoint_tensor_dtypes",
                 return_value={
                     "linear.weight": torch.bfloat16,
                     "norm.weight": torch.float32,
@@ -1153,7 +1153,7 @@ class TestModelMappingKeyErrorFallback:
         with (
             patch("nemo_automodel._transformers.model_init.get_hf_config", return_value=fake_config),
             patch(
-                "nemo_automodel.components.checkpoint.utils._get_checkpoint_tensor_dtypes",
+                "nemo_automodel._transformers.model_init.get_checkpoint_tensor_dtypes",
                 return_value={
                     "linear.weight": torch.bfloat16,
                     "norm.weight": torch.float32,
@@ -1201,7 +1201,7 @@ class TestModelMappingKeyErrorFallback:
         with (
             patch("nemo_automodel._transformers.model_init.get_hf_config", return_value=fake_config),
             patch(
-                "nemo_automodel.components.checkpoint.utils._get_checkpoint_tensor_dtypes",
+                "nemo_automodel._transformers.model_init.get_checkpoint_tensor_dtypes",
                 return_value={
                     "linear.weight": torch.bfloat16,
                     "norm.weight": torch.float32,
@@ -1279,7 +1279,7 @@ class TestModelMappingKeyErrorFallback:
         with (
             patch("nemo_automodel._transformers.model_init.get_hf_config", return_value=fake_config),
             patch(
-                "nemo_automodel.components.checkpoint.utils._get_checkpoint_tensor_dtypes",
+                "nemo_automodel._transformers.model_init.get_checkpoint_tensor_dtypes",
                 return_value={"lm_head.weight": torch.bfloat16},
             ),
             patch("nemo_automodel._transformers.model_init._get_mixin_wrapped_class") as mock_wrap,

--- a/tests/unit_tests/_transformers/test_infrastructure.py
+++ b/tests/unit_tests/_transformers/test_infrastructure.py
@@ -1028,11 +1028,11 @@ def test_apply_model_infrastructure_attaches_cp_hooks_for_non_te(monkeypatch):
         patch(f"{_INFRA_MODULE}._uses_te_attention", return_value=False),
         patch(f"{_INFRA_MODULE}.Checkpointer") as MockCheckpointer,
         patch(
-            "nemo_automodel.components.distributed.context_parallel.utils.attach_context_parallel_hooks",
+            "nemo_automodel.components.distributed.attach_context_parallel_hooks",
             side_effect=lambda mp: attached.__setitem__("ctx", attached["ctx"] + 1),
         ),
         patch(
-            "nemo_automodel.components.distributed.context_parallel.utils.attach_cp_sdpa_hooks",
+            "nemo_automodel.components.distributed.attach_cp_sdpa_hooks",
             side_effect=lambda mp, cp_mesh: attached.__setitem__("attn", attached["attn"] + 1),
         ),
     ):
@@ -1079,11 +1079,11 @@ def test_apply_model_infrastructure_configures_dense_thd_te_and_bshd_sdpa_cp():
         patch(f"{_INFRA_MODULE}._uses_thd_only_te_attention", return_value=True),
         patch(f"{_INFRA_MODULE}.Checkpointer") as MockCheckpointer,
         patch(
-            "nemo_automodel.components.distributed.context_parallel.utils.attach_te_context_parallel",
+            "nemo_automodel.components.distributed.attach_te_context_parallel",
             return_value=1,
         ) as attach_te,
         patch(
-            "nemo_automodel.components.distributed.context_parallel.utils.attach_context_parallel_hooks",
+            "nemo_automodel.components.distributed.attach_context_parallel_hooks",
         ) as attach_sdpa,
     ):
         mock_ckpt = MockCheckpointer.return_value
@@ -1130,11 +1130,11 @@ def test_apply_model_infrastructure_configures_dense_thd_te_for_tp_without_cp():
         patch(f"{_INFRA_MODULE}._uses_thd_only_te_attention", return_value=True),
         patch(f"{_INFRA_MODULE}.Checkpointer") as MockCheckpointer,
         patch(
-            "nemo_automodel.components.distributed.context_parallel.utils.attach_te_context_parallel",
+            "nemo_automodel.components.distributed.attach_te_context_parallel",
             return_value=1,
         ) as attach_te,
         patch(
-            "nemo_automodel.components.distributed.context_parallel.utils.attach_context_parallel_hooks",
+            "nemo_automodel.components.distributed.attach_context_parallel_hooks",
         ) as attach_sdpa,
     ):
         mock_ckpt = MockCheckpointer.return_value

--- a/tests/unit_tests/_transformers/test_model_init.py
+++ b/tests/unit_tests/_transformers/test_model_init.py
@@ -479,7 +479,7 @@ def test_remote_code_cache_serialization_uses_model_process_group(tmp_path):
     process_group = object()
 
     with (
-        patch("nemo_automodel._transformers.model_init.dist_utils.FirstRankPerNode") as first_rank,
+        patch("nemo_automodel._transformers.model_init.FirstRankPerNode") as first_rank,
         patch("transformers.dynamic_module_utils.get_cached_module_file", return_value="remote/modeling_remote.py"),
     ):
         first_rank.return_value.__enter__.return_value = True

--- a/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_cp_preembed.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_cp_preembed.py
@@ -261,7 +261,6 @@ class TestEmbedAndSpliceForCP:
 
 class TestPackedCPDispatch:
     def test_full_attention_routes_through_blockdiag_sdpa(self, monkeypatch):
-        from nemo_automodel.components.distributed import blockdiag_cp
         from nemo_automodel.components.models.qwen3_next import layers as qwen3_next_layers
 
         attention = _Qwen3_5MoeAttention.__new__(_Qwen3_5MoeAttention)
@@ -284,8 +283,10 @@ class TestPackedCPDispatch:
             return q
 
         monkeypatch.setattr(qwen3_next_layers, "apply_rotary_emb_qk", lambda q, k, *args, **kwargs: (q, k))
-        monkeypatch.setattr(blockdiag_cp, "current_blockdiag_cp_state", lambda: {"row_offset": 0})
-        monkeypatch.setattr(blockdiag_cp, "cp_blockdiag_sdpa", _cp_sdpa)
+        monkeypatch.setattr(
+            "nemo_automodel.components.distributed.current_blockdiag_cp_state", lambda: {"row_offset": 0}
+        )
+        monkeypatch.setattr("nemo_automodel.components.distributed.cp_blockdiag_sdpa", _cp_sdpa)
 
         x = torch.randn(1, 3, 4)
         out = attention(x, freqs_cis=torch.zeros(3, 1, 3, 2))
@@ -296,7 +297,6 @@ class TestPackedCPDispatch:
         assert calls[0][3]["is_causal"] is True
 
     def test_gdn_forward_receives_active_blockdiag_state(self, monkeypatch):
-        from nemo_automodel.components.distributed import blockdiag_cp
         from nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn import CPAwareGatedDeltaNet
 
         module = CPAwareGatedDeltaNet.__new__(CPAwareGatedDeltaNet)
@@ -310,7 +310,7 @@ class TestPackedCPDispatch:
 
         module._forward_with_cp = types.MethodType(_forward_with_cp, module)
         state = {"doc_ids": torch.tensor([[1, 1, 2, 2]])}
-        monkeypatch.setattr(blockdiag_cp, "current_blockdiag_cp_state", lambda: state)
+        monkeypatch.setattr("nemo_automodel.components.distributed.current_blockdiag_cp_state", lambda: state)
 
         hidden = torch.randn(1, 2, 4)
         assert module(hidden) is hidden

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -502,6 +502,100 @@ def _import_parallelizer_with_stubs(monkeypatch):
         parallel_styles_stub,
     )
 
+    public_exports = {
+        "MambaContextParallel": (
+            "nemo_automodel.components.distributed.context_parallel.mamba",
+            "MambaContextParallel",
+        ),
+        "PARALLELIZE_FUNCTIONS": (
+            "nemo_automodel.components.distributed.optimized_tp_plans",
+            "PARALLELIZE_FUNCTIONS",
+        ),
+        "SELECTIVE_AC_WRAPPER_FLAG": (
+            "nemo_automodel.components.distributed.activation_checkpointing",
+            "SELECTIVE_AC_WRAPPER_FLAG",
+        ),
+        "apply_submodule_checkpointing": (
+            "nemo_automodel.components.distributed.activation_checkpointing",
+            "apply_submodule_checkpointing",
+        ),
+        "configure_fsdp_unused_param_reduction": (
+            "nemo_automodel.components.distributed.parallelizer_utils",
+            "configure_fsdp_unused_param_reduction",
+        ),
+        "ensure_fsdp_ops_sac_ignored": (
+            "nemo_automodel.components.distributed.activation_checkpointing",
+            "ensure_fsdp_ops_sac_ignored",
+        ),
+        "ensure_profiler_ops_sac_ignored": (
+            "nemo_automodel.components.distributed.activation_checkpointing",
+            "ensure_profiler_ops_sac_ignored",
+        ),
+        "fully_shard_by_dtype": (
+            "nemo_automodel.components.distributed.parallelizer_utils",
+            "fully_shard_by_dtype",
+        ),
+        "get_class_qualname": (
+            "nemo_automodel.components.distributed.optimized_tp_plans",
+            "_get_class_qualname",
+        ),
+        "get_fsdp_dp_mesh": ("nemo_automodel.components.distributed.mesh_utils", "get_fsdp_dp_mesh"),
+        "get_internal_fsdp_mp_policy": (
+            "nemo_automodel.components.distributed.parallelizer_utils",
+            "get_internal_fsdp_mp_policy",
+        ),
+        "get_model_layer_groups": (
+            "nemo_automodel.components.distributed.parallelizer",
+            "get_model_layer_groups",
+        ),
+        "get_parallel_plan": (
+            "nemo_automodel.components.distributed.parallelizer",
+            "_get_parallel_plan",
+        ),
+        "get_submesh": ("nemo_automodel.components.distributed.mesh_utils", "get_submesh"),
+        "get_text_module": (
+            "nemo_automodel.components.distributed.pipelining.hf_utils",
+            "get_text_module",
+        ),
+        "make_selective_checkpoint_context_fn": (
+            "nemo_automodel.components.distributed.activation_checkpointing",
+            "make_selective_checkpoint_context_fn",
+        ),
+        "normalize_activation_checkpointing_scope": (
+            "nemo_automodel.components.distributed.config",
+            "normalize_activation_checkpointing_scope",
+        ),
+        "reject_unsupported_mtp_cp": (
+            "nemo_automodel.components.distributed.parallelizer_utils",
+            "reject_unsupported_mtp_cp",
+        ),
+        "reject_unsupported_mtp_cp_pp": (
+            "nemo_automodel.components.distributed.parallelizer_utils",
+            "reject_unsupported_mtp_cp_pp",
+        ),
+        "sdpa_backend_snapshot_context_fn": (
+            "nemo_automodel.components.distributed.activation_checkpointing",
+            "sdpa_backend_snapshot_context_fn",
+        ),
+        "transformer_engine_attention_backend_snapshot_context_fn": (
+            "nemo_automodel.components.distributed.activation_checkpointing",
+            "transformer_engine_attention_backend_snapshot_context_fn",
+        ),
+        "translate_to_lora": (
+            "nemo_automodel.components.distributed.parallel_styles",
+            "translate_to_lora",
+        ),
+    }
+
+    def get_public_export(name):
+        try:
+            module_name, attribute = public_exports[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+        return getattr(importlib.import_module(module_name), attribute)
+
+    distributed_stub.__getattr__ = get_public_export
+
     return importlib.import_module("nemo_automodel.components.moe.parallelizer")
 
 
@@ -935,7 +1029,7 @@ def test_apply_fsdp_routes_strict_fp32_contract_and_expert_exclusions_to_shared_
     fully_shard_mock = MagicMock()
     monkeypatch.setattr(P, "fully_shard", fully_shard_mock)
     shared_sharder_mock = MagicMock()
-    monkeypatch.setattr(P.parallelizer_utils, "fully_shard_by_dtype", shared_sharder_mock)
+    monkeypatch.setattr(P, "fully_shard_by_dtype", shared_sharder_mock)
 
     block = DummyBlock(mlp=DummyMoE())
     model = DummyModel([block])

--- a/tests/unit_tests/recipes/test_diffusion_train_metrics.py
+++ b/tests/unit_tests/recipes/test_diffusion_train_metrics.py
@@ -314,10 +314,11 @@ def test_diffusion_recipe_enables_hunyuan_flash_varlen_mask_optimization_before_
         MagicMock(return_value=(SimpleNamespace(transformer=nn.Linear(1, 1)), None)),
     )
 
-    from nemo_automodel.components.flow_matching.adapters import hunyuan as hunyuan_module
-
     enable_optimization = MagicMock(return_value=True)
-    monkeypatch.setattr(hunyuan_module, "enable_hunyuan_flash_varlen_mask_optimization", enable_optimization)
+    monkeypatch.setattr(
+        "nemo_automodel.components.flow_matching.enable_hunyuan_flash_varlen_mask_optimization",
+        enable_optimization,
+    )
 
     recipe = TrainDiffusionRecipe(_minimal_diffusion_recipe_cfg())
 

--- a/tests/unit_tests/speculative/test_bench_common.py
+++ b/tests/unit_tests/speculative/test_bench_common.py
@@ -72,9 +72,7 @@ def _args(**overrides):
 
 def test_load_prompts_prompt_column_wraps_single_turn_user_message(monkeypatch):
     rows = [{"question": "2+2=?"}, {"question": "3+3=?"}]
-    monkeypatch.setattr(
-        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
-    )
+    monkeypatch.setattr("nemo_automodel.components.datasets.load_openai_messages", lambda *a, **k: rows)
     prompts = _load_prompts(_args(prompt_column="question"))
     assert prompts == [
         [{"role": "user", "content": "2+2=?"}],
@@ -85,18 +83,14 @@ def test_load_prompts_prompt_column_wraps_single_turn_user_message(monkeypatch):
 def test_load_prompts_prompt_column_takes_precedence_over_messages_column(monkeypatch):
     """A dataset can carry both columns; --prompt-column wins when set."""
     rows = [{"question": "raw text", "messages": [{"role": "user", "content": "chat text"}]}]
-    monkeypatch.setattr(
-        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
-    )
+    monkeypatch.setattr("nemo_automodel.components.datasets.load_openai_messages", lambda *a, **k: rows)
     prompts = _load_prompts(_args(prompt_column="question"))
     assert prompts == [[{"role": "user", "content": "raw text"}]]
 
 
 def test_load_prompts_prompt_column_drops_unusable_rows(monkeypatch):
     rows = [{"question": "ok"}, {"question": ""}, {"question": None}, {"other": "x"}]
-    monkeypatch.setattr(
-        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
-    )
+    monkeypatch.setattr("nemo_automodel.components.datasets.load_openai_messages", lambda *a, **k: rows)
     prompts = _load_prompts(_args(prompt_column="question"))
     assert prompts == [[{"role": "user", "content": "ok"}]]
 
@@ -104,9 +98,7 @@ def test_load_prompts_prompt_column_drops_unusable_rows(monkeypatch):
 def test_load_prompts_prompt_column_list_field_uses_first_turn(monkeypatch):
     """MT-Bench-shaped rows: a list-of-turns column, first turn used."""
     rows = [{"turns": ["first", "second"]}]
-    monkeypatch.setattr(
-        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
-    )
+    monkeypatch.setattr("nemo_automodel.components.datasets.load_openai_messages", lambda *a, **k: rows)
     prompts = _load_prompts(_args(prompt_column="turns"))
     assert prompts == [[{"role": "user", "content": "first"}]]
 
@@ -115,9 +107,7 @@ def test_load_prompts_no_prompt_column_attribute_falls_back_to_messages(monkeypa
     """Callers whose Namespace never sets prompt_column (the two single-dataset
     benchmarks' existing test fixtures) keep working via getattr's default."""
     rows = [{"messages": [{"role": "user", "content": "hi"}]}]
-    monkeypatch.setattr(
-        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
-    )
+    monkeypatch.setattr("nemo_automodel.components.datasets.load_openai_messages", lambda *a, **k: rows)
     args = SimpleNamespace(
         input_data="d", split="train", dataset_name=None, shuffle_seed=None, messages_column="messages", num_prompts=10
     )  # no prompt_column attr at all
@@ -127,9 +117,7 @@ def test_load_prompts_no_prompt_column_attribute_falls_back_to_messages(monkeypa
 
 def test_load_prompts_prompt_column_respects_num_prompts_cap(monkeypatch):
     rows = [{"question": f"q{i}"} for i in range(5)]
-    monkeypatch.setattr(
-        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
-    )
+    monkeypatch.setattr("nemo_automodel.components.datasets.load_openai_messages", lambda *a, **k: rows)
     prompts = _load_prompts(_args(prompt_column="question", num_prompts=2))
     assert len(prompts) == 2
 
@@ -142,9 +130,7 @@ def test_load_prompts_prompt_column_respects_num_prompts_cap(monkeypatch):
 def test_load_prompts_appends_context_column_when_present(monkeypatch):
     """Alpaca-shaped rows: instruction + non-empty input are joined into one prompt."""
     rows = [{"instruction": "Identify the odd one out.", "input": "Twitter, Instagram, Telegram."}]
-    monkeypatch.setattr(
-        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
-    )
+    monkeypatch.setattr("nemo_automodel.components.datasets.load_openai_messages", lambda *a, **k: rows)
     prompts = _load_prompts(_args(prompt_column="instruction", prompt_context_column="input"))
     assert prompts == [[{"role": "user", "content": "Identify the odd one out.\n\nTwitter, Instagram, Telegram."}]]
 
@@ -152,9 +138,7 @@ def test_load_prompts_appends_context_column_when_present(monkeypatch):
 def test_load_prompts_omits_empty_context_column(monkeypatch):
     """A blank/missing context field leaves the bare instruction untouched."""
     rows = [{"instruction": "Name a color.", "input": ""}, {"instruction": "Name a fruit."}]
-    monkeypatch.setattr(
-        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
-    )
+    monkeypatch.setattr("nemo_automodel.components.datasets.load_openai_messages", lambda *a, **k: rows)
     prompts = _load_prompts(_args(prompt_column="instruction", prompt_context_column="input"))
     assert prompts == [
         [{"role": "user", "content": "Name a color."}],
@@ -165,9 +149,7 @@ def test_load_prompts_omits_empty_context_column(monkeypatch):
 def test_load_prompts_context_column_attribute_optional(monkeypatch):
     """A Namespace that never sets prompt_context_column behaves as before (no append)."""
     rows = [{"instruction": "Name a color.", "input": "ignored"}]
-    monkeypatch.setattr(
-        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
-    )
+    monkeypatch.setattr("nemo_automodel.components.datasets.load_openai_messages", lambda *a, **k: rows)
     args = _args(prompt_column="instruction")  # _args never sets prompt_context_column
     assert not hasattr(args, "prompt_context_column")
     prompts = _load_prompts(args)

--- a/tests/unit_tests/speculative/test_bench_sglang.py
+++ b/tests/unit_tests/speculative/test_bench_sglang.py
@@ -405,7 +405,7 @@ def _run_args(**over):
 def test_load_prompts_caps_and_drops_unusable(monkeypatch):
     rows = [{"messages": "a"}, {"messages": "b"}, {"messages": "c"}]
     monkeypatch.setattr(
-        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages",
+        "nemo_automodel.components.datasets.load_openai_messages",
         lambda *a, **k: rows,
     )
     # "b" yields no usable prompt and must be skipped; the cap stops at 2.

--- a/tests/unit_tests/speculative/test_regenerate.py
+++ b/tests/unit_tests/speculative/test_regenerate.py
@@ -438,7 +438,7 @@ def test_run_resume_skips_already_written_shards(tmp_path: Path, monkeypatch):
         for i in range(4)
     ]
     monkeypatch.setattr(
-        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages",
+        "nemo_automodel.components.datasets.load_openai_messages",
         lambda *args, **kwargs: fake_dataset,
     )
 

--- a/tests/unit_tests/test_component_imports.py
+++ b/tests/unit_tests/test_component_imports.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from unittest.mock import Mock
+
+from tools.component_imports import ComponentImport, find_component_imports
+from tools.import_linter_contracts import ComponentInterfaceContract
+
+COMPONENTS = {"sample.components.alpha", "sample.components.beta"}
+
+
+def _write(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents, encoding="utf-8")
+
+
+def test_component_imports_allow_symbols_exported_from_package(tmp_path):
+    _write(tmp_path / "sample/components/alpha/__init__.py", "")
+    _write(
+        tmp_path / "sample/components/alpha/consumer.py",
+        "from sample.components.beta import PublicName\n",
+    )
+    _write(
+        tmp_path / "sample/components/beta/__init__.py",
+        '_LAZY_ATTRS = {"PublicName": (".implementation", "PublicName")}\n__all__ = sorted(_LAZY_ATTRS.keys())\n',
+    )
+
+    component_imports = find_component_imports(tmp_path, COMPONENTS)
+
+    assert len(component_imports) == 1
+    assert component_imports[0].is_public
+
+
+def test_component_imports_check_consumers_outside_components(tmp_path):
+    _write(tmp_path / "sample/components/alpha/__init__.py", "")
+    _write(tmp_path / "sample/components/beta/__init__.py", '__all__ = ["PublicName"]\n')
+    _write(tmp_path / "sample/recipes/train.py", "from sample.components.beta import PublicName\n")
+
+    [component_import] = find_component_imports(tmp_path, COMPONENTS)
+
+    assert component_import.importer == "sample.recipes.train"
+    assert component_import.is_public
+
+
+def test_component_imports_reject_private_modules_outside_components(tmp_path):
+    _write(tmp_path / "sample/components/alpha/__init__.py", "")
+    _write(tmp_path / "sample/components/beta/__init__.py", '__all__ = ["PublicName"]\n')
+    _write(tmp_path / "sample/components/beta/implementation.py", "PublicName = object()\n")
+    _write(
+        tmp_path / "sample/recipes/train.py",
+        "from sample.components.beta.implementation import PublicName\n",
+    )
+
+    [component_import] = find_component_imports(tmp_path, COMPONENTS)
+
+    assert component_import.importer == "sample.recipes.train"
+    assert component_import.violation == (
+        "sample.components.beta.implementation is private; import exported symbols from sample.components.beta"
+    )
+
+
+def test_component_imports_reject_non_exported_symbols_outside_components(tmp_path):
+    _write(tmp_path / "sample/components/alpha/__init__.py", "")
+    _write(tmp_path / "sample/components/beta/__init__.py", '__all__ = ["PublicName"]\n')
+    _write(tmp_path / "sample/recipes/train.py", "from sample.components.beta import PrivateName\n")
+
+    [component_import] = find_component_imports(tmp_path, COMPONENTS)
+
+    assert component_import.importer == "sample.recipes.train"
+    assert component_import.violation == "PrivateName not exported by sample.components.beta.__all__"
+
+
+def test_component_imports_reject_non_exported_symbols(tmp_path):
+    _write(tmp_path / "sample/components/alpha/__init__.py", "")
+    _write(
+        tmp_path / "sample/components/alpha/consumer.py",
+        "from sample.components.beta import PrivateName\n",
+    )
+    _write(tmp_path / "sample/components/beta/__init__.py", '__all__ = ["PublicName"]\n')
+
+    [component_import] = find_component_imports(tmp_path, COMPONENTS)
+
+    assert component_import.violation == "PrivateName not exported by sample.components.beta.__all__"
+
+
+def test_component_imports_reject_private_module_even_when_symbol_is_exported(tmp_path):
+    _write(tmp_path / "sample/components/alpha/__init__.py", "")
+    _write(
+        tmp_path / "sample/components/alpha/consumer.py",
+        "from sample.components.beta.implementation import PublicName\n",
+    )
+    _write(tmp_path / "sample/components/beta/__init__.py", '__all__ = ["PublicName"]\n')
+    _write(tmp_path / "sample/components/beta/implementation.py", '__all__ = ["PublicName"]\n')
+
+    [component_import] = find_component_imports(tmp_path, COMPONENTS)
+
+    assert component_import.violation == (
+        "sample.components.beta.implementation is private; import exported symbols from sample.components.beta"
+    )
+
+
+def test_component_imports_reject_component_module_imports(tmp_path):
+    _write(tmp_path / "sample/components/alpha/__init__.py", "")
+    _write(
+        tmp_path / "sample/components/alpha/consumer.py",
+        "import sample.components.beta\nfrom sample.components import beta\n",
+    )
+    _write(tmp_path / "sample/components/beta/__init__.py", '__all__ = ["PublicName"]\n')
+
+    component_imports = find_component_imports(tmp_path, COMPONENTS)
+
+    assert [component_import.line_number for component_import in component_imports] == [1, 2]
+    assert all(not component_import.is_public for component_import in component_imports)
+
+
+def test_component_imports_resolve_relative_public_imports(tmp_path):
+    _write(tmp_path / "sample/components/alpha/__init__.py", "")
+    _write(
+        tmp_path / "sample/components/alpha/consumer.py",
+        "from ..beta import PublicName\n",
+    )
+    _write(tmp_path / "sample/components/beta/__init__.py", '__all__ = ["PublicName"]\n')
+
+    [component_import] = find_component_imports(tmp_path, COMPONENTS)
+
+    assert component_import.is_public
+    assert component_import.imported_module == "sample.components.beta"
+
+
+def test_component_imports_ignore_same_component_and_type_checking_imports(tmp_path):
+    _write(tmp_path / "sample/components/alpha/__init__.py", "")
+    _write(tmp_path / "sample/components/alpha/local.py", "LocalName = object()\n")
+    _write(
+        tmp_path / "sample/components/alpha/consumer.py",
+        "from typing import TYPE_CHECKING\n"
+        "from sample.components.alpha.local import LocalName\n"
+        "if TYPE_CHECKING:\n"
+        "    from sample.components.beta.implementation import PrivateName\n",
+    )
+    _write(tmp_path / "sample/components/beta/__init__.py", "")
+    _write(tmp_path / "sample/components/beta/implementation.py", "PrivateName = object()\n")
+
+    assert find_component_imports(tmp_path, COMPONENTS) == []
+
+
+def test_component_contract_skips_importers_absent_from_import_graph():
+    graph = Mock()
+    graph.modules = set()
+    component_import = ComponentImport(
+        path=Path("sample/recipes/train.py"),
+        line_number=1,
+        importer="sample.recipes.train",
+        target_component="sample.components.beta",
+        imported_module="sample.components.beta",
+        imported_names=("PublicName",),
+        violation=None,
+    )
+
+    ComponentInterfaceContract._remove_direct_import(graph, component_import)
+
+    graph.find_modules_directly_imported_by.assert_not_called()

--- a/tests/unit_tests/test_improved_error_messages.py
+++ b/tests/unit_tests/test_improved_error_messages.py
@@ -90,8 +90,9 @@ class TestModelsAlias:
     ``nemo_automodel.components.models``."""
 
     def test_alias_package_is_same_object(self):
-        import nemo_automodel.components.models as real
         import nemo_automodel.models as alias
+
+        import nemo_automodel.components.models as real
 
         assert alias is real
 
@@ -277,7 +278,7 @@ class TestCheckpointDtypeRestoration:
 
         model = DummyModel().to(torch.float32)
         with patch(
-            "nemo_automodel.components.checkpoint.utils._get_checkpoint_tensor_dtypes",
+            "nemo_automodel._transformers.model_init.get_checkpoint_tensor_dtypes",
             return_value={
                 "linear.weight": torch.bfloat16,
                 "norm.weight": torch.float32,
@@ -315,7 +316,7 @@ class TestCheckpointDtypeRestoration:
 
         model = DummyModel().to(torch.float32)
         with patch(
-            "nemo_automodel.components.checkpoint.utils._get_checkpoint_tensor_dtypes",
+            "nemo_automodel._transformers.model_init.get_checkpoint_tensor_dtypes",
             return_value={
                 "model.language_model.layers.0.linear_attn.A_log": torch.bfloat16,
                 "model.language_model.layers.0.linear_attn.dt_bias": torch.bfloat16,
@@ -355,7 +356,7 @@ class TestCheckpointDtypeRestoration:
 
         model = DummyModel().to(torch.float32)
         with patch(
-            "nemo_automodel.components.checkpoint.utils._get_checkpoint_tensor_dtypes",
+            "nemo_automodel._transformers.model_init.get_checkpoint_tensor_dtypes",
             return_value={"layer.linear_attn.A_log": torch.bfloat16},
         ):
             _restore_loaded_model_dtype(
@@ -382,7 +383,7 @@ class TestCheckpointDtypeRestoration:
 
         model = DummyModel().to(torch.float32)
         with patch(
-            "nemo_automodel.components.checkpoint.utils._get_checkpoint_tensor_dtypes",
+            "nemo_automodel._transformers.model_init.get_checkpoint_tensor_dtypes",
             return_value={"lm_head.weight": torch.bfloat16},
         ):
             _restore_loaded_model_dtype(

--- a/tests/unit_tests/test_validation.py
+++ b/tests/unit_tests/test_validation.py
@@ -31,7 +31,7 @@ from nemo_automodel._transformers.capabilities import (
 )
 from nemo_automodel.components.distributed.optimized_tp_plans import _get_class_qualname
 
-_PARALLELIZE_PATH = "nemo_automodel.components.distributed.optimized_tp_plans.PARALLELIZE_FUNCTIONS"
+_PARALLELIZE_PATH = "nemo_automodel.components.distributed.PARALLELIZE_FUNCTIONS"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/component_imports.py
+++ b/tools/component_imports.py
@@ -1,0 +1,345 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static analysis for imports through Automodel component interfaces."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ComponentImport:
+    """An import of a configured component from outside that component."""
+
+    path: Path
+    line_number: int
+    importer: str
+    target_component: str
+    imported_module: str
+    imported_names: tuple[str, ...]
+    violation: str | None
+
+    @property
+    def is_public(self) -> bool:
+        """Return whether the import uses only the target component's public API."""
+        return self.violation is None
+
+
+def find_component_imports(
+    project_root: Path,
+    component_modules: set[str],
+) -> list[ComponentImport]:
+    """Find runtime imports of configured components from outside their package."""
+    components = sorted(component_modules, key=lambda module: (-len(module), module))
+    root_packages = {component.partition(".")[0] for component in components}
+    if len(root_packages) != 1:
+        raise ValueError("Configured components must share one root package")
+
+    root_package = root_packages.pop()
+    source_root = project_root / root_package
+    if not source_root.is_dir():
+        raise ValueError(f"Root package does not exist: {root_package}")
+
+    exports = {
+        component: _read_exports(project_root / Path(*component.split(".")) / "__init__.py") for component in components
+    }
+    imports: list[ComponentImport] = []
+
+    for component in components:
+        component_path = project_root / Path(*component.split("."))
+        if not component_path.is_dir():
+            raise ValueError(f"Component package does not exist: {component}")
+
+    for path in sorted(source_root.rglob("*.py")):
+        importer = _module_name(project_root, path)
+        package = importer if path.name == "__init__.py" else importer.rpartition(".")[0]
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        visitor = _ComponentImportVisitor(
+            path=path.relative_to(project_root),
+            importer=importer,
+            importer_package=package,
+            source_component=_component_for_module(importer, components),
+            components=components,
+            exports=exports,
+        )
+        visitor.visit(tree)
+        imports.extend(visitor.imports)
+
+    return sorted(imports, key=lambda item: (str(item.path), item.line_number, item.target_component))
+
+
+class _ComponentImportVisitor(ast.NodeVisitor):
+    def __init__(
+        self,
+        *,
+        path: Path,
+        importer: str,
+        importer_package: str,
+        source_component: str | None,
+        components: list[str],
+        exports: dict[str, frozenset[str]],
+    ) -> None:
+        self.path = path
+        self.importer = importer
+        self.importer_package = importer_package
+        self.source_component = source_component
+        self.components = components
+        self.exports = exports
+        self.imports: list[ComponentImport] = []
+
+    def visit_If(self, node: ast.If) -> None:
+        type_checking_value = _evaluate_type_checking_guard(node.test)
+        if type_checking_value is False:
+            for statement in node.orelse:
+                self.visit(statement)
+            return
+        if type_checking_value is True:
+            for statement in node.body:
+                self.visit(statement)
+            return
+        self.generic_visit(node)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            target_component = _component_for_module(alias.name, self.components)
+            if target_component is None or target_component == self.source_component:
+                continue
+            self.imports.append(
+                ComponentImport(
+                    path=self.path,
+                    line_number=node.lineno,
+                    importer=self.importer,
+                    target_component=target_component,
+                    imported_module=alias.name,
+                    imported_names=("<module>",),
+                    violation=(f"component imports must name symbols from {target_component}.__all__"),
+                )
+            )
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        imported_module = _resolve_import_from(node, self.importer_package)
+        if imported_module is None:
+            return
+
+        target_component = _component_for_module(imported_module, self.components)
+        if target_component is not None:
+            if target_component != self.source_component:
+                self._record_from_import(node, imported_module, target_component)
+            return
+
+        for alias in node.names:
+            possible_module = f"{imported_module}.{alias.name}"
+            target_component = _component_for_module(possible_module, self.components)
+            if target_component is None or target_component == self.source_component:
+                continue
+            self.imports.append(
+                ComponentImport(
+                    path=self.path,
+                    line_number=node.lineno,
+                    importer=self.importer,
+                    target_component=target_component,
+                    imported_module=possible_module,
+                    imported_names=("<module>",),
+                    violation=(f"component imports must name symbols from {target_component}.__all__"),
+                )
+            )
+
+    def _record_from_import(
+        self,
+        node: ast.ImportFrom,
+        imported_module: str,
+        target_component: str,
+    ) -> None:
+        imported_names = tuple(alias.name for alias in node.names)
+        if imported_module != target_component:
+            violation = f"{imported_module} is private; import exported symbols from {target_component}"
+        else:
+            missing_exports = sorted(
+                name for name in imported_names if name == "*" or name not in self.exports[target_component]
+            )
+            violation = None
+            if missing_exports:
+                names = ", ".join(missing_exports)
+                violation = f"{names} not exported by {target_component}.__all__"
+
+        self.imports.append(
+            ComponentImport(
+                path=self.path,
+                line_number=node.lineno,
+                importer=self.importer,
+                target_component=target_component,
+                imported_module=imported_module,
+                imported_names=imported_names,
+                violation=violation,
+            )
+        )
+
+
+def _module_name(project_root: Path, path: Path) -> str:
+    relative = path.relative_to(project_root).with_suffix("")
+    parts = relative.parts[:-1] if relative.name == "__init__" else relative.parts
+    return ".".join(parts)
+
+
+def _component_for_module(module: str, components: list[str]) -> str | None:
+    for component in components:
+        if module == component or module.startswith(f"{component}."):
+            return component
+    return None
+
+
+def _resolve_import_from(node: ast.ImportFrom, importer_package: str) -> str | None:
+    if node.level == 0:
+        return node.module
+    relative_name = f"{'.' * node.level}{node.module or ''}"
+    try:
+        return importlib.util.resolve_name(relative_name, importer_package)
+    except ImportError:
+        return None
+
+
+def _evaluate_type_checking_guard(node: ast.expr) -> bool | None:
+    if isinstance(node, ast.Name) and node.id == "TYPE_CHECKING":
+        return False
+    if isinstance(node, ast.Attribute) and node.attr == "TYPE_CHECKING":
+        return False
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        value = _evaluate_type_checking_guard(node.operand)
+        return None if value is None else not value
+    if isinstance(node, ast.BoolOp):
+        values = [_evaluate_type_checking_guard(value) for value in node.values]
+        if isinstance(node.op, ast.And):
+            if False in values:
+                return False
+            return True if all(value is True for value in values) else None
+        if True in values:
+            return True
+        return False if all(value is False for value in values) else None
+    return None
+
+
+def _read_exports(init_path: Path) -> frozenset[str]:
+    if not init_path.is_file():
+        raise ValueError(f"Component package is missing __init__.py: {init_path}")
+
+    tree = ast.parse(init_path.read_text(encoding="utf-8"), filename=str(init_path))
+    values: dict[str, object] = {}
+    exports: set[str] = set()
+
+    for statement in tree.body:
+        if isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            target = statement.targets[0] if isinstance(statement, ast.Assign) else statement.target
+            value_node = statement.value
+            if isinstance(target, ast.Name) and value_node is not None:
+                value = _static_value(value_node, values)
+                if value is not _UNKNOWN:
+                    values[target.id] = value
+                    if target.id == "__all__":
+                        exports = _string_set(value)
+        elif (
+            isinstance(statement, ast.AugAssign)
+            and isinstance(statement.target, ast.Name)
+            and statement.target.id == "__all__"
+            and isinstance(statement.op, ast.Add)
+        ):
+            value = _static_value(statement.value, values)
+            if value is not _UNKNOWN:
+                exports.update(_string_set(value))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if not isinstance(node.func.value, ast.Name) or node.func.value.id != "__all__":
+            continue
+        if node.func.attr == "append" and len(node.args) == 1:
+            value = _static_value(node.args[0], values)
+            if isinstance(value, str):
+                exports.add(value)
+        elif node.func.attr == "extend" and len(node.args) == 1:
+            value = _static_value(node.args[0], values)
+            if value is not _UNKNOWN:
+                exports.update(_string_set(value))
+
+    return frozenset(exports)
+
+
+_UNKNOWN = object()
+
+
+def _static_value(node: ast.AST, values: dict[str, object]) -> object:
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name):
+        return values.get(node.id, _UNKNOWN)
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        items: list[object] = []
+        for element in node.elts:
+            if isinstance(element, ast.Starred):
+                value = _static_value(element.value, values)
+                if not isinstance(value, (list, tuple, set, frozenset)):
+                    return _UNKNOWN
+                items.extend(value)
+            else:
+                value = _static_value(element, values)
+                if value is _UNKNOWN:
+                    return _UNKNOWN
+                items.append(value)
+        return items
+    if isinstance(node, ast.Dict):
+        result: dict[object, object] = {}
+        for key_node, value_node in zip(node.keys, node.values):
+            if key_node is None:
+                return _UNKNOWN
+            key = _static_value(key_node, values)
+            value = _static_value(value_node, values)
+            if key is _UNKNOWN or value is _UNKNOWN:
+                return _UNKNOWN
+            result[key] = value
+        return result
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _static_value(node.left, values)
+        right = _static_value(node.right, values)
+        if isinstance(left, (list, tuple)) and isinstance(right, (list, tuple)):
+            return [*left, *right]
+        return _UNKNOWN
+    if isinstance(node, ast.Call) and not node.keywords and len(node.args) == 1:
+        value = _static_value(node.args[0], values)
+        if isinstance(node.func, ast.Name) and node.func.id in {"list", "set", "sorted", "tuple"}:
+            if not isinstance(value, (list, tuple, set, frozenset, dict)):
+                return _UNKNOWN
+            iterable = value.keys() if isinstance(value, dict) else value
+            if node.func.id == "sorted":
+                return sorted(iterable)
+            return list(iterable)
+    if (
+        isinstance(node, ast.Call)
+        and not node.args
+        and not node.keywords
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "keys"
+    ):
+        value = _static_value(node.func.value, values)
+        if isinstance(value, dict):
+            return list(value)
+    return _UNKNOWN
+
+
+def _string_set(value: object) -> set[str]:
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        return set()
+    return {item for item in value if isinstance(item, str)}

--- a/tools/import_linter_contracts.py
+++ b/tools/import_linter_contracts.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Repository-specific Import Linter contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from grimp import ImportGraph
+from importlinter import ContractCheck, output
+from importlinter.contracts.independence import IndependenceContract
+from importlinter.domain.helpers import module_expressions_to_modules
+
+from tools.component_imports import ComponentImport, find_component_imports
+
+
+class ComponentInterfaceContract(IndependenceContract):
+    """Require every component consumer to use exported interfaces."""
+
+    type_name = "component_interface"
+
+    # Import Linter discovers fields on the concrete class rather than base classes.
+    modules = IndependenceContract.modules
+    ignore_imports = IndependenceContract.ignore_imports
+    unmatched_ignore_imports_alerting = IndependenceContract.unmatched_ignore_imports_alerting
+
+    def check(self, graph: ImportGraph, verbose: bool) -> ContractCheck:
+        """Allow direct component edges only when they use package exports."""
+        modules = {
+            module.name
+            for module in module_expressions_to_modules(graph, self.modules)  # type: ignore[arg-type]
+        }
+        component_imports = find_component_imports(_PROJECT_ROOT, modules)
+
+        for component_import in component_imports:
+            self._remove_direct_import(graph, component_import)
+
+        independence_check = super().check(graph, verbose)
+        violations = [component_import for component_import in component_imports if not component_import.is_public]
+        independence_check.kept = independence_check.kept and not violations
+        independence_check.metadata["component_interface_violations"] = violations
+        return independence_check
+
+    def render_broken_contract(self, check: ContractCheck) -> None:
+        """Render public-interface violations before any remaining dependency chains."""
+        violations: list[ComponentImport] = check.metadata["component_interface_violations"]
+        if violations:
+            output.print_error("Component imports must use exported symbols:", bold=False)
+            output.new_line()
+            for violation in violations:
+                output.print_error(
+                    f"- {violation.path}:{violation.line_number}: {violation.violation}",
+                    bold=False,
+                )
+                output.new_line()
+            output.new_line()
+
+        if check.metadata["invalid_chains"]:
+            super().render_broken_contract(check)
+
+    @staticmethod
+    def _remove_direct_import(graph: ImportGraph, component_import: ComponentImport) -> None:
+        if component_import.importer not in graph.modules:
+            return
+        imported_modules = graph.find_modules_directly_imported_by(component_import.importer)
+        for imported_module in imported_modules:
+            if not (
+                imported_module == component_import.target_component
+                or imported_module.startswith(f"{component_import.target_component}.")
+            ):
+                continue
+            import_details = graph.get_import_details(
+                importer=component_import.importer,
+                imported=imported_module,
+            )
+            if any(detail["line_number"] == component_import.line_number for detail in import_details):
+                graph.remove_import(importer=component_import.importer, imported=imported_module)
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
# What does this PR do ?

Enforces imports of configured Automodel components through package-level symbols declared in `__all__`, including recipes and every other runtime consumer under `nemo_automodel`.

# Changelog

- Add a custom Import Linter component-interface contract that scans all runtime modules under `nemo_automodel`.
- Reject private component-submodule imports and component-root names absent from `__all__`.
- Migrate existing recipe, framework, model, CLI, and cross-component imports to their public component interfaces.
- Add lazy package exports to preserve optional-dependency and import-cycle behavior.
- Add focused contract tests and update repository policy documentation.

# Validation

- `uvx --from import-linter==2.4.0 lint-imports --debug --verbose --no-cache` — 1 contract kept, 0 broken.
- `uvx --from "ruff~=0.12.0" ruff check .` — passed.
- `uvx --from "ruff~=0.12.0" ruff format --check .` — 799 files already formatted.
- Focused and upstream-overlap pytest selection — 450 passed.
- `uvx --from bandit bandit -r app.py nemo_automodel examples scripts tools tutorials -t B614 -q` — passed.
- `git diff HEAD^ --check` — passed.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

- Draft while the full CI matrix runs.