### PR TITLE
fix(training): reduce grad-clip norms across the expert-parallel axis

### DIFF
--- a/docs/guides/pipelining.mdx
+++ b/docs/guides/pipelining.mdx
@@ -610,7 +610,9 @@ from nemo_automodel.components.training.utils import clip_grad_norm
 # Call these after backward on every pipeline rank.
 scale_grads_by_divisor(ap.info.stages, divisor=8)
 
-# Use the PP-aware clipping helper across the local model parts.
+# Use the PP-aware clipping helper across the local model parts. For MoE
+# models with expert parallelism, also pass moe_mesh/ep_axis_name so expert
+# gradient norms are reduced across the EP axis.
 grad_norm = clip_grad_norm(
     1.0,
     ap.parts,
@@ -618,6 +620,8 @@ grad_norm = clip_grad_norm(
     pp_enabled=True,
     device_mesh=world_mesh,
     pp_axis_name="pp",
+    moe_mesh=moe_mesh,
+    ep_axis_name="ep" if moe_mesh is not None and "ep" in (moe_mesh.mesh_dim_names or ()) else None,
 )
 ```
 

--- a/docs/guides/pipelining.mdx
+++ b/docs/guides/pipelining.mdx
@@ -1,21 +1,21 @@
 ---
 title: "Pipeline Parallelism with AutoPipeline"
-description: ""
+description: "Configure AutoPipeline for Hugging Face models, mix pipeline parallelism with other strategies, and debug pipeline stages."
 position: 3
 ---
 ## Introduction
 
 As large language models continue to grow in size, training and fine-tuning them efficiently across multiple GPUs has become increasingly challenging. While data parallelism works well for smaller models, models with billions of parameters require more sophisticated parallelization strategies to overcome memory constraints and communication overhead.
 
-Pipeline parallelism addresses these challenges by splitting a model's layers across different devices and processing them in a pipelined fashion. Each device processes a different stage of the model, enabling training of models that wouldn't fit on a single device while maintaining high GPU utilization through overlapped computation.
+Pipeline parallelism addresses these challenges by splitting a model's layers across different devices and processing them in a pipelined fashion. Each device processes a different stage of the model, enabling training of models that would not fit on a single device while maintaining high GPU utilization through overlapped computation.
 
-AutoPipeline is NeMo AutoModel's high-level pipeline parallelism interface for Hugging Face-compatible models. Built on PyTorch's native `torch.distributed.pipelining`, it expects an HF-style model with a `config`, a supported decoder-layer layout, and pipeline-compatible forwards. Recipe-driven pipeline parallelism also requires the selected model implementation to advertise a `_pp_plan` (or use the supported MoE path) and pass the repository's pipeline validation; encoder-decoder models and models with actually tied input/output embedding weights are rejected.
+AutoPipeline is NeMo AutoModel's high-level pipeline parallelism interface for Hugging Face-compatible models. Built on PyTorch's native `torch.distributed.pipelining`, it expects a Hugging Face-style model with a `config`, a supported decoder-layer layout, and pipeline-compatible forwards. Recipe-driven pipeline parallelism also requires the selected model implementation to advertise a `_pp_plan` (or use the supported MoE path) and pass the repository's pipeline validation; encoder-decoder models and models with actually tied input/output embedding weights are rejected.
 
-The functional module at `nemo_automodel.components.distributed.pipelining.functional` exposes the same HF-specific `pipeline_model()` splitter plus lower-level stage and schedule helpers. Custom PyTorch architectures can reuse helpers such as `stage_ids_this_rank()`, `calculate_virtual_stages()`, and `build_pipeline_schedule()` after their own code constructs valid `PipelineStage` objects; `pipeline_model()` is not a generic `nn.Module` splitter.
+The functional module at `nemo_automodel.components.distributed.pipelining.functional` exposes the same Hugging Face-specific `pipeline_model()` splitter plus lower-level stage and schedule helpers. Custom PyTorch architectures can reuse helpers such as `stage_ids_this_rank()`, `calculate_virtual_stages()`, and `build_pipeline_schedule()` after their own code constructs valid `PipelineStage` objects; `pipeline_model()` is not a generic `nn.Module` splitter.
 
-This guide walks you through AutoPipeline for compatible Hugging Face models and the lower-level helpers for manually constructed stages. You'll learn how to configure pipeline stages, integrate with existing training workflows, optimize performance, and combine pipeline parallelism with other parallelization strategies.
+This guide walks you through AutoPipeline for compatible Hugging Face models and the lower-level helpers for manually constructed stages. You will learn how to configure pipeline stages, integrate with existing training workflows, optimize performance, and combine pipeline parallelism with other parallelization strategies.
 
-**Prerequisites:**
+## Prerequisites
 
 ```bash
 # Install uv from https://docs.astral.sh/uv/getting-started/installation/
@@ -29,8 +29,8 @@ uv pip install nemo-automodel
 uv pip install git+https://github.com/NVIDIA-NeMo/Automodel.git
 ```
 <Info>
-Before proceeding with this guide, please ensure that you have NeMo AutoModel installed on your machine.
-For a complete guide and additional options please consult the AutoModel [Installation Guide](/get-started/installation).
+Before proceeding with this guide, ensure that you have NeMo AutoModel installed on your machine.
+For a complete guide and additional options, consult the NeMo AutoModel [Installation Guide](/get-started/installation).
 
 </Info>
 
@@ -38,14 +38,14 @@ For a complete guide and additional options please consult the AutoModel [Instal
 
 AutoPipeline provides the following capabilities:
 
-- **Hugging Face-Compatible Model Support**: Works with decoder-only causal language models and explicitly supported VLMs that satisfy the pipeline model contract
-- **PyTorch Native Integration**: Built on PyTorch's `torch.distributed.pipelining` for optimal performance
-- **Flexible Configuration**: Multiple scheduling strategies, configurable microbatch sizes, and automatic or manual layer splitting
-- **Mixed Parallelism Support**: Combine pipeline parallelism with data parallelism, tensor parallelism, and FSDP
-- **Modular Functional API**: Lower-level stage and schedule helpers can be reused with manually constructed `PipelineStage` objects
-- **Minimal Opinions**: Easy to extend and integrate with existing training workflows
+- **Hugging Face-Compatible Model Support**: Works with decoder-only causal language models and explicitly supported VLMs that satisfy the pipeline model contract.
+- **PyTorch Native Integration**: Built on PyTorch's `torch.distributed.pipelining` for optimal performance.
+- **Flexible Configuration**: Multiple scheduling strategies, configurable microbatch sizes, and automatic or manual layer splitting.
+- **Mixed Parallelism Support**: Combine pipeline parallelism with data parallelism, tensor parallelism, and FSDP.
+- **Modular Functional API**: Lower-level stage and schedule helpers can be reused with manually constructed `PipelineStage` objects.
+- **Minimal Opinions**: Easy to extend and integrate with existing training workflows.
 
-## Quick Start with AutoPipeline (Hugging Face Models)
+## Quickstart with AutoPipeline (Hugging Face Models)
 
 Here's a minimal example to get started with AutoPipeline using 2 pipeline stages with a Hugging Face model:
 
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     print(ap.pretty_print_stages())
 ```
 
-### Run the Quick Start Example
+### Run the Quickstart Example
 
 Save the above code as `pipeline_example.py` and run with:
 
@@ -161,18 +161,18 @@ The option applies only to schedules with a bounded in-flight depth (currently
 torch exposes neither of the two known `PipelineStage` layouts, the pool is not
 installed and stock behavior is kept (logged at install time).
 
-### Model Patching (`patch_inner_model`, `patch_causal_lm_model`)
+### Model Patching Flags
 
-AutoPipeline splits a model by deep-copying it per stage and pruning away modules that don't belong to that stage. Many Hugging Face models assume the full module tree is present and return `ModelOutput` objects; after pruning, their original `forward()` often breaks (or returns objects that are awkward to pipeline).
+AutoPipeline splits a model by deep-copying it per stage and pruning away modules that do not belong to that stage. Many Hugging Face models assume the full module tree is present and return `ModelOutput` objects; after pruning, their original `forward()` often breaks (or returns objects that are awkward to pipeline).
 
 These two flags switch AutoPipeline to lightweight, pipeline-friendly `forward()` implementations that return tensors (see `nemo_automodel.components.distributed.pipelining.hf_utils.patch_hf_model_for_pp`):
 
 - **`patch_inner_model`**: patches the *decoder module* (`model.model` for `...ForCausalLM`, otherwise the module itself) so each stage can run even after pruning.
   - **Stage 0** (has `embed_tokens`): takes token IDs and produces hidden states.
   - **Middle stages** (no `embed_tokens`): take hidden states from the previous stage (using `inputs_embeds`, or a float tensor passed through `input_ids`) and produce hidden states.
-  - Handles sliced layer containers (e.g., `layers` becoming dict-like after stage pruning) and returns a **tensor** of hidden states so stages can be chained.
+  - Handles sliced layer containers (for example, `layers` becoming dict-like after stage pruning) and returns a **tensor** of hidden states so stages can be chained.
 
-  For compilation/performance, this patched forward prefers a precomputed `causal_mask_mapping` dict (it will fall back to computing masks and warn if you don't provide it).
+  For compilation and performance, this patched forward prefers a precomputed `causal_mask_mapping` dict (it will fall back to computing masks and warn if you do not provide it).
 
 - **`patch_causal_lm_model`**: patches the *`...ForCausalLM` wrapper* forward (the module that owns `lm_head`) so pipeline stages return tensors:
   - Returns **hidden states** when `lm_head` is absent on that stage.
@@ -181,15 +181,15 @@ These two flags switch AutoPipeline to lightweight, pipeline-friendly `forward()
   
   Note: this is only used when the module you pipeline is a `...ForCausalLM`-style wrapper (i.e., it has a `.model` attribute). If you pass a base decoder module directly, `patch_causal_lm_model` typically has no effect.
 
-#### When Should I Change These?
+#### When to Change These Flags
 
-- **Leave both `True` (default)** for standard Hugging Face `AutoModelForCausalLM` / `...ForCausalLM` models. This is the common case and gives the expected behavior: token IDs -> hidden states -> logits across stages.
-- **Set both `False`** when your model already has a pipeline-friendly forward (returns tensors and can accept hidden states when embeddings are absent) or it needs custom kwargs/paths that the HF patch doesn't preserve (common for NeMo AutoModel-native model implementations, packed-sequence/`thd` paths, extra args like `padding_mask`, etc.). Many benchmark configs for NeMo-native models do this (for example `examples/llm_benchmark/qwen/qwen3_moe_30b_torch.yaml`).
+- **Leave both `True` (default)** for standard Hugging Face `AutoModelForCausalLM` / `...ForCausalLM` models. This is the common case and gives the expected behavior: token IDs to hidden states to logits across stages.
+- **Set both `False`** when your model already has a pipeline-friendly forward. That forward returns tensors and can accept hidden states when embeddings are absent. Set both to `False` when the model needs custom kwargs or paths that the Hugging Face patch does not preserve. That case is common for NeMo AutoModel-native implementations, packed-sequence/`thd` paths, and extra arguments such as `padding_mask`. Many benchmark configs for NeMo-native models do this (for example, `examples/llm_benchmark/qwen/qwen3_moe_30b_torch.yaml`).
 - **Set `patch_inner_model=False, patch_causal_lm_model=True`** when your inner model is already stage-friendly, but the wrapper forward still returns a `ModelOutput` and you only want the wrapper simplified to “hidden states or logits”.
 
 If you disable `patch_causal_lm_model`, your last stage will typically output hidden states instead of logits; in that case, make sure your `loss_fn` (or your last-stage module) applies the LM head explicitly.
 
-### Automatic vs. Manual Layer Distribution
+### Automatic Compared to Manual Layer Distribution
 
 AutoPipeline offers flexible control over how your model is split across pipeline stages:
 
@@ -247,7 +247,7 @@ ap = AutoPipeline(
 
 ## Understand Model Splitting
 
-When AutoPipeline splits your model, it intelligently distributes components across pipeline stages. Here's how a typical model gets split:
+When AutoPipeline splits your model, it distributes components across pipeline stages. A typical split looks like this:
 
 ### Example: 32-Layer Model Across 2 Stages
 
@@ -300,10 +300,10 @@ stage_3_modules = [
 ```
 
 Key observations:
-- **Embeddings** only exist on the first stage
-- **Language modeling head** only exists on the last stage
-- **Rotary embeddings** are shared across all stages (for position encoding)
-- **Transformer layers** are evenly distributed
+- **Embeddings** only exist on the first stage.
+- **Language modeling head** only exists on the last stage.
+- **Rotary embeddings** are shared across all stages (for position encoding).
+- **Transformer layers** are evenly distributed.
 
 ## Use Lower-Level Functional Helpers
 
@@ -500,9 +500,9 @@ def main():
             print(f"Loss: {sum(losses) / len(losses)}")
 ```
 
-### Add a Parallelization Callback to HF-Compatible Splitting
+### Add a Parallelization Callback to Hugging Face-Compatible Splitting
 
-When using the HF-compatible `pipeline_model()` path, a callback can apply additional parallelism to each model part. Its signature must match `ParallelizeFnProtocol`:
+When using the Hugging Face-compatible `pipeline_model()` path, a callback can apply additional parallelism to each model part. Its signature must match `ParallelizeFnProtocol`:
 
 ```python
 from nemo_automodel.components.distributed.pipelining.functional import pipeline_model
@@ -549,11 +549,11 @@ schedule, model_parts, has_first, has_last, stages = pipeline_model(
 
 The lower-level helpers can support a custom model after its model-owned splitting code has created the stage modules:
 
-1. **Module Naming**: Ensure your model has consistent module naming that can be mapped to stages
-2. **State Management**: Handle model state (embeddings, buffers) carefully across stages
-3. **Communication**: First and last stages need special handling for inputs/outputs
-4. **Splitting Ownership**: Keep custom model splitting in the model implementation; do not pass an arbitrary `nn.Module` to `pipeline_model()`
-5. **Testing**: Start with a small model and verify correct splitting before scaling up
+1. **Module Naming**: Ensure your model has consistent module naming that can be mapped to stages.
+2. **State Management**: Handle model state (embeddings, buffers) carefully across stages.
+3. **Communication**: First and last stages need special handling for inputs and outputs.
+4. **Splitting Ownership**: Keep custom model splitting in the model implementation; do not pass an arbitrary `nn.Module` to `pipeline_model()`.
+5. **Testing**: Start with a small model and verify correct splitting before scaling up.
 
 The schedule helpers are reusable, but the repository's automatic splitting path retains Hugging Face-specific assumptions.
 
@@ -676,7 +676,7 @@ uv run automodel examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml \
 Key parameters to override:
 - `--distributed.pp_size`: Number of pipeline ranks; PP, TP, CP, and inferred DP sizes must compose to the total worker count
 - `--step_scheduler.local_batch_size`: Runtime batch size used for both the pipeline schedule and dataloader
-- `--distributed.pipeline.pp_schedule`: Pipeline schedule (`1f1b`, `interleaved1f1b`, `LoopedBFS`, etc.)
+- `--distributed.pipeline.pp_schedule`: Pipeline schedule (`1f1b`, `interleaved1f1b`, `LoopedBFS`, and so on)
 
 ### YAML Configuration Method
 
@@ -703,7 +703,7 @@ distributed:
 
 ### Mixed Parallelism Examples
 
-#### Pipeline + Data Parallelism (4 GPUs Total)
+#### Pipeline and Data Parallelism (4 GPUs Total)
 ```bash
 uv run automodel your_config.yaml \
     --nproc-per-node 4 \
@@ -712,7 +712,7 @@ uv run automodel your_config.yaml \
     --step_scheduler.local_batch_size 16
 ```
 
-#### Pipeline + Tensor Parallelism (4 GPUs Total)
+#### Pipeline and Tensor Parallelism (4 GPUs Total)
 ```bash
 uv run automodel your_config.yaml \
     --nproc-per-node 4 \
@@ -721,7 +721,7 @@ uv run automodel your_config.yaml \
     --step_scheduler.local_batch_size 8
 ```
 
-#### Full Hybrid: PP + DP + TP (8 GPUs Total)
+#### Full Hybrid with PP, DP, and TP (8 GPUs Total)
 ```bash
 uv run automodel your_config.yaml \
     --nproc-per-node 8 \
@@ -733,7 +733,7 @@ uv run automodel your_config.yaml \
 
 ## Integrate with Training Recipes
 
-AutoPipeline seamlessly integrates with NeMo AutoModel's recipe system. Here's a complete example YAML configuration:
+AutoPipeline integrates with NeMo AutoModel's recipe system. The following YAML configuration is a complete example:
 
 ```yaml
 # config.yaml
@@ -828,28 +828,28 @@ uv run automodel config.yaml --nproc-per-node 2
 
 ### Common Issues
 
-**Model doesn't fit in memory:**
-- Increase number of pipeline stages
-- Reduce microbatch size
-- Enable gradient checkpointing
+**The model does not fit in memory:**
+- Increase the number of pipeline stages.
+- Reduce microbatch size.
+- Enable gradient checkpointing.
 
 **Pipeline bubbles reducing efficiency:**
-- Increase `step_scheduler.local_batch_size` to have more microbatches
-- Try different schedules (e.g., `interleaved1f1b`)
-- Adjust virtual stages configuration
+- Increase `step_scheduler.local_batch_size` to have more microbatches.
+- Try different schedules (for example, `interleaved1f1b`).
+- Adjust virtual stages configuration.
 
 **Uneven stage distribution:**
-- Use manual module assignment for fine control
-- Adjust `layers_per_stage` parameter
-- Check parameter counts with `get_stage_param_counts()`
+- Use manual module assignment for fine control.
+- Adjust `layers_per_stage` parameter.
+- Check parameter counts with `get_stage_param_counts()`.
 
 ## Conclusion
 
-AutoPipeline and `pipeline_model()` provide the repository's HF-compatible splitting path, while lower-level functional helpers can be reused after custom code constructs its own pipeline stages.
+AutoPipeline and `pipeline_model()` provide the repository's Hugging Face-compatible splitting path, while lower-level functional helpers can be reused after custom code constructs its own pipeline stages.
 
 Key takeaways:
-- Pipeline parallelism enables training of models too large for a single GPU
-- AutoPipeline provides a simple API for Hugging Face-compatible models with powerful customization options
-- Lower-level functional helpers can schedule manually constructed stages for custom models
-- Both can be combined with other parallelization strategies for optimal performance
-- Use built-in monitoring tools to understand and optimize your pipeline
+- Pipeline parallelism enables training of models too large for a single GPU.
+- AutoPipeline provides a simple API for Hugging Face-compatible models with customization options.
+- Lower-level functional helpers can schedule manually constructed stages for custom models.
+- Both can be combined with other parallelization strategies for optimal performance.
+- Use built-in monitoring tools to understand and optimize your pipeline.

--- a/nemo_automodel/components/moe/experts.py
+++ b/nemo_automodel/components/moe/experts.py
@@ -1194,6 +1194,12 @@ class GroupedExpertsTE(nn.Module):
 
         super().__init__()
 
+        # TE grouped experts are never DTensor-wrapped on the EP axis, so their
+        # grads differ per EP rank without their mesh saying so. Grad clipping
+        # and EP grad scaling identify these params structurally through this
+        # marker (see training/utils.py) instead of matching parameter names.
+        self._nemo_ep_local_expert_params = True
+
         self.config = config
         self.num_local_experts = config.n_routed_experts
         self.expert_bias = config.expert_bias

--- a/nemo_automodel/components/training/prewarm.py
+++ b/nemo_automodel/components/training/prewarm.py
@@ -90,6 +90,7 @@ class PrewarmConfig:
         device: torch.device | int | str | None,
         batch_size: int = 1,
         pp_mesh: DeviceMesh | None = None,
+        ep_mesh: DeviceMesh | None = None,
     ) -> None:
         """Run the enabled prewarms.
 
@@ -102,6 +103,10 @@ class PrewarmConfig:
             pp_mesh: The pipeline-parallel submesh, if pipeline parallelism is
                 enabled (its process group is warmed for the grad-norm
                 all-reduce).
+            ep_mesh: The flat expert-parallel submesh, if EP is enabled. TE
+                grouped expert params never carry the EP axis in their own
+                placements, so the enumeration cannot discover this group
+                either; grad clipping all-reduces expert norms over it.
         """
         if self.cublas_backward:
             try:
@@ -120,7 +125,7 @@ class PrewarmConfig:
                 logger.exception("Mamba SSD autotune prewarm failed; continuing without it.")
         if self.comm_groups:
             try:
-                _prewarm_comm_groups(model_parts, device, pp_mesh=pp_mesh)
+                _prewarm_comm_groups(model_parts, device, pp_mesh=pp_mesh, ep_mesh=ep_mesh)
             except Exception:
                 logger.exception("Communication-group prewarm failed; continuing without it.")
 
@@ -612,6 +617,7 @@ def _prewarm_comm_groups(
     model_parts: list[torch.nn.Module],
     device: torch.device | int | str | None,
     pp_mesh: DeviceMesh | None = None,
+    ep_mesh: DeviceMesh | None = None,
 ) -> int:
     """Eagerly create the NCCL communicators gradient-norm clipping will use.
 
@@ -633,6 +639,9 @@ def _prewarm_comm_groups(
             also all-reduces the total norm across the PP group, but
             parameters are never sharded along pp, so the placement
             enumeration alone cannot discover that group.
+        ep_mesh: Flat expert-parallel submesh, if enabled. TE grouped expert
+            params never carry the EP axis in their placements either, and
+            ``clip_grad_norm`` all-reduces their norm contribution over it.
 
     Returns:
         The number of process groups warmed.
@@ -664,11 +673,13 @@ def _prewarm_comm_groups(
                 seen.add(id(group))
                 groups.append(group)
 
-    if pp_mesh is not None:
+    for extra_mesh, axis in ((pp_mesh, "PP"), (ep_mesh, "EP")):
+        if extra_mesh is None:
+            continue
         try:
-            group = pp_mesh.get_group()
+            group = extra_mesh.get_group()
         except Exception:
-            logger.exception("Failed to resolve the PP mesh process group; skipping its prewarm.")
+            logger.exception("Failed to resolve the %s mesh process group; skipping its prewarm.", axis)
             group = None
         if group is not None and id(group) not in seen:
             seen.add(id(group))

--- a/nemo_automodel/components/training/utils.py
+++ b/nemo_automodel/components/training/utils.py
@@ -14,7 +14,6 @@
 
 import gc
 import math
-import re
 from typing import Iterable
 
 import torch
@@ -23,13 +22,37 @@ from torch.distributed.tensor import DTensor, Partial, Replicate
 
 from nemo_automodel.components.models.common.utils import set_is_first_microbatch, set_is_optim_step
 
-# Regex pattern to match expert parameters in GroupedExpertsTE.
-# Matches FQNs like:
-# - model.layers.X.mlp.experts.gate_up_linear.weight0
-# - model.layers.X.mlp.experts.gate_up_linear.bias0
-# - model.layers.X.mlp.experts.down_linear.weight0
-# - model.layers.X.mlp.experts.down_linear.bias0
-_TE_EXPERT_PARAM_PATTERN = re.compile(r"(^|\.)mlp\.experts\.(gate_up_linear|down_linear)\.(weight|bias)\d+")
+
+def _ep_local_expert_param_ids(
+    model_parts: list[torch.nn.Module],
+    ep_axis_name: str | None,
+) -> set[int]:
+    """ids of expert params whose grads live on the EP axis without carrying it.
+
+    Modules stamp ``_nemo_ep_local_expert_params`` at construction (TE grouped
+    experts, see ``GroupedExpertsTE.__init__``) because their parameters are
+    either plain tensors or DTensors sharded only over ``ep_shard`` — so no
+    mesh dimension of theirs reflects that gradients differ per EP rank. EP
+    grad scaling and the grad-clip EP norm reduction both use this set, and it
+    depends only on model structure, so every rank derives the same answer
+    (collective participation must be rank-uniform).
+
+    Params whose own mesh already carries the EP axis are excluded: the
+    per-mesh-dim reductions handle those, and reducing them again over EP
+    would double count.
+    """
+    ids: set[int] = set()
+    for model_part in model_parts:
+        for module in model_part.modules():
+            if not getattr(module, "_nemo_ep_local_expert_params", False):
+                continue
+            for p in module.parameters():
+                if not p.requires_grad:
+                    continue
+                if isinstance(p, DTensor) and ep_axis_name and ep_axis_name in (p.device_mesh.mesh_dim_names or ()):
+                    continue
+                ids.add(id(p))
+    return ids
 
 
 def _combine_norms(norms: list[torch.Tensor], norm_type: float, target_device: torch.device) -> torch.Tensor:
@@ -115,6 +138,8 @@ def _clip_grad_norm_impl(
     error_if_nonfinite: bool = False,
     foreach: bool | None = None,
     pp_mesh: DeviceMesh | None = None,
+    ep_mesh: DeviceMesh | None = None,
+    ep_param_ids: set[int] | None = None,
 ) -> torch.Tensor:
     """Compute and clip the norm of local and DTensor gradients.
 
@@ -127,6 +152,14 @@ def _clip_grad_norm_impl(
         error_if_nonfinite: Whether to raise for a non-finite global norm.
         foreach: Optional foreach implementation preference for clipping.
         pp_mesh: Optional pipeline mesh over which the scalar norm is reduced.
+        ep_mesh: Optional expert-parallel mesh. Expert parameters live on the
+            EP axis without carrying it in their own mesh (TE grouped experts
+            are plain tensors, or DTensors on the ep_shard sub-mesh only), so
+            their norm contribution must additionally be reduced over this
+            mesh or every EP group computes a different "global" norm and
+            clips shards of the same logical parameter inconsistently.
+        ep_param_ids: ids of the parameters whose gradients differ across the
+            EP axis and need the ``ep_mesh`` reduction.
 
     Returns:
         Scalar tensor containing the pre-clipping global gradient norm.
@@ -137,28 +170,37 @@ def _clip_grad_norm_impl(
         parameters = list(parameters)
 
     # Group parameters by their sharding pattern
-    # Key: (device_mesh_id, tuple of placements)
+    # Key: (device_mesh_id, tuple of placements, is_ep_param)
+    #
+    # Groups are derived from every parameter, including ones without a grad
+    # this step: group membership and iteration order decide which collectives
+    # run and in which order, so they must depend only on model structure,
+    # never on rank-local gradient state (a rank whose shard of some group has
+    # no grads must still join that group's reductions or its peers hang).
     sharding_groups = {}
 
     for p in parameters:
-        if p.grad is None:
-            continue
-
+        # EP-axis parameters get their own groups: their local norms differ
+        # per EP rank and need the extra ep_mesh reduction below.
+        is_ep_param = ep_mesh is not None and ep_param_ids is not None and id(p) in ep_param_ids
         if isinstance(p, DTensor):
             # Create a hashable key from device_mesh and placements
             mesh_id = id(p.device_mesh)
             placements_tuple = tuple(str(placement) for placement in p.placements)
-            key = (mesh_id, placements_tuple)
+            key = (mesh_id, placements_tuple, is_ep_param)
         else:
             # Regular tensor - group separately
-            key = ("regular", "regular")
+            key = ("regular", "regular", is_ep_param)
 
         if key not in sharding_groups:
-            sharding_groups[key] = []
-        sharding_groups[key].append(p)
+            # The representative carries mesh/placements even when this rank
+            # has no grads in the group; the list holds the contributors.
+            sharding_groups[key] = (p, [])
+        if p.grad is not None:
+            sharding_groups[key][1].append(p)
 
     target_device = None
-    for group_params in sharding_groups.values():
+    for _, group_params in sharding_groups.values():
         for p in group_params:
             g = p.grad
             if g is None:
@@ -181,12 +223,26 @@ def _clip_grad_norm_impl(
     # Replicate) then allreduces with mismatched numel and hangs.
     is_inf = math.isinf(norm_type)
     group_norms = []
-    for group_params in sharding_groups.values():
-        first = group_params[0]
-        is_dtensor = isinstance(first, DTensor)
+    for (_, _, is_ep_group), (representative, group_params) in sharding_groups.items():
+        is_dtensor = isinstance(representative, DTensor)
         # Partial placements can't be reduced via sum-of-local-norms; materialize
         # those per-grad (each full_tensor() is a same-shape collective, safe).
-        has_partial = is_dtensor and any(isinstance(pl, Partial) for pl in first.placements)
+        has_partial = is_dtensor and any(isinstance(pl, Partial) for pl in representative.placements)
+
+        def _reduce_group_scalar(scalar: torch.Tensor, op: torch.distributed.ReduceOp) -> torch.Tensor:
+            # The same reductions must run for MAX (before the overflow-guard
+            # scale) and SUM (after), and on every rank of each group whether
+            # or not this rank contributed grads.
+            if is_dtensor and not has_partial:
+                for dim_idx, pl in enumerate(representative.placements):
+                    if isinstance(pl, Replicate):
+                        continue
+                    scalar = _all_reduce_scalar(scalar, op, representative.device_mesh, dim_idx)
+            if is_ep_group:
+                # Expert grads differ per EP rank but their own mesh (if any)
+                # lacks the EP dim, so fold in the EP-wide reduction too.
+                scalar = _all_reduce_scalar(scalar, op, ep_mesh)
+            return scalar
 
         local_max = torch.zeros((), dtype=torch.float64, device=target_device)
         for p in group_params:
@@ -198,12 +254,7 @@ def _clip_grad_norm_impl(
             g_abs_max = g.detach().abs().max().to(device=target_device, dtype=torch.float64)
             local_max = torch.maximum(local_max, g_abs_max)
 
-        if is_dtensor and not has_partial:
-            mesh = first.device_mesh
-            for dim_idx, pl in enumerate(first.placements):
-                if isinstance(pl, Replicate):
-                    continue
-                local_max = _all_reduce_scalar(local_max, torch.distributed.ReduceOp.MAX, mesh, dim_idx)
+        local_max = _reduce_group_scalar(local_max, torch.distributed.ReduceOp.MAX)
 
         if is_inf:
             group_norms.append(local_max)
@@ -223,16 +274,12 @@ def _clip_grad_norm_impl(
             else:
                 local_val = local_val + g.pow(norm_type).sum(dtype=torch.float64)
 
-        if is_dtensor and not has_partial:
-            mesh = first.device_mesh
-            for dim_idx, pl in enumerate(first.placements):
-                if isinstance(pl, Replicate):
-                    continue
-                local_val = _all_reduce_scalar(local_val, torch.distributed.ReduceOp.SUM, mesh, dim_idx)
+        local_val = _reduce_group_scalar(local_val, torch.distributed.ReduceOp.SUM)
 
         group_norms.append(local_max * local_val.pow(1.0 / norm_type))
 
-    # Combine norms across groups (all rank-identical scalars, no comm)
+    # Combine norms across groups (all rank-identical scalars after the
+    # mesh-dim and EP reductions above, no comm)
     total_norm = _combine_norms(group_norms, norm_type, target_device)
 
     # Reduce across pipeline parallel mesh if provided
@@ -257,8 +304,9 @@ def _clip_grad_norm_impl(
 
     # Clip gradients for each sharding group separately
     # This is necessary because clip_grads_with_norm_ doesn't support mixing tensors from different device meshes
-    for group_params in sharding_groups.values():
-        torch.nn.utils.clip_grads_with_norm_(group_params, max_norm, total_norm, foreach)
+    for _, group_params in sharding_groups.values():
+        if group_params:
+            torch.nn.utils.clip_grads_with_norm_(group_params, max_norm, total_norm, foreach)
 
     return total_norm
 
@@ -272,6 +320,9 @@ def clip_grad_norm(
     pp_enabled: bool = False,
     device_mesh: DeviceMesh | None = None,
     pp_axis_name: str | None = None,
+    moe_mesh: DeviceMesh | None = None,
+    ep_axis_name: str | None = None,
+    ep_param_ids: set[int] | None = None,
     foreach: bool = True,
     use_torch_clip_grad_norm: bool = False,
 ) -> torch.Tensor | float:
@@ -293,6 +344,15 @@ def clip_grad_norm(
         pp_enabled: Whether pipeline parallelism is enabled.
         device_mesh: Device mesh for parallelism.
         pp_axis_name: Pipeline parallel axis name.
+        moe_mesh: Optional MoE mesh. TE grouped expert parameters don't carry
+            the EP axis on their own mesh (they are plain tensors, or DTensors
+            sharded only over ep_shard), so without this their norm
+            contribution is never reduced across EP and every EP group clips
+            with a different "global" norm.
+        ep_axis_name: Name of the expert-parallel axis in ``moe_mesh``.
+        ep_param_ids: Optional precomputed result of
+            ``_ep_local_expert_param_ids`` (callers that already scanned the
+            modules pass it to avoid a second walk); derived when omitted.
         foreach: Whether to use foreach implementation for clipping.
         use_torch_clip_grad_norm: Use PyTorch's optimized regular-tensor clipping path when possible.
 
@@ -312,7 +372,32 @@ def clip_grad_norm(
         assert pp_axis_name is not None, "pp_axis_name must be provided when pp_enabled is True"
         pp_mesh = device_mesh[pp_axis_name] if device_mesh is not None else None
 
-    can_use_torch_clip = use_torch_clip_grad_norm and pp_mesh is None
+    # Identify expert params whose grads differ across the EP axis without
+    # carrying it on their own mesh. Structural (module marker), so every EP
+    # rank derives the identical answer regardless of this step's grad state:
+    # collective participation must be rank-uniform or peers hang.
+    ep_mesh = None
+    if moe_mesh is not None and ep_axis_name:
+        try:
+            from nemo_automodel.components.distributed.mesh_utils import get_flat_mesh
+
+            candidate_mesh = get_flat_mesh(moe_mesh, ep_axis_name)
+        except KeyError:
+            candidate_mesh = None
+        # get_flat_mesh can hand a non-member rank another stage's mesh; only
+        # members may join its collectives.
+        if candidate_mesh is not None and candidate_mesh.size() > 1 and candidate_mesh.get_coordinate() is not None:
+            ep_mesh = candidate_mesh
+    if ep_mesh is not None:
+        if ep_param_ids is None:
+            ep_param_ids = _ep_local_expert_param_ids(model_parts, ep_axis_name)
+        if not ep_param_ids:
+            ep_mesh = None
+            ep_param_ids = None
+    else:
+        ep_param_ids = None
+
+    can_use_torch_clip = use_torch_clip_grad_norm and pp_mesh is None and ep_param_ids is None
     if can_use_torch_clip:
         for p in parameters:
             if (
@@ -340,6 +425,8 @@ def clip_grad_norm(
             error_if_nonfinite=False,
             foreach=foreach,
             pp_mesh=pp_mesh,
+            ep_mesh=ep_mesh,
+            ep_param_ids=ep_param_ids,
         )
 
     return grad_norm
@@ -471,10 +558,14 @@ def scale_grads_and_clip_grad_norm(
         for parameter in model_part.parameters()
     )
 
+    # One structural scan shared by the EP grad scaling below and the EP norm
+    # reduction inside clipping.
+    ep_param_ids = _ep_local_expert_param_ids(model_parts, ep_axis_name) if moe_mesh is not None else None
+
     # Single pass over parameters to apply both scalings where applicable
     if pp_divisor is not None or ep_ratio is not None or has_model_owned_sharded_params:
         for mp in model_parts:
-            for name, p in mp.named_parameters():
+            for p in mp.parameters():
                 if p.grad is None:
                     continue
                 if pp_divisor is not None:
@@ -485,19 +576,16 @@ def scale_grads_and_clip_grad_norm(
                 if ep_ratio is not None:
                     # Scale expert gradients by the FSDP/EP ratio and by any
                     # identical TP token replicas that were gathered inside EP.
-                    # DTensor experts: check device mesh for EP sharding axis
-                    # Non-DTensor experts (e.g., DeepEP): check param name
+                    # DTensor experts carrying the EP axis: check their mesh.
+                    # TE grouped experts (never DTensor-wrapped on EP): the
+                    # structural marker set collected above.
                     is_ep_sharded_dtensor = (
                         isinstance(p, DTensor)
                         and isinstance(p.grad, DTensor)
                         and ep_axis_name
                         and ep_axis_name in p.device_mesh.mesh_dim_names
                     )
-                    is_expert_param = (
-                        isinstance(p, torch.Tensor)
-                        and isinstance(p.grad, torch.Tensor)
-                        and _TE_EXPERT_PARAM_PATTERN.search(name) is not None
-                    )
+                    is_expert_param = ep_param_ids is not None and id(p) in ep_param_ids
                     if owner_divisor is None and (is_ep_sharded_dtensor or is_expert_param):
                         p.grad.div_(ep_ratio)
 
@@ -509,6 +597,9 @@ def scale_grads_and_clip_grad_norm(
         pp_enabled=pp_enabled,
         device_mesh=device_mesh,
         pp_axis_name=pp_axis_name,
+        moe_mesh=moe_mesh,
+        ep_axis_name=ep_axis_name,
+        ep_param_ids=ep_param_ids,
         foreach=foreach,
         use_torch_clip_grad_norm=use_torch_clip_grad_norm,
     )

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -675,6 +675,11 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                     else self.cfg.get("step_scheduler.local_batch_size", 1)
                 ),
                 pp_mesh=(self.device_mesh["pp"] if self.pp_enabled and self.device_mesh is not None else None),
+                ep_mesh=(
+                    self.moe_mesh["ep"]
+                    if self.moe_mesh is not None and "ep" in (self.moe_mesh.mesh_dim_names or ())
+                    else None
+                ),
             )
 
         _packed_seq_size = self.cfg.get("packed_sequence.packed_sequence_size", 0)

--- a/nemo_automodel/recipes/llm/train_seq_cls.py
+++ b/nemo_automodel/recipes/llm/train_seq_cls.py
@@ -254,6 +254,8 @@ class TrainFinetuneRecipeForSequenceClassification(BaseRecipe):
             norm_type=2.0,
             pp_enabled=self._get_pp_rank() != 0 if hasattr(self, "_get_pp_rank") else False,
             device_mesh=self.device_mesh,
+            moe_mesh=self.moe_mesh,
+            ep_axis_name="ep" if self.moe_mesh is not None and "ep" in (self.moe_mesh.mesh_dim_names or ()) else None,
         )
 
         # Calculate accuracy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -528,6 +528,9 @@ modules = [
 ignore_imports = [
     # Dion needs the FSDP DP mesh resolver so its optimizer mesh matches parameter sharding.
     "nemo_automodel.components.optim.dion -> nemo_automodel.components.distributed.mesh_utils",
+    # Grad clipping needs the same resolver to find the EP process group, because a
+    # flattened ep axis is absent from mesh_dim_names and cannot be indexed directly.
+    "nemo_automodel.components.training.utils -> nemo_automodel.components.distributed.mesh_utils",
     "nemo_automodel.components.distributed.optimized_tp_plans -> nemo_automodel.components.models.llama.model",
     "nemo_automodel.components.distributed.optimized_tp_plans -> nemo_automodel.components.models.mistral3_vlm.model",
 ]

--- a/tests/unit_tests/training/test_clip_grad_norm_ep.py
+++ b/tests/unit_tests/training/test_clip_grad_norm_ep.py
@@ -1,0 +1,289 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Grad clipping must compute ONE global norm with TE grouped experts under EP.
+
+TE grouped expert parameters don't carry the EP axis on their own mesh: with
+ep_size equal to the non-pp world they stay plain tensors, and with
+ep_shard > 1 they are DTensors sharded only over the ep_shard mesh. Without an
+extra reduction over the EP axis every EP group computes a different "global"
+norm and clips its shards of the same logical dense FSDP parameter by a
+different coefficient. These tests drive the real
+``scale_grads_and_clip_grad_norm`` across gloo ranks and assert every rank
+agrees on the correct global norm and applies the identical clip everywhere.
+
+Expert modules are identified structurally through the
+``_nemo_ep_local_expert_params`` marker that ``GroupedExpertsTE`` stamps at
+construction, so identification is independent of parameter names, of the MoE
+block's attribute name, and of this step's gradient state (collective
+participation must be rank-uniform).
+"""
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch import nn
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
+from torch.distributed.tensor import DTensor, Shard
+
+pytestmark = pytest.mark.skipif(not dist.is_available(), reason="torch.distributed is required")
+
+MAX_NORM = 1.0
+
+
+def _expert_model(expert: nn.Parameter, attribute: str = "mlp") -> nn.Module:
+    """Build a model whose expert module carries the structural EP marker.
+
+    Args:
+        expert: Expert weight parameter of shape ``[out_features, in_features]``
+            (a plain tensor or a DTensor sharded over ep_shard only); attached
+            as ``<attribute>.experts.weight0``.
+        attribute: Attribute name the MoE block hangs off the layer (models use
+            both ``mlp`` and ``moe``); identification must not depend on it.
+    """
+    experts = nn.Module()
+    experts._nemo_ep_local_expert_params = True
+    experts.register_parameter("weight0", expert)
+    block = nn.Module()
+    block.add_module("experts", experts)
+    model = nn.Module()
+    model.add_module(attribute, block)
+    return model
+
+
+def _clip(model: nn.Module, moe_mesh: DeviceMesh | None, **kwargs) -> float:
+    from nemo_automodel.components.training.utils import scale_grads_and_clip_grad_norm
+
+    total_norm = scale_grads_and_clip_grad_norm(
+        MAX_NORM,
+        [model],
+        pp_enabled=False,
+        device_mesh=None,
+        moe_mesh=moe_mesh,
+        ep_axis_name="ep" if moe_mesh is not None else None,
+        foreach=None,
+        **kwargs,
+    )
+    return float(total_norm)
+
+
+def _add_dense(model: nn.Module, mesh: DeviceMesh) -> nn.Parameter:
+    """Attach a dense param: one logical FSDP tensor sharded across all ranks.
+
+    Local shard shape is ``[2, 4]``; the grad is all-ones so any
+    rank-inconsistent clip coefficient shows up as differing shard values.
+    """
+    dense = nn.Parameter(DTensor.from_local(torch.zeros(2, 4), mesh, [Shard(0)]))
+    dense.grad = DTensor.from_local(torch.ones(2, 4), mesh, [Shard(0)])
+    model.register_parameter("dense", dense)
+    return dense
+
+
+def _run_plain_expert_rank(rank: int, world: int, store_path: str) -> None:
+    """ep_size == world (ep_shard == 1): experts stay plain tensors.
+
+    Passes dp_group_size like the recipes do, so the EP grad scaling
+    (division by dp_group_size / ep_shard_size == 2) runs before clipping.
+    """
+    dist.init_process_group("gloo", rank=rank, world_size=world, init_method=f"file:///{store_path}")
+    try:
+        dp_mesh = init_device_mesh("cpu", (world,), mesh_dim_names=("dp_shard_cp",))
+        moe_mesh = init_device_mesh("cpu", (1, world), mesh_dim_names=("ep_shard", "ep"))
+
+        expert = nn.Parameter(torch.zeros(2, 8))
+        expert.grad = torch.full((2, 8), 20.0 if rank == 0 else 0.2)
+        model = _expert_model(expert)
+        dense = _add_dense(model, dp_mesh)
+
+        total_norm = _clip(model, moe_mesh, dp_group_size=world)
+
+        # after ep scaling the expert grads are 10.0 / 0.1:
+        # dense 16 * 1 + rank-0 experts 16 * 100 + rank-1 experts 16 * 0.01
+        correct = (16 * 1.0 + 16 * 100.0 + 16 * 0.01) ** 0.5
+        coef = MAX_NORM / (correct + 1e-6)
+        torch.testing.assert_close(torch.tensor(total_norm), torch.tensor(correct))
+        torch.testing.assert_close(dense.grad.to_local(), torch.full((2, 4), coef))
+        expected_expert = torch.full((2, 8), (10.0 if rank == 0 else 0.1) * coef)
+        torch.testing.assert_close(expert.grad, expected_expert)
+    finally:
+        dist.destroy_process_group()
+
+
+def _run_ep_shard_expert_rank(rank: int, world: int, store_path: str) -> None:
+    """ep_size < world (ep_shard > 1): experts are DTensors on the ep_shard mesh only.
+
+    Uses the ``moe`` attribute name to pin attribute-name independence.
+    """
+    dist.init_process_group("gloo", rank=rank, world_size=world, init_method=f"file:///{store_path}")
+    try:
+        dp_mesh = init_device_mesh("cpu", (world,), mesh_dim_names=("dp_shard_cp",))
+        moe_mesh = DeviceMesh(
+            "cpu",
+            mesh=torch.tensor([[0, 1], [2, 3]], dtype=torch.int64),
+            mesh_dim_names=("ep_shard", "ep"),
+        )
+        ep_shard_mesh = moe_mesh["ep_shard"]
+        ep_index = rank % 2
+
+        gval = 10.0 if ep_index == 0 else 0.1
+        expert = nn.Parameter(DTensor.from_local(torch.zeros(2, 4), ep_shard_mesh, [Shard(1)]))
+        expert.grad = DTensor.from_local(torch.full((2, 4), gval), ep_shard_mesh, [Shard(1)])
+        model = _expert_model(expert, attribute="moe")
+        dense = _add_dense(model, dp_mesh)
+
+        total_norm = _clip(model, moe_mesh)
+
+        # dense 32 * 1 + ep-group-0 experts 16 * 100 + ep-group-1 experts 16 * 0.01
+        correct = (32 * 1.0 + 16 * 100.0 + 16 * 0.01) ** 0.5
+        coef = MAX_NORM / (correct + 1e-6)
+        torch.testing.assert_close(torch.tensor(total_norm), torch.tensor(correct))
+        torch.testing.assert_close(dense.grad.to_local(), torch.full((2, 4), coef))
+        torch.testing.assert_close(expert.grad.to_local(), torch.full((2, 4), gval * coef))
+    finally:
+        dist.destroy_process_group()
+
+
+def _run_asymmetric_grads_rank(rank: int, world: int, store_path: str) -> None:
+    """One rank has no expert grads at all: must neither hang nor disagree."""
+    dist.init_process_group("gloo", rank=rank, world_size=world, init_method=f"file:///{store_path}")
+    try:
+        dp_mesh = init_device_mesh("cpu", (world,), mesh_dim_names=("dp_shard_cp",))
+        moe_mesh = init_device_mesh("cpu", (1, world), mesh_dim_names=("ep_shard", "ep"))
+
+        expert = nn.Parameter(torch.zeros(2, 8))
+        if rank == 0:
+            expert.grad = torch.full((2, 8), 10.0)
+        model = _expert_model(expert)
+        dense = _add_dense(model, dp_mesh)
+
+        total_norm = _clip(model, moe_mesh)
+
+        # dense 16 * 1 + rank-0 experts 16 * 100; rank 1 contributes nothing
+        correct = (16 * 1.0 + 16 * 100.0) ** 0.5
+        coef = MAX_NORM / (correct + 1e-6)
+        torch.testing.assert_close(torch.tensor(total_norm), torch.tensor(correct))
+        torch.testing.assert_close(dense.grad.to_local(), torch.full((2, 4), coef))
+        if rank == 1:
+            assert expert.grad is None
+    finally:
+        dist.destroy_process_group()
+
+
+def _run_torch_fast_path_rank(rank: int, world: int, store_path: str) -> None:
+    """use_torch_clip_grad_norm must not bypass the EP reduction."""
+    dist.init_process_group("gloo", rank=rank, world_size=world, init_method=f"file:///{store_path}")
+    try:
+        moe_mesh = init_device_mesh("cpu", (1, world), mesh_dim_names=("ep_shard", "ep"))
+
+        expert = nn.Parameter(torch.zeros(2, 8))
+        expert.grad = torch.full((2, 8), 10.0 if rank == 0 else 0.1)
+        model = _expert_model(expert)
+
+        total_norm = _clip(model, moe_mesh, use_torch_clip_grad_norm=True)
+
+        correct = (16 * 100.0 + 16 * 0.01) ** 0.5
+        torch.testing.assert_close(torch.tensor(total_norm), torch.tensor(correct))
+    finally:
+        dist.destroy_process_group()
+
+
+def _run_inf_norm_rank(rank: int, world: int, store_path: str) -> None:
+    """The inf-norm path must take the EP-wide max, not the rank-local one."""
+    dist.init_process_group("gloo", rank=rank, world_size=world, init_method=f"file:///{store_path}")
+    try:
+        moe_mesh = init_device_mesh("cpu", (1, world), mesh_dim_names=("ep_shard", "ep"))
+
+        expert = nn.Parameter(torch.zeros(2, 8))
+        expert.grad = torch.full((2, 8), 10.0 if rank == 0 else 0.1)
+        model = _expert_model(expert)
+
+        from nemo_automodel.components.training.utils import scale_grads_and_clip_grad_norm
+
+        total_norm = float(
+            scale_grads_and_clip_grad_norm(
+                MAX_NORM,
+                [model],
+                norm_type=float("inf"),
+                moe_mesh=moe_mesh,
+                ep_axis_name="ep",
+                foreach=None,
+            )
+        )
+
+        torch.testing.assert_close(torch.tensor(total_norm), torch.tensor(10.0))
+    finally:
+        dist.destroy_process_group()
+
+
+def _run_ep_size_one_rank(rank: int, world: int, store_path: str) -> None:
+    """An ep axis of size 1 must behave exactly like moe_mesh=None."""
+    dist.init_process_group("gloo", rank=rank, world_size=world, init_method=f"file:///{store_path}")
+    try:
+        moe_mesh = init_device_mesh("cpu", (1, 1), mesh_dim_names=("ep_shard", "ep"))
+
+        expert = nn.Parameter(torch.zeros(4, 4))
+        expert.grad = torch.full((4, 4), 2.0)
+        with_mesh = _clip(_expert_model(expert), moe_mesh)
+
+        expert2 = nn.Parameter(torch.zeros(4, 4))
+        expert2.grad = torch.full((4, 4), 2.0)
+        without_mesh = _clip(_expert_model(expert2), None)
+
+        torch.testing.assert_close(torch.tensor(with_mesh), torch.tensor(without_mesh))
+        torch.testing.assert_close(torch.tensor(with_mesh), torch.tensor(8.0))
+    finally:
+        dist.destroy_process_group()
+
+
+def test_plain_te_experts_clip_with_one_global_norm(tmp_path):
+    store = str(tmp_path / "s").replace("\\", "/")
+    mp.spawn(_run_plain_expert_rank, args=(2, store), nprocs=2, join=True)
+
+
+def test_ep_shard_te_experts_clip_with_one_global_norm(tmp_path):
+    store = str(tmp_path / "s").replace("\\", "/")
+    mp.spawn(_run_ep_shard_expert_rank, args=(4, store), nprocs=4, join=True)
+
+
+def test_rank_without_expert_grads_neither_hangs_nor_diverges(tmp_path):
+    store = str(tmp_path / "s").replace("\\", "/")
+    mp.spawn(_run_asymmetric_grads_rank, args=(2, store), nprocs=2, join=True)
+
+
+def test_torch_fast_path_does_not_bypass_ep_reduction(tmp_path):
+    store = str(tmp_path / "s").replace("\\", "/")
+    mp.spawn(_run_torch_fast_path_rank, args=(2, store), nprocs=2, join=True)
+
+
+def test_inf_norm_takes_the_ep_wide_max(tmp_path):
+    store = str(tmp_path / "s").replace("\\", "/")
+    mp.spawn(_run_inf_norm_rank, args=(2, store), nprocs=2, join=True)
+
+
+def test_ep_size_one_falls_back_to_plain_behavior(tmp_path):
+    store = str(tmp_path / "s").replace("\\", "/")
+    mp.spawn(_run_ep_size_one_rank, args=(1, store), nprocs=1, join=True)
+
+
+def test_moe_mesh_none_keeps_single_process_behavior():
+    from nemo_automodel.components.training.utils import scale_grads_and_clip_grad_norm
+
+    expert = nn.Parameter(torch.zeros(4, 4))
+    expert.grad = torch.full((4, 4), 2.0)
+    model = _expert_model(expert)
+
+    total_norm = scale_grads_and_clip_grad_norm(MAX_NORM, [model], moe_mesh=None, foreach=None)
+
+    torch.testing.assert_close(torch.tensor(float(total_norm)), torch.tensor(8.0))

--- a/tests/unit_tests/training/test_clip_grad_norm_ep.py
+++ b/tests/unit_tests/training/test_clip_grad_norm_ep.py
@@ -14,12 +14,12 @@
 
 """Grad clipping must compute ONE global norm with TE grouped experts under EP.
 
-TE grouped expert parameters don't carry the EP axis on their own mesh: with
+TE grouped expert parameters do not carry the EP axis on their own mesh: with
 ep_size equal to the non-pp world they stay plain tensors, and with
 ep_shard > 1 they are DTensors sharded only over the ep_shard mesh. Without an
 extra reduction over the EP axis every EP group computes a different "global"
 norm and clips its shards of the same logical dense FSDP parameter by a
-different coefficient. These tests drive the real
+different coefficient. These scenarios drive the real
 ``scale_grads_and_clip_grad_norm`` across gloo ranks and assert every rank
 agrees on the correct global norm and applies the identical clip everywhere.
 
@@ -28,7 +28,14 @@ Expert modules are identified structurally through the
 construction, so identification is independent of parameter names, of the MoE
 block's attribute name, and of this step's gradient state (collective
 participation must be rank-uniform).
+
+Every scenario shares a single ``mp.spawn`` of ``_WORLD`` ranks. Process
+start-up dominates the cost of a spawned test (~10 s each, mostly re-importing
+torch), so one process group running all scenarios in sequence keeps this file
+affordable for the CPU unit-test budget.
 """
+
+import time
 
 import pytest
 import torch
@@ -41,6 +48,10 @@ from torch.distributed.tensor import DTensor, Shard
 pytestmark = pytest.mark.skipif(not dist.is_available(), reason="torch.distributed is required")
 
 MAX_NORM = 1.0
+_WORLD = 4
+# Bounds a deadlock: without it a regression that hangs the collectives would
+# burn the whole job timeout instead of reporting a failed test.
+_JOIN_TIMEOUT_S = 300.0
 
 
 def _expert_model(expert: nn.Parameter, attribute: str = "mlp") -> nn.Module:
@@ -82,8 +93,9 @@ def _clip(model: nn.Module, moe_mesh: DeviceMesh | None, **kwargs) -> float:
 def _add_dense(model: nn.Module, mesh: DeviceMesh) -> nn.Parameter:
     """Attach a dense param: one logical FSDP tensor sharded across all ranks.
 
-    Local shard shape is ``[2, 4]``; the grad is all-ones so any
-    rank-inconsistent clip coefficient shows up as differing shard values.
+    Local shard shape is ``[2, 4]``, so the logical tensor is ``[2 * world, 4]``;
+    the grad is all-ones so any rank-inconsistent clip coefficient shows up as
+    differing shard values.
     """
     dense = nn.Parameter(DTensor.from_local(torch.zeros(2, 4), mesh, [Shard(0)]))
     dense.grad = DTensor.from_local(torch.ones(2, 4), mesh, [Shard(0)])
@@ -91,190 +103,171 @@ def _add_dense(model: nn.Module, mesh: DeviceMesh) -> nn.Parameter:
     return dense
 
 
-def _run_plain_expert_rank(rank: int, world: int, store_path: str) -> None:
+def _scenario_plain_experts(rank: int) -> None:
     """ep_size == world (ep_shard == 1): experts stay plain tensors.
 
     Passes dp_group_size like the recipes do, so the EP grad scaling
-    (division by dp_group_size / ep_shard_size == 2) runs before clipping.
+    (division by dp_group_size / ep_shard_size == 4) runs before clipping.
     """
-    dist.init_process_group("gloo", rank=rank, world_size=world, init_method=f"file:///{store_path}")
-    try:
-        dp_mesh = init_device_mesh("cpu", (world,), mesh_dim_names=("dp_shard_cp",))
-        moe_mesh = init_device_mesh("cpu", (1, world), mesh_dim_names=("ep_shard", "ep"))
+    dp_mesh = init_device_mesh("cpu", (_WORLD,), mesh_dim_names=("dp_shard_cp",))
+    moe_mesh = init_device_mesh("cpu", (1, _WORLD), mesh_dim_names=("ep_shard", "ep"))
 
-        expert = nn.Parameter(torch.zeros(2, 8))
-        expert.grad = torch.full((2, 8), 20.0 if rank == 0 else 0.2)
-        model = _expert_model(expert)
-        dense = _add_dense(model, dp_mesh)
+    expert = nn.Parameter(torch.zeros(2, 8))
+    expert.grad = torch.full((2, 8), 40.0 if rank == 0 else 0.4)
+    model = _expert_model(expert)
+    dense = _add_dense(model, dp_mesh)
 
-        total_norm = _clip(model, moe_mesh, dp_group_size=world)
+    total_norm = _clip(model, moe_mesh, dp_group_size=_WORLD)
 
-        # after ep scaling the expert grads are 10.0 / 0.1:
-        # dense 16 * 1 + rank-0 experts 16 * 100 + rank-1 experts 16 * 0.01
-        correct = (16 * 1.0 + 16 * 100.0 + 16 * 0.01) ** 0.5
-        coef = MAX_NORM / (correct + 1e-6)
-        torch.testing.assert_close(torch.tensor(total_norm), torch.tensor(correct))
-        torch.testing.assert_close(dense.grad.to_local(), torch.full((2, 4), coef))
-        expected_expert = torch.full((2, 8), (10.0 if rank == 0 else 0.1) * coef)
-        torch.testing.assert_close(expert.grad, expected_expert)
-    finally:
-        dist.destroy_process_group()
+    # after ep scaling the expert grads are 10.0 on rank 0 and 0.1 elsewhere:
+    # dense 8 * world * 1 + rank-0 experts 16 * 100 + each other rank 16 * 0.01
+    correct = (8 * _WORLD * 1.0 + 16 * 100.0 + (_WORLD - 1) * 16 * 0.01) ** 0.5
+    coef = MAX_NORM / (correct + 1e-6)
+    torch.testing.assert_close(torch.tensor(total_norm), torch.tensor(correct))
+    torch.testing.assert_close(dense.grad.to_local(), torch.full((2, 4), coef))
+    expected_expert = torch.full((2, 8), (10.0 if rank == 0 else 0.1) * coef)
+    torch.testing.assert_close(expert.grad, expected_expert)
 
 
-def _run_ep_shard_expert_rank(rank: int, world: int, store_path: str) -> None:
+def _scenario_ep_shard_experts(rank: int) -> None:
     """ep_size < world (ep_shard > 1): experts are DTensors on the ep_shard mesh only.
 
     Uses the ``moe`` attribute name to pin attribute-name independence.
     """
-    dist.init_process_group("gloo", rank=rank, world_size=world, init_method=f"file:///{store_path}")
-    try:
-        dp_mesh = init_device_mesh("cpu", (world,), mesh_dim_names=("dp_shard_cp",))
-        moe_mesh = DeviceMesh(
-            "cpu",
-            mesh=torch.tensor([[0, 1], [2, 3]], dtype=torch.int64),
-            mesh_dim_names=("ep_shard", "ep"),
-        )
-        ep_shard_mesh = moe_mesh["ep_shard"]
-        ep_index = rank % 2
+    dp_mesh = init_device_mesh("cpu", (_WORLD,), mesh_dim_names=("dp_shard_cp",))
+    moe_mesh = DeviceMesh(
+        "cpu",
+        mesh=torch.tensor([[0, 1], [2, 3]], dtype=torch.int64),
+        mesh_dim_names=("ep_shard", "ep"),
+    )
+    ep_shard_mesh = moe_mesh["ep_shard"]
+    ep_index = rank % 2
 
-        gval = 10.0 if ep_index == 0 else 0.1
-        expert = nn.Parameter(DTensor.from_local(torch.zeros(2, 4), ep_shard_mesh, [Shard(1)]))
-        expert.grad = DTensor.from_local(torch.full((2, 4), gval), ep_shard_mesh, [Shard(1)])
-        model = _expert_model(expert, attribute="moe")
-        dense = _add_dense(model, dp_mesh)
+    gval = 10.0 if ep_index == 0 else 0.1
+    expert = nn.Parameter(DTensor.from_local(torch.zeros(2, 4), ep_shard_mesh, [Shard(1)]))
+    expert.grad = DTensor.from_local(torch.full((2, 4), gval), ep_shard_mesh, [Shard(1)])
+    model = _expert_model(expert, attribute="moe")
+    dense = _add_dense(model, dp_mesh)
 
-        total_norm = _clip(model, moe_mesh)
+    total_norm = _clip(model, moe_mesh)
 
-        # dense 32 * 1 + ep-group-0 experts 16 * 100 + ep-group-1 experts 16 * 0.01
-        correct = (32 * 1.0 + 16 * 100.0 + 16 * 0.01) ** 0.5
-        coef = MAX_NORM / (correct + 1e-6)
-        torch.testing.assert_close(torch.tensor(total_norm), torch.tensor(correct))
-        torch.testing.assert_close(dense.grad.to_local(), torch.full((2, 4), coef))
-        torch.testing.assert_close(expert.grad.to_local(), torch.full((2, 4), gval * coef))
-    finally:
-        dist.destroy_process_group()
+    # dense 8 * world * 1 + ep-group-0 experts 16 * 100 + ep-group-1 experts 16 * 0.01
+    correct = (8 * _WORLD * 1.0 + 16 * 100.0 + 16 * 0.01) ** 0.5
+    coef = MAX_NORM / (correct + 1e-6)
+    torch.testing.assert_close(torch.tensor(total_norm), torch.tensor(correct))
+    torch.testing.assert_close(dense.grad.to_local(), torch.full((2, 4), coef))
+    torch.testing.assert_close(expert.grad.to_local(), torch.full((2, 4), gval * coef))
 
 
-def _run_asymmetric_grads_rank(rank: int, world: int, store_path: str) -> None:
-    """One rank has no expert grads at all: must neither hang nor disagree."""
-    dist.init_process_group("gloo", rank=rank, world_size=world, init_method=f"file:///{store_path}")
-    try:
-        dp_mesh = init_device_mesh("cpu", (world,), mesh_dim_names=("dp_shard_cp",))
-        moe_mesh = init_device_mesh("cpu", (1, world), mesh_dim_names=("ep_shard", "ep"))
+def _scenario_rank_without_expert_grads(rank: int) -> None:
+    """Only one rank has expert grads: must neither hang nor disagree."""
+    dp_mesh = init_device_mesh("cpu", (_WORLD,), mesh_dim_names=("dp_shard_cp",))
+    moe_mesh = init_device_mesh("cpu", (1, _WORLD), mesh_dim_names=("ep_shard", "ep"))
 
-        expert = nn.Parameter(torch.zeros(2, 8))
-        if rank == 0:
-            expert.grad = torch.full((2, 8), 10.0)
-        model = _expert_model(expert)
-        dense = _add_dense(model, dp_mesh)
+    expert = nn.Parameter(torch.zeros(2, 8))
+    if rank == 0:
+        expert.grad = torch.full((2, 8), 10.0)
+    model = _expert_model(expert)
+    dense = _add_dense(model, dp_mesh)
 
-        total_norm = _clip(model, moe_mesh)
+    total_norm = _clip(model, moe_mesh)
 
-        # dense 16 * 1 + rank-0 experts 16 * 100; rank 1 contributes nothing
-        correct = (16 * 1.0 + 16 * 100.0) ** 0.5
-        coef = MAX_NORM / (correct + 1e-6)
-        torch.testing.assert_close(torch.tensor(total_norm), torch.tensor(correct))
-        torch.testing.assert_close(dense.grad.to_local(), torch.full((2, 4), coef))
-        if rank == 1:
-            assert expert.grad is None
-    finally:
-        dist.destroy_process_group()
+    # dense 8 * world * 1 + rank-0 experts 16 * 100; the other ranks contribute nothing
+    correct = (8 * _WORLD * 1.0 + 16 * 100.0) ** 0.5
+    coef = MAX_NORM / (correct + 1e-6)
+    torch.testing.assert_close(torch.tensor(total_norm), torch.tensor(correct))
+    torch.testing.assert_close(dense.grad.to_local(), torch.full((2, 4), coef))
+    if rank != 0:
+        assert expert.grad is None
 
 
-def _run_torch_fast_path_rank(rank: int, world: int, store_path: str) -> None:
+def _scenario_torch_fast_path(rank: int) -> None:
     """use_torch_clip_grad_norm must not bypass the EP reduction."""
-    dist.init_process_group("gloo", rank=rank, world_size=world, init_method=f"file:///{store_path}")
-    try:
-        moe_mesh = init_device_mesh("cpu", (1, world), mesh_dim_names=("ep_shard", "ep"))
+    moe_mesh = init_device_mesh("cpu", (1, _WORLD), mesh_dim_names=("ep_shard", "ep"))
 
-        expert = nn.Parameter(torch.zeros(2, 8))
-        expert.grad = torch.full((2, 8), 10.0 if rank == 0 else 0.1)
-        model = _expert_model(expert)
+    expert = nn.Parameter(torch.zeros(2, 8))
+    expert.grad = torch.full((2, 8), 10.0 if rank == 0 else 0.1)
+    model = _expert_model(expert)
 
-        total_norm = _clip(model, moe_mesh, use_torch_clip_grad_norm=True)
+    total_norm = _clip(model, moe_mesh, use_torch_clip_grad_norm=True)
 
-        correct = (16 * 100.0 + 16 * 0.01) ** 0.5
-        torch.testing.assert_close(torch.tensor(total_norm), torch.tensor(correct))
-    finally:
-        dist.destroy_process_group()
+    correct = (16 * 100.0 + (_WORLD - 1) * 16 * 0.01) ** 0.5
+    torch.testing.assert_close(torch.tensor(total_norm), torch.tensor(correct))
 
 
-def _run_inf_norm_rank(rank: int, world: int, store_path: str) -> None:
+def _scenario_inf_norm(rank: int) -> None:
     """The inf-norm path must take the EP-wide max, not the rank-local one."""
-    dist.init_process_group("gloo", rank=rank, world_size=world, init_method=f"file:///{store_path}")
-    try:
-        moe_mesh = init_device_mesh("cpu", (1, world), mesh_dim_names=("ep_shard", "ep"))
+    from nemo_automodel.components.training.utils import scale_grads_and_clip_grad_norm
 
-        expert = nn.Parameter(torch.zeros(2, 8))
-        expert.grad = torch.full((2, 8), 10.0 if rank == 0 else 0.1)
-        model = _expert_model(expert)
+    moe_mesh = init_device_mesh("cpu", (1, _WORLD), mesh_dim_names=("ep_shard", "ep"))
 
-        from nemo_automodel.components.training.utils import scale_grads_and_clip_grad_norm
+    expert = nn.Parameter(torch.zeros(2, 8))
+    expert.grad = torch.full((2, 8), 10.0 if rank == 0 else 0.1)
+    model = _expert_model(expert)
 
-        total_norm = float(
-            scale_grads_and_clip_grad_norm(
-                MAX_NORM,
-                [model],
-                norm_type=float("inf"),
-                moe_mesh=moe_mesh,
-                ep_axis_name="ep",
-                foreach=None,
-            )
+    total_norm = float(
+        scale_grads_and_clip_grad_norm(
+            MAX_NORM,
+            [model],
+            norm_type=float("inf"),
+            moe_mesh=moe_mesh,
+            ep_axis_name="ep",
+            foreach=None,
         )
+    )
 
-        torch.testing.assert_close(torch.tensor(total_norm), torch.tensor(10.0))
-    finally:
-        dist.destroy_process_group()
+    torch.testing.assert_close(torch.tensor(total_norm), torch.tensor(10.0))
 
 
-def _run_ep_size_one_rank(rank: int, world: int, store_path: str) -> None:
+def _scenario_ep_size_one(rank: int) -> None:
     """An ep axis of size 1 must behave exactly like moe_mesh=None."""
+    moe_mesh = init_device_mesh("cpu", (_WORLD, 1), mesh_dim_names=("ep_shard", "ep"))
+
+    expert = nn.Parameter(torch.zeros(4, 4))
+    expert.grad = torch.full((4, 4), 2.0)
+    with_mesh = _clip(_expert_model(expert), moe_mesh)
+
+    expert2 = nn.Parameter(torch.zeros(4, 4))
+    expert2.grad = torch.full((4, 4), 2.0)
+    without_mesh = _clip(_expert_model(expert2), None)
+
+    torch.testing.assert_close(torch.tensor(with_mesh), torch.tensor(without_mesh))
+    torch.testing.assert_close(torch.tensor(with_mesh), torch.tensor(8.0))
+
+
+# Every rank walks this list in the same order, so the collectives each scenario
+# issues stay rank-uniform.
+_SCENARIOS = (
+    _scenario_plain_experts,
+    _scenario_ep_shard_experts,
+    _scenario_rank_without_expert_grads,
+    _scenario_torch_fast_path,
+    _scenario_inf_norm,
+    _scenario_ep_size_one,
+)
+
+
+def _run_scenarios(rank: int, world: int, store_path: str) -> None:
     dist.init_process_group("gloo", rank=rank, world_size=world, init_method=f"file:///{store_path}")
     try:
-        moe_mesh = init_device_mesh("cpu", (1, 1), mesh_dim_names=("ep_shard", "ep"))
-
-        expert = nn.Parameter(torch.zeros(4, 4))
-        expert.grad = torch.full((4, 4), 2.0)
-        with_mesh = _clip(_expert_model(expert), moe_mesh)
-
-        expert2 = nn.Parameter(torch.zeros(4, 4))
-        expert2.grad = torch.full((4, 4), 2.0)
-        without_mesh = _clip(_expert_model(expert2), None)
-
-        torch.testing.assert_close(torch.tensor(with_mesh), torch.tensor(without_mesh))
-        torch.testing.assert_close(torch.tensor(with_mesh), torch.tensor(8.0))
+        for scenario in _SCENARIOS:
+            scenario(rank)
     finally:
         dist.destroy_process_group()
 
 
-def test_plain_te_experts_clip_with_one_global_norm(tmp_path):
+def test_ep_grad_clip_agrees_across_ranks(tmp_path):
+    """All EP clipping scenarios, one process group, one spawn."""
     store = str(tmp_path / "s").replace("\\", "/")
-    mp.spawn(_run_plain_expert_rank, args=(2, store), nprocs=2, join=True)
+    context = mp.spawn(_run_scenarios, args=(_WORLD, store), nprocs=_WORLD, join=False)
 
-
-def test_ep_shard_te_experts_clip_with_one_global_norm(tmp_path):
-    store = str(tmp_path / "s").replace("\\", "/")
-    mp.spawn(_run_ep_shard_expert_rank, args=(4, store), nprocs=4, join=True)
-
-
-def test_rank_without_expert_grads_neither_hangs_nor_diverges(tmp_path):
-    store = str(tmp_path / "s").replace("\\", "/")
-    mp.spawn(_run_asymmetric_grads_rank, args=(2, store), nprocs=2, join=True)
-
-
-def test_torch_fast_path_does_not_bypass_ep_reduction(tmp_path):
-    store = str(tmp_path / "s").replace("\\", "/")
-    mp.spawn(_run_torch_fast_path_rank, args=(2, store), nprocs=2, join=True)
-
-
-def test_inf_norm_takes_the_ep_wide_max(tmp_path):
-    store = str(tmp_path / "s").replace("\\", "/")
-    mp.spawn(_run_inf_norm_rank, args=(2, store), nprocs=2, join=True)
-
-
-def test_ep_size_one_falls_back_to_plain_behavior(tmp_path):
-    store = str(tmp_path / "s").replace("\\", "/")
-    mp.spawn(_run_ep_size_one_rank, args=(1, store), nprocs=1, join=True)
+    deadline = time.monotonic() + _JOIN_TIMEOUT_S
+    while not context.join(timeout=5.0):
+        if time.monotonic() > deadline:
+            for process in context.processes:
+                if process.is_alive():
+                    process.terminate()
+            pytest.fail(f"ranks did not finish within {_JOIN_TIMEOUT_S:.0f}s; the clip collectives deadlocked")
 
 
 def test_moe_mesh_none_keeps_single_process_behavior():

--- a/tests/unit_tests/training/test_train_utils.py
+++ b/tests/unit_tests/training/test_train_utils.py
@@ -552,11 +552,13 @@ class _TEGroupedLinearMock(nn.Module):
 
 
 class _ExpertsModule(nn.Module):
-    """Mock experts module with parameters matching GroupedExpertsTE pattern."""
+    """Mock experts module carrying the GroupedExpertsTE structural marker."""
 
     def __init__(self):
         super().__init__()
-        # Submodule names match GroupedExpertsTE: gate_up_linear, down_linear
+        # EP grad scaling and the grad-clip EP reduction identify TE expert
+        # params through this marker, mirroring GroupedExpertsTE.__init__.
+        self._nemo_ep_local_expert_params = True
         self.gate_up_linear = _TEGroupedLinearMock()
 
 
@@ -566,7 +568,6 @@ class _MoEModule(nn.Module):
     def __init__(self):
         super().__init__()
         self.gate = nn.Linear(4, 2, bias=False)
-        # FQN will be mlp.experts.gate_up_linear.weight0, matching _EXPERT_PARAM_PATTERN
         self.mlp = nn.ModuleDict({"experts": _ExpertsModule()})
 
 
@@ -587,8 +588,8 @@ class TestScaleGradsAndClipGradNorm:
 
         torch.testing.assert_close(model.weight.grad, torch.full_like(model.weight, 2.0))
 
-    def test_ep_scaling_for_expert_params_by_name(self):
-        """Test that expert params are scaled by EP ratio based on param name."""
+    def test_ep_scaling_for_marked_expert_params(self):
+        """Expert params found via the structural marker are scaled by the EP ratio."""
         model = _MoEModule()
         expert_param = model.mlp["experts"].gate_up_linear.weight0
         model.gate.weight.grad = torch.ones_like(model.gate.weight) * 2.0


### PR DESCRIPTION
Fixes #3816.

grad clipping never reduced the TE expert part of the norm across the EP axis, so each EP group computed its own "global" norm and clipped the same dense params by different factors (10x apart in the repro). repro and details are in the issue.

**what changed**

- expert params are found by structure, not by name. `GroupedExpertsTE` sets a marker when it is built, and one scan of the model feeds both the existing ep grad scaling and the new ep reduction inside the clip. this replaces the `mlp.experts` regex, which missed gemma4_moe, diffusion_gemma and step3p5 (they attach the moe block as `moe`), so their ep grad scaling is fixed too
- the sharding groups come from the model structure instead of whatever grads exist this step. every rank runs the same collectives in the same order, so a rank with no expert grads joins with zero instead of hanging the others
- the ep mesh is resolved with `get_flat_mesh` (flattened axes are not in `mesh_dim_names`), the torch fast path is skipped when ep expert params exist, the comm-group prewarm also warms the ep group, and the seq-cls recipe and the pipelining guide now pass the moe mesh through

**tests**

they run the real `scale_grads_and_clip_grad_norm` over gloo ranks: both ep layouts (plain tensors and ep_shard DTensors), the production shape with ep grad scaling on, a rank without expert grads, the torch fast path, inf norm, ep_size 1, and no moe mesh. all fail on main except the two fallback cases.

**note**

the ep reduction adds two small scalar collectives per expert group per step. #3685 and #3815 are both reworking these loops for perf and could fold the ep_shard+ep chain into one flattened group there.