### PR TITLE
fix(models): honor TE linear backend and native initialization

### DIFF
--- a/nemo_automodel/_transformers/model_init.py
+++ b/nemo_automodel/_transformers/model_init.py
@@ -1433,17 +1433,30 @@ def _apply_backend_module_overrides(model: torch.nn.Module, backend: BackendConf
                 continue
 
             replacement = replacements.get(id(child))
-            if replacement is None and backend.linear == "quack" and type(child) is torch.nn.Linear:
-                replacement = initialize_linear_module(
-                    "quack",
-                    child.in_features,
-                    child.out_features,
-                    bias=child.bias is not None,
-                    device=child.weight.device,
-                    dtype=child.weight.dtype,
-                )
+            if replacement is None and backend.linear in ("te", "quack") and type(child) is torch.nn.Linear:
+                if backend.linear == "te":
+                    from nemo_automodel.components.models.common.te_linear import TELinear
+
+                    replacement = TELinear(
+                        child.in_features,
+                        child.out_features,
+                        bias=child.bias is not None,
+                        device=child.weight.device,
+                        params_dtype=child.weight.dtype,
+                    )
+                else:
+                    replacement = initialize_linear_module(
+                        backend.linear,
+                        child.in_features,
+                        child.out_features,
+                        bias=child.bias is not None,
+                        device=child.weight.device,
+                        dtype=child.weight.dtype,
+                    )
                 replacement.weight = child.weight
                 replacement.bias = child.bias
+                if hasattr(child, "_is_hf_initialized"):
+                    replacement._is_hf_initialized = child._is_hf_initialized
             elif replacement is None and backend.rms_norm == "quack" and type(child) is torch.nn.RMSNorm:
                 normalized_shape = tuple(child.normalized_shape)
                 if len(normalized_shape) == 1:

--- a/nemo_automodel/components/models/common/te_linear.py
+++ b/nemo_automodel/components/models/common/te_linear.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Linear type compatibility for projections replaced in HuggingFace models."""
+
+import torch
+
+from nemo_automodel.components.models.common.utils import _patch_te_modules
+from nemo_automodel.shared.import_utils import safe_import_from
+
+HAVE_TE, TransformerEngineLinear = safe_import_from("transformer_engine.pytorch", "Linear")
+if not HAVE_TE:
+    raise ImportError("linear='te' requires Transformer Engine. Install nemo-automodel[cuda].")
+
+
+class TELinear(torch.nn.Linear, TransformerEngineLinear):
+    """Execute TE kernels while retaining native ``nn.Linear`` initialization hooks.
+
+    ``nn.Linear`` must precede TE in the MRO: TE's cooperative base constructor
+    must reach ``nn.Module.__init__``, not ``nn.Linear.__init__`` (which requires
+    dimensions). Explicitly select TE's constructor, forward, and reset so the
+    PyTorch base supplies only Linear type compatibility and metadata formatting.
+    No model-owned initializer or owner reference is captured on the instance.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        *,
+        bias: bool,
+        device: torch.device | str,
+        params_dtype: torch.dtype,
+    ) -> None:
+        """Construct a replacement using the existing TE backend patches."""
+        _patch_te_modules()
+        TransformerEngineLinear.__init__(
+            self, in_features, out_features, bias=bias, device=device, params_dtype=params_dtype
+        )
+
+    def forward(self, inp: torch.Tensor, is_first_microbatch: bool | None = None) -> torch.Tensor:
+        """Apply the patched TE linear kernel.
+
+        Args:
+            inp: Tensor of shape [..., in_features], with arbitrary leading dimensions.
+            is_first_microbatch: Whether to refresh the cached FP8 weights.
+
+        Returns:
+            Tensor of shape [..., out_features], preserving the leading dimensions.
+        """
+        return TransformerEngineLinear.forward(self, inp, is_first_microbatch=is_first_microbatch)
+
+    reset_parameters = TransformerEngineLinear.reset_parameters

