### PR TITLE
fix(checkpoint): preserve module extra state through adapters

### DIFF
--- a/nemo_automodel/components/checkpoint/_backports/consolidate_hf_safetensors.py
+++ b/nemo_automodel/components/checkpoint/_backports/consolidate_hf_safetensors.py
@@ -773,6 +773,10 @@ def _write_overall_metadata_file_from_shards(
     weight_map = {}
 
     for fqn, (tensor_shape, dtype_str) in fqn_to_size_mapping.items():
+        # Adapter-owned module state is resume-only and intentionally omitted
+        # from the consolidated Hugging Face mapping.
+        if fqn not in fqn_to_index_mapping and "_extra_state" in fqn.split("."):
+            continue
         output_dtype, _ = _resolve_output_dtype(
             fqn,
             dtype_str,

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -48,6 +48,7 @@ from safetensors.torch import load as safetensors_load
 from safetensors.torch import load_file, save_file
 from safetensors.torch import save as safetensors_save
 from torch import nn
+from torch.distributed.checkpoint.metadata import BytesStorageMetadata, TensorStorageMetadata
 from torch.distributed.checkpoint.storage import StorageReader, StorageWriter
 from torch.distributed.device_mesh import DeviceMesh
 from torch.nn.parallel import DistributedDataParallel
@@ -314,14 +315,14 @@ def _summarize_state_dict_key_diff(
     }
 
 
-def _get_checkpoint_metadata_keys(
+def _get_checkpoint_state_dict_metadata(
     path: str,
     storage_reader: StorageReader | None = None,
-) -> set[str]:
-    """Return checkpoint FQNs present in metadata."""
+) -> dict[str, TensorStorageMetadata | BytesStorageMetadata]:
+    """Return checkpoint FQN -> storage metadata mapping."""
     reader = storage_reader if storage_reader is not None else FileSystemReader(path)
     metadata = reader.read_metadata()
-    return set(metadata.state_dict_metadata.keys())
+    return dict(metadata.state_dict_metadata)
 
 
 if _is_geq_torch_2_9():
@@ -965,15 +966,42 @@ class Checkpointer:
             and isinstance(lm_head_param_name, str)
             and lm_head_param_name in state_dict
         )
+        checkpoint_metadata: dict[str, TensorStorageMetadata | BytesStorageMetadata] = {}
         checkpoint_metadata_keys: set[str] = set()
-        extra_state_keys = sorted(key for key in state_dict if key.endswith("_extra_state"))
+        extra_state_keys = sorted(key for key in state_dict if key.rsplit(".", 1)[-1] == "_extra_state")
+        # Reinsert missing entries after DCP so strict module loading retains them.
+        preserved_extra_state: dict[str, Any] = {}
         if should_try_tied_lm_head_compat or allow_checkpoint_key_subset or extra_state_keys:
-            checkpoint_metadata_keys = _get_checkpoint_metadata_keys(model_path, storage_reader)
+            checkpoint_metadata = _get_checkpoint_state_dict_metadata(model_path, storage_reader)
+            checkpoint_metadata_keys = set(checkpoint_metadata.keys())
+            # DCP flattens dictionary/list extra state into descendant FQNs. Key
+            # compatibility checks operate on module entries, not those leaves;
+            # keep the original metadata mapping for tensor allocation below.
+            for key in checkpoint_metadata:
+                parts = key.split(".")
+                if "_extra_state" in parts:
+                    checkpoint_metadata_keys.discard(key)
+                    checkpoint_metadata_keys.add(".".join(parts[: parts.index("_extra_state") + 1]))
         if extra_state_keys:
             missing_extra_state_keys = [key for key in extra_state_keys if key not in checkpoint_metadata_keys]
             if missing_extra_state_keys:
+                required_missing = [
+                    key
+                    for key in missing_extra_state_keys
+                    if not is_init_step
+                    and not (
+                        type(state_dict[key]) is torch.Tensor
+                        and state_dict[key].dtype == torch.uint8
+                        and state_dict[key].ndim == 1
+                        and state_dict[key].numel() == 0
+                    )
+                ]
+                if required_missing:
+                    raise RuntimeError(
+                        f"Checkpoint {model_path} is missing required module extra state: {required_missing[:10]}"
+                    )
                 for key in missing_extra_state_keys:
-                    state_dict.pop(key, None)
+                    preserved_extra_state[key] = state_dict.pop(key)
                 logging.warning(
                     "Checkpoint %s is missing %d requested module _extra_state keys. Keeping current module "
                     "extra state for those entries (examples=%s).",
@@ -981,6 +1009,24 @@ class Checkpointer:
                     len(missing_extra_state_keys),
                     missing_extra_state_keys[:10],
                 )
+            # Serialized byte state (e.g. TE quantizer state) has a checkpoint-owned
+            # length, not a parameter shape. A fresh module may return an empty
+            # placeholder even when resuming the same recipe. Allocate its full saved
+            # payload for DCP and let set_extra_state validate/restore it; dropping it
+            # would silently reset training state. Other tensor contracts stay strict.
+            for key in extra_state_keys:
+                saved_meta = checkpoint_metadata.get(key)
+                current = state_dict.get(key)
+                if (
+                    type(current) is torch.Tensor
+                    and current.dtype == torch.uint8
+                    and current.ndim == 1
+                    and isinstance(saved_meta, TensorStorageMetadata)
+                    and saved_meta.properties.dtype == torch.uint8
+                    and len(saved_meta.size) == 1
+                    and saved_meta.size != current.size()
+                ):
+                    state_dict[key] = torch.empty(saved_meta.size, dtype=current.dtype, device=current.device)
         if should_try_tied_lm_head_compat:
             if lm_head_param_name not in checkpoint_metadata_keys:
                 for source_name in get_tied_lm_head_source_names(model_state.model[0], lm_head_param_name):
@@ -1048,6 +1094,10 @@ class Checkpointer:
 
         state_dict = self._do_load(state_dict, model_path, storage_reader, is_init_step=is_init_step)
         storage_read_complete = time.monotonic()
+
+        # Missing extra state keeps its current value while satisfying strict loading.
+        if preserved_extra_state:
+            state_dict.update(preserved_extra_state)
 
         if compat_tied_lm_head_source_key is not None and isinstance(lm_head_param_name, str):
             state_dict[lm_head_param_name] = state_dict.pop(compat_tied_lm_head_source_key)

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -619,17 +619,26 @@ class Checkpointer:
             model_state.model[0],
             state_dict,
             quantization=False,
+            preserve_extra_state=True,
             device_mesh=self.moe_mesh,
             v4_compatible=self.config.v4_compatible,
         )
         # MoE adapters return non-contiguous views; safetensors.save rejects those.
         _materialize_to_hf_views_for_save(state_dict)
