### PR TITLE
fix(deepseek-v4): advance PP media cursor for text-only microbatches

### DIFF
--- a/nemo_automodel/components/models/deepseek_v4/model.py
+++ b/nemo_automodel/components/models/deepseek_v4/model.py
@@ -1379,24 +1379,25 @@ class DeepseekV4ForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         # PP VLM batches keep variable-length patch tensors off the pipeline
         # schedule and stage them per microbatch on the first model part. Pull
         # the matching chunk back here, where the DSV4-owned embedding bridge
-        # consumes it. Later PP stages have no embed_tokens and must neither
+        # consumes it. Text-only microbatches consume their empty media slots.
+        # Later PP stages have no embed_tokens and must neither
         # read nor advance the shared media cursor.
         on_first_stage = getattr(self.model, "embed_tokens", None) is not None
         if pixel_values is None and on_first_stage and getattr(self, "_vlm_pixel_values_chunks", None) is not None:
+            chunk_idx = int(getattr(self, "_vlm_chunk_idx", 0) or 0)
+            if chunk_idx >= len(self._vlm_pixel_values_chunks):
+                raise RuntimeError(
+                    f"DeepSeek-V4 PP media cursor {chunk_idx} exceeds "
+                    f"{len(self._vlm_pixel_values_chunks)} staged chunks"
+                )
             has_visual_tokens = vision_token_types is not None and bool((vision_token_types >= 0).any().item())
             if has_visual_tokens:
-                chunk_idx = int(getattr(self, "_vlm_chunk_idx", 0) or 0)
-                if chunk_idx >= len(self._vlm_pixel_values_chunks):
-                    raise RuntimeError(
-                        f"DeepSeek-V4 PP media cursor {chunk_idx} exceeds "
-                        f"{len(self._vlm_pixel_values_chunks)} staged chunks"
-                    )
                 pixel_values = self._vlm_pixel_values_chunks[chunk_idx]
                 grid_chunks = getattr(self, "_vlm_image_grid_hws_chunks", None)
                 if grid_chunks is None or chunk_idx >= len(grid_chunks):
                     raise RuntimeError("DeepSeek-V4 PP media is missing image_grid_hws for the current chunk")
                 image_grid_hws = grid_chunks[chunk_idx]
-                self._vlm_chunk_idx = chunk_idx + 1
+            self._vlm_chunk_idx = chunk_idx + 1
 
         use_mtp = self.mtp is not None and self.training
         if use_mtp and vision_token_types is not None and bool((vision_token_types >= 0).any().item()):

--- a/tests/unit_tests/models/deepseek_v4/test_dsv4_vision.py
+++ b/tests/unit_tests/models/deepseek_v4/test_dsv4_vision.py
@@ -586,7 +586,8 @@ def test_parallelizer_discovers_language_and_vision_blocks():
     assert "mtp.layers.0.mlp.gate.bias_vl" in model.state_dict()
 
 
-def test_causal_lm_consumes_staged_pp_media_chunk():
+@pytest.mark.parametrize("image_microbatches", [(True,), (False, True, False, True)])
+def test_causal_lm_consumes_staged_pp_media_chunk(image_microbatches: tuple[bool, ...]) -> None:
     config = _vision_config(
         hidden_size=64,
         moe_intermediate_size=32,
@@ -613,25 +614,52 @@ def test_causal_lm_consumes_staged_pp_media_chunk():
         dispatcher="torch",
         experts="torch_mm",
     )
+    torch.manual_seed(42)
     model = DeepseekV4ForCausalLM(config, backend=backend).eval()
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
     types, _ = build_image_block(1, 1, start_pos=0)
     vision_token_types = torch.cat([types, torch.tensor([-1])]).unsqueeze(0)
     input_ids = torch.cat([config.vocab_size + types, torch.tensor([3])]).unsqueeze(0)