--- a/tests/functional_tests/training/test_te_linear_backend_init.py
+++ b/tests/functional_tests/training/test_te_linear_backend_init.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real-TE regression coverage for checkpoint-free nested Qwen3 construction."""
+
+import copy
+
+import pytest
+import torch
+from transformers import Qwen3Config
+
+from nemo_automodel._transformers.model_init import _apply_backend_module_overrides
+from nemo_automodel.components.checkpoint.checkpointing import Checkpointer
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.qwen3.model import Qwen3ForCausalLM
+from nemo_automodel.shared.import_utils import safe_import
+
+HAVE_TE, te = safe_import("transformer_engine.pytorch")
+
+# Real TE kernels require CUDA; MXFP8 additionally requires Blackwell or newer.
+pytestmark = pytest.mark.skipif(not HAVE_TE or not torch.cuda.is_available(), reason="requires TE and CUDA")
+
+
+@pytest.mark.parametrize("copy_before_init", [False, True])
+@pytest.mark.parametrize("tied", [False, True])
+@pytest.mark.parametrize("quantized", [False, True], ids=["bf16", "mxfp8"])
+def test_te_linear_meta_init_and_backward(tied: bool, quantized: bool, copy_before_init: bool) -> None:
+    """Preserve parameters, initialize nested projections, and execute real kernels."""
+    if quantized and torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("MXFP8 kernels require Blackwell or newer")
+    from transformer_engine.common.recipe import MXFP8BlockScaling
+    from transformer_engine.pytorch.quantization import autocast
+
+    torch.manual_seed(42)
+    config = Qwen3Config(
+        architectures=["Qwen3ForCausalLM"],
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        tie_word_embeddings=tied,
+        initializer_range=0.03,
+        pad_token_id=None,
+        attention_dropout=0.0,
+    )
+    config._attn_implementation = "sdpa"
+    backend = BackendConfig(attn="sdpa", linear="te", rms_norm="torch", rope_fusion=False)
+    with torch.device("meta"):
+        model = Qwen3ForCausalLM(config, backend=backend)
+    original_parameters = dict(model.named_parameters())
+    original_keys = set(model.state_dict())
+    projection_count = sum(type(module) is torch.nn.Linear for module in model.modules())
+    model.eval()
+
+    _apply_backend_module_overrides(model, backend)
+
+    linears = [module for module in model.modules() if isinstance(module, te.Linear)]
+    assert len(linears) == projection_count == 15
+    assert not any(type(module) is torch.nn.Linear for module in model.modules())
+    assert all(not module.training for module in linears)
+    assert all(dict(model.named_parameters())[name] is value for name, value in original_parameters.items())
+    assert {key for key in model.state_dict() if not key.endswith("_extra_state")} == original_keys
+
+    if copy_before_init:
+        source = model
+        model = copy.deepcopy(source)
+        linears = [module for module in model.modules() if isinstance(module, te.Linear)]
+        assert all(parameter.is_meta for parameter in source.parameters())
+
+    # Do not load any checkpoint: exercise the production materialize/init path.
+    Checkpointer.initialize_model_weights(model, device=torch.device("cuda"))
+    assert (model.lm_head.weight is model.model.embed_tokens.weight) == tied
+    if copy_before_init:
+        assert all(parameter.is_meta for parameter in source.parameters())
+    for module in linears:
+        assert torch.isfinite(module.weight).all()
+        # Many independent samples per matrix; a 10% band catches skipped/default
+        # initialization without requiring identical RNG draw order across backends.
+        assert abs(module.weight.float().std().item() - config.initializer_range) < 0.003
+        assert abs(module.weight.float().mean().item()) < 0.003
+
+    model = model.to(dtype=torch.bfloat16).train()
+    input_ids = torch.randint(0, config.vocab_size, (2, 32), device="cuda")
+    labels = torch.randint(0, config.vocab_size, (2, 32), device="cuda")
+    with torch.autocast("cuda", dtype=torch.bfloat16), autocast(enabled=quantized, recipe=MXFP8BlockScaling()):
+        logits = model(input_ids).logits
+        loss = torch.nn.functional.cross_entropy(logits.float().reshape(-1, config.vocab_size), labels.reshape(-1))
+    loss.backward()
+    assert logits.shape == (2, 32, config.vocab_size)
+    assert torch.isfinite(logits).all()
+    assert torch.isfinite(loss)
+    for parameter in model.parameters():
+        assert parameter.grad is not None
+        assert torch.isfinite(parameter.grad).all()
+    assert model.model.layers[0].self_attn.q_proj.weight.grad.abs().sum() > 0
+
+
+@pytest.mark.parametrize("device", ["cuda", "meta"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("bias", [False, True])
+def test_te_compatible_linear_deepcopy_forward_backward_parity(
+    device: str, dtype: torch.dtype, bias: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Check the real subtype and TE kernels against an ordinary torch Linear."""
+    from nemo_automodel.components.models.common.te_linear import TELinear
+
+    # Compare full fp32 GEMMs rather than torch's optional TF32 approximation.
+    monkeypatch.setattr(torch.backends.cuda.matmul, "allow_tf32", False)
+
+    model = torch.nn.Sequential(torch.nn.Linear(32, 64, bias=bias, device=device, dtype=dtype))
+    _apply_backend_module_overrides(model, BackendConfig(linear="te"))
+    layer = copy.deepcopy(model)[0]
+    assert isinstance(layer, TELinear)
+    assert isinstance(layer, torch.nn.Linear)
+    assert isinstance(layer, te.Linear)
+    layer.to_empty(device="cuda")
+    reference = torch.nn.Linear(32, 64, bias=bias, device="cuda", dtype=dtype)
+    with torch.no_grad():
+        layer.weight.copy_(reference.weight)
+        if bias:
+            layer.bias.copy_(reference.bias)
+    inputs = torch.randn(16, 32, device="cuda", dtype=dtype, requires_grad=True)
+    reference_inputs = inputs.detach().clone().requires_grad_()
+    actual = layer(inputs)
+    expected = reference(reference_inputs)
+    upstream = torch.randn_like(actual)
+    actual.backward(upstream)
+    expected.backward(upstream)
+    # TE's fp32 GEMMs use reduced-precision products independently of torch's
+    # TF32 setting; bf16 also rounds bias/gradient reductions differently. Check
+    # both against torch within product/reduction error, then native TE exactly.
+    tolerance = dict(rtol=0.02, atol=0.02) if dtype == torch.bfloat16 else dict(rtol=0.002, atol=0.01)
+    torch.testing.assert_close(actual, expected, **tolerance)
+    torch.testing.assert_close(inputs.grad, reference_inputs.grad, **tolerance)
+    torch.testing.assert_close(layer.weight.grad, reference.weight.grad, **tolerance)
+    if bias:
+        torch.testing.assert_close(layer.bias.grad, reference.bias.grad, **tolerance)
+
+    native = te.Linear(32, 64, bias=bias, device="cuda", params_dtype=dtype)
+    with torch.no_grad():
+        native.weight.copy_(layer.weight)
+        if bias:
+            native.bias.copy_(layer.bias)
+    native_inputs = inputs.detach().clone().requires_grad_()
+    native_output = native(native_inputs)
+    native_output.backward(upstream)
+    torch.testing.assert_close(actual, native_output, rtol=0, atol=0)
+    torch.testing.assert_close(inputs.grad, native_inputs.grad, rtol=0, atol=0)
+    torch.testing.assert_close(layer.weight.grad, native.weight.grad, rtol=0, atol=0)
+    if bias:
+        torch.testing.assert_close(layer.bias.grad, native.bias.grad, rtol=0, atol=0)

