### PR TITLE
fix(loss): make ChunkedCrossEntropy reductions independent of chunk_len

### DIFF
--- a/nemo_automodel/components/loss/chunked_ce.py
+++ b/nemo_automodel/components/loss/chunked_ce.py
@@ -211,9 +211,26 @@ class ChunkedCrossEntropy(nn.Module):
 
             seq_len = logits.shape[0]
             num_chunks = (seq_len + self.chunk_len - 1) // self.chunk_len
-            loss = 0.0
-            for logits_chunk, targets_chunk in zip(logits.chunk(num_chunks, dim=0), labels.chunk(num_chunks, dim=0)):
-                loss += compute_loss(logits_chunk, targets_chunk, self.ignore_index, self.reduction)
+            logit_chunks = logits.chunk(num_chunks, dim=0)
+            target_chunks = labels.chunk(num_chunks, dim=0)
+
+            if self.reduction == "none":
+                # Per-token losses: chunks must be concatenated. Accumulating them
+                # adds the chunks together instead, yielding chunk_len values.
+                loss = torch.cat(
+                    [
+                        compute_loss(logits_chunk, targets_chunk, self.ignore_index, "none")
+                        for logits_chunk, targets_chunk in zip(logit_chunks, target_chunks)
+                    ]
+                )
+            else:
+                # "mean": a mean of per-chunk means cannot be summed -- that returns
+                # num_chunks x the loss. Accumulate the sum and divide once by the
+                # non-ignored token count, which matches F.cross_entropy exactly.
+                loss = 0.0
+                for logits_chunk, targets_chunk in zip(logit_chunks, target_chunks):
+                    loss = loss + compute_loss(logits_chunk, targets_chunk, self.ignore_index, "sum")
+                loss = loss / (labels != self.ignore_index).sum()
         if num_label_tokens is not None:
             assert self.reduction == "sum", "num_label_tokens is only supported when reduction is 'sum'"
             loss = loss / num_label_tokens  # pragma: no cover

--- a/tests/unit_tests/loss/test_chunked_ce.py
+++ b/tests/unit_tests/loss/test_chunked_ce.py
@@ -270,3 +270,55 @@ def test_chunked_cross_entropy_cuda_bf16_matches_fp32_reference():
     reference.backward()
     torch.cuda.synchronize(device)
     torch.testing.assert_close(logits.grad.float(), reference_logits.grad, rtol=2e-2, atol=2e-3)
