### PR TITLE
feat(recipe): use HybridEP for Qwen3.5 35B

### DIFF
--- a/examples/vlm_finetune/qwen3_5_moe/qwen3_5_35b.yaml
+++ b/examples/vlm_finetune/qwen3_5_moe/qwen3_5_35b.yaml
@@ -45,7 +45,7 @@ model:
     rms_norm: torch_fp32
     rope_fusion: false
     experts: gmm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: false
     enable_hf_state_dict_adapter: true
 


### PR DESCRIPTION
# What does this PR do ?

Switch the Qwen3.5-35B-A3B VLM fine-tuning recipe default expert dispatcher from DeepEP to HybridEP.

The exact full-model recipe was validated before and after the dispatcher change for 100 optimizer steps on the same node. Model, data order, seed, batch semantics, topology, and optimizer configuration were unchanged.

# Changelog

- Set `model.backend.dispatcher: hybridep` in `examples/vlm_finetune/qwen3_5_moe/qwen3_5_35b.yaml`.

# Validation

## Setup

- Slurm job: `18033257`
- Hardware: 1 node, 8x H100 80GB
- Model: full 40-layer Qwen3.5-35B-A3B (`35,951,822,704` parameters)
- Topology: FSDP2, EP=8, TP=CP=PP=1
- Batch: GBS=16, LBS=1, gradient accumulation=2
- Sequence length: 2048
- Dataset: `mmoukouba/MedPix-VQA`
- Seed: 1234
- Activation checkpointing: enabled
- Steps: 100 optimizer steps plus validation and final checkpoint

A machine comparison of the logged configs found only three differences: the dispatcher, the W&B run name, and the dispatcher tag. All 100 `num_label_tokens` values matched exactly.

| | DeepEP | HybridEP |
|---|---:|---:|
| Result | 100 steps, RC=0 | 100 steps, RC=0 |
| First loss | 2.024350166 | 2.024350166 |
| Last loss | 1.764299273 | 1.765398026 |
| Validation loss | 1.516986739 | 1.517053222 |
| Maximum memory | 56.384 GiB | 56.483 GiB |
| W&B | [run 3ppd8jll](https://wandb.ai/Nemo-automodel/qwen3-5-hybridep-loss-parity/runs/3ppd8jll) | [run sjkon1ux](https://wandb.ai/Nemo-automodel/qwen3-5-hybridep-loss-parity/runs/sjkon1ux) |

Loss parity, computed from the 100 unrounded W&B history points:

- Mean absolute difference: `0.001958023`
- P95 absolute difference: `0.004657024`
- Maximum absolute difference: `0.006458282` (`0.464%` relative)
- RMSE: `0.002443695`
- Validation absolute difference: `0.000066483`
- No NaN, Inf, OOM, or distributed failure

## Observed throughput

Step 0 compilation was excluded. Both steady-state samples cover the same 564,770 tokens over steps 1-99.

| Metric | DeepEP | HybridEP | Observed change |
|---|---:|---:|---:|
| Aggregate TPS (total tokens / total step time) | 2,186 | 2,368 | +8.3% |
| Mean TPS | 2,265 | 2,488 | +9.8% |
| Median TPS | 2,279 | 2,554 | +12.1% |
| Median TPS/GPU | 285 | 319 | +12.1% |

HybridEP was faster on 79 of 99 steady-state steps. These performance numbers are from one sequential A/B run, with HybridEP running second, so they are evidence of an observed improvement rather than a controlled performance claim; the second run may benefit from warmed kernel caches.

W&B project: [qwen3-5-hybridep-loss-parity](https://wandb.ai/Nemo-automodel/qwen3-5-hybridep-loss-parity)

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? No new test is needed for this one-line recipe change; full-model training validation is recorded above.
- [x] Did you add or update any necessary documentation? The recipe itself is the user-facing configuration being updated.

# Additional Information

- No related issue.