--- a/tests/unit_tests/_transformers/test_model_init.py
+++ b/tests/unit_tests/_transformers/test_model_init.py
@@ -14,8 +14,12 @@
 
 """Tests for nested config override handling in get_hf_config and _consume_config_overrides."""
 
+import copy
+import importlib.util
 import os
+import sys
 import types
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -41,7 +45,199 @@ from nemo_automodel._transformers.model_init import (
 from nemo_automodel.components.models.common.utils import BackendConfig
 
 
+@pytest.fixture
+def fake_te(monkeypatch):
+    # Exercise the real compatibility class with only the CUDA-only TE base stubbed.
+    class FakeTELinear(nn.Module):
+        def __init__(self, in_features, out_features, *, bias=True, device=None, params_dtype=None):
+            super().__init__()
+            self.in_features = in_features
+            self.out_features = out_features
+            self.weight = nn.Parameter(torch.empty(out_features, in_features, device=device, dtype=params_dtype))
+            self.bias = nn.Parameter(torch.empty(out_features, device=device, dtype=params_dtype)) if bias else None
+
+        def reset_parameters(self):
+            nn.init.zeros_(self.weight)
+
+    from nemo_automodel.components.models.common import utils
+
+    name = "nemo_automodel.components.models.common.te_linear"
+    spec = importlib.util.spec_from_file_location(name, Path(utils.__file__).with_name("te_linear.py"))
+    module = importlib.util.module_from_spec(spec)
+    with patch("nemo_automodel.shared.import_utils.safe_import_from", return_value=(True, FakeTELinear)):
+        spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "_patch_te_modules", lambda: None)
+    monkeypatch.setitem(sys.modules, name, module)
+    return FakeTELinear
+
+
 class TestBackendModuleOverrides:
+    def test_te_missing_dependency_is_actionable(self):
+        from nemo_automodel.components.models.common import utils
+
+        spec = importlib.util.spec_from_file_location("missing_te_test", Path(utils.__file__).with_name("te_linear.py"))
+        module = importlib.util.module_from_spec(spec)
+        with patch("nemo_automodel.shared.import_utils.safe_import_from", return_value=(False, object)):
+            with pytest.raises(ImportError, match="linear='te' requires Transformer Engine"):
+                spec.loader.exec_module(module)
+
+    def test_te_preserves_initialized_flags_and_frozen_shared_parameters(self, fake_te):
+        from transformers import PretrainedConfig, PreTrainedModel
+
+        model = PreTrainedModel(PretrainedConfig())
+        model.projection = nn.Linear(8, 8)
+        model.other = nn.Linear(8, 8)
+        model.other.weight = model.projection.weight
+        model.projection.weight.requires_grad_(False)
+        model.projection.weight._is_hf_initialized = True
+        model.projection._is_hf_initialized = True
+        weight = model.projection.weight
+        before = weight.detach().clone()
+        _apply_backend_module_overrides(model, BackendConfig(linear="te"))
+        assert model.projection.weight is model.other.weight is weight
+        assert not weight.requires_grad
+        assert weight._is_hf_initialized
+        with patch.object(model, "_init_weights", side_effect=AssertionError("initialized module revisited")):
+            model._initialize_weights(model.projection)
+        torch.testing.assert_close(weight, before)
+
+    def test_te_forward_uses_current_backend_patch(self, fake_te):
+        module = sys.modules["nemo_automodel.components.models.common.te_linear"]
+        with patch.object(module, "_patch_te_modules") as patch_backend:
+            layer = module.TELinear(8, 16, bias=False, device="cpu", params_dtype=torch.float32)
+        patch_backend.assert_called_once_with()
+        inputs = torch.ones(2, 8)
+        expected = torch.ones(2, 16)
+        with patch.object(fake_te, "forward", return_value=expected) as forward:
+            assert layer(inputs, is_first_microbatch=False) is expected
+        forward.assert_called_once_with(layer, inputs, is_first_microbatch=False)
+
+    @pytest.mark.parametrize("device", ["cpu", "meta"])
+    @pytest.mark.parametrize("nested_scale", [0.0, 0.25])
+    @pytest.mark.parametrize("copy_before_init", [False, True])
+    def test_te_preserves_nested_model_initialization_policy(self, device, nested_scale, copy_before_init, fake_te):
+        from transformers import PretrainedConfig, PreTrainedModel
+
+        from nemo_automodel.components.checkpoint.checkpointing import Checkpointer
+
+        FakeTELinear = fake_te
+
+        class PolicyModel(PreTrainedModel):
+            def __init__(self, scale):
+                super().__init__(PretrainedConfig(initializer_range=scale, tie_word_embeddings=False))
+                self.projection = nn.Linear(8, 16)
+                self.projection_alias = self.projection
+                self.biasless = nn.Linear(16, 8, bias=False)
+                self.native = FakeTELinear(8, 16)
+                self.norm = nn.LayerNorm(8)
+                for parameter in self.parameters():
+                    nn.init.constant_(parameter, -7.0)
+
+            def _init_weights(self, module):
+                if isinstance(module, nn.Linear):
+                    # Non-Gaussian, dimension-dependent weights and nonzero bias:
+                    # generic normal_/zeros_ is not this model's contract.
+                    nn.init.constant_(module.weight, self.config.initializer_range * module.in_features)
+                    if module.bias is not None:
+                        nn.init.constant_(module.bias, -2.0)
+                elif isinstance(module, FakeTELinear):
+                    nn.init.constant_(module.weight, 3.0)
+                    if module.bias is not None:
+                        nn.init.constant_(module.bias, 4.0)
+                elif isinstance(module, nn.LayerNorm):
+                    nn.init.constant_(module.weight, 5.0)
+                    nn.init.zeros_(module.bias)
+
+        with torch.device(device):
+            model = PolicyModel(0.125)
+            model.nested = PolicyModel(nested_scale)
+        model.eval()
+        parameters = dict(model.named_parameters())
+        original_keys = set(model.state_dict())
+        native = model.native
+        backend = BackendConfig(linear="te")
+        _apply_backend_module_overrides(model, backend)
+        _apply_backend_module_overrides(model, backend)
+
+        assert model.native is native
+        assert model.projection_alias is model.projection
+        assert model.nested.projection_alias is model.nested.projection
+        assert model.projection.training is False
+        assert all(dict(model.named_parameters())[name] is value for name, value in parameters.items())
+        assert set(model.state_dict()) == original_keys
+        source = model
+        source_values = {name: value.detach().clone() for name, value in source.named_parameters()}
+        if copy_before_init:
+            model = copy.deepcopy(source)
+            model.config.initializer_range = 0.5
+            model.nested.config.initializer_range = nested_scale + 0.5
+        Checkpointer.initialize_model_weights(model, torch.device("cpu"))
+        if copy_before_init:
+            assert source.config.initializer_range == 0.125
+            assert source.nested.config.initializer_range == nested_scale
+            for name, parameter in source.named_parameters():
+                assert parameter.device.type == device
+                if device == "cpu":
+                    torch.testing.assert_close(parameter, source_values[name])
+        for owner in (model, model.nested):
+            for projection, width in ((owner.projection, 8), (owner.biasless, 16)):
+                torch.testing.assert_close(
+                    projection.weight, torch.full_like(projection.weight, owner.config.initializer_range * width)
+                )
+            torch.testing.assert_close(owner.projection.bias, torch.full_like(owner.projection.bias, -2.0))
+            assert owner.biasless.bias is None
+            torch.testing.assert_close(owner.native.weight, torch.full_like(owner.native.weight, 3.0))
+            torch.testing.assert_close(owner.native.bias, torch.full_like(owner.native.bias, 4.0))
+            torch.testing.assert_close(owner.norm.weight, torch.full_like(owner.norm.weight, 5.0))
+
+    @pytest.mark.parametrize("device", ["cpu", "meta"])
+    @pytest.mark.parametrize("copy_before_init", [False, True])
+    def test_te_preserves_identity_sensitive_bf16_head_initialization(self, device, copy_before_init, fake_te):
+        from nemo_automodel.components.models.llama_bidirectional.model import (
+            LlamaBidirectionalConfig,
+            LlamaBidirectionalForSequenceClassification,
+        )
+
+        config = LlamaBidirectionalConfig(
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            vocab_size=64,
+            num_labels=8,
+        )
+        config._attn_implementation = "eager"
+        with torch.device(device):
+            model = LlamaBidirectionalForSequenceClassification(config)
+        _apply_backend_module_overrides(model, BackendConfig(linear="te"))
+        source = model
+        if copy_before_init:
+            model = copy.deepcopy(source)
+            model.config.initializer_range = 0.125
+        config = model.config
+        model.score.to_empty(device="cpu")
+        model.score.to(dtype=torch.bfloat16)
+        nn.init.constant_(model.score.weight, float("nan"))
+        model.score._is_hf_initialized = False
+        weight = model.score.weight
+        # Compare to the model-owned identity branch, not HF's generic Linear
+        # initializer (which writes to a float copy in the affected HF version).
+        torch.manual_seed(123)
+        expected = torch.empty_like(weight)
+        nn.init.normal_(expected, mean=0.0, std=config.initializer_range)
+        torch.manual_seed(123)
+        with patch.object(
+            type(model).__mro__[1], "_init_weights", side_effect=AssertionError("identity branch missed")
+        ):
+            model._initialize_weights(model.score)
+        assert model.score.weight is weight
+        torch.testing.assert_close(weight, expected, rtol=0, atol=0)
+        if copy_before_init:
+            assert source.score.weight is not weight
+            assert source.score.weight.device.type == device
+            assert source.config.initializer_range != config.initializer_range
+
     def test_quack_replaces_standard_modules_without_replacing_parameters(self):
         class FakeQuackLinear(nn.Linear):
             pass


