### PR TITLE
fix(checkpoint): skip size estimation on non-rank-0 processes

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -443,12 +443,16 @@ def _warn_if_large_inline_consolidation(
         return
     if config.save_consolidated != SaveConsolidatedMode.EVERY:
         return
+    # Only rank 0 emits this warning, so bail out before estimating. Neither
+    # helper below is collective -- one is a local file read, the other walks
+    # the state dict without materializing tensors -- so skipping them on the
+    # other ranks cannot deadlock.
+    if not is_rank_0():
+        return
     estimated_bytes = _get_original_hf_index_total_size(config)
     is_hf_index_estimate = estimated_bytes is not None
     if estimated_bytes is None:
         estimated_bytes = estimate_state_dict_bytes(state_dict)
-    if not is_rank_0():
-        return
     if estimated_bytes is None or estimated_bytes < _CONSOLIDATED_SIZE_WARNING_THRESHOLD_BYTES:
         return
     world_size = get_world_size_safe()

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -2591,6 +2591,56 @@ class TestOfflineConsolidationScriptAndWarnings:
         assert "1 output file, world_size=64" in caplog.text
         assert "~64.0 GiB" in caplog.text
 
+    def test_non_rank_0_skips_size_estimation_entirely(self, tmp_path, monkeypatch):
+        """Only rank 0 logs, so no other rank should pay for the estimate.
+
+        Both helpers are local (a file read and a state-dict walk), so every
+        rank was opening the same HF index on shared storage and walking its
+        state dict on every save, only for all but one to discard the result.
+        """
+        import nemo_automodel.components.checkpoint.checkpointing as ckpt_mod
+
+        monkeypatch.setenv("WORLD_SIZE", "256")
+        checkpointer = self._make_checkpointer(tmp_path, save_consolidated=True)
+
+        calls = {"index": 0, "walk": 0}
+
+        def _count_index(_config):
+            calls["index"] += 1
+            return None
+
+        def _count_walk(_state_dict):
+            calls["walk"] += 1
+            return 0
+
+        monkeypatch.setattr(ckpt_mod, "is_rank_0", lambda: False)
+        monkeypatch.setattr(ckpt_mod, "_get_original_hf_index_total_size", _count_index)
+        monkeypatch.setattr(ckpt_mod, "estimate_state_dict_bytes", _count_walk)
+
+        _warn_if_large_inline_consolidation(checkpointer.config, {"w": object()}, {"w": 1})
+
+        assert calls == {"index": 0, "walk": 0}
+
+    def test_rank_0_still_estimates(self, tmp_path, monkeypatch):
+        """The guard must not silence the warning on the rank that emits it."""
+        import nemo_automodel.components.checkpoint.checkpointing as ckpt_mod
+
+        monkeypatch.setenv("WORLD_SIZE", "256")
+        checkpointer = self._make_checkpointer(tmp_path, save_consolidated=True)
+
+        calls = {"index": 0}
+
+        def _count_index(_config):
+            calls["index"] += 1
+            return 64 * 1024**3
+
+        monkeypatch.setattr(ckpt_mod, "is_rank_0", lambda: True)
+        monkeypatch.setattr(ckpt_mod, "_get_original_hf_index_total_size", _count_index)
+
+        _warn_if_large_inline_consolidation(checkpointer.config, {"w": object()}, {"w": 1})
+
+        assert calls["index"] == 1
+
 
 class TestOfflineHFConsolidationTool:
     """Focused tests for the root offline consolidation tool."""


### PR DESCRIPTION
# What does this PR do ?

Moves the `is_rank_0()` guard in `_warn_if_large_inline_consolidation` above the
size estimation, so only the rank that actually logs does the work.

`components/checkpoint/checkpointing.py` estimated first and checked rank second:

```python
estimated_bytes = _get_original_hf_index_total_size(config)   # open() + json.load()
is_hf_index_estimate = estimated_bytes is not None
if estimated_bytes is None:
    estimated_bytes = estimate_state_dict_bytes(state_dict)   # walks every tensor
if not is_rank_0():                                           # <- guard was here
    return
```

The output is one rank-0 log line, so every other rank paid for a result it
discarded. The estimate is not free:

- `_get_original_hf_index_total_size` → `get_safetensors_index_total_size`
  (`checkpoint/utils.py` L82-96) resolves a path, `open()`s it and `json.load()`s it.
- `estimate_state_dict_bytes` (`utils.py` L71-79) iterates the whole state dict.

On an N-rank job that is N processes opening the *same* HF index on shared
storage on every checkpoint save — the metadata-storm pattern shared
filesystems handle worst — or, when the index is absent, N full state-dict
walks so N-1 ranks can throw the number away. It only fires under
`save_consolidated=every`, which is exactly the config the warning exists to
discourage, so the ranks paying the cost are already on the slow path.

The helper immediately above it, `_warn_if_inline_consolidation_enabled`
(L421-427), already returns on non-rank-0 before doing anything, so the two
adjacent warn helpers disagreed. This makes them consistent.

**Why moving the guard is safe.** Neither helper is collective — one is a local
file read, the other is documented as estimating "without materializing
tensors" — and nothing between the two guards communicates. Had either
participated in a collective, having only rank 0 execute it would deadlock and
the original ordering would have been deliberate. I checked that first; it is
not.

This is redundant I/O, not a correctness bug: the emitted warning is unchanged.

# Changelog

- `is_rank_0()` check moved above the estimation in
  `_warn_if_large_inline_consolidation`, with a comment recording why skipping
  the helpers on other ranks cannot deadlock.
- Two CPU tests in `TestOfflineConsolidationScriptAndWarnings`:
  a non-rank-0 process calls neither helper; rank 0 still does.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

No user-facing behaviour changed, so no doc update was needed.

**Verification** (CPU, no GPU needed):

- Reverting the source hunk fails `test_non_rank_0_skips_size_estimation_entirely`.
  `test_rank_0_still_estimates` passes either way by design — it pins the
  behaviour this must not break, so the guard cannot silence the warning.
- The tests assert on the externally observable effect (whether the helpers are
  invoked) rather than mirroring the implementation.
- `pytest tests/unit_tests/checkpoint/` → 361 passed, 19 skipped. The 3 failures
  in that directory (`test_optimizer_state.py` x2,
  `test_rank_local_rng_checkpoint.py` x1) reproduce identically on unmodified
  `main` — they need multiple ranks — and are unrelated to this change.
- `ruff format` / `ruff check` clean.

# Additional Information

- Related to #3825