+        # State-dict adapters preserve native module state for resumable DCP
+        # checkpoints, but it is not part of the consolidated HF weight format.
+        has_state_dict_adapter = bool(getattr(_unwrap_ddp_model(model_state.model[0]), "state_dict_adapter", None))
+        hf_export_state_dict = (
+            {key: value for key, value in state_dict.items() if key.rsplit(".", 1)[-1] != "_extra_state"}
+            if has_state_dict_adapter
+            else state_dict
+        )
         # Build the consolidated model.safetensors.index.json if needed
-        fqn_to_file_index_mapping = self._maybe_build_consolidated_index(model_state, state_dict)
-        fqn_to_dtype_mapping = self._maybe_build_original_dtype_mapping(model_state, state_dict)
+        fqn_to_file_index_mapping = self._maybe_build_consolidated_index(model_state, hf_export_state_dict)
+        fqn_to_dtype_mapping = self._maybe_build_original_dtype_mapping(model_state, hf_export_state_dict)
         _warn_if_large_inline_consolidation(
             self.config,
-            state_dict,
+            hf_export_state_dict,
             fqn_to_file_index_mapping,
             is_final_checkpoint,
         )
@@ -948,6 +957,7 @@ class Checkpointer:
             # Training checkpoints are saved from the dequantized native model.
             # Only base-checkpoint initialization needs FP8 scale destinations.
             quantization=bool(is_init_step and self.config.dequantize_base_checkpoint),
