### PR TITLE
fix(qwen3-moe): sample initial weights in fp32

### DIFF
--- a/nemo_automodel/components/models/qwen3_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_moe/model.py
@@ -32,7 +32,7 @@ from nemo_automodel.components.models.common.tie_word_embeddings import (
     TieSupport,
     reject_unsupported_tie_word_embeddings,
 )
-from nemo_automodel.components.models.common.utils import cast_model_to_dtype, compute_lm_head_logits
+from nemo_automodel.components.models.common.utils import compute_lm_head_logits, yield_fp32_model
 from nemo_automodel.components.models.gpt_oss.rope_utils import RotaryEmbedding, position_ids_to_freqs_cis
 from nemo_automodel.components.models.qwen3_moe.layers import Qwen3MoeAttention
 from nemo_automodel.components.models.qwen3_moe.state_dict_adapter import Qwen3MoeStateDictAdapter
@@ -353,8 +353,9 @@ class Qwen3MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
     def initialize_weights(
         self, buffer_device: torch.device | None = None, dtype: torch.dtype = torch.bfloat16
     ) -> None:
+        """Sample model weights in fp32 and restore the requested storage dtype."""
         buffer_device = buffer_device or torch.device(f"cuda:{torch.cuda.current_device()}")
-        with buffer_device:
+        with yield_fp32_model(self, dtype), buffer_device:
             self.model.init_weights(buffer_device=buffer_device)
             final_out_std = self.config.hidden_size**-0.5
             cutoff_factor = 3
@@ -367,7 +368,6 @@ class Qwen3MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
                     b=cutoff_factor * final_out_std,
                 )
 
-        cast_model_to_dtype(self, dtype)
         with buffer_device:
             # Ensure rotary embedding uses correct device after dtype move
             self.model.rotary_emb.device = buffer_device

--- a/tests/unit_tests/models/qwen3_moe/test_qwen3_moe_initialization.py
+++ b/tests/unit_tests/models/qwen3_moe/test_qwen3_moe_initialization.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+from unittest.mock import patch
+
+import pytest
+import torch
+from transformers.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.qwen3_moe.model import Qwen3MoeForCausalLM
+
+
+def _model(dtype: torch.dtype) -> Qwen3MoeForCausalLM:
+    config = Qwen3MoeConfig(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=64,
+        moe_intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        num_experts=4,
+        num_experts_per_tok=2,
+        max_position_embeddings=64,
+        tie_word_embeddings=False,
+        torch_dtype=dtype,
+    )
+    backend = BackendConfig(
+        linear="torch",
+        attn="sdpa",
+        rms_norm="torch",
+        experts="torch",
+        dispatcher="torch",
+        fake_balanced_gate=False,
+        enable_hf_state_dict_adapter=False,
+    )
+    # Construction records a CUDA device for the lazy RoPE cache. Initialization
+    # below selects CPU before the cache is built.
+    with patch("torch.cuda.current_device", return_value=0):
+        return Qwen3MoeForCausalLM(config, backend=backend)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("seed", [0, 42])
+def test_initialization_matches_fp32_sampling(dtype: torch.dtype, seed: int) -> None:
+    """Storage precision preserves the seeded fp32 initialization distribution."""
+    model = _model(dtype)
+    reference = _model(torch.float32)
+    torch.manual_seed(seed)
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=dtype)
+    torch.manual_seed(seed)
+    reference.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
+
+    reference_parameters = dict(reference.named_parameters())
+    for name, parameter in model.named_parameters():
+        assert parameter.dtype == dtype
+        assert torch.isfinite(parameter).all(), name
+        torch.testing.assert_close(parameter, reference_parameters[name].to(dtype), rtol=0, atol=0, msg=name)
+
+
+def test_initialized_model_trains_and_roundtrips() -> None:
+    """Checkpoint-free weights support the first update and an exact state round trip."""
+    torch.manual_seed(42)
+    model = _model(torch.bfloat16)
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.bfloat16)
+    input_ids = torch.randint(0, model.config.vocab_size, (2, 8))
+    original_head = model.lm_head.weight.detach().clone()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    logits = model(input_ids).logits
+    loss = torch.nn.functional.cross_entropy(logits.flatten(0, 1).float(), input_ids.flatten())
+    loss.backward()
+    assert torch.isfinite(loss)
+    for parameter in model.parameters():
+        if parameter.grad is not None:
+            assert torch.isfinite(parameter.grad).all()
+    optimizer.step()
+    assert not torch.equal(original_head, model.lm_head.weight)
+
+    restored = _model(torch.bfloat16)
+    restored.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.bfloat16)
+    restored.load_state_dict(copy.deepcopy(model.state_dict()))
+    torch.testing.assert_close(restored(input_ids).logits, model(input_ids).logits, rtol=0, atol=0)


### PR DESCRIPTION
## Summary

Sample Qwen3-MoE weights in FP32 through the existing `yield_fp32_model` context, then restore the requested storage dtype. This applies the initialization contract from #2457 to the model's embedding, attention, router, experts, norms, and output head. The shared context also preserves DTensor placement and parameter identity.

The previous initializer sampled the output head directly into its allocated dtype. With the same seed, BF16 initialization diverged from FP32 initialization followed by a cast. The new regression failed on the original implementation for seed 0 in BF16.

Related to #2457.

## Validation

Python 3.12, PyTorch 2.14.0, Transformers 5.15.1; CPU torch/SDPA/expert backends:

- `pytest -q --cpu tests/unit_tests/models/qwen3_moe/test_qwen3_moe_initialization.py`: **5 passed**. Exact parameter comparisons cover seeds 0 and 42 in FP32 and BF16. A BF16 forward/backward and SGD update produce finite values; reloaded state produces bit-exact logits.
- `pytest -q --cpu tests/unit_tests/models/qwen3_moe/test_qwen3_moe_initialization.py tests/unit_tests/models/common/test_cast_model_to_dtype.py tests/unit_tests/models/gpt_oss/test_gptoss_rope_utils.py`: **129 passed, 1 skipped**.
- Single-rank Gloo DTensor initialization: 14 sharded parameters retain identity, `Shard(0)` placement, finite values, and BF16 storage.
- `ruff check` and `ruff format --check` pass for both changed files.
