### PR TITLE
feat(quantization): support copy-safe TE module exclusions

### DIFF
--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -17,6 +17,7 @@ import logging
 import math
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
+from types import MethodType
 from typing import Any, Literal, Protocol
 
 import torch
@@ -113,9 +114,18 @@ class TEFp8Config:
     scales). Unlike torchao's MXFP8 grouped GEMM, TE's MXFP8 backward is mature (no
     e8m0-overflow NaN), which is why GPT-OSS experts (grouped + bias) use the
     ``experts="te"`` path with this recipe instead of ``experts="torch_mm_mxfp8"``.
+
+    ``filter_fqns`` lists substrings matched against TE base-module names by
+    :meth:`apply_filter_fqns`. Matched modules run with TE quantization disabled,
+    even inside an enabled outer TE autocast; non-TE modules are untouched.
+    This does not cast weights or override PyTorch autocast. For example,
+    ``["lm_head", "layers.3."]`` excludes the TE LM head and TE modules under
+    layer 3. The LLM training recipe applies this once during setup; standalone
+    callers must apply it explicitly before the first forward.
     """
 
     recipe: Literal["current", "block", "mxfp8"] | Any = "current"
+    filter_fqns: list[str] = field(default_factory=list)
 
     def build_recipe(self):
         """Build and return the TE FP8 recipe object.
@@ -154,6 +164,85 @@ class TEFp8Config:
         from transformer_engine.pytorch.quantization import autocast as te_autocast
 
         return te_autocast(enabled=True, recipe=self.build_recipe())
+
+    def apply_filter_fqns(self, model: nn.Module) -> list[str]:
+        """Exclude modules matching ``filter_fqns`` from quantization.
+
+        Wraps the forward of every TE base module whose logical fully qualified
+        name contains one of the ``filter_fqns`` substrings in ``te_autocast(enabled=False)``,
+        so it runs in its original precision even inside the enabled autocast
+        that the training loop places around the whole forward pass. TE saves
+        this precision choice for backward. Exclusions are permanent for the
+        module instance: repeated calls are idempotent and may add exclusions,
+        but changing the config does not remove previous exclusions. Apply after
+        constructing the model and before its first forward or graph capture.
+        Activation-checkpoint wrapper components are removed before matching.
+        All registered aliases are considered; matching any alias excludes the
+        shared instance through every alias, with only one forward wrapper.
+
+        Args:
+            model: The root module to scan (module names are relative to it).
+
+        Returns:
+            Logical fully qualified names matching this call, including matching
+            aliases and prior exclusions.
+            An empty list when TE is absent or no modules match.
+
+        Raises:
+            ImportError: TE is installed but the required exclusion APIs are unavailable.
+        """
+        if not HAVE_TE or not self.filter_fqns:
+            return []
+        have_base, TransformerEngineBaseModule = safe_import_from(
+            "transformer_engine.pytorch.module.base", "TransformerEngineBaseModule"
+        )
+        have_autocast, te_autocast = safe_import_from("transformer_engine.pytorch.quantization", "autocast")
+        if not have_base or not have_autocast:
+            raise ImportError("te_fp8.filter_fqns requires Transformer Engine base modules and quantization.autocast")
+
+        def forward_without_fp8(module, *args, **kwargs):
+            """Call the module-owned forward without changing its tensor contract.
+
+            Args:
+                module: TE module owning the original bound forward.
+                *args: Original forward's positional inputs; tensor shapes and axis
+                    order are preserved exactly as documented by that TE module.
+                **kwargs: Original forward's keyword inputs, with unchanged tensor layouts.
+
+            Returns:
+                Original forward's outputs, with tensor shapes, layouts, and aliasing unchanged.
+            """
+            with te_autocast(enabled=False):
+                return module._te_fp8_original_forward(*args, **kwargs)
+
+        excluded: list[str] = []
+        for name, module in model.named_modules(remove_duplicate=False):
+            if not isinstance(module, TransformerEngineBaseModule):
+                continue
+            name = canonical_parameter_fqn(name)
+            if not any(fqn in name for fqn in self.filter_fqns):
+                continue
+            if getattr(module, "_te_fp8_filtered", False):
+                excluded.append(name)
+                continue
+
+            # Bound methods are rebound to the copied module by deepcopy;
+            # a decorated bound-forward closure instead retains the source.
+            module._te_fp8_original_forward = module.forward
+            module.forward = MethodType(forward_without_fp8, module)
+            module._te_fp8_filtered = True
+            excluded.append(name)
+
+        if excluded:
+            logger.info(
+                "te_fp8: excluded %d modules from quantization via filter_fqns=%s: %s",
+                len(excluded),
+                self.filter_fqns,
+                excluded if len(excluded) <= 20 else excluded[:20] + ["..."],
+            )
+        else:
+            logger.warning("te_fp8: filter_fqns=%s matched no TE modules; nothing excluded.", self.filter_fqns)
+        return excluded
 
 
 @dataclass(kw_only=True)

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -658,6 +658,9 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
 
         # Extract TE FP8 config from model backend (set after model construction)
         self.te_fp8 = self.model_parts[0].backend.te_fp8 if hasattr(self.model_parts[0], "backend") else None