+            preserve_extra_state=not is_init_step,
             device_mesh=self.moe_mesh,
             for_checkpoint_load=True,
         )
@@ -2584,14 +2594,43 @@ def _convert_checkpoint_with_transformers(
 
 
 def _maybe_adapt_state_dict_to_hf(
-    model_part: nn.Module, state_dict: dict[str, torch.Tensor], quantization: bool = False, **kwargs
-) -> dict[str, torch.Tensor]:
-    """
-    Custom models use state dict adapters to convert the state dict to the Hugging Face format.
+    model_part: nn.Module,
+    state_dict: dict[str, Any],
+    quantization: bool = False,
+    preserve_extra_state: bool = False,
+    **kwargs,
+) -> dict[str, Any]:
+    """Convert model state to Hugging Face keys while optionally retaining native module state.
+
+    Args:
+        model_part: Model that may own a state-dict adapter.
+        state_dict: Native state mapping. Tensor values retain their model-defined
+            rank, shape, and axis order; module extra state may be non-tensor data.
+        quantization: Whether the adapter should emit quantization metadata.
+        preserve_extra_state: Whether native ``_extra_state`` entries should be
+            reattached after ordinary weights are converted.
+        **kwargs: Additional adapter-specific conversion options.
+
+    Returns:
+        State mapping with ordinary weights in Hugging Face format. When requested,
+        module extra state remains under its native fully qualified name.
     """
     adapter = getattr(_unwrap_ddp_model(model_part), "state_dict_adapter", None)
     if adapter:
-        return adapter.to_hf(state_dict, exclude_key_regex=r".*_extra_state.*", quantization=quantization, **kwargs)
+        # Module-owned serialized state has no Hugging Face equivalent. Keep its
+        # native FQN so DCP can checkpoint it independently of weight conversion.
+        module_extra_state = {
+            key: value for key, value in state_dict.items() if key.rsplit(".", 1)[-1] == "_extra_state"
+        }
+        state_dict = {key: value for key, value in state_dict.items() if key not in module_extra_state}
+        state_dict = adapter.to_hf(
+            state_dict,
+            exclude_key_regex=r".*_extra_state.*",
+            quantization=quantization,
+            **kwargs,
+        )
+        if preserve_extra_state:
+            state_dict.update(module_extra_state)
     return state_dict
 
 
@@ -2835,14 +2874,29 @@ def _load_hf_bin_checkpoint(model_path: str) -> dict[str, torch.Tensor] | None:
 
 
 def _maybe_adapt_state_dict_from_hf(
-    model_part: nn.Module, state_dict: dict[str, torch.Tensor], moe_mesh: DeviceMesh | None = None
-) -> dict[str, torch.Tensor]:
-    """
-    Custom models use state dict adapters to convert the state dict from the Hugging Face format to the native format.
+    model_part: nn.Module, state_dict: dict[str, Any], moe_mesh: DeviceMesh | None = None
+) -> dict[str, Any]:
+    """Convert Hugging Face weights to native keys without transforming module state.
+
+    Args:
+        model_part: Model that may own a state-dict adapter.
+        state_dict: Checkpoint state mapping. Tensor values retain their checkpoint-defined
+            rank, shape, and axis order; module extra state may be non-tensor data.
+        moe_mesh: Optional device mesh used by expert-parallel adapter conversion.
+
+    Returns:
+        Native model state mapping, including any untouched ``_extra_state`` entries.
     """
     adapter = getattr(_unwrap_ddp_model(model_part), "state_dict_adapter", None)
     if adapter:
+        # Convert only HF weight keys, then put the native module state back for
+        # ModelState.load_state_dict() to deliver to the owning module.
+        module_extra_state = {
+            key: value for key, value in state_dict.items() if key.rsplit(".", 1)[-1] == "_extra_state"
+        }
+        state_dict = {key: value for key, value in state_dict.items() if key not in module_extra_state}
         ep_mesh_dims = [dim for dim in moe_mesh.mesh_dim_names if dim != "pp"] if moe_mesh is not None else []
         ep_mesh = moe_mesh[tuple(ep_mesh_dims)] if ep_mesh_dims else moe_mesh
