### PR TITLE
fix(qwen3_8_flash_next): keep flex QSA membership lookup in int64

### DIFF
--- a/nemo_automodel/components/models/qwen3_8_flash_next/flex_qsa.py
+++ b/nemo_automodel/components/models/qwen3_8_flash_next/flex_qsa.py
@@ -71,6 +71,39 @@ def _routes_to_membership(
     return membership, has_routes
 
 
+def _membership_flat_offset(
+    batch_idx: torch.Tensor,
+    query_idx: torch.Tensor,
+    kv_idx: torch.Tensor,
+    query_length: int,
+    kv_length: int,
+) -> torch.Tensor:
+    """Flat offset into a ``[B, S_q, kv_length]`` membership table, evaluated in int64.
+
+    FlexAttention inlines ``mask_mod`` into its Triton template and emits that
+    inlined index arithmetic in int32. The membership table crosses
+    ``INT32_MAX`` once ``B * S_q * kv_length > 2**31`` -- a square 46341-token
+    sequence is already past it -- and from that point ``query_idx * kv_length``
+    wraps negative inside the kernel. The wrapped address still lands in mapped
+    memory for a while, so the tail queries silently read a wrong mask before
+    the failure escalates to ``CUDA error: an illegal memory access`` at larger
+    sequence lengths. Widening the operands here keeps the generated address
+    arithmetic in int64.
+
+    Args:
+        batch_idx: Scalar batch coordinate supplied by FlexAttention.
+        query_idx: Scalar query coordinate, already clamped in range.
+        kv_idx: Scalar key/value coordinate, already clamped in range.
+        query_length: Number of query rows in the membership table.
+        kv_length: Number of physical K/V rows in the membership table.
+
+    Returns:
+        int64 offset of ``[batch_idx, query_idx, kv_idx]`` in the flattened table.
+    """
+    flat_query = batch_idx.to(torch.int64) * query_length + query_idx.to(torch.int64)
+    return flat_query * kv_length + kv_idx.to(torch.int64)
+
+
 def flex_sparse_gqa_attention(
     query: torch.Tensor,
     key: torch.Tensor,
@@ -110,6 +143,10 @@ def flex_sparse_gqa_attention(
     scale = head_dim**-0.5 if softmax_scale is None else float(softmax_scale)
 
     membership, has_routes = _routes_to_membership(selected_token_ids, kv_length)
+    # Looked up through a flat int64 offset rather than membership[b, q, kv]:
+    # the inlined mask_mod indexes this table in int32, which overflows for
+    # long sequences. See _membership_flat_offset.
+    membership_flat = membership.reshape(-1)
 
     def mask_mod(b, h, q_idx, kv_idx):
         # FlexAttention pads Q/KV to block multiples and probes the padded
@@ -118,7 +155,8 @@ def flex_sparse_gqa_attention(
         in_range = (q_idx < query_length) & (kv_idx < kv_length)
         safe_q = torch.clamp(q_idx, max=query_length - 1)
         safe_kv = torch.clamp(kv_idx, max=kv_length - 1)
-        return in_range & membership[b, safe_q, safe_kv]
+        offset = _membership_flat_offset(b, safe_q, safe_kv, query_length, kv_length)
+        return in_range & membership_flat[offset]
 
     block_mask = create_block_mask(
         mask_mod,

--- a/tests/unit_tests/models/qwen3_8_flash_next/test_qwen3_8_flash_next_qsa.py
+++ b/tests/unit_tests/models/qwen3_8_flash_next/test_qwen3_8_flash_next_qsa.py
@@ -22,6 +22,7 @@ from nemo_automodel.components.models.qwen3_8_flash_next import layers as qwen3_
 from nemo_automodel.components.models.qwen3_8_flash_next import qsa as qwen3_8_flash_next_qsa
 from nemo_automodel.components.models.qwen3_8_flash_next.config import Qwen3_8_FlashNextTextConfig
 from nemo_automodel.components.models.qwen3_8_flash_next.flex_qsa import (
+    _membership_flat_offset,
     _routes_to_membership,
     flex_sparse_gqa_attention,
 )
@@ -359,6 +360,43 @@ def test_flex_membership_gives_empty_rows_a_kernel_safe_dummy_route() -> None:
         ),
     )
     assert bool(membership.any(dim=-1).all())
+
+
+def test_flex_membership_offset_is_exact_past_int32_range() -> None:
+    # A 65536-token square membership table holds 2**32 entries, so the last
+    # rows sit beyond INT32_MAX. Python ints are the arbitrary-precision
+    # reference: an int32 evaluation would wrap negative here instead.
+    query_length = kv_length = 65536
+    batch_idx, query_idx, kv_idx = 0, 65535, 65535
+
+    offset = _membership_flat_offset(
+        torch.tensor(batch_idx),
+        torch.tensor(query_idx),
+        torch.tensor(kv_idx),
+        query_length,
+        kv_length,
+    )
+
+    assert offset.dtype == torch.int64
+    assert int(offset) == (batch_idx * query_length + query_idx) * kv_length + kv_idx
+    assert int(offset) > torch.iinfo(torch.int32).max
+
+
+def test_flex_membership_offset_matches_direct_indexing() -> None:
+    membership = torch.rand(2, 5, 7) > 0.5
+    flat = membership.reshape(-1)
+
+    for batch_idx in range(membership.shape[0]):
+        for query_idx in range(membership.shape[1]):
+            for kv_idx in range(membership.shape[2]):
+                offset = _membership_flat_offset(
+                    torch.tensor(batch_idx),
+                    torch.tensor(query_idx),
+                    torch.tensor(kv_idx),
+                    membership.shape[1],
+                    membership.shape[2],
+                )
+                assert bool(flat[offset]) == bool(membership[batch_idx, query_idx, kv_idx])
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="FlexAttention requires CUDA")


### PR DESCRIPTION
# What does this PR do ?

Fixes an int32 overflow in the flex QSA mask lookup that silently corrupts the attention mask past ~46k tokens and crashes outright at 64k.

# Changelog

- `flex_qsa.py`: index the membership table through a new `_membership_flat_offset` helper that computes the offset in int64, instead of `membership[b, q, kv]`.
- `test_qwen3_8_flash_next_qsa.py`: two CPU unit tests covering the offset value past `INT32_MAX` and its agreement with direct indexing.

# Details

`flex_sparse_gqa_attention` builds a `[B, S_q, kv_length]` boolean membership table and indexes it from inside `mask_mod`. FlexAttention inlines `mask_mod` into its Triton template and emits that inlined index arithmetic in **int32**, so the lookup silently overflows once `B * S_q * kv_length > 2**31` — a square 46341-token sequence is already past the limit, and the documented `max_position_embeddings` for this model is 262144.

This PR indexes the table through an explicit int64 flat offset so the generated address arithmetic stays 64-bit.

## Why it matters

Past the limit, `query_idx * kv_length` wraps negative inside the kernel. The wrapped address still lands in mapped memory for a while, so the model **first trains against a wrong attention mask with no error at all**, and only escalates to a hard failure at longer sequences:

| S (square) | membership numel | behaviour |
|---|---|---|
| 46340 | 2,147,395,600 (`< 2**31`) | correct |
| 46341 | 2,147,488,281 | outputs still bit-identical |
| 47000 | 2,209,000,000 | **silent**: 1,337,539 output elements wrong, query rows `[45692, 46999]` |
| 50000 | 2,500,000,000 | **silent**: 7,216,154 output elements wrong, query rows `[42950, 49999]` |
| 65536 | 4,294,967,296 | `CUDA error: an illegal memory access was encountered` |

In both silent cases the first corrupted query row equals `ceil(2**31 / S)` exactly (45692 and 42950), which pins the overflow to the `query_idx * kv_length` term rather than anything else in the kernel.

We hit this as a hard crash at step 0 of a 64k full-parameter SFT run on 64 H20G. Note that the crash is reported far from its cause: under activation checkpointing the exception surfaces inside `torch/random.py: fork_rng -> set_rng_state` while unwinding, and only `CUDA_LAUNCH_BLOCKING=1` moves the report onto the flex attention kernel.

## Root cause, in the generated kernel

`TORCH_LOGS=output_code` at S=65536. The template selects `tl.int32` for its own offsets — correctly, since Q/K/V are far below the limit — and the inlined `mask_mod` inherits it:

```python
def triton_tem_fused_flex_attention_0(arg_Q, ..., in_ptr9, out_ptr0):
    INDEX_DTYPE : tl.constexpr = tl.int32
    ...
        tmp9  = triton_helpers.minimum(tmp1, tmp8)     # clamped query_idx, int32
        tmp10 = triton_helpers.minimum(tmp4, tmp8)     # clamped kv_idx,    int32
        tmp11 = tl.load(in_ptr9 + tmp10 + 65536*tmp9)  # 65536*tmp9 overflows int32
```

`in_ptr9` is the captured membership table. After this PR the same region is emitted with 64-bit arithmetic:

```python
        tmp10 = tmp8 * tmp9        # int64
        tmp14 = tmp10 + tmp13
        tmp15 = tmp14 * tmp9
        tmp19 = tl.load(in_ptr9 + tmp18)
```

This is a PyTorch codegen limitation rather than a bug in this file: the `INDEX_DTYPE` decision in `select_algorithm.py` did not account for buffers captured by the `mask_mod` subgraph. It is **already fixed on PyTorch main** (`INDEX_DTYPE` now resolves to `tl.int64` for this kernel), by pytorch/pytorch#187904 — "determine index type on all input/output nodes", merged 2026-06-23.

That commit landed after the 2.13.0 branch cut, so **no released PyTorch has the fix yet**:

| torch | released | S=47000 silent corruption | S=65536 | `INDEX_DTYPE` |
|---|---|---|---|---|
| 2.10.0+cu128 | 2026-02-10 | yes (167,297 elements) | crash | `tl.int32` |
| 2.12.0a0+nv26.04 (NGC) | ~2026-04 | yes | crash | `tl.int32` |
| 2.13.0+cu130 (latest stable) | 2026-07-08 | yes (167,285 elements) | crash | `tl.int32` |
| 2.15.0.dev20260831 (nightly) | — | **no** | **ok** | **`tl.int64`** |

So today every released PyTorch — including the 2.12.0a0 build in the NGC container this model ships with — miscompiles this lookup. Given `AGENTS.md` declares PyTorch 2.6+ support, the workaround stays useful until the minimum supported torch includes pytorch/pytorch#187904; it can be dropped then. The memory improvement below is independent of the PyTorch version.

## Why a flat offset instead of casting the 3-D indices

Widening the operands of the existing 3-D lookup (`membership[b.to(int64), safe_q.to(int64), safe_kv.to(int64)]`) also fixes the overflow, but `create_block_mask` evaluates `mask_mod` eagerly over the whole `[B, Q, KV]` grid, and the 3-D form materializes several broadcast index tensors there. The flat offset computes one offset tensor and does a single gather, which turns out to be *cheaper than the code it replaces*:

| mask_mod form | peak, S=32768 | peak, S=65536 |
|---|---|---|
| upstream 3-D int32 (today) | 27.2 GiB | crashes |
| 3-D lookup with int64 casts | — | 108.3 GiB |
| **flat int64 offset (this PR)** | **11.2 GiB** | **48.2 GiB** |

So the fix removes the overflow and cuts peak memory 2.4x at 32k, rather than trading correctness for memory.

### Follow-up we measured but did not include

Passing `_compile=True` to `create_block_mask` halves peak memory again at 64k (48.2 GiB -> 24.5 GiB), because the default eager path materializes the mask over the full grid. The resulting `BlockMask` is identical (`kv_num_blocks` and `kv_indices` compare equal at S=2048). It is left out of this PR to keep the change to the correctness fix, and because `_compile` is an underscore-prefixed argument whose stability is upstream's call — happy to add it here or in a follow-up if you prefer.

## Testing

Unit tests, on GPU so the CUDA-gated case actually runs (H800 sm90, torch 2.13.0+cu129, checked out from this branch):

```
pytest tests/unit_tests/models/qwen3_8_flash_next/test_qwen3_8_flash_next_qsa.py -v
=> 15 passed in 16.87s
```

Two of those are new, both CPU-only:

- `test_flex_membership_offset_is_exact_past_int32_range` -- checks the offset for the last entry of a 65536-square table against Python's arbitrary-precision integer result, and asserts it is int64 and above `INT32_MAX`. An int32 evaluation wraps negative and fails this.
- `test_flex_membership_offset_matches_direct_indexing` -- checks the flat lookup agrees with direct `membership[b, q, kv]` indexing over a small table.

Behaviour checks on this branch's `flex_sparse_gqa_attention`:

- S=65536 forward+backward completes; on `main` the same call raises `CUDA error: an illegal memory access was encountered`.
- Bit-exact equivalence at S=32768, where int32 is still exact: identical over all 67,108,864 output elements.
- `create_block_mask` output is unchanged: `kv_num_blocks` and `kv_indices` compare equal against the pre-patch construction at S=2048.
- Empty-route rows stay exactly zero and output matches `gathered_qsa_gqa_attention` (the PyTorch oracle) to 0.35% relative error in bf16 at S=65536.

Reproduced on two architectures, so this is not device-specific:

| GPU | torch | S=47000 silent corruption | first corrupted row |
|---|---|---|---|
| H20G, sm103 | 2.13.0+cu130 | 167,285 elements | 45692 |
| H800, sm90 | 2.13.0+cu129 | 167,173 elements | 45692 |

`ceil(2**31 / 47000)` is 45692 in both cases.

One practical side effect worth calling out: on an 80 GB card the *unpatched* path cannot run S=65536 at all -- it dies with `CUDA OutOfMemoryError: Tried to allocate 32.00 GiB` while materializing the 3-D broadcast index tensors. With this patch the same case peaks at 44.0 GiB and completes, so 64k QSA becomes reachable on 80 GB GPUs rather than only on larger-memory parts.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? (no user-facing behaviour change)

# Additional Information

Related upstream fix: pytorch/pytorch#187904 (already on PyTorch main, not in any released version yet — see the version table above).

## Notes for reviewers

While measuring this we also noticed that `_routes_to_membership` materializes a dense `[B, S_q, kv_length]` table plus an `int32` `hit_counts` tensor of the same shape — at 64k that is 4.3 GiB + 17.2 GiB of transient allocation for what is a *sparse* routing structure. That is orthogonal to this correctness fix, so it is left alone here, but it looks worth revisiting (bit-packing the table, or building the BlockMask directly from the route IDs).

Submitted by [RedNote Machine Learning Framework Team](https://github.com/rednote-machine-learning)