### PR TITLE
fix(datasets): log the VLM pre-filter threshold that is actually applied

### DIFF
--- a/nemo_automodel/components/datasets/vlm/samplers.py
+++ b/nemo_automodel/components/datasets/vlm/samplers.py
@@ -114,8 +114,8 @@ class LengthGroupedSampler(Sampler):
         # rare case where the heuristic underestimates the true tokenized length.
         all_indices = range(len(dataset))
         if max_length is not None:
-            # Use 1.2x headroom: the estimated length is a heuristic, so only
-            # drop samples that are clearly overlong.  Borderline samples are
+            # Fixed 512-token headroom: the estimated length is a heuristic, so
+            # only drop samples that are clearly overlong.  Borderline samples are
             # left to PreTokenizedDatasetWrapper's precise tokenize-and-retry.
             filter_threshold = max_length + 512
             kept = [i for i in all_indices if self.lengths[i] <= filter_threshold]
@@ -123,7 +123,7 @@ class LengthGroupedSampler(Sampler):
             if n_dropped:
                 logger.info(
                     "LengthGroupedSampler: pre-filtered %d/%d samples with "
-                    "estimated length > %.0f tokens (1.2 * max_length %d).",
+                    "estimated length > %d tokens (max_length %d + 512 headroom).",
                     n_dropped,
                     len(dataset),
                     filter_threshold,

--- a/tests/unit_tests/datasets/vlm/test_samplers.py
+++ b/tests/unit_tests/datasets/vlm/test_samplers.py
@@ -542,3 +542,51 @@ class TestEdgeCases:
         }
         length = LengthGroupedSampler([example], seed=0, processor=processor).lengths[0]
         assert length == 200
+
+
+# ---------------------------------------------------------------------------
+# max_length pre-filter threshold
+# ---------------------------------------------------------------------------
+
+
+class TestPreFilterThreshold:
+    """The pre-filter keeps samples up to ``max_length + 512``, and says so.
+
+    The log line is the only signal a user gets for why samples left the run, so
+    it has to name the threshold that was actually applied.
+    """
+
+    MAX_LENGTH = 2048
+    HEADROOM = 512
+
+    def _dataset_at(self, *estimates):
+        # The no-processor heuristic is ``len(text) // 3``.
+        return _make_dataset([_text_msg("x" * (3 * e)) for e in estimates])
+
+    def test_keeps_sample_exactly_at_threshold(self):
+        threshold = self.MAX_LENGTH + self.HEADROOM
+        ds = self._dataset_at(threshold)
+        sampler = LengthGroupedSampler(ds, seed=0, max_length=self.MAX_LENGTH)
+        assert sampler.lengths == [threshold]
+        assert len(sampler.sorted_indices) == 1, "a sample at the threshold must be kept"
+
+    def test_drops_sample_one_token_over_threshold(self):
+        threshold = self.MAX_LENGTH + self.HEADROOM
+        ds = self._dataset_at(threshold + 1)
+        sampler = LengthGroupedSampler(ds, seed=0, max_length=self.MAX_LENGTH)
+        assert len(sampler.sorted_indices) == 0
+
+    def test_log_reports_the_threshold_actually_applied(self, caplog):
+        threshold = self.MAX_LENGTH + self.HEADROOM
+        ds = self._dataset_at(8, threshold + 1)
+
+        with caplog.at_level("INFO", logger="nemo_automodel.components.datasets.vlm.samplers"):
+            sampler = LengthGroupedSampler(ds, seed=0, max_length=self.MAX_LENGTH)
+
+        assert len(sampler.sorted_indices) == 1
+        line = next(m for m in caplog.messages if "pre-filtered" in m)
+        assert f"> {threshold} tokens" in line
+        # `max_length + 512` is not `1.2 * max_length`; claiming so misstates the
+        # rule, and the gap grows with context length (0.4% headroom at 128k).
+        assert "1.2" not in line
+        assert str(int(self.MAX_LENGTH * 1.2)) not in line


### PR DESCRIPTION
# What does this PR do ?

Makes the VLM `LengthGroupedSampler` pre-filter log state the threshold it
actually applies. No behaviour change.

`nemo_automodel/components/datasets/vlm/samplers.py` filtered with
`max_length + 512`, but the comment said "Use 1.2x headroom" and the log line
printed that flat threshold labelled as `1.2 * max_length` — so the message
asserted that `max_length + 512` *is* `1.2 * max_length`. Reproduced on `main`:

```
LengthGroupedSampler: pre-filtered 1/3 samples with estimated length > 2560 tokens (1.2 * max_length 2048).
```

`1.2 * 2048` is 2457, not 2560.

The two readings diverge as context grows, so this is not only cosmetic:

| `max_length` | code (`+512`) | stated (`1.2x`) | effective headroom |
|---:|---:|---:|---:|
| 2048 | 2560 | 2457 | 25.0% |
| 8192 | 8704 | 9830 | 6.2% |
| 32768 | 33280 | 39321 | 1.6% |
| 131072 | 131584 | 157286 | 0.4% |

Beyond `max_length=2560` the filter is stricter than the documented rule, by
~6k tokens' worth of samples at 32k. The comment's stated design is that
borderline samples are *not* dropped here — they go to
`PreTokenizedDatasetWrapper`'s precise tokenize-and-retry, because
`self.lengths[i]` is only an estimate. The log is the only signal a user gets
for why samples left the run, so it has to name the real rule.

After:

```
LengthGroupedSampler: pre-filtered 1/3 samples with estimated length > 2560 tokens (max_length 2048 + 512 headroom).
```

**Scope.** This PR fixes only the reporting, which is true regardless of intent.
Whether the flat `+512` or the `1.2x` it claimed is the right *policy* is a
separate call I have deliberately not made — see #3798. If 1.2x was intended,
say so and I will send `filter_threshold = int(max_length * 1.2)` instead.

# Changelog

- Comment and log message in `LengthGroupedSampler.__init__` now state
  `max_length + 512`; the filter itself is unchanged.
- `%.0f` → `%d` for the threshold, which is an int.
- New `TestPreFilterThreshold` in `tests/unit_tests/datasets/vlm/test_samplers.py`:
  a sample exactly at the threshold is kept, one token over is dropped, and the
  logged threshold matches the applied one.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

The stale comment was the documentation; it is corrected here.

**Verification** (CPU, no GPU, dataset or processor needed):

- Reverting the source hunk makes
  `test_log_reports_the_threshold_actually_applied` fail. The two threshold
  tests pass either way by design — they pin the filter behaviour this must not
  change.
- `pytest tests/unit_tests/datasets/vlm/` → 368 passed, no regressions.
- `ruff format` / `ruff check` clean.

# Additional Information

- Related to #3798
