### PR TITLE
fix(ci): honor checkpoint tokenizer in vLLM deploy

### DIFF
--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_vllm_deploy.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_vllm_deploy.py
@@ -93,6 +93,7 @@ def _resolve_args(custom_args):
     model_cfg = cfg.get("model", {})
     tokenizer_cfg = cfg.get("tokenizer", {})
     ci_cfg = cfg.get("ci", {})
+    ckpt_robustness_cfg = ci_cfg.get("checkpoint_robustness") or {}
 
     # -- model_path and adapter_path --
     if mode == "peft":
@@ -115,6 +116,8 @@ def _resolve_args(custom_args):
     # -- tokenizer --
     if "tokenizer" in custom_args:
         tokenizer = custom_args["tokenizer"]
+    elif ckpt_robustness_cfg.get("tokenizer_name"):
+        tokenizer = ckpt_robustness_cfg["tokenizer_name"]
     elif tokenizer_cfg.get("pretrained_model_name_or_path"):
         tokenizer = tokenizer_cfg["pretrained_model_name_or_path"]
     else:
@@ -123,7 +126,6 @@ def _resolve_args(custom_args):
     # -- flags --
     # trust_remote_code placement varies: top-level `model:` or nested under
     # `ci.checkpoint_robustness:`. Accept any source that says true.
-    ckpt_robustness_cfg = ci_cfg.get("checkpoint_robustness") or {}
     trust_remote_code = bool(
         custom_args.get("trust_remote_code")
         or model_cfg.get("trust_remote_code")

--- a/tests/unit_tests/ci_tests/test_vllm_deploy_args.py
+++ b/tests/unit_tests/ci_tests/test_vllm_deploy_args.py
@@ -58,3 +58,50 @@ ci:
     )
 
     assert args["enable_expert_parallel"] is False
+
+
+def test_resolve_args_uses_checkpoint_robustness_tokenizer(tmp_path):
+    config_path = tmp_path / "recipe.yaml"
+    config_path.write_text(
+        """
+model:
+  pretrained_model_name_or_path: test/model
+ci:
+  checkpoint_robustness:
+    tokenizer_name: test/tokenizer
+"""
+    )
+
+    args = _resolve_args(
+        {
+            "config_path": str(config_path),
+            "deploy_mode": "peft",
+            "adapter_path": "/tmp/adapter",
+        }
+    )
+
+    assert args["tokenizer"] == "test/tokenizer"
+
+
+def test_resolve_args_prefers_cli_tokenizer_over_recipe(tmp_path):
+    config_path = tmp_path / "recipe.yaml"
+    config_path.write_text(
+        """
+model:
+  pretrained_model_name_or_path: test/model
+ci:
+  checkpoint_robustness:
+    tokenizer_name: test/recipe-tokenizer
+"""
+    )
+
+    args = _resolve_args(
+        {
+            "config_path": str(config_path),
+            "deploy_mode": "peft",
+            "adapter_path": "/tmp/adapter",
+            "tokenizer": "test/cli-tokenizer",
+        }
+    )
+
+    assert args["tokenizer"] == "test/cli-tokenizer"


### PR DESCRIPTION
# What does this PR do ?

Use the checkpoint-robustness tokenizer override when resolving arguments for vLLM deployment tests.

# Changelog

- Resolve `ci.checkpoint_robustness.tokenizer_name` before falling back to the model path.
- Preserve an explicit `--tokenizer` as the highest-priority override.
- Add focused unit coverage for recipe and CLI tokenizer precedence.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (No documentation change is needed for this resolver fix.)

# Validation

- `pytest tests/unit_tests/ci_tests/test_vllm_deploy_args.py -q` (`4 passed`)
- Scoped checkpoint producer [passed](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/424642489).
- Scoped vLLM deploy [attempt](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/424642490) and [exact retry](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/424676932) both passed tokenizer/model loading and completed generation, confirming the original `NemotronHConfig` / `AutoTokenizer` failure is fixed. Both subsequently reproduced the same existing five-token parity assertion (three matching tokens on prompt 2, on different EOS nodes); that follow-up is tracked in [AMINT-285](https://linear.app/nvidia/issue/AMINT-285/add-native-vllm-logprob-parity-metrics-and-representative-model).

# Additional Information

- Fixes [AMINT-302](https://linear.app/nvidia/issue/AMINT-302/autotokenizer-fails-due-to-unrecognized-nemotronhconfig-class).
- The post-fix numerical parity follow-up is tracked separately in [AMINT-285](https://linear.app/nvidia/issue/AMINT-285/add-native-vllm-logprob-parity-metrics-and-representative-model).
