### PR TITLE
fix(checkpoint): restore serialized module extra state safely

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -48,6 +48,7 @@ from safetensors.torch import load as safetensors_load
 from safetensors.torch import load_file, save_file
 from safetensors.torch import save as safetensors_save
 from torch import nn
+from torch.distributed.checkpoint.metadata import BytesStorageMetadata, TensorStorageMetadata
 from torch.distributed.checkpoint.storage import StorageReader, StorageWriter
 from torch.distributed.device_mesh import DeviceMesh
 from torch.nn.parallel import DistributedDataParallel
@@ -314,14 +315,14 @@ def _summarize_state_dict_key_diff(
     }
 
 
-def _get_checkpoint_metadata_keys(
+def _get_checkpoint_state_dict_metadata(
     path: str,
     storage_reader: StorageReader | None = None,
-) -> set[str]:
-    """Return checkpoint FQNs present in metadata."""
+) -> dict[str, TensorStorageMetadata | BytesStorageMetadata]:
+    """Return checkpoint FQN -> storage metadata mapping."""
     reader = storage_reader if storage_reader is not None else FileSystemReader(path)
     metadata = reader.read_metadata()
-    return set(metadata.state_dict_metadata.keys())
+    return dict(metadata.state_dict_metadata)
 
 
 if _is_geq_torch_2_9():
@@ -965,15 +966,42 @@ class Checkpointer:
             and isinstance(lm_head_param_name, str)
             and lm_head_param_name in state_dict
         )
+        checkpoint_metadata: dict[str, TensorStorageMetadata | BytesStorageMetadata] = {}
         checkpoint_metadata_keys: set[str] = set()
-        extra_state_keys = sorted(key for key in state_dict if key.endswith("_extra_state"))
+        extra_state_keys = sorted(key for key in state_dict if key.rsplit(".", 1)[-1] == "_extra_state")
+        # Reinsert missing entries after DCP so strict module loading retains them.
+        preserved_extra_state: dict[str, Any] = {}
         if should_try_tied_lm_head_compat or allow_checkpoint_key_subset or extra_state_keys:
-            checkpoint_metadata_keys = _get_checkpoint_metadata_keys(model_path, storage_reader)
+            checkpoint_metadata = _get_checkpoint_state_dict_metadata(model_path, storage_reader)
+            checkpoint_metadata_keys = set(checkpoint_metadata.keys())
+            # DCP flattens dictionary/list extra state into descendant FQNs. Key
+            # compatibility checks operate on module entries, not those leaves;
+            # keep the original metadata mapping for tensor allocation below.
+            for key in checkpoint_metadata:
+                parts = key.split(".")
+                if "_extra_state" in parts:
+                    checkpoint_metadata_keys.discard(key)
+                    checkpoint_metadata_keys.add(".".join(parts[: parts.index("_extra_state") + 1]))
         if extra_state_keys:
             missing_extra_state_keys = [key for key in extra_state_keys if key not in checkpoint_metadata_keys]
             if missing_extra_state_keys:
+                required_missing = [
+                    key
+                    for key in missing_extra_state_keys
+                    if not is_init_step
+                    and not (
+                        type(state_dict[key]) is torch.Tensor
+                        and state_dict[key].dtype == torch.uint8
+                        and state_dict[key].ndim == 1
+                        and state_dict[key].numel() == 0
+                    )
+                ]
+                if required_missing:
+                    raise RuntimeError(
+                        f"Checkpoint {model_path} is missing required module extra state: {required_missing[:10]}"
+                    )
                 for key in missing_extra_state_keys:
-                    state_dict.pop(key, None)
+                    preserved_extra_state[key] = state_dict.pop(key)
                 logging.warning(
                     "Checkpoint %s is missing %d requested module _extra_state keys. Keeping current module "
                     "extra state for those entries (examples=%s).",
@@ -981,6 +1009,24 @@ class Checkpointer:
                     len(missing_extra_state_keys),
                     missing_extra_state_keys[:10],
                 )