-        return adapter.from_hf(state_dict, device_mesh=ep_mesh)
+        state_dict = adapter.from_hf(state_dict, device_mesh=ep_mesh)
+        state_dict.update(module_extra_state)
     return state_dict

--- a/tests/functional_tests/training/test_te_checkpoint_extra_state.py
+++ b/tests/functional_tests/training/test_te_checkpoint_extra_state.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Restore trusted TE checkpoints without dropping serialized quantizer state."""
+
+import pytest
+import torch
+import torch.distributed.checkpoint as dcp
+
+from nemo_automodel.components.checkpoint.checkpointing import Checkpointer, CheckpointingConfig
+from nemo_automodel.shared.import_utils import safe_import
+
+HAVE_TE, te = safe_import("transformer_engine.pytorch")
+pytestmark = pytest.mark.skipif(not HAVE_TE or not torch.cuda.is_available(), reason="requires TE and CUDA")
+
+
+@pytest.mark.parametrize("saved_recipe", ["delayed", "current", "nvfp4"])
+def test_te_extra_state_restore_and_runtime_precision(tmp_path, saved_recipe):
+    """Restore state into a fresh module and honor the next runtime precision choice."""
+    from transformer_engine.common.recipe import DelayedScaling, Float8CurrentScaling, NVFP4BlockScaling
+    from transformer_engine.pytorch.quantization import autocast
+
+    if saved_recipe == "nvfp4" and torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("NVFP4 requires Blackwell or newer")
+    recipe = {"delayed": DelayedScaling, "current": Float8CurrentScaling, "nvfp4": NVFP4BlockScaling}[saved_recipe]()
+    torch.manual_seed(123)
+    source = te.Linear(128, 128, params_dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    with autocast(enabled=True, recipe=recipe):
+        source(x).float().square().mean().backward()
+    assert source.get_extra_state().numel() > 0
+    # Only locally generated trusted payloads: upstream TE interprets its own
+    # serialized byte tensor via pickle in set_extra_state.
+    dcp.save(source.state_dict(), checkpoint_id=tmp_path)
+    destination = te.Linear(128, 128, params_dtype=torch.bfloat16, device="cuda")
+    assert destination.get_extra_state().numel() == 0
+    checkpointer = Checkpointer(
+        CheckpointingConfig(
+            enabled=True, checkpoint_dir=str(tmp_path), model_save_format="safetensors", save_consolidated=False
+        ),
+        dp_rank=0,
+        tp_rank=0,
+        pp_rank=0,
+        moe_mesh=None,
+    )
+    checkpointer.load_model(destination, model_path=str(tmp_path))
+    torch.testing.assert_close(destination.weight, source.weight)
+    torch.testing.assert_close(destination.bias, source.bias)
+    assert type(destination.fp8_meta["recipe"]) is type(recipe)
+    if saved_recipe == "delayed":
+        for direction in ("scaling_fwd", "scaling_bwd"):
+            for key in ("scale", "amax_history"):
+                torch.testing.assert_close(
+                    getattr(destination.fp8_meta[direction], key), getattr(source.fp8_meta[direction], key)
+                )
+
+    # Loaded quantizer metadata must not force quantization on a BF16 forward.
+    with autocast(enabled=False):
+        output = destination(x.detach())
+        expected = source(x.detach())
+        torch.testing.assert_close(output, expected, atol=0, rtol=0)
+        output.float().square().mean().backward()
+    assert destination.fp8 is False
+    assert torch.isfinite(destination.weight.grad).all()
+
+    # A subsequent enabled scope must select the requested recipe, not the saved one.
+    destination.zero_grad(set_to_none=True)
+    with autocast(enabled=True, recipe=Float8CurrentScaling()):
+        output = destination(x.detach())
+        output.float().square().mean().backward()
+    assert type(destination.fp8_meta["recipe"]) is Float8CurrentScaling
+    assert destination.fp8 is True
+    assert torch.isfinite(output).all()
+    assert torch.isfinite(destination.weight.grad).all()

--- a/tests/functional_tests/training/test_te_checkpoint_extra_state.py
+++ b/tests/functional_tests/training/test_te_checkpoint_extra_state.py
@@ -17,8 +17,10 @@
 import pytest
 import torch
 import torch.distributed.checkpoint as dcp
+from transformers import LlamaConfig
 
 from nemo_automodel.components.checkpoint.checkpointing import Checkpointer, CheckpointingConfig
+from nemo_automodel.components.models.llama.state_dict_adapter import LlamaStateDictAdapter
 from nemo_automodel.shared.import_utils import safe_import
 
 HAVE_TE, te = safe_import("transformer_engine.pytorch")
@@ -83,3 +85,53 @@ def test_te_extra_state_restore_and_runtime_precision(tmp_path, saved_recipe):
     assert destination.fp8 is True
     assert torch.isfinite(output).all()
     assert torch.isfinite(destination.weight.grad).all()
+
+
+def test_te_extra_state_restore_with_state_dict_adapter(tmp_path):
+    """Restore TE quantizer state while an adapter converts ordinary weight keys."""
+    from transformer_engine.common.recipe import DelayedScaling
+    from transformer_engine.pytorch.quantization import autocast
+
+    class AdapterModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = te.Linear(128, 128, params_dtype=torch.bfloat16, device="cuda")
+            self.state_dict_adapter = LlamaStateDictAdapter(LlamaConfig(tie_word_embeddings=False))
+
+        def forward(self, x):
+            """Apply the TE projection to ``x`` of shape [tokens, hidden]."""
+            return self.model(x)
+
+    torch.manual_seed(123)
+    source = AdapterModel()
+    x = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    with autocast(enabled=True, recipe=DelayedScaling()):
+        source(x).float().square().mean().backward()
+    assert source.model.get_extra_state().numel() > 0
+
+    checkpointer = Checkpointer(
+        CheckpointingConfig(
+            enabled=True,
+            checkpoint_dir=str(tmp_path),
+            model_save_format="safetensors",
+            save_consolidated=False,
+        ),
+        dp_rank=0,
+        tp_rank=0,
+        pp_rank=0,
+        moe_mesh=None,
+    )
+    checkpoint_path = tmp_path / "step_1"
+    checkpointer.save_model(source, str(checkpoint_path))
+
+    destination = AdapterModel()
+    assert destination.model.get_extra_state().numel() == 0
+    checkpointer.load_model(destination, model_path=str(checkpoint_path / "model"))
+
+    torch.testing.assert_close(destination.model.weight, source.model.weight)
+    torch.testing.assert_close(destination.model.bias, source.model.bias)
+    for direction in ("scaling_fwd", "scaling_bwd"):
+        for key in ("scale", "amax_history"):
+            torch.testing.assert_close(
+                getattr(destination.model.fp8_meta[direction], key), getattr(source.model.fp8_meta[direction], key)
+            )

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -1833,8 +1833,8 @@ class TestLoadModelCheckpointKeySubset:
                 side_effect=lambda module, state_dict, **kwargs: state_dict,
             ),
             patch(
-                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
-                return_value={"layer.weight"},
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_state_dict_metadata",
+                return_value={"layer.weight": object()},
             ),
             patch.object(checkpointer, "_do_load", side_effect=fake_do_load),
         ):
@@ -1872,8 +1872,8 @@ class TestLoadModelCheckpointKeySubset:
                 side_effect=lambda module, state_dict, **kwargs: state_dict,
             ),
             patch(
-                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
-                return_value={"unrelated.weight"},
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_state_dict_metadata",
+                return_value={"unrelated.weight": object()},
             ),
         ):
             mock_model_state = mock_model_state_cls.return_value
@@ -1903,8 +1903,8 @@ class TestLoadModelCheckpointKeySubset:
                 side_effect=lambda module, state_dict, **kwargs: state_dict,
             ),
             patch(
-                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
-                return_value={"language_model.layer.weight", "vision_tower.block.weight"},
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_state_dict_metadata",
+                return_value={"language_model.layer.weight": object(), "vision_tower.block.weight": object()},
             ),
         ):
             mock_model_state = mock_model_state_cls.return_value
@@ -1940,8 +1940,8 @@ class TestLoadModelCheckpointKeySubset:
                 side_effect=lambda module, state_dict, **kwargs: {**state_dict, "stray.weight": torch.ones(1)},
             ),
             patch(
-                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
-                return_value={"layer.weight"},
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_state_dict_metadata",
+                return_value={"layer.weight": object()},
             ),
             patch.object(checkpointer, "_do_load", side_effect=lambda state_dict, *args, **kwargs: state_dict),
         ):
@@ -1981,7 +1981,7 @@ class TestLoadModelExtraState:
         model = torch.nn.Module()
         initial_state_dict = {
             "layer.weight": torch.zeros(2, 2),
-            "layer._extra_state": torch.empty(0),
+            "layer._extra_state": torch.empty(0, dtype=torch.uint8),
         }
         captured = {}
 
@@ -2003,8 +2003,8 @@ class TestLoadModelExtraState:
                 side_effect=lambda module, state_dict, **kwargs: state_dict,
             ),
             patch(
-                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
-                return_value={"layer.weight"},
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_state_dict_metadata",
+                return_value={"layer.weight": object()},
             ),
             patch.object(checkpointer, "_do_load", side_effect=fake_do_load),
         ):
@@ -2017,6 +2017,131 @@ class TestLoadModelExtraState:
         assert captured["requested_keys"] == {"layer.weight"}
         assert "module _extra_state keys" in caplog.text
         mock_model_state.load_state_dict.assert_called_once()
+        # The withheld extra-state entry must be re-inserted after the DCP load so a
+        # strict module load still receives every key it expects.
+        loaded_state_dict = mock_model_state.load_state_dict.call_args.args[0]
+        assert "layer._extra_state" in loaded_state_dict
+
+    @pytest.mark.parametrize("checkpoint_format", ["dcp", "safetensors"])
+    @pytest.mark.parametrize("saved_size,current_size", [(5, 0), (5, 2), (2, 5), (5, 5), (0, 5)])
+    def test_tensor_extra_state_round_trip(self, tmp_path, saved_size, current_size, checkpoint_format):
+        """Restore serialized state even when a fresh module has a different-sized placeholder."""
+
+        class StatefulLayer(torch.nn.Linear):
+            def __init__(self, size):
+                super().__init__(2, 2, bias=False)
+                self.extra = torch.arange(size, dtype=torch.uint8)
+
+            def get_extra_state(self):
+                """Return a CPU byte tensor of shape [serialized_bytes]."""
+                return self.extra
+
+            def set_extra_state(self, state):
+                """Install the serialized module state.
+
+                Args:
+                    state: CPU byte tensor of shape [serialized_bytes]; the length
+                        is checkpoint-owned and may differ from the initial state.
+                """
+                self.extra = state.clone()
+
+        source = torch.nn.Sequential(StatefulLayer(saved_size))
+        destination = torch.nn.Sequential(StatefulLayer(current_size))
+        with torch.no_grad():
+            source[0].weight.fill_(7)
+            destination[0].weight.zero_()
+        destination[0].extra.zero_()
+        if checkpoint_format == "safetensors":
+            save_file(source.state_dict(), tmp_path / "model.safetensors")
+        else:
+            dcp.save(source.state_dict(), checkpoint_id=tmp_path)
+
+        checkpointer = self._make_checkpointer()
+        checkpointer.load_model(destination, model_path=str(tmp_path))
+
+        torch.testing.assert_close(destination[0].weight, source[0].weight)
+        torch.testing.assert_close(destination[0].extra, source[0].extra)
+
+    @pytest.mark.parametrize("dtype,shape", [(torch.float32, (5,)), (torch.uint8, (2, 3))])
+    def test_non_serialized_extra_state_shape_mismatch_is_not_dropped(self, tmp_path, dtype, shape):
+        """Ordinary tensor extra state must retain DCP's shape validation."""
+
+        class StatefulLayer(torch.nn.Linear):
+            def get_extra_state(self):
+                return torch.zeros(1, dtype=dtype)
+
+            def set_extra_state(self, state):
+                """Accept extra state.
+
+                Args:
+                    state: Tensor of shape [1] using the test's dtype.
+                """
+                raise AssertionError("Mismatched state must fail before module installation")
+
+        model = StatefulLayer(2, 2, bias=False)
+        saved = model.state_dict()
+        saved["_extra_state"] = torch.ones(shape, dtype=dtype)
+        dcp.save(saved, checkpoint_id=tmp_path)
+        with pytest.raises(dcp.CheckpointException, match="Size mismatch"):
+            self._make_checkpointer().load_model(model, model_path=str(tmp_path))
+
+    @pytest.mark.parametrize("allow_checkpoint_key_subset", [False, True])
+    def test_dict_extra_state_round_trip(self, tmp_path, allow_checkpoint_key_subset):
+        """DCP-flattened dictionary state must not be mistaken for missing state."""
+
+        class StatefulLayer(torch.nn.Linear):
+            def __init__(self, counter):
+                super().__init__(2, 2, bias=False)
+                self.counter = counter
+
+            def get_extra_state(self):
+                return {"counter": self.counter}
+
+            def set_extra_state(self, state):
+                self.counter = state["counter"]
+
+        source = torch.nn.Sequential(StatefulLayer(17))
+        destination = torch.nn.Sequential(StatefulLayer(0))
+        dcp.save(source.state_dict(), checkpoint_id=tmp_path)
+        self._make_checkpointer().load_model(
+            destination,
+            model_path=str(tmp_path),
+            allow_checkpoint_key_subset=allow_checkpoint_key_subset,
+        )
+        assert destination[0].counter == 17
+        torch.testing.assert_close(destination[0].weight, source[0].weight)
+
+    @pytest.mark.parametrize("required", [False, True])
+    def test_missing_extra_state_real_strict_load(self, tmp_path, required):
+        """Only empty serialized placeholders tolerate absent state on resume."""
+
+        class StatefulLayer(torch.nn.Linear):
+            def __init__(self):
+                super().__init__(2, 2, bias=False)
+                self.extra = torch.tensor([3, 4] if required else [], dtype=torch.uint8)
+
+            def get_extra_state(self):
+                return self.extra
+
+            def set_extra_state(self, state):
+                """Install extra state.
+
+                Args:
+                    state: CPU byte tensor of shape [serialized_bytes].
+                """
+                self.extra = state.clone()
+
+        model = StatefulLayer()
+        expected_extra = model.extra.clone()
+        expected_weight = torch.full_like(model.weight, 7)
+        dcp.save({"weight": expected_weight}, checkpoint_id=tmp_path)
+        if required:
+            with pytest.raises(RuntimeError, match="missing required module extra state"):
+                self._make_checkpointer().load_model(model, model_path=str(tmp_path))
+            return
+        self._make_checkpointer().load_model(model, model_path=str(tmp_path))
+        torch.testing.assert_close(model.weight, expected_weight)
+        torch.testing.assert_close(model.extra, expected_extra)
 
 
 # =============================================================================

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -2062,6 +2062,70 @@ class TestLoadModelExtraState:
         torch.testing.assert_close(destination[0].weight, source[0].weight)
         torch.testing.assert_close(destination[0].extra, source[0].extra)
 
