### PR TITLE
fix(mimo-v2-flash): preserve fp32 router parameters and weights

### DIFF
--- a/nemo_automodel/components/models/mimo_v2_flash/model.py
+++ b/nemo_automodel/components/models/mimo_v2_flash/model.py
@@ -426,6 +426,9 @@ class MiMoV2FlashModel(nn.Module):
             expert_activation="swiglu",
             softmax_before_topk=False,
             force_e_score_correction_bias=True,
+            # The checkpoint stores fp32 gates; the reference router returns fp32 weights.
+            gate_dtype=torch.float32,
+            router_weights_fp32=True,
             dtype=get_dtype(config.torch_dtype, torch.bfloat16),
         )
         if moe_overrides:
@@ -593,7 +596,12 @@ class MiMoV2FlashForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
     # "rotary_emb" (matches self.rotary_emb + self.swa_rotary_emb) pins their inv_freq
     # buffers in fp32: cast_model_to_dtype's bf16 cast would otherwise round inv_freq and
     # degrade RoPE precision vs HF (see llama/rope_utils.py).
-    _keep_in_fp32_modules_strict = ["mlp.gate.e_score_correction_bias", "attention_sink_bias", "rotary_emb"]
+    _keep_in_fp32_modules_strict = [
+        "mlp.gate.weight",
+        "mlp.gate.e_score_correction_bias",
+        "attention_sink_bias",
+        "rotary_emb",
+    ]
     _pp_keep_self_forward = True
     _skip_init_weights_on_load = True
 