+            # Serialized byte state (e.g. TE quantizer state) has a checkpoint-owned
+            # length, not a parameter shape. A fresh module may return an empty
+            # placeholder even when resuming the same recipe. Allocate its full saved
+            # payload for DCP and let set_extra_state validate/restore it; dropping it
+            # would silently reset training state. Other tensor contracts stay strict.
+            for key in extra_state_keys:
+                saved_meta = checkpoint_metadata.get(key)
+                current = state_dict.get(key)
+                if (
+                    type(current) is torch.Tensor
+                    and current.dtype == torch.uint8
+                    and current.ndim == 1
+                    and isinstance(saved_meta, TensorStorageMetadata)
+                    and saved_meta.properties.dtype == torch.uint8
+                    and len(saved_meta.size) == 1
+                    and saved_meta.size != current.size()
+                ):
+                    state_dict[key] = torch.empty(saved_meta.size, dtype=current.dtype, device=current.device)
         if should_try_tied_lm_head_compat:
             if lm_head_param_name not in checkpoint_metadata_keys:
                 for source_name in get_tied_lm_head_source_names(model_state.model[0], lm_head_param_name):
@@ -1048,6 +1094,10 @@ class Checkpointer:
 
         state_dict = self._do_load(state_dict, model_path, storage_reader, is_init_step=is_init_step)
         storage_read_complete = time.monotonic()
+
+        # Missing extra state keeps its current value while satisfying strict loading.
+        if preserved_extra_state:
+            state_dict.update(preserved_extra_state)
 
         if compat_tied_lm_head_source_key is not None and isinstance(lm_head_param_name, str):
             state_dict[lm_head_param_name] = state_dict.pop(compat_tied_lm_head_source_key)

