### PR TITLE
test(deepseek): update router parity for transformers 5.15

### DIFF
--- a/tests/unit_tests/models/test_deepseek_gate_precision_policy.py
+++ b/tests/unit_tests/models/test_deepseek_gate_precision_policy.py
@@ -297,9 +297,8 @@ _PARITY_CASES = (
 def test_deepseek_gate_matches_hf_reference_router_grouped(bias_mean, bias_std, router_overrides, weight_atol):
     """Proj/Score/Out parity vs the pinned HF reference, grouped routing.
 
-    The reference splits the router across two objects: DeepseekV3TopkRouter does
-    the fp32 projection and returns logits only, while DeepseekV3MoE.route_tokens_to_experts
-    does sigmoid/bias/group-mask/top-k/norm/scale. Automodel's Gate does all of it,
+    The reference's DeepseekV3TopkRouter does the fp32 projection and
+    sigmoid/bias/group-mask/top-k/norm/scale. Automodel's Gate does the same,
     so the comparison drives both.
     """
     # Imported here, not at module scope: modeling_deepseek_v3 pulls in the whole
@@ -333,8 +332,7 @@ def test_deepseek_gate_matches_hf_reference_router_grouped(bias_mean, bias_std, 
     w_am, i_am, _ = gate(x, torch.ones(64, dtype=torch.bool), None)
 
     with torch.no_grad():
-        router_logits = hf_moe.gate(x)
-        i_hf, w_hf = hf_moe.route_tokens_to_experts(router_logits)
+        router_logits, w_hf, i_hf = hf_moe.gate(x)
 
     assert router_logits.dtype is torch.float32  # Proj: reference projects in fp32
     assert w_hf.dtype is torch.float32  # Out: reference never casts back


### PR DESCRIPTION
# What does this PR do ?

Updates the DeepSeek router parity test for the Transformers 5.15.1 router API. This fixes all three failed unit-test jobs in [CICD run 33916551566](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/33916551566).

# Changelog

- Unpack logits, selected weights, and selected indices directly from `DeepseekV3TopkRouter`.
- Remove the stale description of the deleted `DeepseekV3MoE.route_tokens_to_experts` helper.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Updated the existing parity test; no additional test is needed.
- [x] No documentation change is needed.

# Additional Information

Follow-up to #3781.

Failing jobs fixed by the same root cause:

- [L0_Unit_Tests_GPU_1_of_2](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/33916551566/job/101180506199)
- [L0_Unit_Tests_GPU_2_of_2](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/33916551566/job/101180506147)
- [L0_Unit_Tests_CPU](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/33916551566/job/101180506234)

Validation:

- `transformers==5.15.1`: `25 passed` in `tests/unit_tests/models/test_deepseek_gate_precision_policy.py`
- `ruff format --check` and `ruff check` on the changed file