### PR DESCRIPTION
# What does this PR do?

Honor backend.linear="te" for standard projections left by custom-model constructors while preserving native model initialization and parameter identity.

# Changelog

- Extend the existing backend override pass to replace exact nn.Linear modules when the TE linear backend is requested.
- Introduce a TE-backed, nn.Linear-compatible subtype so model-owned initialization continues to recognize the live projection.
- Preserve parameter objects, shared/tied weights, aliases, frozen parameters, training mode, and initialization flags.
- Retain existing TE backend patches and dynamically dispatch to TE’s forward implementation.
- Add CPU-compatible initialization-contract tests and real-TE forward/backward tests.

Before your PR is "Ready for review"

Pre checks:

- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? The compatibility subtype documents its inheritance and execution contract.

# Additional Information

## Motivation

During Qwen3-style dense pretraining, requesting backend.linear="te" left Hugging Face-derived projections as ordinary nn.Linear modules. The generic backend override pass handled Quack but not TE. Consequently, enabling TE quantization could appear successful while leaving those matrix multiplications unquantized.

Replacing modules alone is insufficient for checkpoint-free training. TE Linear is not normally an nn.Linear subclass, so model initialization based on `isinstance(module, nn.Linear)` can skip the replacement after meta-device materialization.

The fix preserves native initialization dispatch rather than imposing a generic Gaussian initializer or wrapping model owners in closures. This matters for nested configurations, identity-sensitive initialization such as module is `self.score`, and models copied before materialization for pipeline construction.

