### PR TITLE
fix(recipes): normalize seq-cls loss and gradients by a global label count

### DIFF
--- a/nemo_automodel/recipes/llm/train_seq_cls.py
+++ b/nemo_automodel/recipes/llm/train_seq_cls.py
@@ -229,10 +229,18 @@ class TrainFinetuneRecipeForSequenceClassification(BaseRecipe):
         )
         num_tokens_in_batch = self._dp_allreduce(num_tokens_in_batch).item()
 
-        # Each backward() adds to .grad, so accumulating N micro-batch means
-        # gives N x the mean over the full accumulated batch. Divide it back out
-        # so gradients do not depend on how a global batch is split.
-        num_batches = len(batches)
+        # Global number of labels over the whole accumulated batch and every DP
+        # rank. Normalizing the backward loss by this -- rather than by a local
+        # per-microbatch mean -- is what makes the gradient invariant to both the
+        # micro-batch split and dp_size. It is the convention train_ft.py uses
+        # with num_label_tokens, and it is what makes the `* dp_size` below
+        # correct: that factor cancels the DP gradient average, which only
+        # reconstructs the global mean when the denominator is already global.
+        num_label_samples = torch.tensor(
+            sum(batch["labels"].numel() for batch in batches),
+            dtype=torch.long,
+        )
+        num_label_samples = max(int(self._dp_allreduce(num_label_samples).item()), 1)
 
         for batch in batches:
             batch = {
@@ -250,7 +258,13 @@ class TrainFinetuneRecipeForSequenceClassification(BaseRecipe):
             preds = torch.argmax(logits, dim=-1)
             all_preds.append(preds.detach())
             all_labels.append(labels.view(-1).detach())
-            (loss * self._get_dp_group_size(include_cp=True) / num_batches).backward()
+            # `loss` is the mean over this micro-batch, so `loss * n_local` is its
+            # summed loss; dividing by the global count gives this micro-batch's
+            # share of the global mean. Every sequence-classification sample
+            # carries exactly one label, so `numel()` is the supervised count and
+            # matches how num_label_samples above was accumulated.
+            local_loss = loss * labels.numel() / num_label_samples
+            (local_loss * self._get_dp_group_size(include_cp=True)).backward()
 
         # Calculate gradient norm (distributed-aware)
         grad_norm = clip_grad_norm(

--- a/nemo_automodel/recipes/llm/train_seq_cls.py
+++ b/nemo_automodel/recipes/llm/train_seq_cls.py
@@ -229,6 +229,11 @@ class TrainFinetuneRecipeForSequenceClassification(BaseRecipe):
         )
         num_tokens_in_batch = self._dp_allreduce(num_tokens_in_batch).item()
 
+        # Each backward() adds to .grad, so accumulating N micro-batch means
+        # gives N x the mean over the full accumulated batch. Divide it back out
+        # so gradients do not depend on how a global batch is split.
+        num_batches = len(batches)
+
         for batch in batches:
             batch = {
                 k: (v.to(self.dist_env.device, non_blocking=True) if v is not None else None) for k, v in batch.items()
@@ -245,7 +250,7 @@ class TrainFinetuneRecipeForSequenceClassification(BaseRecipe):
             preds = torch.argmax(logits, dim=-1)
             all_preds.append(preds.detach())
             all_labels.append(labels.view(-1).detach())
-            (loss * self._get_dp_group_size(include_cp=True)).backward()
+            (loss * self._get_dp_group_size(include_cp=True) / num_batches).backward()
 
         # Calculate gradient norm (distributed-aware)
         grad_norm = clip_grad_norm(

--- a/nemo_automodel/recipes/llm/train_seq_cls.py
+++ b/nemo_automodel/recipes/llm/train_seq_cls.py
@@ -252,7 +252,10 @@ class TrainFinetuneRecipeForSequenceClassification(BaseRecipe):
                 out = model(**batch)
                 logits = getattr(out, "logits", out)
                 loss = self.loss_fn(logits, labels.view(-1))
-            losses.append(loss.detach().clone())
+            # Keep the summed loss, not the per-microbatch mean: means cannot be
+            # added back together, and the reported metric is normalized by the
+            # same global label count the gradient uses.
+            losses.append((loss * labels.numel()).detach().clone())
 
             # Collect predictions for accuracy calculation
             preds = torch.argmax(logits, dim=-1)
@@ -330,9 +333,13 @@ class TrainFinetuneRecipeForSequenceClassification(BaseRecipe):
                     reference_mfu=mfu_calculator.reference_mfu,
                 )
 
+        # Global summed loss over every micro-batch and DP rank, divided by the
+        # same global label count as the gradient. Dividing by len(batches)
+        # instead would report a mean of means: inflated by dp_size, and wrong
+        # whenever micro-batches are unevenly sized.
         total_loss = torch.sum(torch.stack(losses))
         total_loss = self._dp_allreduce(total_loss, include_cp=True).detach()
-        loss = total_loss / len(batches)
+        loss = total_loss / num_label_samples
 
         return MetricsSample(
             step=self.step_scheduler.step,

--- a/tests/unit_tests/recipes/test_train_seq_cls_grad_accum.py
+++ b/tests/unit_tests/recipes/test_train_seq_cls_grad_accum.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gradients must not depend on how a global batch is split into micro-batches.
+
+``torch.nn.CrossEntropyLoss`` reduces with ``mean``, and every ``backward()``
+adds to ``.grad``. Accumulating N micro-batch means therefore yields N x the
+mean over the full accumulated batch unless the count is divided back out, which
+silently multiplies the effective learning rate by ``grad_accumulation_steps``.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import torch
+import torch.nn as nn
+
+from nemo_automodel.recipes.llm import train_seq_cls as seq_cls_mod
+from nemo_automodel.recipes.llm.train_seq_cls import TrainFinetuneRecipeForSequenceClassification
+
+VOCAB, N_CLASSES, HIDDEN = 16, 3, 8
+
+
+class _TinyClassifier(nn.Module):
+    """Smallest model with the sequence-classification forward contract."""
+
+    def __init__(self):
+        super().__init__()
+        self.embed = nn.Embedding(VOCAB, HIDDEN)
+        self.head = nn.Linear(HIDDEN, N_CLASSES, bias=False)
+
+    def forward(self, input_ids, attention_mask=None):
+        pooled = self.embed(input_ids).mean(dim=1)
+        return SimpleNamespace(logits=self.head(pooled))
+
+
+def _make_recipe(model):
+    """A recipe instance with only what ``_run_train_optim_step`` touches."""
+    recipe = object.__new__(TrainFinetuneRecipeForSequenceClassification)
+    recipe.model_parts = [model]
+    recipe.dist_env = SimpleNamespace(device=torch.device("cpu"), world_size=1)
+    recipe.loss_fn = nn.CrossEntropyLoss()
+    recipe.optimizer = [torch.optim.SGD(model.parameters(), lr=0.0)]
+    recipe.lr_scheduler = None
+    recipe.max_grad_norm = 1.0
+    recipe.device_mesh = None
+    recipe.timestamp = 0.0
+    recipe.mfu_calculator = None
+    recipe.step_scheduler = SimpleNamespace(step=0, epoch=0)
+    recipe._get_dp_group_size = lambda include_cp=False: 1
+    recipe._get_cp_group_size = lambda: 1
+    recipe._get_pp_rank = lambda: 0
+    recipe._dp_allreduce = lambda t, *a, **k: t
+    return recipe
+
+
+def _grads_for(split, seed=0):
+    """Run one optimizer step over ``split`` micro-batches; return the accumulated grads.
+
+    Gradients are captured at ``clip_grad_norm``, which runs after the
+    accumulation loop and before ``optimizer.step()`` zeroes them.
+    """
+    torch.manual_seed(seed)
+    model = _TinyClassifier()
+    recipe = _make_recipe(model)
+
+    torch.manual_seed(123)
+    input_ids = torch.randint(0, VOCAB, (8, 4))
+    labels = torch.randint(0, N_CLASSES, (8,))
+
+    batches = [
+        {
+            "input_ids": input_ids[i : i + 8 // split],
+            "attention_mask": torch.ones_like(input_ids[i : i + 8 // split]),
+            "labels": labels[i : i + 8 // split],
+        }
+        for i in range(0, 8, 8 // split)
+    ]
+    assert len(batches) == split
+
+    captured = {}
+
+    def _capture(**kwargs):
+        captured["grads"] = [p.grad.detach().clone() for p in model.parameters() if p.grad is not None]
+        return torch.tensor(0.0)
+
+    with (
+        mock.patch.object(seq_cls_mod, "clip_grad_norm", _capture),
+        mock.patch.object(torch.cuda, "max_memory_allocated", lambda: 0),
+    ):
+        recipe._run_train_optim_step(batches)
+
+    assert captured["grads"], "no gradients were captured"
+    return captured["grads"]
+
+
+@pytest.mark.parametrize("split", [2, 4, 8])
+def test_gradients_are_invariant_to_microbatch_split(split):
+    """Splitting one global batch into more micro-batches must not change grads."""
+    single = _grads_for(1)
+    accumulated = _grads_for(split)
+
+    assert len(single) == len(accumulated)
+    for g_one, g_many in zip(single, accumulated):
+        ratio = (g_many.norm() / g_one.norm()).item()
+        assert torch.allclose(g_many, g_one, rtol=1e-5, atol=1e-6), (
+            f"{split} micro-batches scaled the gradient by ~{ratio:.2f}x"
+        )

--- a/tests/unit_tests/recipes/test_train_seq_cls_grad_accum.py
+++ b/tests/unit_tests/recipes/test_train_seq_cls_grad_accum.py
@@ -118,3 +118,86 @@ def test_gradients_are_invariant_to_microbatch_split(split):
         assert torch.allclose(g_many, g_one, rtol=1e-5, atol=1e-6), (
             f"{split} micro-batches scaled the gradient by ~{ratio:.2f}x"
         )
+
+
+# ---------------------------------------------------------------------------
+# Data-parallel scaling
+# ---------------------------------------------------------------------------
+
+
+def _ddp_averaged_grads(dp_size, accum, per_rank_bs, seed=0):
+    """Run one step on every simulated DP rank and average the grads, as DDP does.
+
+    ``_dp_allreduce`` is a SUM across ranks, so with equally sized shards it
+    multiplies a per-rank count by ``dp_size``.
+    """
+    torch.manual_seed(seed)
+    reference = _TinyClassifier()
+    init_state = {k: v.clone() for k, v in reference.state_dict().items()}
+
+    total = dp_size * accum * per_rank_bs
+    torch.manual_seed(123)
+    input_ids = torch.randint(0, VOCAB, (total, 4))
+    labels = torch.randint(0, N_CLASSES, (total,))
+
+    per_rank_grads = []
+    for rank in range(dp_size):
+        model = _TinyClassifier()
+        model.load_state_dict(init_state)
+        recipe = _make_recipe(model)
+        recipe._get_dp_group_size = lambda include_cp=False: dp_size
+        recipe._dp_allreduce = lambda t, *a, **k: t * dp_size
+
+        batches = []
+        for a in range(accum):
+            lo = (rank * accum + a) * per_rank_bs
+            hi = lo + per_rank_bs
+            batches.append(
+                {
+                    "input_ids": input_ids[lo:hi],
+                    "attention_mask": torch.ones_like(input_ids[lo:hi]),
+                    "labels": labels[lo:hi],
+                }
+            )
+
+        captured = {}
+
+        def _capture(**kwargs):
+            captured["grads"] = [p.grad.detach().clone() for p in model.parameters() if p.grad is not None]
+            return torch.tensor(0.0)
+
+        with (
+            mock.patch.object(seq_cls_mod, "clip_grad_norm", _capture),
+            mock.patch.object(torch.cuda, "max_memory_allocated", lambda: 0),
+        ):
+            recipe._run_train_optim_step(batches)
+        per_rank_grads.append(captured["grads"])
+
+    averaged = [torch.stack(g).mean(0) for g in zip(*per_rank_grads)]
+
+    # Truth: gradient of the mean loss over the entire global batch.
+    truth_model = _TinyClassifier()
+    truth_model.load_state_dict(init_state)
+    logits = truth_model(input_ids).logits
+    nn.CrossEntropyLoss()(logits, labels).backward()
+    truth = [p.grad.detach().clone() for p in truth_model.parameters() if p.grad is not None]
+
+    return averaged, truth
+
+
+@pytest.mark.parametrize("dp_size,accum", [(1, 1), (1, 4), (2, 1), (2, 2), (4, 2)])
+def test_gradients_match_global_mean_across_dp_and_accumulation(dp_size, accum):
+    """The DP-averaged gradient must equal the global-mean gradient.
+
+    `* dp_size` cancels DDP's averaging, but only reconstructs the global mean
+    when the loss is already normalized by a global denominator. Normalizing by
+    a local per-microbatch mean instead over-scaled by `dp_size * accum`.
+    """
+    averaged, truth = _ddp_averaged_grads(dp_size, accum, per_rank_bs=2)
+
+    assert len(averaged) == len(truth)
+    for g_got, g_ref in zip(averaged, truth):
+        ratio = (g_got.norm() / g_ref.norm()).item()
+        assert torch.allclose(g_got, g_ref, rtol=1e-5, atol=1e-6), (
+            f"dp_size={dp_size}, accum={accum}: gradient scaled by ~{ratio:.2f}x"
+        )

--- a/tests/unit_tests/recipes/test_train_seq_cls_grad_accum.py
+++ b/tests/unit_tests/recipes/test_train_seq_cls_grad_accum.py
@@ -12,12 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Gradients must not depend on how a global batch is split into micro-batches.
+"""Gradients and reported loss must both equal the global-batch reference.
 
-``torch.nn.CrossEntropyLoss`` reduces with ``mean``, and every ``backward()``
-adds to ``.grad``. Accumulating N micro-batch means therefore yields N x the
-mean over the full accumulated batch unless the count is divided back out, which
-silently multiplies the effective learning rate by ``grad_accumulation_steps``.
+``CrossEntropyLoss`` reduces with ``mean``, so a per-micro-batch loss is a local
+average. Averages cannot be added back together: summing them across
+accumulation steps and across DP ranks over-counts by ``grad_acc`` and by
+``dp_size`` respectively, and misweights any unevenly sized micro-batch.
+
+Both the gradient and the reported metric are therefore normalized by one
+DP-allreduced global label count, the convention ``train_ft.py`` uses with
+``num_label_tokens``. ``* dp_size`` is kept: it cancels the DDP/FSDP gradient
+average, which only reconstructs the global mean once the denominator is global.
+
+The tests below drive the real ``_run_train_optim_step``, simulate the DP
+average, and compare against ``F.cross_entropy(..., reduction="mean")`` over the
+whole global batch. Uneven splits such as ``3 + 1`` are covered explicitly:
+equal splits are the one case where a mean of means happens to be correct.
 """
 
 from types import SimpleNamespace
@@ -26,11 +36,12 @@ from unittest import mock
 import pytest
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 from nemo_automodel.recipes.llm import train_seq_cls as seq_cls_mod
 from nemo_automodel.recipes.llm.train_seq_cls import TrainFinetuneRecipeForSequenceClassification
 
-VOCAB, N_CLASSES, HIDDEN = 16, 3, 8
+VOCAB, N_CLASSES, HIDDEN, SEQ = 16, 3, 8, 4
 
 
 class _TinyClassifier(nn.Module):
@@ -46,11 +57,16 @@ class _TinyClassifier(nn.Module):
         return SimpleNamespace(logits=self.head(pooled))
 
 
-def _make_recipe(model):
-    """A recipe instance with only what ``_run_train_optim_step`` touches."""
+def _make_recipe(model, dp_size, allreduce):
+    """A recipe instance with only what ``_run_train_optim_step`` touches.
+
+    ``allreduce`` stands in for ``_dp_allreduce``, a SUM across DP ranks. Ranks
+    hold different data, so it cannot be faked as ``value * dp_size``; the
+    caller supplies a real cross-rank sum.
+    """
     recipe = object.__new__(TrainFinetuneRecipeForSequenceClassification)
     recipe.model_parts = [model]
-    recipe.dist_env = SimpleNamespace(device=torch.device("cpu"), world_size=1)
+    recipe.dist_env = SimpleNamespace(device=torch.device("cpu"), world_size=dp_size)
     recipe.loss_fn = nn.CrossEntropyLoss()
     recipe.optimizer = [torch.optim.SGD(model.parameters(), lr=0.0)]
     recipe.lr_scheduler = None
@@ -59,107 +75,57 @@ def _make_recipe(model):
     recipe.timestamp = 0.0
     recipe.mfu_calculator = None
     recipe.step_scheduler = SimpleNamespace(step=0, epoch=0)
-    recipe._get_dp_group_size = lambda include_cp=False: 1
+    recipe._get_dp_group_size = lambda include_cp=False: dp_size
     recipe._get_cp_group_size = lambda: 1
     recipe._get_pp_rank = lambda: 0
-    recipe._dp_allreduce = lambda t, *a, **k: t
+    recipe._dp_allreduce = allreduce
     return recipe
 
 
-def _grads_for(split, seed=0):
-    """Run one optimizer step over ``split`` micro-batches; return the accumulated grads.
+def _global_batch(splits, dp_size, seed=123):
+    """Build one global batch and the per-rank micro-batch shards over it."""
+    total = sum(splits) * dp_size
+    torch.manual_seed(seed)
+    input_ids = torch.randint(0, VOCAB, (total, SEQ))
+    labels = torch.randint(0, N_CLASSES, (total,))
+
+    shards, cursor = [], 0
+    for _ in range(dp_size):
+        rank_batches = []
+        for size in splits:
+            sl = slice(cursor, cursor + size)
+            rank_batches.append(
+                {
+                    "input_ids": input_ids[sl],
+                    "attention_mask": torch.ones_like(input_ids[sl]),
+                    "labels": labels[sl],
+                }
+            )
+            cursor += size
+        shards.append(rank_batches)
+    return input_ids, labels, shards
+
+
+def _run(splits, dp_size, seed=0):
+    """Return (DDP-averaged grads, reported loss, reference grads, reference loss).
+
+    ``_dp_allreduce`` is simulated in two phases. Every value the recipe reduces
+    (label count, token count, summed loss, accuracy) is computed from the
+    forward pass alone and never from a previous reduction, so phase one can
+    record each rank's inputs with an identity stub and phase two can replay the
+    true cross-rank sum in the same call order.
 
     Gradients are captured at ``clip_grad_norm``, which runs after the
     accumulation loop and before ``optimizer.step()`` zeroes them.
     """
     torch.manual_seed(seed)
-    model = _TinyClassifier()
-    recipe = _make_recipe(model)
+    init_state = {k: v.clone() for k, v in _TinyClassifier().state_dict().items()}
+    input_ids, labels, shards = _global_batch(splits, dp_size)
 
-    torch.manual_seed(123)
-    input_ids = torch.randint(0, VOCAB, (8, 4))
-    labels = torch.randint(0, N_CLASSES, (8,))
-
-    batches = [
-        {
-            "input_ids": input_ids[i : i + 8 // split],
-            "attention_mask": torch.ones_like(input_ids[i : i + 8 // split]),
-            "labels": labels[i : i + 8 // split],
-        }
-        for i in range(0, 8, 8 // split)
-    ]
-    assert len(batches) == split
-
-    captured = {}
-
-    def _capture(**kwargs):
-        captured["grads"] = [p.grad.detach().clone() for p in model.parameters() if p.grad is not None]
-        return torch.tensor(0.0)
-
-    with (
-        mock.patch.object(seq_cls_mod, "clip_grad_norm", _capture),
-        mock.patch.object(torch.cuda, "max_memory_allocated", lambda: 0),
-    ):
-        recipe._run_train_optim_step(batches)
-
-    assert captured["grads"], "no gradients were captured"
-    return captured["grads"]
-
-
-@pytest.mark.parametrize("split", [2, 4, 8])
-def test_gradients_are_invariant_to_microbatch_split(split):
-    """Splitting one global batch into more micro-batches must not change grads."""
-    single = _grads_for(1)
-    accumulated = _grads_for(split)
-
-    assert len(single) == len(accumulated)
-    for g_one, g_many in zip(single, accumulated):
-        ratio = (g_many.norm() / g_one.norm()).item()
-        assert torch.allclose(g_many, g_one, rtol=1e-5, atol=1e-6), (
-            f"{split} micro-batches scaled the gradient by ~{ratio:.2f}x"
-        )
-
-
-# ---------------------------------------------------------------------------
-# Data-parallel scaling
-# ---------------------------------------------------------------------------
-
-
-def _ddp_averaged_grads(dp_size, accum, per_rank_bs, seed=0):
-    """Run one step on every simulated DP rank and average the grads, as DDP does.
-
-    ``_dp_allreduce`` is a SUM across ranks, so with equally sized shards it
-    multiplies a per-rank count by ``dp_size``.
-    """
-    torch.manual_seed(seed)
-    reference = _TinyClassifier()
-    init_state = {k: v.clone() for k, v in reference.state_dict().items()}
-
-    total = dp_size * accum * per_rank_bs
-    torch.manual_seed(123)
-    input_ids = torch.randint(0, VOCAB, (total, 4))
-    labels = torch.randint(0, N_CLASSES, (total,))
-
-    per_rank_grads = []
-    for rank in range(dp_size):
+    def drive(rank_batches, allreduce):
         model = _TinyClassifier()
         model.load_state_dict(init_state)
-        recipe = _make_recipe(model)
-        recipe._get_dp_group_size = lambda include_cp=False: dp_size
-        recipe._dp_allreduce = lambda t, *a, **k: t * dp_size
-
-        batches = []
-        for a in range(accum):
-            lo = (rank * accum + a) * per_rank_bs
-            hi = lo + per_rank_bs
-            batches.append(
-                {
-                    "input_ids": input_ids[lo:hi],
-                    "attention_mask": torch.ones_like(input_ids[lo:hi]),
-                    "labels": labels[lo:hi],
-                }
-            )
-
+        recipe = _make_recipe(model, dp_size, allreduce)
         captured = {}
 
         def _capture(**kwargs):
@@ -170,34 +136,99 @@ def _ddp_averaged_grads(dp_size, accum, per_rank_bs, seed=0):
             mock.patch.object(seq_cls_mod, "clip_grad_norm", _capture),
             mock.patch.object(torch.cuda, "max_memory_allocated", lambda: 0),
         ):
-            recipe._run_train_optim_step(batches)
-        per_rank_grads.append(captured["grads"])
+            sample = recipe._run_train_optim_step(rank_batches)
+        return captured["grads"], sample
+
+    # Phase 1: record what each rank feeds into every reduction, in order.
+    recorded = []
+    for rank_batches in shards:
+        calls = []
+        drive(rank_batches, lambda t, *a, **k: (calls.append(t.detach().clone()), t)[1])
+        recorded.append(calls)
+
+    totals = [torch.stack(vals).sum(0) for vals in zip(*recorded)]
+
+    # Phase 2: replay the real cross-rank sum.
+    per_rank_grads, reported = [], []
+    for rank_batches in shards:
+        idx = {"i": 0}
+
+        def allreduce(t, *a, **k):
+            out = totals[idx["i"]]
+            idx["i"] += 1
+            return out.clone()
+
+        grads, sample = drive(rank_batches, allreduce)
+        per_rank_grads.append(grads)
+        reported.append(float(sample.metrics["loss"]))
 
     averaged = [torch.stack(g).mean(0) for g in zip(*per_rank_grads)]
 
-    # Truth: gradient of the mean loss over the entire global batch.
-    truth_model = _TinyClassifier()
-    truth_model.load_state_dict(init_state)
-    logits = truth_model(input_ids).logits
-    nn.CrossEntropyLoss()(logits, labels).backward()
-    truth = [p.grad.detach().clone() for p in truth_model.parameters() if p.grad is not None]
+    # Reference: the mean loss over the entire global batch.
+    ref_model = _TinyClassifier()
+    ref_model.load_state_dict(init_state)
+    ref_loss = F.cross_entropy(ref_model(input_ids).logits, labels, reduction="mean")
+    ref_loss.backward()
+    ref_grads = [p.grad.detach().clone() for p in ref_model.parameters() if p.grad is not None]
 
-    return averaged, truth
+    # Every rank logs the same global number, so any of them represents the step.
+    return averaged, reported[0], ref_grads, float(ref_loss)
 
 
-@pytest.mark.parametrize("dp_size,accum", [(1, 1), (1, 4), (2, 1), (2, 2), (4, 2)])
-def test_gradients_match_global_mean_across_dp_and_accumulation(dp_size, accum):
-    """The DP-averaged gradient must equal the global-mean gradient.
+# splits per rank, dp_size -- includes the uneven 3 + 1 case at several dp sizes
+CASES = [
+    ([2], 1),
+    ([2, 2], 1),
+    ([1, 1, 1, 1], 1),
+    ([3, 1], 1),
+    ([2], 2),
+    ([2, 2], 2),
+    ([3, 1], 2),
+    ([2, 2], 4),
+    ([3, 1], 4),
+]
+IDS = [f"splits={s}-dp={d}" for s, d in CASES]
 
-    `* dp_size` cancels DDP's averaging, but only reconstructs the global mean
-    when the loss is already normalized by a global denominator. Normalizing by
-    a local per-microbatch mean instead over-scaled by `dp_size * accum`.
-    """
-    averaged, truth = _ddp_averaged_grads(dp_size, accum, per_rank_bs=2)
 
-    assert len(averaged) == len(truth)
-    for g_got, g_ref in zip(averaged, truth):
-        ratio = (g_got.norm() / g_ref.norm()).item()
-        assert torch.allclose(g_got, g_ref, rtol=1e-5, atol=1e-6), (
-            f"dp_size={dp_size}, accum={accum}: gradient scaled by ~{ratio:.2f}x"
+@pytest.mark.parametrize("splits,dp_size", CASES, ids=IDS)
+def test_gradients_match_global_batch_reference(splits, dp_size):
+    """Neither the micro-batch split nor dp_size may change the gradient."""
+    got, _, ref, _ = _run(splits, dp_size)
+
+    assert len(got) == len(ref)
+    for g, r in zip(got, ref):
+        ratio = (g.norm() / r.norm()).item()
+        assert torch.allclose(g, r, rtol=1e-5, atol=1e-6), (
+            f"splits={splits}, dp={dp_size}: gradient scaled by ~{ratio:.2f}x"
         )
+
+
+@pytest.mark.parametrize("splits,dp_size", CASES, ids=IDS)
+def test_reported_loss_matches_global_batch_reference(splits, dp_size):
+    """The logged loss is the global mean, not a mean of per-micro-batch means.
+
+    A mean of means is inflated by dp_size and misweights uneven splits, so the
+    metric would disagree with the objective the gradient actually optimizes.
+    """
+    _, got, _, ref = _run(splits, dp_size)
+
+    assert got == pytest.approx(ref, rel=1e-5), (
+        f"splits={splits}, dp={dp_size}: reported {got:.4f} vs global {ref:.4f} (~{got / ref:.2f}x)"
+    )
+
+
+def test_uneven_split_differs_from_mean_of_means():
+    """Guards the guard: 3 + 1 must be a case where the two conventions disagree.
+
+    If they happened to coincide, the uneven parametrizations above would pass
+    for the wrong reason.
+    """
+    input_ids, labels, shards = _global_batch([3, 1], dp_size=1)
+    model = _TinyClassifier()
+
+    with torch.no_grad():
+        means = [F.cross_entropy(model(b["input_ids"]).logits, b["labels"]) for b in shards[0]]
+        mean_of_means = float(torch.stack(means).mean())
+        global_mean = float(F.cross_entropy(model(input_ids).logits, labels, reduction="mean"))
+
+    assert mean_of_means != pytest.approx(global_mean, rel=1e-3)


### PR DESCRIPTION
# What does this PR do ?

Puts the sequence-classification **gradient** and **reported loss** on one
normalization: the global summed loss over a DP-allreduced global label count.
Both were previously derived from per-micro-batch *means*, which cannot be added
back together.

`torch.nn.CrossEntropyLoss` reduces with `mean`, so each micro-batch loss is a
local average. Summing those averages over-counts by `grad_accumulation_steps`,
summing them across ranks over-counts by `dp_size`, and neither weights an
unevenly sized micro-batch correctly.

`* dp_size` is **not** the bug and is kept. It cancels the DDP/FSDP gradient
average — but only reconstructs the global mean when the denominator is already
global, which is exactly what `train_ft.py` does with `num_label_tokens`
(L1211-1213):

```
(1/dp) * sum_r [ dp * local_sum_r / N_global ] = global_sum / N_global   correct
(1/dp) * sum_r [ dp * local_mean_r ]           = dp x global_mean        wrong
```

## Measured against the global-batch reference

Driving the real `_run_train_optim_step` and averaging per-rank gradients as the
framework does:

| splits | dp | gradient on `main` | reported loss on `main` | after |
|---|---:|---:|---:|---:|
| `[2]` | 1 | 1.00x | 1.00x | exact |
| `[2, 2]` | 1 | 2.00x | 1.00x | exact |
| `[1,1,1,1]` | 1 | 4.00x | 1.00x | exact |
| **`[3, 1]`** | 1 | **2.69x** | **0.98x** | exact |
| `[2]` | 2 | 2.00x | **2.00x** | exact |
| `[2, 2]` | 2 | 4.00x | **2.00x** | exact |
| **`[3, 1]`** | 2 | **4.90x** | **1.96x** | exact |
| `[2, 2]` | 4 | 8.00x | **4.00x** | exact |
| **`[3, 1]`** | 4 | **11.94x** | **3.92x** | exact |

Even splits give clean integer factors (`dp x acc`). **Uneven splits give
non-integer ones** — 2.69x, 4.90x, 11.94x — because a mean of means also
misweights the shorter micro-batch. Equal splits cannot expose that, which is
why `3 + 1` is covered at every `dp_size`.

Only `splits=[2], dp=1` is correct on `main`, and that is the configuration a
single-GPU smoke test runs.

# Changelog

- **Gradient**: normalized by a DP-allreduced global label count instead of a
  local per-micro-batch mean. `loss * labels.numel()` recovers the summed loss
  from the mean `self.loss_fn` already returns, so there is no second
  cross-entropy pass and `self.loss_fn` stays authoritative.
- **Reported loss**: accumulates summed losses and divides by that same global
  count, rather than summing means and dividing by `len(batches)`.
- **Tests** (`tests/unit_tests/recipes/test_train_seq_cls_grad_accum.py`):
  gradients *and* reported loss asserted against
  `F.cross_entropy(..., reduction="mean")` over the global batch, across a
  `splits x dp_size` matrix including uneven `3 + 1` at dp 1, 2 and 4. A further
  test pins that `3 + 1` genuinely separates the two conventions, so the uneven
  cases cannot pass for the wrong reason.
- The DP average is simulated in **two phases** rather than as `value * dp_size`:
  ranks hold different data, so that shortcut is valid for counts but not for
  losses. Phase one records each rank's reduction inputs; phase two replays the
  true cross-rank sum in the same call order.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

**Verification** (CPU, no GPU needed):

- On unmodified `main`, 8 of 9 gradient cases and 5 of 9 reported-loss cases
  fail, with the factors in the table. Restoring the fix passes all 19.
- `pytest tests/unit_tests/recipes/` → 1180 passed, 12 skipped, no regressions.
  (`recipes/dllm` excluded locally: it fails to import
  `transformers.models.diffusion_gemma` on unmodified `main` too — my
  `transformers` is older than the pinned 5.12.1.)
- `ruff format` / `ruff check` clean.

**Learning rates.** The correction is not uniform: each existing run absorbed a
`dp_size x grad_acc` factor specific to its own parallelism and batch config, so
a rate tuned under one configuration will not transfer to another. I do not have
multi-GPU hardware for those experiments and can only offer the CPU invariant
tests.

# Additional Information

- Closes #3829, closes #3846