--- a/tests/functional_tests/training/test_te_checkpoint_extra_state.py
+++ b/tests/functional_tests/training/test_te_checkpoint_extra_state.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Restore trusted TE checkpoints without dropping serialized quantizer state."""
+
+import pytest
+import torch
+import torch.distributed.checkpoint as dcp
+
+from nemo_automodel.components.checkpoint.checkpointing import Checkpointer, CheckpointingConfig
+from nemo_automodel.shared.import_utils import safe_import
+
+HAVE_TE, te = safe_import("transformer_engine.pytorch")
+pytestmark = pytest.mark.skipif(not HAVE_TE or not torch.cuda.is_available(), reason="requires TE and CUDA")
+
+
+@pytest.mark.parametrize("saved_recipe", ["delayed", "current", "nvfp4"])
+def test_te_extra_state_restore_and_runtime_precision(tmp_path, saved_recipe):
+    """Restore state into a fresh module and honor the next runtime precision choice."""
+    from transformer_engine.common.recipe import DelayedScaling, Float8CurrentScaling, NVFP4BlockScaling
+    from transformer_engine.pytorch.quantization import autocast
+
+    if saved_recipe == "nvfp4" and torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("NVFP4 requires Blackwell or newer")
+    recipe = {"delayed": DelayedScaling, "current": Float8CurrentScaling, "nvfp4": NVFP4BlockScaling}[saved_recipe]()
+    torch.manual_seed(123)
+    source = te.Linear(128, 128, params_dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    with autocast(enabled=True, recipe=recipe):
+        source(x).float().square().mean().backward()
+    assert source.get_extra_state().numel() > 0
+    # Only locally generated trusted payloads: upstream TE interprets its own
+    # serialized byte tensor via pickle in set_extra_state.
+    dcp.save(source.state_dict(), checkpoint_id=tmp_path)
+    destination = te.Linear(128, 128, params_dtype=torch.bfloat16, device="cuda")
+    assert destination.get_extra_state().numel() == 0
+    checkpointer = Checkpointer(
+        CheckpointingConfig(
+            enabled=True, checkpoint_dir=str(tmp_path), model_save_format="safetensors", save_consolidated=False
+        ),
+        dp_rank=0,
+        tp_rank=0,
+        pp_rank=0,
+        moe_mesh=None,
+    )
+    checkpointer.load_model(destination, model_path=str(tmp_path))
+    torch.testing.assert_close(destination.weight, source.weight)
+    torch.testing.assert_close(destination.bias, source.bias)
+    assert type(destination.fp8_meta["recipe"]) is type(recipe)
+    if saved_recipe == "delayed":
+        for direction in ("scaling_fwd", "scaling_bwd"):
+            for key in ("scale", "amax_history"):
+                torch.testing.assert_close(
+                    getattr(destination.fp8_meta[direction], key), getattr(source.fp8_meta[direction], key)
+                )
+
+    # Loaded quantizer metadata must not force quantization on a BF16 forward.
+    with autocast(enabled=False):
+        output = destination(x.detach())
+        expected = source(x.detach())
+        torch.testing.assert_close(output, expected, atol=0, rtol=0)
+        output.float().square().mean().backward()
+    assert destination.fp8 is False
+    assert torch.isfinite(destination.weight.grad).all()
+
+    # A subsequent enabled scope must select the requested recipe, not the saved one.
+    destination.zero_grad(set_to_none=True)
+    with autocast(enabled=True, recipe=Float8CurrentScaling()):
+        output = destination(x.detach())
+        output.float().square().mean().backward()
+    assert type(destination.fp8_meta["recipe"]) is Float8CurrentScaling
+    assert destination.fp8 is True
+    assert torch.isfinite(output).all()
+    assert torch.isfinite(destination.weight.grad).all()

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -1833,8 +1833,8 @@ class TestLoadModelCheckpointKeySubset:
                 side_effect=lambda module, state_dict, **kwargs: state_dict,
             ),
             patch(
-                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
-                return_value={"layer.weight"},
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_state_dict_metadata",
+                return_value={"layer.weight": object()},
             ),
             patch.object(checkpointer, "_do_load", side_effect=fake_do_load),
         ):
@@ -1872,8 +1872,8 @@ class TestLoadModelCheckpointKeySubset:
                 side_effect=lambda module, state_dict, **kwargs: state_dict,
             ),
             patch(
-                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
-                return_value={"unrelated.weight"},
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_state_dict_metadata",
+                return_value={"unrelated.weight": object()},
             ),
         ):
             mock_model_state = mock_model_state_cls.return_value
@@ -1903,8 +1903,8 @@ class TestLoadModelCheckpointKeySubset:
                 side_effect=lambda module, state_dict, **kwargs: state_dict,
             ),
             patch(
-                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
-                return_value={"language_model.layer.weight", "vision_tower.block.weight"},
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_state_dict_metadata",
+                return_value={"language_model.layer.weight": object(), "vision_tower.block.weight": object()},
             ),
         ):
             mock_model_state = mock_model_state_cls.return_value
@@ -1940,8 +1940,8 @@ class TestLoadModelCheckpointKeySubset:
                 side_effect=lambda module, state_dict, **kwargs: {**state_dict, "stray.weight": torch.ones(1)},
             ),
             patch(
-                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
-                return_value={"layer.weight"},
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_state_dict_metadata",
+                return_value={"layer.weight": object()},
             ),
             patch.object(checkpointer, "_do_load", side_effect=lambda state_dict, *args, **kwargs: state_dict),
         ):
@@ -1981,7 +1981,7 @@ class TestLoadModelExtraState:
         model = torch.nn.Module()
         initial_state_dict = {
             "layer.weight": torch.zeros(2, 2),
-            "layer._extra_state": torch.empty(0),
+            "layer._extra_state": torch.empty(0, dtype=torch.uint8),
         }
         captured = {}
 
@@ -2003,8 +2003,8 @@ class TestLoadModelExtraState:
                 side_effect=lambda module, state_dict, **kwargs: state_dict,
             ),
             patch(
-                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
-                return_value={"layer.weight"},
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_state_dict_metadata",
+                return_value={"layer.weight": object()},
             ),
             patch.object(checkpointer, "_do_load", side_effect=fake_do_load),
         ):
@@ -2017,6 +2017,131 @@ class TestLoadModelExtraState:
         assert captured["requested_keys"] == {"layer.weight"}
         assert "module _extra_state keys" in caplog.text
         mock_model_state.load_state_dict.assert_called_once()
+        # The withheld extra-state entry must be re-inserted after the DCP load so a
+        # strict module load still receives every key it expects.
+        loaded_state_dict = mock_model_state.load_state_dict.call_args.args[0]
+        assert "layer._extra_state" in loaded_state_dict
+
+    @pytest.mark.parametrize("checkpoint_format", ["dcp", "safetensors"])
+    @pytest.mark.parametrize("saved_size,current_size", [(5, 0), (5, 2), (2, 5), (5, 5), (0, 5)])
+    def test_tensor_extra_state_round_trip(self, tmp_path, saved_size, current_size, checkpoint_format):
+        """Restore serialized state even when a fresh module has a different-sized placeholder."""
+
+        class StatefulLayer(torch.nn.Linear):
+            def __init__(self, size):
+                super().__init__(2, 2, bias=False)
+                self.extra = torch.arange(size, dtype=torch.uint8)
+
+            def get_extra_state(self):
+                """Return a CPU byte tensor of shape [serialized_bytes]."""
+                return self.extra
+
+            def set_extra_state(self, state):
+                """Install the serialized module state.
+
+                Args:
+                    state: CPU byte tensor of shape [serialized_bytes]; the length
+                        is checkpoint-owned and may differ from the initial state.
+                """
+                self.extra = state.clone()
+
+        source = torch.nn.Sequential(StatefulLayer(saved_size))
+        destination = torch.nn.Sequential(StatefulLayer(current_size))
+        with torch.no_grad():
+            source[0].weight.fill_(7)
+            destination[0].weight.zero_()
+        destination[0].extra.zero_()
+        if checkpoint_format == "safetensors":
+            save_file(source.state_dict(), tmp_path / "model.safetensors")
+        else:
+            dcp.save(source.state_dict(), checkpoint_id=tmp_path)
+
+        checkpointer = self._make_checkpointer()
+        checkpointer.load_model(destination, model_path=str(tmp_path))
+
+        torch.testing.assert_close(destination[0].weight, source[0].weight)
+        torch.testing.assert_close(destination[0].extra, source[0].extra)
+
+    @pytest.mark.parametrize("dtype,shape", [(torch.float32, (5,)), (torch.uint8, (2, 3))])
+    def test_non_serialized_extra_state_shape_mismatch_is_not_dropped(self, tmp_path, dtype, shape):
+        """Ordinary tensor extra state must retain DCP's shape validation."""
+
+        class StatefulLayer(torch.nn.Linear):
+            def get_extra_state(self):
+                return torch.zeros(1, dtype=dtype)
+
+            def set_extra_state(self, state):
+                """Accept extra state.
+
+                Args:
+                    state: Tensor of shape [1] using the test's dtype.
+                """
+                raise AssertionError("Mismatched state must fail before module installation")
+
+        model = StatefulLayer(2, 2, bias=False)
+        saved = model.state_dict()
+        saved["_extra_state"] = torch.ones(shape, dtype=dtype)
+        dcp.save(saved, checkpoint_id=tmp_path)
+        with pytest.raises(dcp.CheckpointException, match="Size mismatch"):
+            self._make_checkpointer().load_model(model, model_path=str(tmp_path))
+
+    @pytest.mark.parametrize("allow_checkpoint_key_subset", [False, True])
+    def test_dict_extra_state_round_trip(self, tmp_path, allow_checkpoint_key_subset):
+        """DCP-flattened dictionary state must not be mistaken for missing state."""
+
+        class StatefulLayer(torch.nn.Linear):
+            def __init__(self, counter):
+                super().__init__(2, 2, bias=False)
+                self.counter = counter
+
+            def get_extra_state(self):
+                return {"counter": self.counter}
+
+            def set_extra_state(self, state):
+                self.counter = state["counter"]
+
+        source = torch.nn.Sequential(StatefulLayer(17))
+        destination = torch.nn.Sequential(StatefulLayer(0))
+        dcp.save(source.state_dict(), checkpoint_id=tmp_path)
+        self._make_checkpointer().load_model(
+            destination,
+            model_path=str(tmp_path),
+            allow_checkpoint_key_subset=allow_checkpoint_key_subset,
+        )
+        assert destination[0].counter == 17
+        torch.testing.assert_close(destination[0].weight, source[0].weight)
+
+    @pytest.mark.parametrize("required", [False, True])
+    def test_missing_extra_state_real_strict_load(self, tmp_path, required):
+        """Only empty serialized placeholders tolerate absent state on resume."""
+
+        class StatefulLayer(torch.nn.Linear):
+            def __init__(self):
+                super().__init__(2, 2, bias=False)
+                self.extra = torch.tensor([3, 4] if required else [], dtype=torch.uint8)
+
+            def get_extra_state(self):
+                return self.extra
+
+            def set_extra_state(self, state):
+                """Install extra state.
+
+                Args:
+                    state: CPU byte tensor of shape [serialized_bytes].
+                """
+                self.extra = state.clone()
+
+        model = StatefulLayer()
+        expected_extra = model.extra.clone()
+        expected_weight = torch.full_like(model.weight, 7)
+        dcp.save({"weight": expected_weight}, checkpoint_id=tmp_path)
+        if required:
+            with pytest.raises(RuntimeError, match="missing required module extra state"):
+                self._make_checkpointer().load_model(model, model_path=str(tmp_path))
+            return
+        self._make_checkpointer().load_model(model, model_path=str(tmp_path))
+        torch.testing.assert_close(model.weight, expected_weight)
+        torch.testing.assert_close(model.extra, expected_extra)
 
 
 # =============================================================================