-    patches = torch.randn(9, 3, config.vision_patch_size, config.vision_patch_size)
-    image_grid_hws = torch.tensor([[3, 3]])
-    model._vlm_pixel_values_chunks = [patches]
-    model._vlm_image_grid_hws_chunks = [image_grid_hws]
+    pixel_chunks = [
+        torch.randn(9 if has_image else 0, 3, config.vision_patch_size, config.vision_patch_size)
+        for has_image in image_microbatches
+    ]
+    grid_chunks = [
+        torch.tensor([[3, 3]]) if has_image else torch.empty((0, 2), dtype=torch.long)
+        for has_image in image_microbatches
+    ]
+    input_chunks = [input_ids if has_image else torch.full_like(input_ids, 3) for has_image in image_microbatches]
+    type_chunks = [
+        vision_token_types if has_image else torch.full_like(vision_token_types, -1) for has_image in image_microbatches
+    ]
+
+    with torch.inference_mode():
+        expected = [
+            model(
+                ids,
+                attention_mask=torch.ones_like(ids),
+                vision_token_types=token_types,
+                pixel_values=pixels if has_image else None,
+                image_grid_hws=grid if has_image else None,
+            ).logits
+            for has_image, ids, token_types, pixels, grid in zip(
+                image_microbatches, input_chunks, type_chunks, pixel_chunks, grid_chunks
+            )
+        ]
+
+    model._vlm_pixel_values_chunks = pixel_chunks
+    model._vlm_image_grid_hws_chunks = grid_chunks
     model._vlm_chunk_idx = 0
 
     with torch.inference_mode():
-        output = model(
-            input_ids,
-            attention_mask=torch.ones_like(input_ids),
-            vision_token_types=vision_token_types,
-        )
-
-    assert output.logits.shape[:2] == input_ids.shape
-    assert model._vlm_chunk_idx == 1
+        for chunk_idx, (ids, token_types, expected_logits) in enumerate(zip(input_chunks, type_chunks, expected)):
+            output = model(
+                ids,
+                attention_mask=torch.ones_like(ids),
+                vision_token_types=token_types,
+            )
+            torch.testing.assert_close(output.logits, expected_logits, rtol=0, atol=0)
+            assert model._vlm_chunk_idx == chunk_idx + 1
 
 
 def test_vision_blocks_expose_fp32_norm_islands_to_dsv4_fsdp():


### PR DESCRIPTION
## Summary

Fixes #3820.

Advance the DeepSeek-V4-Vision staged-media cursor once per first-stage microbatch, including text-only microbatches. The media chunker reserves one slot per microbatch, including empty slots for text-only microbatches. The previous cursor skipped that slot, and the next image microbatch failed with `Found 1 image spans but got 0 grids`.

Media tensors are assigned to image microbatches, preserving the text-only input contract. Existing bounds checks, later-stage isolation, metadata-probe reset, and schedule cleanup remain in place.

This fixes the native Vision pipeline integration added in #3772 for [DeepSeek-V4-Flash-Vision-Exp](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp).

## Validation

Python 3.12.14, PyTorch 2.14.0, Transformers 5.15.1, CPU:

- Expanded the existing staged-media regression to cover image-only and text/image/text/different-image sequences. Each result exactly matches a direct call with that microbatch's media. The original implementation produces **1 failed, 1 passed**.
- `pytest -q --cpu tests/unit_tests/models/deepseek_v4/test_dsv4_vision.py`: **60 passed, 1 skipped**. The skipped case requires CUDA.
- Real `prepare_vlm_media_for_pp` and `split_model_into_stages` reproduce the original failure. After the fix, `[0, 9]` patch slots advance the cursor to 1 after the text microbatch and complete the image microbatch successfully.
- A six-layer tiny Vision model split into two real model parts with `LoopedBFS`, hosted on one CPU/Gloo rank, matches the unsplit model exactly for both text and image logits. All 138 text-path and 157 image-path parameter gradients are finite and match exactly. This is a CPU model-part parity experiment; distributed GPU execution is outside this validation.
- Ruff lint, format checks, and `git diff --check` pass for both changed files.