+        if self.te_fp8 is not None:
+            for part in self.model_parts:
+                self.te_fp8.apply_filter_fqns(part)
 
         if self.pp_enabled:
             self._configure_pipeline_loss_fn()

--- a/tests/functional_tests/models/test_te_fp8_exclusions.py
+++ b/tests/functional_tests/models/test_te_fp8_exclusions.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real TE kernels are necessary to verify saved backward precision choices."""
+
+import copy
+
+import pytest
+import torch
+from torch import nn
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import CheckpointImpl, checkpoint_wrapper
+from torch.utils.checkpoint import set_checkpoint_early_stop
+
+from nemo_automodel.components.models.common.utils import TEFp8Config
+from nemo_automodel.shared.import_utils import safe_import
+
+HAVE_TE, te = safe_import("transformer_engine.pytorch")
+pytestmark = pytest.mark.skipif(not HAVE_TE or not torch.cuda.is_available(), reason="requires TE and CUDA")
+
+
+@pytest.mark.parametrize("recipe", ["current", "block", "mxfp8"])
+def test_exclusions_preserve_bf16_forward_backward_and_nested_autocast(recipe):
+    supported, reason = {
+        "current": te.quantization.is_fp8_available,
+        "block": te.quantization.is_fp8_block_scaling_available,
+        "mxfp8": te.quantization.is_mxfp8_available,
+    }[recipe](return_reason=True)
+    if not supported:
+        # TE's block recipe needs CUDA >= 12.9; MXFP8 needs Blackwell.
+        pytest.skip(reason)
+    torch.manual_seed(42)
+    # Block scaling needs 128-wide GEMMs. Match a non-TE parent name to select
+    # multiple TE children, not just one leaf, and catch incorrectly bound forwards.
+    model = nn.ModuleDict(
+        {
+            "keep": nn.Sequential(
+                te.Linear(128, 128, params_dtype=torch.bfloat16),
+                te.Linear(128, 128, params_dtype=torch.bfloat16),
+            ),
+            "quantized": te.Linear(128, 128, params_dtype=torch.bfloat16),
+            "norm": nn.LayerNorm(128, device="cuda", dtype=torch.bfloat16),
+        }
+    )
+    reference = nn.Sequential(
+        te.Linear(128, 128, params_dtype=torch.bfloat16),
+        te.Linear(128, 128, params_dtype=torch.bfloat16),
+    )
+    reference.load_state_dict(model["keep"].state_dict())
+    cfg = TEFp8Config(recipe=recipe, filter_fqns=["keep", "norm"])
+    norm_forward = model["norm"].forward
+    assert cfg.apply_filter_fqns(model) == ["keep.0", "keep.1"]
+    forwards = [layer.forward for layer in model["keep"]]
+    assert cfg.apply_filter_fqns(model) == ["keep.0", "keep.1"]
+    assert [layer.forward for layer in model["keep"]] == forwards
+    assert model["norm"].forward == norm_forward
+
+    x = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    reference_x = x.detach().clone().requires_grad_()
+    upstream = torch.randn_like(x)
+    expected = reference(reference_x)
+    expected.backward(upstream)
+    with torch.no_grad():
+        unquantized = model["quantized"](x)
+
+    # Repeated calls recreate the disabled context and leave both enclosing
+    # enabled scopes intact, including for the sibling called after exclusion.
+    for _ in range(2):
+        model.zero_grad(set_to_none=True)
+        x.grad = None
+        with cfg.maybe_te_autocast():
+            before = model["quantized"](x)
+            with cfg.maybe_te_autocast():
+                actual = model["keep"](x)
+            after = model["quantized"](x)
+        # Identical TE BF16 kernels and operands must be bit-exact: no FP8-sized
+        # tolerance that could accidentally allow a quantized execution path.
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+        torch.testing.assert_close(before, after, atol=0, rtol=0)
+        assert not torch.equal(after, unquantized), "unmatched sibling must still use quantized GEMM"
+        # Additional coverage for backward outside autocast; the recipe keeps
+        # backward inside the enabled region (covered by the checkpoint test).
+        actual.backward(upstream)
+        torch.testing.assert_close(x.grad, reference_x.grad, atol=0, rtol=0)
+        for parameter, reference_parameter in zip(model["keep"].parameters(), reference.parameters()):
+            assert torch.isfinite(parameter.grad).all()
+            torch.testing.assert_close(parameter.grad, reference_parameter.grad, atol=0, rtol=0)
+        sibling_grads = torch.autograd.grad(after, (x, *model["quantized"].parameters()), upstream)
+        assert all(torch.isfinite(gradient).all() for gradient in sibling_grads)
+
+
+@pytest.mark.parametrize("recipe", ["current", "block", "mxfp8"])
+@pytest.mark.parametrize("checkpointed", [False, True])
+def test_exclusions_preserve_bf16_through_checkpoint_recompute(recipe, checkpointed):
+    supported, reason = {
+        "current": te.quantization.is_fp8_available,
+        "block": te.quantization.is_fp8_block_scaling_available,
+        "mxfp8": te.quantization.is_mxfp8_available,
+    }[recipe](return_reason=True)
+    if not supported:
+        # TE's block recipe needs CUDA >= 12.9; MXFP8 needs Blackwell.
+        pytest.skip(reason)
+    torch.manual_seed(44)
+
+    class Projections(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.q_proj = te.Linear(128, 128, params_dtype=torch.bfloat16)
+            self.k_proj = te.Linear(128, 128, params_dtype=torch.bfloat16)
+            self.outputs = []
+
+        def forward(self, query: torch.Tensor, key: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            """Run independent projections so sibling quantization cannot mask query parity.
+
+            Args:
+                query: BF16 CUDA tensor of shape [tokens, hidden].
+                key: BF16 CUDA tensor of shape [tokens, hidden].
+
+            Returns:
+                Query and key projections, each of shape [tokens, hidden].
+            """
+            query_out = self.q_proj(query)
+            key_out = self.k_proj(key)
+            self.outputs.append((query_out.detach().clone(), key_out.detach().clone()))
+            return query_out, key_out
+
+    attention = Projections()
+    model = nn.ModuleDict(
+        {
+            "self_attn": checkpoint_wrapper(attention, checkpoint_impl=CheckpointImpl.NO_REENTRANT)
+            if checkpointed
+            else attention
+        }
+    )
+    reference = te.Linear(128, 128, params_dtype=torch.bfloat16)
+    reference.load_state_dict(attention.q_proj.state_dict())
+    cfg = TEFp8Config(recipe=recipe, filter_fqns=["self_attn.q_proj"])
+    assert cfg.apply_filter_fqns(model) == ["self_attn.q_proj"]
+    query = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    key = torch.randn_like(query, requires_grad=True)
+    reference_query = query.detach().clone().requires_grad_()
+    upstream = torch.randn_like(query)
+    sibling_upstream = torch.randn_like(key)
+    expected = reference(reference_query)
+    expected.backward(upstream)
+    with torch.no_grad():
+        sibling_bf16 = attention.k_proj(key)
+
+    # Disable early stopping only to observe completed GEMMs in recompute.
+    # Forward AND backward remain inside the enabled region, as in train_ft.
+    with cfg.maybe_te_autocast():
+        with set_checkpoint_early_stop(False):
+            actual, sibling = model["self_attn"](query, key)
+        assert len(attention.outputs) == 1
+        torch.autograd.backward((actual, sibling), (upstream, sibling_upstream))
+        with torch.no_grad():
+            sibling_after = attention.k_proj(key)
+
+    assert len(attention.outputs) == (2 if checkpointed else 1)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    torch.testing.assert_close(query.grad, reference_query.grad, atol=0, rtol=0)
+    for parameter, reference_parameter in zip(attention.q_proj.parameters(), reference.parameters()):
+        assert torch.isfinite(parameter.grad).all()
+        torch.testing.assert_close(parameter.grad, reference_parameter.grad, atol=0, rtol=0)
+    # Inspect actual GEMM results, not just the FP8 flag: both the original
+    # forward and recompute must leave the unmatched sibling quantized.
+    for query_out, key_out in attention.outputs:
+        torch.testing.assert_close(query_out, expected, atol=0, rtol=0)
+        torch.testing.assert_close(key_out, sibling, atol=0, rtol=0)
+        assert not torch.equal(key_out, sibling_bf16)
+    torch.testing.assert_close(sibling_after, sibling, atol=0, rtol=0)
+    assert torch.isfinite(key.grad).all()
+    assert all(torch.isfinite(parameter.grad).all() for parameter in attention.k_proj.parameters())
+
+
+def test_exclusion_deepcopy_owns_weights_and_gradients():
+    supported, reason = te.quantization.is_fp8_available(return_reason=True)
+    if not supported:
+        pytest.skip(reason)
+    torch.manual_seed(45)
+    source = nn.ModuleDict({"proj": te.Linear(32, 32, params_dtype=torch.bfloat16)})
+    cfg = TEFp8Config(filter_fqns=["proj"])
+    cfg.apply_filter_fqns(source)
+    cloned = copy.deepcopy(source)
+    with torch.no_grad():
+        source["proj"].weight.zero_()
+        source["proj"].bias.zero_()
+        cloned["proj"].weight.normal_()
+        cloned["proj"].bias.fill_(2)
+    reference = te.Linear(32, 32, params_dtype=torch.bfloat16)
+    reference.load_state_dict(cloned["proj"].state_dict())
+    x = torch.randn(32, 32, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    reference_x = x.detach().clone().requires_grad_()
+    upstream = torch.randn_like(x)
+    expected = reference(reference_x)
+    expected.backward(upstream)
+    with cfg.maybe_te_autocast():
+        actual = cloned["proj"](x)
+        actual.backward(upstream)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    torch.testing.assert_close(x.grad, reference_x.grad, atol=0, rtol=0)
+    for parameter, reference_parameter in zip(cloned["proj"].parameters(), reference.parameters()):
+        assert torch.isfinite(parameter.grad).all()
+        torch.testing.assert_close(parameter.grad, reference_parameter.grad, atol=0, rtol=0)
+    assert all(parameter.grad is None for parameter in source.parameters())
+
+
+def test_exclusion_restores_autocast_after_forward_failure():
+    supported, reason = te.quantization.is_fp8_available(return_reason=True)
+    if not supported:
+        pytest.skip(reason)
+    torch.manual_seed(43)
+    model = nn.ModuleDict(
+        {
+            "keep": te.Linear(32, 32, params_dtype=torch.bfloat16),
+            "quantized": te.Linear(32, 32, params_dtype=torch.bfloat16),
+        }
+    )
+    cfg = TEFp8Config(filter_fqns=["keep"])
+    cfg.apply_filter_fqns(model)
+    x = torch.randn(32, 32, device="cuda", dtype=torch.bfloat16)
+    with torch.no_grad():
+        baseline = model["quantized"](x)
+        with cfg.maybe_te_autocast():
+            before = model["quantized"](x)
+            # A real TE forward failure must propagate without leaking the
+            # nested disabled state into the remainder of the training step.
+            with pytest.raises((RuntimeError, AssertionError)):
+                model["keep"](x[:, :16])
+            after = model["quantized"](x)
+        restored = model["quantized"](x)
+    torch.testing.assert_close(before, after, atol=0, rtol=0)
+    assert not torch.equal(after, baseline)
+    torch.testing.assert_close(restored, baseline, atol=0, rtol=0)

--- a/tests/unit_tests/models/common/test_model_common_utils.py
+++ b/tests/unit_tests/models/common/test_model_common_utils.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import nullcontext
+import copy
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -166,6 +167,155 @@ class TestTEFp8Config:
         cfg = TEFp8Config()
         with patch("nemo_automodel.components.models.common.utils.HAVE_TE", False):
             assert cfg.build_recipe() is None
+
+    def test_filter_fqns_default_empty(self):
+        """filter_fqns defaults to an empty list (backward compatible)."""
+        cfg = TEFp8Config()
+        assert cfg.filter_fqns == []
+
+    def test_apply_filter_fqns_without_te(self):
+        """Without TE installed, apply_filter_fqns is a no-op returning []."""
+        cfg = TEFp8Config(filter_fqns=["lm_head"])
+        model = torch.nn.Linear(4, 4)
+        with patch("nemo_automodel.components.models.common.utils.HAVE_TE", False):
+            assert cfg.apply_filter_fqns(model) == []
+
+    def test_apply_filter_fqns_empty_list_noop(self):
+        """With no filter_fqns, apply_filter_fqns returns [] without importing TE."""
+        cfg = TEFp8Config()
+        model = torch.nn.Linear(4, 4)
+        assert cfg.apply_filter_fqns(model) == []
+        assert not hasattr(model, "_te_fp8_filtered")
+
+    @pytest.mark.parametrize(
+        "missing_module", ["transformer_engine.pytorch.module.base", "transformer_engine.pytorch.quantization"]
+    )
+    def test_apply_filter_fqns_missing_te_api_fails_before_mutation(self, missing_module):
+        model = nn.Sequential(nn.Linear(4, 4))
+        original_forward = model[0].forward
+        cfg = TEFp8Config(filter_fqns=["0"])
+
+        # Simulate a partial TE installation without importing its CUDA extension.
+        def import_te(module, symbol):
+            if module == missing_module:
+                return False, object()
+            return True, nn.Linear if symbol == "TransformerEngineBaseModule" else nullcontext
+
+        with (
+            patch("nemo_automodel.components.models.common.utils.HAVE_TE", True),
+            patch("nemo_automodel.components.models.common.utils.safe_import_from", side_effect=import_te),
+            pytest.raises(ImportError, match="filter_fqns.*Transformer Engine"),
+        ):
+            cfg.apply_filter_fqns(model)
+        assert model[0].forward == original_forward
+
+    @pytest.mark.parametrize("checkpointed", [False, True])
+    def test_apply_filter_fqns_uses_logical_checkpoint_names(self, checkpointed):
+        from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
+
+        attention = nn.ModuleDict({"q_proj": nn.Linear(4, 4), "k_proj": nn.Linear(4, 4)})
+        model = nn.ModuleDict({"self_attn": checkpoint_wrapper(attention) if checkpointed else attention})
+        calls = []
+
+        @contextmanager
+        def autocast(*, enabled):
+            calls.append(enabled)
+            yield
+
+        cfg = TEFp8Config(filter_fqns=["self_attn.q_proj"])
+        with (
+            patch("nemo_automodel.components.models.common.utils.HAVE_TE", True),
+            patch(
+                "nemo_automodel.components.models.common.utils.safe_import_from",
+                side_effect=[(True, nn.Linear), (True, autocast)],
+            ),
+        ):
+            assert cfg.apply_filter_fqns(model) == ["self_attn.q_proj"]
+        x = torch.randn(2, 4)
+        attention["q_proj"](x)
+        attention["k_proj"](x)
+        assert calls == [False]
+
+    def test_apply_filter_fqns_matches_shared_alias_once(self):
+        shared = nn.Linear(4, 4)
+        model = nn.ModuleDict({"first": shared, "alias": shared, "other": nn.Linear(4, 4)})
+        calls = []
+
+        @contextmanager
+        def autocast(*, enabled):
+            calls.append(enabled)
+            yield
+
+        cfg = TEFp8Config(filter_fqns=["alias"])
+        with (
+            patch("nemo_automodel.components.models.common.utils.HAVE_TE", True),
+            patch(
+                "nemo_automodel.components.models.common.utils.safe_import_from",
+                side_effect=lambda module, symbol: (
+                    True,
+                    nn.Linear if symbol == "TransformerEngineBaseModule" else autocast,
+                ),
+            ),
+        ):
+            assert cfg.apply_filter_fqns(model) == ["alias"]
+            forward = shared.forward
+            cfg.filter_fqns = ["first", "alias", "other"]
+            assert cfg.apply_filter_fqns(model) == ["first", "alias", "other"]
+            assert shared.forward is forward
+            cfg.filter_fqns = []
+            assert cfg.apply_filter_fqns(model) == []
+        x = torch.randn(2, 4)
+        model["first"](x)
+        model["alias"](x)
+        model["other"](x)
+        assert calls == [False, False, False]
+
+    def test_apply_filter_fqns_deepcopy_owns_weights_and_gradients(self):
+        source = nn.ModuleDict({"proj": nn.Linear(4, 4)})
+        calls = []
+
+        @contextmanager
+        def autocast(*, enabled):
+            calls.append(enabled)
+            yield
+
+        cfg = TEFp8Config(filter_fqns=["proj"])
+        with (
+            patch("nemo_automodel.components.models.common.utils.HAVE_TE", True),
+            patch(
+                "nemo_automodel.components.models.common.utils.safe_import_from",
+                side_effect=[(True, nn.Linear), (True, autocast)],
+            ),
+        ):
+            cfg.apply_filter_fqns(source)
+        cloned = copy.deepcopy(source)
+        with torch.no_grad():
+            source["proj"].weight.zero_()
+            source["proj"].bias.zero_()
+            cloned["proj"].weight.fill_(1)
+            cloned["proj"].bias.fill_(2)
+        x = torch.ones(2, 4, requires_grad=True)
+        actual = cloned["proj"](x)
+        actual.sum().backward()
+        torch.testing.assert_close(actual, torch.full_like(actual, 6), atol=0, rtol=0)
+        torch.testing.assert_close(x.grad, torch.full_like(x, 4), atol=0, rtol=0)
+        for parameter in cloned.parameters():
+            torch.testing.assert_close(parameter.grad, torch.full_like(parameter, 2), atol=0, rtol=0)
+        assert all(parameter.grad is None for parameter in source.parameters())
+        assert calls == [False]
+
+    def test_apply_filter_fqns_no_matches_warns(self, caplog):
+        model = nn.Sequential(nn.Linear(4, 4))
+        cfg = TEFp8Config(filter_fqns=["absent"])
+        with (
+            patch("nemo_automodel.components.models.common.utils.HAVE_TE", True),
+            patch(
+                "nemo_automodel.components.models.common.utils.safe_import_from",
+                side_effect=[(True, nn.Linear), (True, nullcontext)],
+            ),
+        ):
+            assert cfg.apply_filter_fqns(model) == []
+        assert "matched no TE modules" in caplog.text
 
 
 class TestBackendConfigTeFp8:

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -1126,6 +1126,30 @@ def test_nvtx_false_skips_patching(monkeypatch):
     assert patch_calls == []
 
 
+def test_setup_applies_te_exclusions_from_model_backend(monkeypatch):
+    from nemo_automodel.components.models.common.utils import BackendConfig, TEFp8Config
+
+    cfg = _minimal_cfg_with_nvtx(nvtx_value=False)
+    _patch_setup_minimals(monkeypatch, lambda *a, **k: None)
+    model = DummyModel()
+    te_config = TEFp8Config(filter_fqns=["lm_head"])
+    model.backend = BackendConfig(te_fp8=te_config)
+    monkeypatch.setattr("nemo_automodel.recipes.llm.train_ft.build_model", lambda *a, **k: model)
+    calls = []
+
+    def apply_filter(config, part):
+        calls.append((config, part))
+        return []
+
+    # Wiring only: actual precision and gradient behavior is covered by the
+    # TE functional test, not simulated in this CPU recipe setup test.
+    monkeypatch.setattr(TEFp8Config, "apply_filter_fqns", apply_filter)
+    trainer = TrainFinetuneRecipeForNextTokenPrediction(cfg)
+    trainer.setup()
+    assert trainer.te_fp8 is te_config
+    assert calls == [(te_config, model)]
+
+
 def test_setup_does_not_change_storage_dtype_for_non_kd_recipe(monkeypatch):
     cfg = _minimal_cfg_with_nvtx(nvtx_value=False, optimizer_target="torch.optim.AdamW")
 


### PR DESCRIPTION
# What does this PR do ?

Allow selected TE modules to execute without quantization inside an otherwise enabled TE autocast region, including activation recomputation and copied models.

# Changelog

- Add an empty-by-default filter_fqns setting to TEFp8Config.
- Match substrings against logical module names after canonicalizing activation-checkpoint wrapper components.
- Consider all registered shared-module aliases while applying only one wrapper per module instance.
- Apply exclusions during LLM recipe setup.
- Preserve copied-module ownership of forward execution and gradients.
- Add CPU contract tests and real-TE tests for precision, gradients, nesting, exceptions, recomputation, and deepcopy.

Before your PR is "Ready for review"

Pre checks:

- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? Config and method docstrings explain matching, lifecycle, and precision semantics.

# Additional Information

## Motivation

Low-precision training experiments often need selected projections or blocks to remain outside quantization while the rest of the model uses a TE recipe. A model-wide enabled autocast region does not provide that selection by itself.

This adds named-module exclusions without requiring architecture-specific edits. For example, filter_fqns=["lm_head", "self_attn.q_proj"] excludes matching TE modules.

## Two lifecycle details are important:

- Activation checkpointing inserts wrapper components into module paths. Matching canonical logical names prevents exclusions from silently disappearing when checkpointing is enabled.
- Decorating a bound forward directly can retain references to the original module after deepcopy. The implementation keeps forward ownership with the module so copied models use their own parameters and receive their own gradients.

## Semantics

- An exclusion disables TE quantization; it does not cast parameters or override PyTorch autocast.
- Unmatched modules retain the enclosing TE recipe.
- Exclusions are permanent and additive for the module instance; repeated application is idempotent.
- Matching any alias excludes the shared instance through all aliases.
- Apply exclusions before the first forward or graph capture.
- Integration in this PR covers the LLM training recipe. Standalone callers apply the method explicitly.
- The default empty filter list preserves existing behavior.

## Validation

Executed on B200 through SLURM with PyTorch 2.10.0+cu128 and TE 2.15.0:

- Relevant unit and functional suites: 398 passed, 3 skipped.
- Real-TE tests check bit-exact BF16 output, input-gradient, and parameter-gradient parity for excluded modules.
- Tests verify that unmatched siblings remain quantized during both the original forward and non-reentrant activation recomputation.
- Tests cover nested autocast restoration, exception handling, shared aliases, repeated application, and copied-model weight/gradient ownership.
- The three skipped block-scaling cases require CUDA >=12.9, beyond the CUDA 12.8 test environment.
- Scoped Ruff lint/format and whitespace checks passed.

## Test command:

    python -m pytest tests/unit_tests/models/common tests/unit_tests/moe/test_backend_config.py tests/unit_tests/recipes/test_train_ft.py tests/unit_tests/shared/test_parameter_names.py tests/unit_tests/quantization/test_fp8.py tests/functional_tests/models/test_te_fp8_exclusions.py -q

## Limitations

No multi-rank, torch.compile, or CUDA-graph validation is claimed. This PR provides a precision-selection mechanism; it does not claim exclusions eliminate training-loss gaps or reproduce a particular paper’s results. Recipe-object pass-through already exists in the base and is not introduced here.