+
+
+# ---------------------------------------------------------------------------
+# Chunking must not change the answer, for every reduction
+# ---------------------------------------------------------------------------
+
+
+class TestReductionIsChunkInvariant:
+    """``chunk_len`` is a memory knob; it must not alter the returned loss.
+
+    The fallback loop accumulated per-chunk results, which is only valid for
+    ``sum``: summing per-chunk *means* returned ``num_chunks`` x the loss, and
+    adding per-chunk *vectors* returned ``chunk_len`` values instead of one per
+    token. Both were silent.
+    """
+
+    N, V = 512, 16
+
+    def _batch(self, with_ignored=True):
+        torch.manual_seed(0)
+        logits = torch.randn(self.N, self.V)
+        labels = torch.randint(0, self.V, (self.N,))
+        if with_ignored:
+            labels[::7] = -100  # scatter ignored positions across chunk boundaries
+        return logits, labels
+
+    # 96 and 100 do not divide 512 evenly; 512 is a single chunk.
+    CHUNK_LENS = [1, 32, 96, 100, 128, 512]
+
+    @pytest.mark.parametrize("chunk_len", CHUNK_LENS)
+    @pytest.mark.parametrize("with_ignored", [False, True])
+    def test_mean_matches_reference(self, chunk_len, with_ignored):
+        logits, labels = self._batch(with_ignored)
+        ref = F.cross_entropy(logits.float(), labels, reduction="mean", ignore_index=-100)
+        got = ChunkedCrossEntropy(reduction="mean", chunk_len=chunk_len, compile=False)(logits.clone(), labels.clone())
+        assert torch.allclose(got, ref, rtol=1e-5, atol=1e-5), f"chunk_len={chunk_len}: {got} vs {ref}"
+
+    @pytest.mark.parametrize("chunk_len", CHUNK_LENS)
+    def test_none_returns_one_value_per_token(self, chunk_len):
+        logits, labels = self._batch()
+        ref = F.cross_entropy(logits.float(), labels, reduction="none", ignore_index=-100)
+        got = ChunkedCrossEntropy(reduction="none", chunk_len=chunk_len, compile=False)(logits.clone(), labels.clone())
+        assert got.shape == (self.N,), f"chunk_len={chunk_len}: got {tuple(got.shape)}"
+        assert torch.allclose(got, ref, rtol=1e-5, atol=1e-5)
+
+    @pytest.mark.parametrize("chunk_len", CHUNK_LENS)
+    def test_sum_matches_reference(self, chunk_len):
+        """The default reduction, unchanged by this fix -- guards against regression."""
+        logits, labels = self._batch()
+        ref = F.cross_entropy(logits.float(), labels, reduction="sum", ignore_index=-100)
+        got = ChunkedCrossEntropy(reduction="sum", chunk_len=chunk_len)(logits.clone(), labels.clone())
+        assert torch.allclose(got, ref, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
# What does this PR do ?

Makes `ChunkedCrossEntropy` return the same loss regardless of `chunk_len`.
`chunk_len` is a memory knob; it was changing the answer.

The fallback loop accumulated per-chunk results with `+=`
(`components/loss/chunked_ce.py` L199-216). That is valid for
`reduction="sum"` — which takes the separate `_ChunkedCrossEntropySum` kernel
anyway — but wrong for the two reductions that actually reach the loop:

- **`"mean"`** summed per-chunk *means*, returning `num_chunks x` the loss.
- **`"none"`** element-wise added the per-chunk *vectors* instead of
  concatenating, returning `chunk_len` values instead of one per token.

Neither raised. Measured against `F.cross_entropy` on 4096 tokens:

| `chunk_len` | chunks | `"mean"` before | `"mean"` after |
|---:|---:|---:|---:|
| 32 (default) | 128 | **128.0x** | 1.0x |
| 1024 | 4 | **4.0x** | 1.0x |
| 2048 | 2 | **2.0x** | 1.0x |
| 4096 | 1 | 1.0x | 1.0x |

`"none"` returned `(32,)` instead of `(4096,)` at the default `chunk_len`.

Note the last row: with `chunk_len >= seq_len` there is exactly one chunk, so
accumulation is a no-op and the result is correct. The error only appears once
the sequence is long enough to chunk — which is the case this loss exists for —
so a short smoke test passes.

Because the gradients scale with the loss, a config using `reduction: mean`
trained with an effectively multiplied learning rate.

# Changelog

- `"mean"` accumulates the per-chunk **sum** and divides once by the
  non-ignored token count, which matches `F.cross_entropy(..., reduction="mean")`
  exactly rather than approximately.
- `"none"` concatenates the per-chunk vectors.
- `"sum"` is untouched — it never used this loop.
- New `TestReductionIsChunkInvariant` in `tests/unit_tests/loss/test_chunked_ce.py`
  comparing all three reductions against `F.cross_entropy` across
  `chunk_len` in `{1, 32, 96, 100, 128, 512}` — including 96 and 100, which do
  not divide the 512-token sequence evenly — with and without ignored positions
  scattered across chunk boundaries.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

The class docstring already describes the fallback loop; its behaviour now
matches the description, so no doc change was needed.

**Verification** (CPU, no GPU needed):

- Reverting the source hunk fails 15 of the new cases (every `"mean"` and
  `"none"` case with more than one chunk); the `"sum"` cases and the
  single-chunk cases pass either way, which is intended — they pin the paths
  this must not change.
- `pytest tests/unit_tests/loss/` → 318 passed, 36 skipped, no regressions.
- `ruff format` / `ruff check` clean.

**Scope note.** `"mean"` over a batch where every label is ignored divides by
zero and yields `NaN`, exactly as `F.cross_entropy` does — I kept that identical
rather than changing it here, since this PR is only about chunk-invariance. That
separate question is #3796 / #3797.

# Additional Information

- Related to #3803