+    @pytest.mark.parametrize(
+        ("model_save_format", "save_consolidated"),
+        [("torch_save", False), ("safetensors", False), ("safetensors", True)],
+    )
+    def test_tensor_extra_state_round_trip_with_state_dict_adapter(
+        self, tmp_path, model_save_format, save_consolidated
+    ):
+        """Keep native module state outside adapter key conversion during save and resume."""
+        from transformers import LlamaConfig
+
+        from nemo_automodel.components.models.llama.state_dict_adapter import LlamaStateDictAdapter
+
+        class StatefulLayer(torch.nn.Linear):
+            def __init__(self, size):
+                super().__init__(2, 2, bias=False)
+                self.extra = torch.arange(size, dtype=torch.uint8)
+
+            def get_extra_state(self):
+                """Return a CPU byte tensor of shape [serialized_bytes]."""
+                return self.extra
+
+            def set_extra_state(self, state):
+                """Install serialized module state.
+
+                Args:
+                    state: CPU byte tensor of shape [serialized_bytes].
+                """
+                self.extra = state.clone()
+
+        class AdapterModel(torch.nn.Module):
+            def __init__(self, size):
+                super().__init__()
+                self.model = StatefulLayer(size)
+                self.state_dict_adapter = LlamaStateDictAdapter(LlamaConfig(tie_word_embeddings=False))
+
+        source = AdapterModel(size=5)
+        destination = AdapterModel(size=0)
+        with torch.no_grad():
+            source.model.weight.fill_(7)
+            destination.model.weight.zero_()
+
+        config = CheckpointingConfig(
+            enabled=True,
+            checkpoint_dir=str(tmp_path),
+            model_save_format=model_save_format,
+            model_cache_dir=str(tmp_path / "cache"),
+            model_repo_id="test/model",
+            save_consolidated=save_consolidated,
+            is_peft=False,
+        )
+        with patch("torch.distributed.is_initialized", return_value=False):
+            checkpointer = Checkpointer(config, dp_rank=0, tp_rank=0, pp_rank=0, moe_mesh=None)
+
+        checkpoint_path = tmp_path / "step_1"
+        checkpointer.save_model(source, str(checkpoint_path))
+        if save_consolidated:
+            exported_state_dict = _load_hf_safetensors_checkpoint(str(checkpoint_path / "model" / "consolidated"))
+            assert exported_state_dict is not None
+            assert set(exported_state_dict) == {"model.weight"}
+        checkpointer.load_model(destination, model_path=str(checkpoint_path / "model"))
+
+        torch.testing.assert_close(destination.model.weight, source.model.weight)
+        torch.testing.assert_close(destination.model.extra, source.model.extra)
+
     @pytest.mark.parametrize("dtype,shape", [(torch.float32, (5,)), (torch.uint8, (2, 3))])
     def test_non_serialized_extra_state_shape_mismatch_is_not_dropped(self, tmp_path, dtype, shape):
         """Ordinary tensor extra state must retain DCP's shape validation."""