### PR DESCRIPTION
# What does this PR do?

Restore serialized module extra state correctly when its saved size differs from a freshly constructed module’s placeholder, without silently discarding checkpoint state.

# Changelog

- Read typed checkpoint storage metadata when checking module extra-state compatibility.
- Allocate checkpoint-sized destination buffers for one-dimensional uint8 serialized extra state, leaving interpretation and restoration to the owning module.
- Recognize dictionary/list extra state represented by flattened DCP descendant keys.
- Reject missing required extra state during resume, while retaining compatibility for initialization and empty serialized placeholders.
- Preserve ordinary tensor shape validation.
- Add real DCP/safetensors round-trip tests and Transformer Engine restore tests.

Before your PR is "Ready for review"

Pre checks:

- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? Implementation comments and test documentation describe the supported compatibility behavior.

# Additional Information

## Motivation

We encountered this while resuming an NVFP4-trained model with BF16 execution. Transformer Engine serializes quantizer metadata into `_extra_state`; a saved payload can have a different length from the empty placeholder returned by a fresh module. DCP rejected the load with a size mismatch before the module could interpret its state.

Simply dropping mismatched entries is unsafe: the same size difference can occur when resuming the same recipe, and discarding that payload loses valid scaling/amax history. Dropping entries can also fail later during strict module loading.

This implementation restores the saved serialized payload rather than treating its length as a model-parameter shape. It also addresses nested extra state: DCP can flatten dictionaries into keys such as `layer._extra_state.counter`, which must not be mistaken for absent module state.

## Validation

Executed on B200 through SLURM with PyTorch 2.10.0+cu128 and Transformer Engine 2.15.0:

- Complete checkpoint unit directory plus real-TE restore tests: 387 passed, 18 skipped.
- Real DCP and safetensors tests cover growing, shrinking, equal-length, and empty byte payloads.
- Tests cover dictionary-valued state, missing required state, and rejection of ordinary tensor shape mismatches.
- Real TE tests cover delayed/current/NVFP4 checkpoint metadata, preservation of delayed-scaling history, and subsequent BF16 or current-scaling execution.
- Scoped Ruff lint/format and whitespace checks passed.

## Test command:

    python -m pytest tests/unit_tests/checkpoint tests/functional_tests/training/test_te_checkpoint_extra_state.py -q

## Limitations

These tests use locally generated, trusted checkpoints. TE’s upstream deserializer interprets serialized byte payloads; this change does not make untrusted checkpoints safe. Validation was single-GPU, not a complete multi-rank restore matrix.