### PR TITLE
fix(loss): return zero, not NaN, when a batch has no supervised tokens

### DIFF
--- a/nemo_automodel/components/loss/chunked_ce.py
+++ b/nemo_automodel/components/loss/chunked_ce.py
@@ -216,5 +216,10 @@ class ChunkedCrossEntropy(nn.Module):
                 loss += compute_loss(logits_chunk, targets_chunk, self.ignore_index, self.reduction)
         if num_label_tokens is not None:
             assert self.reduction == "sum", "num_label_tokens is only supported when reduction is 'sum'"
-            loss = loss / num_label_tokens  # pragma: no cover
+            if num_label_tokens == 0:
+                # A batch with no supervised tokens sums to 0.0; dividing by 0
+                # would make it NaN and poison every gradient. Matches
+                # MaskedCrossEntropy.
+                return loss * 0.0
+            loss = loss / num_label_tokens
         return loss

--- a/nemo_automodel/components/loss/linear_ce.py
+++ b/nemo_automodel/components/loss/linear_ce.py
@@ -261,5 +261,10 @@ class FusedLinearCrossEntropy(nn.Module):
         )
         if num_label_tokens is not None:
             assert self.reduction == "sum", "num_label_tokens is only supported when reduction is 'sum'"
+            if num_label_tokens == 0:
+                # A batch with no supervised tokens sums to 0.0; dividing by 0
+                # would make it NaN and poison every gradient. Matches
+                # MaskedCrossEntropy.
+                return loss * 0.0
             loss = loss / num_label_tokens
         return loss

--- a/nemo_automodel/components/loss/te_parallel_ce.py
+++ b/nemo_automodel/components/loss/te_parallel_ce.py
@@ -185,6 +185,11 @@ class TEParallelCrossEntropy:
         elif self.reduction == "sum":
             loss = te_loss.sum()
             if num_label_tokens is not None:
+                if num_label_tokens == 0:
+                    # A batch with no supervised tokens sums to 0.0; dividing by
+                    # 0 would make it NaN and poison every gradient. Matches
+                    # MaskedCrossEntropy.
+                    return loss * 0.0
                 loss = loss / num_label_tokens
             return loss
         else:

--- a/tests/unit_tests/loss/test_zero_label_tokens.py
+++ b/tests/unit_tests/loss/test_zero_label_tokens.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A batch with no supervised tokens must contribute 0.0, not NaN.
+
+``num_label_tokens`` is the global DP-reduced count of non-ignored labels, so it
+is 0 when every label in the batch is ``ignore_index`` -- e.g. a
+gradient-accumulation window where truncation cut the answer off every sample.
+The sum-reduced loss is then 0.0 and ``loss / num_label_tokens`` is ``0.0 / 0``,
+which is NaN; NaN propagates through ``backward()`` into every parameter, so the
+run continues with a destroyed model instead of failing.
+
+All four losses that accept ``num_label_tokens`` must agree here. The optional
+dependencies of ``linear_ce`` / ``te_parallel_ce`` are stubbed so the guard is
+exercised without the real kernels, following the pattern already used in
+``test_linear_ce.py``.
+"""
+
+import pytest
+import torch
+
+from nemo_automodel.components.loss.chunked_ce import ChunkedCrossEntropy
+from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
+
+B, S, V = 2, 8, 32
+
+
+def _fully_masked_batch():
+    torch.manual_seed(0)
+    logits = torch.randn(B, S, V)
+    labels = torch.full((B, S), -100)
+    num_label_tokens = int((labels != -100).sum())
+    assert num_label_tokens == 0
+    return logits, labels, num_label_tokens
+
+
+def _assert_zero(loss):
+    assert torch.is_tensor(loss)
+    assert torch.isfinite(loss).all(), f"expected a finite loss, got {loss}"
+    assert float(loss) == 0.0
+
+
+def test_masked_ce_zero_label_tokens_is_zero():
+    """The reference behaviour the other three must match."""
+    logits, labels, n = _fully_masked_batch()
+    _assert_zero(MaskedCrossEntropy(reduction="sum")(logits, labels, num_label_tokens=n))
+
+
+def test_chunked_ce_zero_label_tokens_is_zero():
+    logits, labels, n = _fully_masked_batch()
+    _assert_zero(ChunkedCrossEntropy(reduction="sum")(logits, labels, num_label_tokens=n))
+
+
+def test_fused_linear_ce_zero_label_tokens_is_zero(monkeypatch):
+    from nemo_automodel.components.loss import linear_ce as linear_ce_mod
+
+    monkeypatch.setattr(linear_ce_mod, "HAVE_CUT_CROSS_ENTROPY", True)
+    # Sum-reduced loss over zero supervised tokens is 0.0; the bug is 0.0 / 0.
+    monkeypatch.setattr(
+        linear_ce_mod,
+        "linear_cross_entropy",
+        lambda hidden, weight, targets=None, **kw: torch.tensor(0.0),
+        raising=False,
+    )
+
+    loss_fn = linear_ce_mod.FusedLinearCrossEntropy(reduction="sum")
+    out = loss_fn(torch.randn(B, S, 4), torch.full((B, S), -100), torch.randn(V, 4), num_label_tokens=0)
+    _assert_zero(out)
+
+
+def test_te_parallel_ce_zero_label_tokens_is_zero(monkeypatch):
+    from nemo_automodel.components.loss import te_parallel_ce as te_mod
+
+    monkeypatch.setattr(te_mod, "HAVE_TE_PARALLEL_CE", True)
+    monkeypatch.setattr(
+        te_mod,
+        "parallel_cross_entropy",
+        lambda logits, labels, eps, reduce_loss, tp_group, ignore_index: torch.zeros(B, S),
+        raising=False,
+    )
+
+    loss_fn = te_mod.TEParallelCrossEntropy(reduction="sum")
+    out = loss_fn(torch.randn(B, S, V), torch.full((B, S), -100), num_label_tokens=0)
+    _assert_zero(out)
+
+
+@pytest.mark.parametrize("reduction", ["sum"])
+def test_nonzero_label_tokens_still_normalizes(reduction):
+    """The guard must not disturb the normal path."""
+    torch.manual_seed(0)
+    logits = torch.randn(B, S, V)
+    labels = torch.randint(0, V, (B, S))
+    n = int((labels != -100).sum())
+    assert n == B * S
+
+    masked = MaskedCrossEntropy(reduction=reduction)(logits, labels.clone(), num_label_tokens=n)
+    chunked = ChunkedCrossEntropy(reduction=reduction)(logits.clone(), labels.clone(), num_label_tokens=n)
+
+    assert torch.isfinite(masked).all() and float(masked) > 0.0
+    assert torch.isfinite(chunked).all() and float(chunked) > 0.0
+    assert float(masked) == pytest.approx(float(chunked), rel=1e-5)


### PR DESCRIPTION
# What does this PR do ?

Makes a batch with no supervised tokens contribute `0.0` instead of `NaN` in the
three losses that were missing the guard `MaskedCrossEntropy` already has.

`num_label_tokens` is the global, DP-reduced count of non-ignored labels
(`recipes/llm/train_ft.py` L1210-1213). It is `0` when every label in the global
batch is `-100` — for example a gradient-accumulation window where truncation
cut the answer off every sample, or a bad shard. The sum-reduced loss is then
`0.0`, and `0.0 / 0` is `NaN`. `NaN` propagates through `backward()` into every
parameter, so the run keeps going with a destroyed model rather than failing.

`masked_ce.py` L84-88 already handles it:

```python
if num_label_tokens == 0:
    return loss * 0.0
```

The other three divided unconditionally:

| Loss | Before | After |
|---|---|---|
| `MaskedCrossEntropy` | `0.0` | `0.0` (unchanged) |
| `FusedLinearCrossEntropy` | **`NaN`** | `0.0` |
| `ChunkedCrossEntropy` | **`NaN`** | `0.0` |
| `TEParallelCrossEntropy` | **`NaN`** | `0.0` |

So which loss you configured decided whether the step survived. That is
reachable without the user changing anything: `_maybe_downgrade_loss_fn`
(`train_ft.py` L159) swaps a fused loss for `MaskedCrossEntropy` when the model
does not declare `logits_to_keep`, so one config could behave differently across
two models.

The recipe already treats zero as a real case on the validation path
(`train_ft.py` L1382, `max(total_num_label_tokens, 1e-8)`), so the training path
was the inconsistent one.

`loss * 0.0` rather than a fresh `torch.zeros` keeps the autograd graph intact,
so the step contributes zero gradient instead of detaching.

# Changelog

- `FusedLinearCrossEntropy`, `ChunkedCrossEntropy` and `TEParallelCrossEntropy`
  return `loss * 0.0` when `num_label_tokens == 0`, matching
  `MaskedCrossEntropy`.
- New `tests/unit_tests/loss/test_zero_label_tokens.py` covering all four losses
  plus a normalization regression guard.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

Behaviour now matches the documented `num_label_tokens` contract, so no doc
change was needed.

**Verification** (CPU, no GPU needed):

- The `linear_ce` / `te_parallel_ce` tests stub `cut_cross_entropy` and the
  Transformer Engine kernel — following the pattern already in
  `test_linear_ce.py` — so all four guards are actually exercised here rather
  than skipped, even though neither optional package is installed locally.
- Reverting only the three source hunks makes exactly those three tests fail;
  `test_masked_ce_zero_label_tokens_is_zero` and
  `test_nonzero_label_tokens_still_normalizes` pass either way, which is
  intended — they pin the reference behaviour and the path this must not change.
- `pytest tests/unit_tests/loss/` → 299 passed, 36 skipped, no regressions.
- `ruff format` / `ruff check` clean.

# Additional Information

- Related to #3796

I kept this as the minimal guard so it is easy to review. If you would rather
the normalization were factored into one shared helper so the four cannot drift
apart again, say so and I will restructure it that way.