### PR DESCRIPTION
# What does this PR do ?

Preserve serialized module `_extra_state` across training-checkpoint save/resume when a custom model uses a `state_dict_adapter`.

This is a stacked follow-up to #3814. Until that PR lands, the reviewable follow-up commit here is `be92c36b9`.

# Changelog

- Keep native `_extra_state` keys outside `to_hf` / `from_hf` weight conversion and reattach them for resumable DCP checkpoints.
- Continue omitting runtime-only module state from base-HF initialization and consolidated HF exports.
- Cover torch-save DCP, sharded safetensors, consolidated export, and real Transformer Engine FP8 restore.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

## Why this is needed after #3814

#3814 fixes allocation and restoration once a module `_extra_state` key reaches DCP. The adapter path currently calls `to_hf(..., exclude_key_regex=r".*_extra_state.*")` on both save and load destinations, so those keys never reach that logic. This change converts ordinary weights through the adapter while carrying module state under its original native FQN.

## Validation

- `python -m pytest tests/unit_tests/checkpoint -q`: 386 passed, 19 skipped.
- H100, PyTorch `2.13.0a0+8145d630e8.nv26.06`, Transformer Engine `2.14.1+366798ef`: `tests/functional_tests/training/test_te_checkpoint_extra_state.py` completed with 3 passed and 1 NVFP4-on-H100 skip. The adapter case restored TE forward/backward scales and amax history into a fresh module.
- Scoped Ruff lint and format checks passed.