Specialized Linear subclasses and existing native TE modules remain model-owned; this conversion targets exact `nn.Linear` instances.

## Validation

Executed through SLURM with PyTorch 2.10.0+cu128 and TE 2.15.0:

- Final model-init unit and TE functional suites: 92 passed.
- Coverage includes nested and non-Gaussian initialization policies, zero initialization scales, bias/biasless projections, shared/frozen parameters, initialization flags, and deepcopy before materialization.
- Identity-sensitive BF16 head initialization is tested.
- Real-TE tests cover Qwen3 BF16/MXFP8 forward/backward and parity against native TE.
- Scoped Ruff lint/format and whitespace checks passed.

## Test command:

    python -m pytest tests/unit_tests/_transformers/test_model_init.py tests/functional_tests/training/test_te_linear_backend_init.py -q

## Broader test disclosure

The broader Transformers/Qwen3/TE test selection produced 749 passed, 1 failed, 2 skipped. The failure was:

    TestApplyPreloadOverridesPacked::test_packed_non_flash_falls_back_to_available_flash

It expected flash_attention_2 but received sdpa. The same failure reproduced on the pre-fix base, so it is not introduced by this change.

## Limitations

Validation does not establish numerical parity for every custom architecture or a complete multi-rank training matrix. No performance claims or cluster-specific dependency overrides are included.