--- a/tests/unit_tests/models/mimo_v2_flash/test_model.py
+++ b/tests/unit_tests/models/mimo_v2_flash/test_model.py
@@ -20,6 +20,7 @@ import pytest
 import torch
 
 from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.common.utils import cast_model_to_dtype
 from nemo_automodel.components.models.mimo_v2_flash.config import MiMoV2FlashConfig
 from nemo_automodel.components.models.mimo_v2_flash.model import (
     MiMoV2FlashAttention,
@@ -292,12 +293,73 @@ class TestMiMoV2FlashForCausalLM:
         model.set_output_embeddings(new_head)
         assert model.lm_head is new_head
 
-    def test_keep_in_fp32_modules_strict_includes_buffers(self):
-        """Buffers stay in fp32 regardless of activation dtype; gate weight is bf16 (Pattern A)."""
-        assert "mlp.gate.e_score_correction_bias" in MiMoV2FlashForCausalLM._keep_in_fp32_modules_strict
-        assert "attention_sink_bias" in MiMoV2FlashForCausalLM._keep_in_fp32_modules_strict
-        # gate weight is no longer kept in fp32 (Pattern A uses gate_precision instead).
-        assert "mlp.gate.weight" not in MiMoV2FlashForCausalLM._keep_in_fp32_modules_strict
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+    def test_router_checkpoint_precision(self, tiny_config, backend_config, dtype):
+        tiny_config.torch_dtype = dtype
+        backend_config.enable_hf_state_dict_adapter = True
+        model = MiMoV2FlashForCausalLM(tiny_config, backend=backend_config)
+        gate = model.model.layers["1"].mlp.gate
+        assert gate.weight.dtype == torch.float32
+        torch.manual_seed(17)
+        checkpoint_weight = torch.randn(gate.weight.shape, dtype=torch.float32)
+        key = "model.layers.1.mlp.gate.weight"
+        state_dict = model.state_dict_adapter.from_hf({key: checkpoint_weight})
+        model.load_state_dict(state_dict, strict=False)
+        cast_model_to_dtype(model, dtype)
+        torch.testing.assert_close(gate.weight, checkpoint_weight, rtol=0, atol=0)
+        exported = model.state_dict_adapter.to_hf({key: gate.weight.detach()})
+        torch.testing.assert_close(exported[key], checkpoint_weight, rtol=0, atol=0)
+        assert model.lm_head.weight.dtype == dtype
+
+    @pytest.mark.parametrize("n_group", [1, 2])
+    def test_router_fp32_weights_and_gradients(self, tiny_config, backend_config, n_group):
+        tiny_config.torch_dtype = torch.bfloat16
+        tiny_config.n_group = n_group
+        tiny_config.topk_group = 1
+        model = MiMoV2FlashForCausalLM(tiny_config, backend=backend_config)
+        gate = model.model.layers["1"].mlp.gate
+        torch.manual_seed(42)
+        with torch.no_grad():
+            gate.weight.copy_(torch.randn_like(gate.weight))
+            gate.e_score_correction_bias.zero_()
+        hidden_states = torch.randn(8, tiny_config.hidden_size, dtype=torch.bfloat16, requires_grad=True)
+        weights, indices, _ = gate(hidden_states, token_mask=None, cp_mesh=None)
+        assert weights.dtype == torch.float32
+        reference_input = hidden_states.detach().clone().requires_grad_()
+        reference_weight = gate.weight.detach().clone().requires_grad_()
+        scores = torch.nn.functional.linear(reference_input.float(), reference_weight.float()).sigmoid()
+        scores_for_choice = scores
+        if n_group > 1:
+            group_scores = scores.view(8, n_group, -1).topk(2, dim=-1).values.sum(dim=-1)
+            group_indices = group_scores.topk(1, dim=-1).indices
+            group_mask = torch.zeros_like(group_scores).scatter_(1, group_indices, 1)
+            mask = group_mask.unsqueeze(-1).expand(8, n_group, tiny_config.n_routed_experts // n_group)
+            scores_for_choice = scores.masked_fill(~mask.reshape_as(scores).bool(), float("-inf"))
+        expected_indices = scores_for_choice.topk(tiny_config.num_experts_per_tok, dim=-1).indices
+        expected_weights = scores.gather(1, expected_indices)
+        expected_weights = expected_weights / (expected_weights.sum(dim=-1, keepdim=True) + 1e-20)
+        expected_weights = expected_weights * tiny_config.routed_scaling_factor
+        torch.testing.assert_close(indices, expected_indices, rtol=0, atol=0)
+        torch.testing.assert_close(weights, expected_weights, rtol=0, atol=0)
+        upstream_gradient = torch.randn_like(weights)
+        weights.backward(upstream_gradient)
+        expected_weights.backward(upstream_gradient)
+        torch.testing.assert_close(hidden_states.grad, reference_input.grad, rtol=0, atol=0)
+        torch.testing.assert_close(gate.weight.grad, reference_weight.grad, rtol=0, atol=0)
+
+    def test_router_output_precision_override(self, tiny_config, backend_config):
+        tiny_config.torch_dtype = torch.bfloat16
+        model = MiMoV2FlashForCausalLM(
+            tiny_config, backend=backend_config, moe_overrides={"router_weights_fp32": False}
+        )
+        gate = model.model.layers["1"].mlp.gate
+        with torch.no_grad():
+            gate.weight.zero_()
+            gate.e_score_correction_bias.zero_()
+        weights, _, _ = gate(
+            torch.ones(2, tiny_config.hidden_size, dtype=torch.bfloat16), token_mask=None, cp_mesh=None
+        )
+        assert weights.dtype == torch.bfloat16
 
     def test_customize_pipeline_stage_modules_keeps_swa_rotary(self, tiny_config, backend_config):
         model = MiMoV2FlashForCausalLM(tiny_config, backend=backend_config)


### PR DESCRIPTION
## Summary

Preserve MiMo-V2-Flash gate parameters and selected routing weights in FP32. The released checkpoint stores `mlp.gate.weight` as FP32, and its reference gate returns FP32 weights. The model now sets the existing `gate_dtype` and `router_weights_fp32` options and retains gate parameters through the strict dtype-casting path. Explicit output-precision overrides remain supported.

Related to #3650. This change covers the gate's parameter, projection, score, and output precision. Expert-kernel arithmetic and the placement of routing-weight application retain their existing behavior.

## Reference and numerical experiment

Reference: [XiaomiMiMo/MiMo-V2-Flash at `1afd314a2406c282e0956375c34a676501c78649`](https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash/tree/1afd314a2406c282e0956375c34a676501c78649), using the complete `MiMoV2MoEGate` implementation and the actual layer-2 gate and correction-bias tensors from `model_2.safetensors`.

The gate experiment uses the released configuration: 256 experts, hidden size 4096, top 8, one group, and scale 1. Seed 42 produces 64 BF16 input tokens and a nonuniform upstream gradient. These inputs are synthetic. PyTorch 2.14.0 CPU results against the reference:

| Parameter storage | Output weights | Max routing-weight error | Max gate-gradient error |
|---|---|---:|---:|
| BF16 | BF16 | 4.87968e-4 | 3.12515e-4 |
| BF16 | FP32 | 3.06964e-5 | 2.43299e-4 |
| FP32 | BF16 | 4.87968e-4 | 1.82733e-4 |
| FP32 | FP32 | 0 | 0 |

All four configurations select the same experts for this sample. FP32 storage and output also produce exact input gradients.

## Validation

- `pytest -q --cpu tests/unit_tests/models/mimo_v2_flash`: **103 passed**.
- Five focused regression cases cover checkpoint import/export through dtype conversion, exact routing weights and gradients with one and two expert groups, and an explicit BF16-output override. The original implementation fails three of these cases.
- A complete tiny BF16 model runs finite cross-entropy forward/backward; all three MoE layers pass FP32 routing weights into their expert consumers, and gate parameters and gradients remain FP32.
- `ruff check` and `ruff format --check` pass for both changed files.

<details>
<summary>Reproduce the checkpoint gate experiment</summary>

Use an environment with this checkout installed, such as an editable installation. Save the Python script below as `router_ablation.py` in an empty scratch directory. Run these download commands and the script from that directory:

```bash
reference=https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash/resolve/1afd314a2406c282e0956375c34a676501c78649
curl -fL "$reference/modeling_mimo_v2_flash.py" -o modeling_mimo_v2_flash.py
curl -fL -H 'Range: bytes=2376-4196679' "$reference/model_2.safetensors" -o layer2-gate-f32.bin
curl -fL -H 'Range: bytes=1352-2375' "$reference/model_2.safetensors" -o layer2-bias-f32.bin
python router_ablation.py
```

The byte ranges select the layer-2 gate tensor and correction bias from this pinned shard's safetensors header. Their sizes are 4,194,304 and 1,024 bytes.

```python
import ast
import json
from pathlib import Path
from types import SimpleNamespace

import torch
from torch import nn
from torch.nn import functional as F

from nemo_automodel.components.moe.config import MoEConfig
from nemo_automodel.components.moe.layers import Gate

root = Path(__file__).parent
node = next(
    node for node in ast.parse((root / "modeling_mimo_v2_flash.py").read_text()).body
    if isinstance(node, ast.ClassDef) and node.name == "MiMoV2MoEGate"
)
namespace = {"torch": torch, "nn": nn, "F": F}
exec(compile(ast.Module(body=[node], type_ignores=[]), "<official MiMoV2MoEGate>", "exec"), namespace)
# config.json at XiaomiMiMo/MiMo-V2-Flash revision 1afd314a2406c282e0956375c34a676501c78649.
config = SimpleNamespace(
    num_experts_per_tok=8, n_routed_experts=256, routed_scaling_factor=None,
    scoring_func="sigmoid", topk_method="noaux_tc", n_group=1, topk_group=1,
    norm_topk_prob=True, hidden_size=4096,
)
torch.set_num_threads(2)
torch.manual_seed(42)
reference = namespace["MiMoV2MoEGate"](config).eval()
with torch.no_grad():
    reference.weight.copy_(torch.frombuffer(bytearray((root / "layer2-gate-f32.bin").read_bytes()), dtype=torch.float32).view(256, 4096))
    reference.e_score_correction_bias.copy_(torch.frombuffer(bytearray((root / "layer2-bias-f32.bin").read_bytes()), dtype=torch.float32))
hidden = torch.randn(2, 32, 4096, dtype=torch.bfloat16, requires_grad=True)
reference_indices, reference_weights = reference(hidden)
probe = torch.randn(64, 256)
(reference_weights * probe.gather(1, reference_indices)).sum().backward()
reference_dense = torch.zeros(64, 256).scatter(1, reference_indices, reference_weights.detach())
results = []
for storage in (torch.bfloat16, torch.float32):
    for fp32_output in (False, True):
        moe_config = MoEConfig(
            dim=4096, inter_dim=64, moe_inter_dim=64, n_routed_experts=256,
            n_shared_experts=0, n_activated_experts=8, n_expert_groups=1,
            n_limited_groups=1, train_gate=True, gate_bias_update_factor=0,
            aux_loss_coeff=0, score_func="sigmoid_with_bias", norm_topk_prob=True,
            route_scale=1.0, force_e_score_correction_bias=True,
            dtype=torch.bfloat16, gate_dtype=storage, router_weights_fp32=fp32_output,
        )
        gate = Gate(moe_config, gate_precision=torch.float32).eval()
        with torch.no_grad():
            gate.weight.copy_(reference.weight)
            gate.e_score_correction_bias.copy_(reference.e_score_correction_bias)
        candidate_input = hidden.detach().clone().requires_grad_()
        weights, indices, _ = gate(candidate_input.view(-1, 4096), torch.ones(64, dtype=torch.bool), None)
        (weights * probe.gather(1, indices)).sum().backward()
        delta = torch.zeros(64, 256).scatter(1, indices, weights.detach().float()) - reference_dense
        results.append({
            "storage": str(storage), "output": str(weights.dtype),
            "changed_token_routes": int((indices.sort().values != reference_indices.sort().values).any(dim=1).sum()),
            "weight_max_abs": float(delta.abs().max()), "weight_l1": float(delta.abs().sum()),
            "gate_grad_max_abs": float((gate.weight.grad.float() - reference.weight.grad).abs().max()),
            "input_grad_max_abs": float((candidate_input.grad.float() - hidden.grad.float()).abs().max()),
        })
print(json.dumps(results, indent=2))
```

</details>
