### PR TITLE
fix(moe): cast expert output back to compute dtype before fc2_latent_proj

### DIFF
--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -896,7 +896,12 @@ class MoE(nn.Module):
             y = self.experts(x_latent, token_mask, weights, indices)
 
         if self.fc2_latent_proj is not None:
-            y = self.fc2_latent_proj(y)
+            # ``self.experts`` is its own FSDP unit; an ``output_dtype`` in the FSDP
+            # MixedPrecisionPolicy (NeMo-RL uses float32) casts its output above the
+            # block's compute dtype, and TE/torch linears reject an input dtype that
+            # differs from the (param_dtype-cast) weight. Re-enter the compute dtype
+            # of the latent input before the back-projection.
+            y = self.fc2_latent_proj(y.to(x_latent.dtype))
         if z is not None:
             y = y + z
         return y.view(shape)


### PR DESCRIPTION
## Summary

`MoE.forward` casts the routed-expert output back to the latent input's dtype before `fc2_latent_proj`. This is a no-op in Automodel's own recipes and fixes NeMo-RL training of models with `moe_latent_size` (Nemotron 3.5 Super).

## Problem

Running NeMo-RL (automodel/DTensor backend, EP=4, `linear: te`) on `NVIDIA-Nemotron-3.5-Super` (`NemotronH_Omni_Reasoning_V3`, `moe_latent_size: 1024`), the first training forward fails in every MoE layer:

```
File ".../nemo_automodel/components/moe/layers.py", line 899, in forward
    y = self.fc2_latent_proj(y)
...
File ".../transformer_engine/pytorch/module/base.py", line 1108, in set_activation_dtype
TypeError: Data types for parameters must match when outside of autocasted region.
Found input dtype: torch.float32 and 'weight' dtype: torch.bfloat16
```

Root cause:
- The MoE parallelizer wraps `self.experts` as its own FSDP2 unit (separate from the transformer block).
- NeMo-RL's FSDP2 `MixedPrecisionPolicy` is `param_dtype=bf16, reduce_dtype=fp32, output_dtype=fp32` (it wants fp32 logits for logprob math). FSDP2 applies `output_dtype` at *every* `fully_shard` boundary, so the experts' output comes back as fp32.
- That fp32 tensor flows straight into `fc2_latent_proj` inside the same block, with no FSDP input-cast in between. The projection's weight is bf16 (param_dtype), and NeMo-RL disables autocast for custom MoE models, so TE Linear rejects the dtype mismatch.
- Nemotron 3 Nano / Nano 3.5 have no latent projection: the experts' output is added to the residual directly, so the fp32 upcast was harmless there and this path was never exercised.

## Fix

Re-enter `x_latent.dtype` before the back-projection:

```python
y = self.fc2_latent_proj(y.to(x_latent.dtype))
```

When no `output_dtype` cast is active the dtypes already match and the `.to()` is free.
