### PR TITLE
fix(vlm): skip dense masks for compact packing backends

### DIFF
--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -1513,12 +1513,17 @@ def neat_packed_vlm_collater(
     Packs arrive with **variable lengths** (no pre-padding).  This collater:
 
     1. Pads all text tensors to a common length.
-    2. Converts the indexed ``attention_mask`` to the appropriate format:
-       - ``flash_attention_2``: keeps the indexed ``[B, S]`` mask (values
-         1, 2, … for documents, 0 for padding).  The monkey-patched
-         ``_get_unpad_data`` converts this to ``cu_seqlens`` for
-         ``flash_attn_varlen_func``.
-       - ``sdpa`` / ``eager``: converts to a 4D block-causal bool mask.
+    2. Converts the indexed ``attention_mask`` to the representation
+       ``materialize_4d_mask`` selects:
+       - True: a 4D block-causal bool mask. SDPA reads it directly;
+         HF eager consumers must convert it to an additive mask.
+       - False: the indexed ``[B, S]`` map itself (values 1, 2, … for
+         documents, 0 for padding), for consumers that recover document
+         bounds from ``_packed_seq_ids`` rather than from a mask.
+       ``attn_implementation="flash_attention_2"`` also keeps the compact map,
+       whatever ``materialize_4d_mask`` says: the monkey-patched
+       ``_get_unpad_data`` converts it to ``cu_seqlens`` for
+       ``flash_attn_varlen_func``.
     3. Concatenates media tensors across the batch dimension.
 
     **No autoregressive shift** — it was already applied during packing.
@@ -1530,13 +1535,16 @@ def neat_packed_vlm_collater(
             If ``None`` (default), pad to the longest pack in the batch.
             A fixed length avoids recompilation with ``torch.compile``
             and ensures uniform tensor shapes across steps.
-        attn_implementation: Attention backend (``"flash_attention_2"``,
-            ``"sdpa"``, or ``"eager"``).
-        materialize_4d_mask: Whether SDPA/eager packing should expand the
-            indexed ``[B, S]`` document map into a dense
-            ``[B, 1, S, S]`` block-causal mask. Context-parallel VLM paths
-            rebuild their local mask from ``_packed_seq_ids`` and set this to
-            False to avoid the quadratic allocation.
+        attn_implementation: Attention backend the batch is collated for. Only
+            ``"flash_attention_2"`` changes behaviour here, by keeping the
+            compact map; every other value defers to ``materialize_4d_mask``.
+        materialize_4d_mask: Whether packing should expand the indexed
+            ``[B, S]`` document map into a dense ``[B, 1, S, S]`` block-causal
+            mask. Callers set this to False when the consumer recovers document
+            boundaries from ``_packed_seq_ids`` instead of from the mask:
+            context-parallel paths rebuild their local mask from it, and flash
+            attention and Transformer Engine cannot use a dense mask at all.
+            False therefore also forces ``_packed_seq_ids`` to be emitted.
 
     Returns:
         Dict with batched tensors ready for model forward.

--- a/nemo_automodel/components/datasets/vlm/loader.py
+++ b/nemo_automodel/components/datasets/vlm/loader.py
@@ -150,6 +150,19 @@ class VlmDataloaderBuild:
     processor: ProcessorMixin | None
 
 
+# Attention backends the packed collater must hand the compact ``[batch, sequence]`` document map
+# instead of a dense block-causal mask, because a dense mask is not a usable input for them: flash
+# attention rebuilds ``cu_seqlens`` from the compact map (``models/common/packing.get_unpad_data``),
+# and Transformer Engine reduces any non-None mask to a padding mask and drops ``cu_seqlens``
+# (``attention/utils.preprocess_args_and_kwargs_for_attn``), so document isolation has to reach it
+# through the model instead. A ``te`` model that does not rebuild its mask from ``_packed_seq_ids``
+# cannot honour the map either way; this set is about which representation a backend can use, not
+# about whether one arrives.
+_COMPACT_MASK_BACKENDS: frozenset[str] = frozenset(
+    {"flash_attention_2", "flash_attention_3", "flash_attention_4", "te"}
+)
+
+
 @dataclass
 class VlmDataloaderConfig:
     """Typed construction config for the complete VLM input pipeline."""
@@ -295,11 +308,12 @@ class VlmDataloaderConfig:
                     max_length=self.packing.collate_max_length,
                 )
             else:
-                materialize_4d_mask = cp_size <= 1
+                materialize_4d_mask = cp_size <= 1 and packing_attn_implementation not in _COMPACT_MASK_BACKENDS
                 if not materialize_4d_mask:
                     logger.info(
-                        "Skipping the dense packed VLM attention mask at cp_size=%d; "
-                        "the CP path rebuilds it from compact document IDs",
+                        "Skipping the dense packed VLM attention mask (attn_implementation=%r, "
+                        "cp_size=%d); document boundaries travel as the compact _packed_seq_ids map",
+                        packing_attn_implementation,
                         cp_size,
                     )
                 collate_fn = partial(

--- a/nemo_automodel/components/datasets/vlm/loader.py
+++ b/nemo_automodel/components/datasets/vlm/loader.py
@@ -150,17 +150,15 @@ class VlmDataloaderBuild:
     processor: ProcessorMixin | None
 
 
-# Attention backends the packed collater must hand the compact ``[batch, sequence]`` document map
-# instead of a dense block-causal mask, because a dense mask is not a usable input for them: flash
-# attention rebuilds ``cu_seqlens`` from the compact map (``models/common/packing.get_unpad_data``),
-# and Transformer Engine reduces any non-None mask to a padding mask and drops ``cu_seqlens``
-# (``attention/utils.preprocess_args_and_kwargs_for_attn``), so document isolation has to reach it
-# through the model instead. A ``te`` model that does not rebuild its mask from ``_packed_seq_ids``
-# cannot honour the map either way; this set is about which representation a backend can use, not
-# about whether one arrives.
-_COMPACT_MASK_BACKENDS: frozenset[str] = frozenset(
-    {"flash_attention_2", "flash_attention_3", "flash_attention_4", "te"}
-)
+# Attention backends the packed collater hands the compact ``[batch, sequence]`` document map instead
+# of a dense block-causal mask: flash attention rebuilds ``cu_seqlens`` from the compact map through the
+# packing patches (``models/common/packing.get_unpad_data``), so the dense mask would never be read.
+# No other backend name belongs here. Transformer Engine reads any non-None mask as a padding mask and
+# drops ``cu_seqlens`` (``attention/utils.preprocess_args_and_kwargs_for_attn``), and a backend name is
+# not even read by a model whose attention comes from Transformers. A model that rebuilds document
+# isolation from ``_packed_seq_ids`` itself reaches the compact map through the
+# ``consumes_packed_seq_ids`` declaration on ``VlmDataloaderConfig.build`` instead.
+_COMPACT_MASK_BACKENDS: frozenset[str] = frozenset({"flash_attention_2", "flash_attention_3", "flash_attention_4"})
 
 
 @dataclass
@@ -253,6 +251,7 @@ class VlmDataloaderConfig:
         dataset_build_context: AbstractContextManager[object] | None = None,
         get_rope_index: Callable[..., object] | None = None,
         packing_attn_implementation: str | None = None,
+        consumes_packed_seq_ids: bool = False,
         pp_n_microbatches: int | None = None,
         cp_size: int = 1,
     ) -> VlmDataloaderBuild:
@@ -266,6 +265,10 @@ class VlmDataloaderConfig:
             dataset_build_context: Optional rank-ordering context used only for processor and source-dataset build.
             get_rope_index: Optional model callback used to create packed multimodal position IDs.
             packing_attn_implementation: Resolved attention backend for packed-mask construction.
+            consumes_packed_seq_ids: Declaration, read from the live model, that its active text path
+                rebuilds document isolation from ``_packed_seq_ids``. A declared consumer is handed the
+                compact map for NEAT packing at ``cp_size=1`` whatever ``packing_attn_implementation``
+                resolved to; without it only the flash-attention backends skip the dense mask.
             pp_n_microbatches: Optional pipeline microbatch count used to pre-chunk media tensors.
             cp_size: Runtime context-parallel world size. Neat-packed CP uses
                 compact document IDs instead of a dense quadratic attention mask;
@@ -308,12 +311,18 @@ class VlmDataloaderConfig:
                     max_length=self.packing.collate_max_length,
                 )
             else:
-                materialize_4d_mask = cp_size <= 1 and packing_attn_implementation not in _COMPACT_MASK_BACKENDS
+                materialize_4d_mask = (
+                    cp_size <= 1
+                    and packing_attn_implementation not in _COMPACT_MASK_BACKENDS
+                    and not consumes_packed_seq_ids
+                )
                 if not materialize_4d_mask:
                     logger.info(
                         "Skipping the dense packed VLM attention mask (attn_implementation=%r, "
-                        "cp_size=%d); document boundaries travel as the compact _packed_seq_ids map",
+                        "consumes_packed_seq_ids=%s, cp_size=%d); document boundaries travel as the compact "
+                        "_packed_seq_ids map",
                         packing_attn_implementation,
+                        consumes_packed_seq_ids,
                         cp_size,
                     )
                 collate_fn = partial(

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -803,6 +803,9 @@ class Gemma4MoETextModelBackend(nn.Module):
                 mm_token_type_ids.to(device=inputs_embeds.device),
                 dtype=inputs_embeds.dtype,
                 sliding_window=getattr(self.config, "sliding_window", None),
+                # HF eager attention adds the mask to the logits, so it must be additive; a bool
+                # mask would be read as +1/+0 and mask nothing.
+                as_additive=getattr(self.config, "_attn_implementation", None) == "eager",
                 as_block_mask=getattr(self.config, "_attn_implementation", None) == "flex_attention",
                 flex_block_size=(32, 32) if full_attention_head_dim > 256 else 128,
             )

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -1201,6 +1201,30 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
         if getattr(self.config, "tie_word_embeddings", getattr(text_config, "tie_word_embeddings", False)):
             self.lm_head.weight = self.model.language_model.embed_tokens.weight
 
+    @property
+    def consumes_packed_seq_ids(self) -> bool:
+        """Whether the active text path rebuilds document isolation from ``_packed_seq_ids`` at ``cp_size=1``.
+
+        The VLM recipe reads this once after construction and passes it to the packed dataloader, which
+        then hands this model the compact document map instead of a dense mask whatever backend name the
+        config carries: ``backend.attn`` is not read by the HF attention this model runs. True only for
+        the path this repository has numerical evidence for: the MoE text backend with the vision mask
+        rule, dispatching through HF eager or SDPA attention, where ``Gemma4MoETextModelBackend.forward``
+        rebuilds the full and sliding masks from the compact map. Every other variant would read the
+        compact map as a padding mask: the dense variant delegates to the HF forward, a causal-only text
+        config never enters the packed-mask branch, and flex attention has a mask branch but no packed
+        evidence. Reads the final text config, so it reflects the resolved dispatch key at setup time;
+        packed context parallelism is gated separately and rewrites the dispatch key itself.
+        """
+        text_model = self.model.language_model
+        text_config = text_model.config
+        return (
+            isinstance(text_model, Gemma4MoETextModelBackend)
+            and bool(getattr(text_config, "enable_moe_block", False))
+            and getattr(text_config, "use_bidirectional_attention", None) == "vision"
+            and getattr(text_config, "_attn_implementation", None) in ("eager", "sdpa")
+        )
+
     def forward(
         self,
         input_ids: torch.Tensor | None = None,

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -158,6 +158,22 @@ def _validate_cp_packing_support(
     )
 
 
+def _consumes_packed_seq_ids(model: object) -> bool:
+    """Read the live model's declaration that it rebuilds document isolation from ``_packed_seq_ids``.
+
+    Args:
+        model: The first model part, possibly behind a DDP or Megatron-FSDP wrapper that exposes the
+            wrapped model as ``module`` without proxying its attributes. No tensor inputs.
+
+    Returns:
+        True only when the unwrapped model declares exactly ``True``. A missing declaration or any other
+        value stays False, so the packed dataloader keeps the dense mask for it outside the flash-attention
+        backends.
+    """
+    model = getattr(model, "module", model)
+    return getattr(model, "consumes_packed_seq_ids", False) is True
+
+
 def _get_model_name(cfg_model):
     if cfg_model.get("pretrained_model_name_or_path", None) is not None:
         return cfg_model.pretrained_model_name_or_path
@@ -608,6 +624,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
         )
         if dataloader_config.packing is not None and dataloader_config.packing.packing_format != "thd":
             configure_packing(attn_implementation=packing_attn_implementation)
+        consumes_packed_seq_ids = _consumes_packed_seq_ids(self.model_parts[0])
         process_group = getattr(self.mesh_context, "process_group", None)
         dataset_build_context = FirstRankPerNode(group=process_group)
         with ScopedRNG(seed=self.cfg.get("seed", 42), ranked=True):
@@ -619,6 +636,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
                 dataset_build_context=dataset_build_context,
                 get_rope_index=get_rope_index,
                 packing_attn_implementation=packing_attn_implementation,
+                consumes_packed_seq_ids=consumes_packed_seq_ids,
                 pp_n_microbatches=pp_n_microbatches,
                 cp_size=self.mesh_context.cp_size,
             )

--- a/tests/unit_tests/datasets/vlm/test_vlm_loader.py
+++ b/tests/unit_tests/datasets/vlm/test_vlm_loader.py
@@ -15,6 +15,7 @@
 from dataclasses import dataclass
 
 import pytest
+import torch
 from transformers import ProcessorMixin
 
 from nemo_automodel.components.config.loader import ConfigNode
@@ -25,6 +26,7 @@ from nemo_automodel.components.datasets.vlm.collate_fns import (
 )
 from nemo_automodel.components.datasets.vlm.datasets import CordV2DatasetConfig, PreTokenizedDatasetWrapperConfig
 from nemo_automodel.components.datasets.vlm.loader import (
+    _COMPACT_MASK_BACKENDS,
     VlmCollatorConfig,
     VlmDataloaderConfig,
     VlmProcessorConfig,
@@ -58,6 +60,40 @@ class BuildContext:
 
     def __exit__(self, *_):
         self.events.append("exit")
+
+
+@pytest.fixture
+def build_packed_dataloader(monkeypatch):
+    """Build a VLM dataloader with dataset construction stubbed out, leaving collater selection real.
+
+    Dataset, pretokenization and packing are stubbed because only the collater ``build`` selects is
+    under test. Returns a callable taking ``packing=`` (defaults to a NEAT ``NeatPackConfig``) plus
+    any ``VlmDataloaderConfig.build`` keyword; the kwargs packing was built with are recorded on
+    ``.packing_kwargs``.
+    """
+    packing_kwargs = {}
+
+    def _stub_packing_build(self, dataset, **kwargs):
+        packing_kwargs.update(kwargs)
+        return dataset
+
+    monkeypatch.setattr(PreTokenizedDatasetWrapperConfig, "build", lambda self, dataset, processor: dataset)
+    monkeypatch.setattr(NeatPackConfig, "build", _stub_packing_build)
+
+    def _build(*, packing=None, **build_kwargs):
+        config = VlmDataloaderConfig(
+            dataset_config=StaticDatasetConfig([]),
+            processor_config=VlmProcessorConfig(factory=DummyProcessor),
+            pretokenization=PreTokenizedDatasetWrapperConfig(),
+            packing=NeatPackConfig() if packing is None else packing,
+            shuffle=False,
+        )
+        return config.build(
+            pretrained_model_name_or_path="unused", dp_rank=0, dp_world_size=1, batch_size=2, **build_kwargs
+        )
+
+    _build.packing_kwargs = packing_kwargs
+    return _build
 
 
 def test_recipe_config_separates_vlm_dataset_wrapper_and_packing_fields():
@@ -241,61 +277,87 @@ def test_recipe_config_resolves_nested_vlm_video_processor():
     }
 
 
-def test_vlm_dataloader_selects_thd_collater(monkeypatch):
-    processor = DummyProcessor()
-    packing_kwargs = {}
-
-    def _build_packing(self, dataset, **kwargs):
-        packing_kwargs.update(kwargs)
-        return dataset
-
-    monkeypatch.setattr(PreTokenizedDatasetWrapperConfig, "build", lambda self, dataset, processor: dataset)
-    monkeypatch.setattr(NeatPackConfig, "build", _build_packing)
-    config = VlmDataloaderConfig(
-        dataset_config=StaticDatasetConfig([]),
-        processor_config=VlmProcessorConfig(factory=lambda: processor),
-        pretokenization=PreTokenizedDatasetWrapperConfig(),
-        packing=NeatPackConfig(packing_format="thd"),
-        shuffle=False,
-    )
-
-    result = config.build(
-        pretrained_model_name_or_path="unused",
-        dp_rank=0,
-        dp_world_size=1,
-        batch_size=2,
-        cp_size=4,
-    )
+def test_vlm_dataloader_selects_thd_collater(build_packed_dataloader):
+    result = build_packed_dataloader(packing=NeatPackConfig(packing_format="thd"), cp_size=4)
 
     assert result.dataloader.collate_fn.func is packed_sequence_thd_vlm_collater
     assert result.dataloader.collate_fn.keywords == {"padding_idx": 0, "max_length": None}
-    assert packing_kwargs["cp_size"] == 4
+    assert build_packed_dataloader.packing_kwargs["cp_size"] == 4
 
 
-def test_vlm_dataloader_skips_dense_neat_packing_mask_under_cp(monkeypatch):
-    processor = DummyProcessor()
-    monkeypatch.setattr(PreTokenizedDatasetWrapperConfig, "build", lambda self, dataset, processor: dataset)
-    monkeypatch.setattr(NeatPackConfig, "build", lambda self, dataset, **kwargs: dataset)
-    config = VlmDataloaderConfig(
-        dataset_config=StaticDatasetConfig([]),
-        processor_config=VlmProcessorConfig(factory=lambda: processor),
-        pretokenization=PreTokenizedDatasetWrapperConfig(),
-        packing=NeatPackConfig(),
-        shuffle=False,
-    )
+# The value space of ``packing_attn_implementation``: every ``BackendConfig.attn`` name, every
+# Transformers dispatch key packing resolves, ``None``, and a string from neither vocabulary. Not
+# every row is reachable from a shipped VLM recipe today -- the point is that the rule is total over
+# the value space. ``None`` is reachable: the validation dataloader is built without the argument
+# (``recipes/vlm/finetune.py``). The ``cp_size=8`` rows guard behaviour that predates this change --
+# ``flash_attention_2`` there is what ``minimax_m3_vl_sft_tulu3_text_cp8_16k.yaml`` resolves to
+# through ``packed_sequence.attn_implementation`` -- while the decision this change makes is at
+# ``cp_size=1``.
+_DENSE_MASK_CASES = (
+    ("te", 1, False),
+    ("flash_attention_2", 1, False),
+    ("flash_attention_3", 1, False),
+    ("flash_attention_4", 1, False),
+    ("sdpa", 1, True),
+    ("eager", 1, True),
+    ("cudnn", 1, True),
+    ("flex", 1, True),
+    ("magi", 1, True),
+    ("tilelang", 1, True),
+    ("torch", 1, True),
+    (None, 1, True),
+    ("not-a-backend", 1, True),
+    ("te", 8, False),
+    ("sdpa", 8, False),
+    ("flash_attention_2", 8, False),
+)
 
-    result = config.build(
-        pretrained_model_name_or_path="unused",
-        dp_rank=0,
-        dp_world_size=1,
-        batch_size=2,
-        packing_attn_implementation="sdpa",
-        cp_size=32,
-    )
 
-    assert result.dataloader.collate_fn.func is neat_packed_vlm_collater
-    assert result.dataloader.collate_fn.keywords["attn_implementation"] == "sdpa"
-    assert result.dataloader.collate_fn.keywords["materialize_4d_mask"] is False
+@pytest.mark.parametrize(("attn_implementation", "cp_size", "dense"), _DENSE_MASK_CASES)
+def test_vlm_dataloader_builds_the_dense_mask_only_for_backends_that_read_it(
+    build_packed_dataloader, attn_implementation, cp_size, dense
+):
+    """Only a backend that reads the mask is handed the quadratic one.
+
+    Flash attention rebuilds ``cu_seqlens`` from the indexed ``[batch, sequence]`` document map and
+    Transformer Engine drops ``cu_seqlens`` as soon as a mask is non-None, so neither ever reads the
+    dense ``[batch, 1, sequence, sequence]`` tensor that building it costs. A backend from neither
+    vocabulary keeps the dense mask, the representation this collater has always produced for it.
+    The one-document pack below also pins the second half of the contract: whenever the dense mask
+    is skipped, the compact map has to reach the model as ``_packed_seq_ids``, because nothing else
+    carries document bounds. What the mask *contains* is the collater's own contract and is pinned
+    by ``test_collate_fns.py``; this test only decides which representation the collater is asked for.
+    """
+    result = build_packed_dataloader(packing_attn_implementation=attn_implementation, cp_size=cp_size)
+    collate_fn = result.dataloader.collate_fn
+    assert collate_fn.func is neat_packed_vlm_collater
+    assert collate_fn.keywords["attn_implementation"] == attn_implementation
+
+    # One pack holding one document: the dense mask is [1, 1, 8, 8] and the compact map is [1, 8].
+    pack = {
+        "input_ids": torch.zeros(8, dtype=torch.long),
+        "labels": torch.zeros(8, dtype=torch.long),
+        "attention_mask": torch.ones(8, dtype=torch.long),
+        "position_ids": torch.arange(8),
+    }
+    batch = collate_fn([pack])
+
+    assert batch["attention_mask"].shape == ((1, 1, 8, 8) if dense else (1, 8))
+    # One document is the case that can see this change: a multi-document pack emits
+    # ``_packed_seq_ids`` on either path, so only here does the key track the representation.
+    assert ("_packed_seq_ids" in batch) is not dense
+
+
+def test_compact_mask_backends_covers_every_flash_attention_name():
+    """Every flash-attention name packing knows about has to be in the compact-mask set.
+
+    ``datasets/`` imports nothing from ``models/``, so the set repeats those names as literals.
+    A name added to ``_FLASH_ATTN_IMPLEMENTATIONS`` alone would silently go back to receiving the
+    dense mask that flash attention cannot use.
+    """
+    from nemo_automodel.components.models.common.packing import _FLASH_ATTN_IMPLEMENTATIONS
+
+    assert set(_FLASH_ATTN_IMPLEMENTATIONS) <= _COMPACT_MASK_BACKENDS
 
 
 class _NoEosProcessor(ProcessorMixin):

--- a/tests/unit_tests/datasets/vlm/test_vlm_loader.py
+++ b/tests/unit_tests/datasets/vlm/test_vlm_loader.py
@@ -278,7 +278,10 @@ def test_recipe_config_resolves_nested_vlm_video_processor():
 
 
 def test_vlm_dataloader_selects_thd_collater(build_packed_dataloader):
-    result = build_packed_dataloader(packing=NeatPackConfig(packing_format="thd"), cp_size=4)
+    # THD carries document bounds in ``cu_seqlens``; the consumer declaration only concerns NEAT packing.
+    result = build_packed_dataloader(
+        packing=NeatPackConfig(packing_format="thd"), cp_size=4, consumes_packed_seq_ids=True
+    )
 
     assert result.dataloader.collate_fn.func is packed_sequence_thd_vlm_collater
     assert result.dataloader.collate_fn.keywords == {"padding_idx": 0, "max_length": None}
@@ -294,7 +297,7 @@ def test_vlm_dataloader_selects_thd_collater(build_packed_dataloader):
 # through ``packed_sequence.attn_implementation`` -- while the decision this change makes is at
 # ``cp_size=1``.
 _DENSE_MASK_CASES = (
-    ("te", 1, False),
+    ("te", 1, True),
     ("flash_attention_2", 1, False),
     ("flash_attention_3", 1, False),
     ("flash_attention_4", 1, False),
@@ -313,22 +316,29 @@ _DENSE_MASK_CASES = (
 )
 
 
+@pytest.mark.parametrize("consumes_packed_seq_ids", [False, True], ids=["undeclared", "declared"])
 @pytest.mark.parametrize(("attn_implementation", "cp_size", "dense"), _DENSE_MASK_CASES)
 def test_vlm_dataloader_builds_the_dense_mask_only_for_backends_that_read_it(
-    build_packed_dataloader, attn_implementation, cp_size, dense
+    build_packed_dataloader, attn_implementation, cp_size, dense, consumes_packed_seq_ids
 ):
-    """Only a backend that reads the mask is handed the quadratic one.
+    """Only the flash-attention family, or a model that declares itself a consumer, skips the quadratic mask.
 
-    Flash attention rebuilds ``cu_seqlens`` from the indexed ``[batch, sequence]`` document map and
-    Transformer Engine drops ``cu_seqlens`` as soon as a mask is non-None, so neither ever reads the
-    dense ``[batch, 1, sequence, sequence]`` tensor that building it costs. A backend from neither
-    vocabulary keeps the dense mask, the representation this collater has always produced for it.
+    Flash attention rebuilds ``cu_seqlens`` from the indexed ``[batch, sequence]`` document map, so it
+    never reads the dense ``[batch, 1, sequence, sequence]`` tensor that building it costs. Every other
+    name -- ``te`` included, since Transformer Engine reads any non-None mask as a padding mask -- keeps
+    the dense mask unless ``consumes_packed_seq_ids`` says the model rebuilds document isolation from
+    ``_packed_seq_ids`` itself, in which case the name is irrelevant (such a model may not even read it).
     The one-document pack below also pins the second half of the contract: whenever the dense mask
     is skipped, the compact map has to reach the model as ``_packed_seq_ids``, because nothing else
     carries document bounds. What the mask *contains* is the collater's own contract and is pinned
     by ``test_collate_fns.py``; this test only decides which representation the collater is asked for.
     """
-    result = build_packed_dataloader(packing_attn_implementation=attn_implementation, cp_size=cp_size)
+    result = build_packed_dataloader(
+        packing_attn_implementation=attn_implementation,
+        cp_size=cp_size,
+        consumes_packed_seq_ids=consumes_packed_seq_ids,
+    )
+    expect_dense = dense and not consumes_packed_seq_ids
     collate_fn = result.dataloader.collate_fn
     assert collate_fn.func is neat_packed_vlm_collater
     assert collate_fn.keywords["attn_implementation"] == attn_implementation
@@ -342,10 +352,10 @@ def test_vlm_dataloader_builds_the_dense_mask_only_for_backends_that_read_it(
     }
     batch = collate_fn([pack])
 
-    assert batch["attention_mask"].shape == ((1, 1, 8, 8) if dense else (1, 8))
+    assert batch["attention_mask"].shape == ((1, 1, 8, 8) if expect_dense else (1, 8))
     # One document is the case that can see this change: a multi-document pack emits
     # ``_packed_seq_ids`` on either path, so only here does the key track the representation.
-    assert ("_packed_seq_ids" in batch) is not dense
+    assert ("_packed_seq_ids" in batch) is not expect_dense
 
 
 def test_compact_mask_backends_covers_every_flash_attention_name():

--- a/tests/unit_tests/models/gemma4/test_gemma4_packed_mask_eager.py
+++ b/tests/unit_tests/models/gemma4/test_gemma4_packed_mask_eager.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A packed Gemma4-MoE batch must produce the same logits as its documents run alone.
+
+Kept out of ``test_gemma4_model.py`` -- that module is CUDA-gated at module level and this contract
+is observable on CPU -- but it reuses that module's config builder.
+"""
+
+import pytest
+import torch
+
+from nemo_automodel.components.datasets.vlm.collate_fns import neat_packed_vlm_collater
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.gemma4_moe.model import Gemma4ForConditionalGeneration
+from tests.unit_tests.models.gemma4.test_gemma4_model import _make_gemma4_config
+
+SEQ_LEN = 6
+
+
+def _tiny_moe_model(attn_implementation: str) -> Gemma4ForConditionalGeneration:
+    """Two-layer MoE Gemma4 -- one sliding, one full attention layer -- in fp32 on CPU."""
+    config = _make_gemma4_config(
+        num_hidden_layers=2,
+        layer_types=["sliding_attention", "full_attention"],
+        sliding_window=2,
+        use_bidirectional_attention="vision",
+        torch_dtype="float32",
+    )
+    config._attn_implementation = config.text_config._attn_implementation = attn_implementation
+    backend = BackendConfig(linear="torch", attn="sdpa", rms_norm="torch", experts="torch", dispatcher="torch")
+    torch.manual_seed(0)
+    model = Gemma4ForConditionalGeneration(config, backend=backend)
+    # Expert and router weights are allocated with ``torch.empty``; the production initializer fills them.
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
+    return model.eval()
+
+
+def _reference_logits(model: Gemma4ForConditionalGeneration, input_ids: torch.Tensor) -> torch.Tensor:
+    """Forward one document on its own, the result a packed forward must reproduce for it.
+
+    Args:
+        input_ids: Tensor of shape [1, document].
+
+    Returns:
+        Tensor of shape [1, document, vocab].
+    """
+    length = input_ids.shape[1]
+    with torch.no_grad():
+        return model(
+            input_ids=input_ids,
+            attention_mask=torch.ones(1, length, dtype=torch.long),
+            position_ids=torch.arange(length)[None],
+            mm_token_type_ids=torch.zeros(1, length, dtype=torch.long),
+        ).logits
+
+
+@pytest.mark.parametrize("attn_implementation", ["eager", "sdpa"])
+@pytest.mark.parametrize("doc_lengths", [(SEQ_LEN,), (3, 3)], ids=["one-doc", "two-doc"])
+def test_packed_batch_matches_documents_run_alone(attn_implementation, doc_lengths):
+    """The compact-map batch the packed VLM collater emits must not change any document's logits.
+
+    Under eager attention Transformers *adds* the mask to the logits, so the mask Gemma4 builds from
+    ``_packed_seq_ids`` has to be additive; a bool mask is read as +1/+0 and masks nothing at all.
+    """
+    model = _tiny_moe_model(attn_implementation)
+    torch.manual_seed(1)
+    input_ids = torch.randint(1, 256, (1, SEQ_LEN))
+    pack = {
+        "input_ids": input_ids[0],
+        "labels": input_ids[0],
+        "attention_mask": torch.cat([torch.full((n,), i) for i, n in enumerate(doc_lengths, start=1)]),
+        "position_ids": torch.cat([torch.arange(n) for n in doc_lengths]),
+    }
+
+    batch = neat_packed_vlm_collater([pack], max_length=SEQ_LEN, materialize_4d_mask=False)
+    batch.pop("labels")
+    assert batch["attention_mask"].shape == (1, SEQ_LEN), "expected the compact document map"
+
+    with torch.no_grad():
+        packed = model(**batch).logits
+    reference = torch.cat([_reference_logits(model, doc) for doc in input_ids.split(doc_lengths, dim=1)], dim=1)
+
+    torch.testing.assert_close(packed, reference, atol=1e-4, rtol=1e-4)

--- a/tests/unit_tests/models/gemma4/test_gemma4_packed_mask_eager.py
+++ b/tests/unit_tests/models/gemma4/test_gemma4_packed_mask_eager.py
@@ -29,19 +29,32 @@ from tests.unit_tests.models.gemma4.test_gemma4_model import _make_gemma4_config
 SEQ_LEN = 6
 
 
-def _tiny_moe_model(attn_implementation: str) -> Gemma4ForConditionalGeneration:
-    """Two-layer MoE Gemma4 -- one sliding, one full attention layer -- in fp32 on CPU."""
+_BACKEND = BackendConfig(linear="torch", attn="sdpa", rms_norm="torch", experts="torch", dispatcher="torch")
+
+
+def _tiny_config(attn_implementation: str, **text_overrides):
+    """Two-layer Gemma4 config -- one sliding, one full attention layer -- in fp32.
+
+    Defaults to the MoE variant with the vision mask rule; ``text_overrides`` select the other variants.
+    """
     config = _make_gemma4_config(
-        num_hidden_layers=2,
-        layer_types=["sliding_attention", "full_attention"],
-        sliding_window=2,
-        use_bidirectional_attention="vision",
-        torch_dtype="float32",
+        **{
+            "num_hidden_layers": 2,
+            "layer_types": ["sliding_attention", "full_attention"],
+            "sliding_window": 2,
+            "use_bidirectional_attention": "vision",
+            "torch_dtype": "float32",
+            **text_overrides,
+        }
     )
     config._attn_implementation = config.text_config._attn_implementation = attn_implementation
-    backend = BackendConfig(linear="torch", attn="sdpa", rms_norm="torch", experts="torch", dispatcher="torch")
+    return config
+
+
+def _tiny_moe_model(attn_implementation: str) -> Gemma4ForConditionalGeneration:
+    """Two-layer MoE Gemma4 -- one sliding, one full attention layer -- in fp32 on CPU."""
     torch.manual_seed(0)
-    model = Gemma4ForConditionalGeneration(config, backend=backend)
+    model = Gemma4ForConditionalGeneration(_tiny_config(attn_implementation), backend=_BACKEND)
     # Expert and router weights are allocated with ``torch.empty``; the production initializer fills them.
     model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
     return model.eval()
@@ -93,3 +106,25 @@ def test_packed_batch_matches_documents_run_alone(attn_implementation, doc_lengt
     reference = torch.cat([_reference_logits(model, doc) for doc in input_ids.split(doc_lengths, dim=1)], dim=1)
 
     torch.testing.assert_close(packed, reference, atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.parametrize(
+    ("attn_implementation", "text_overrides", "expected"),
+    [
+        ("eager", {}, True),
+        ("sdpa", {}, True),
+        ("flex_attention", {}, False),
+        ("eager", {"use_bidirectional_attention": None}, False),
+        ("eager", {"enable_moe_block": False}, False),
+    ],
+    ids=["moe-vision-eager", "moe-vision-sdpa", "moe-vision-flex", "moe-causal-only-eager", "dense-vision-eager"],
+)
+def test_consumes_packed_seq_ids_follows_the_active_text_path(attn_implementation, text_overrides, expected):
+    """The declaration that gets this model the compact map must track the path that really rebuilds masks
+    from it: the MoE text backend with the vision mask rule, dispatching through HF eager or SDPA, which the
+    test above gives numerical evidence for. Flex attention has a mask branch but no packed evidence; a
+    causal-only text config never enters that branch and the dense variant delegates to the HF forward, so
+    both would read the compact map as a padding mask."""
+    model = Gemma4ForConditionalGeneration(_tiny_config(attn_implementation, **text_overrides), backend=_BACKEND)
+
+    assert model.consumes_packed_seq_ids is expected

--- a/tests/unit_tests/recipes/test_finetune_vlm_cp_wiring.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_cp_wiring.py
@@ -576,6 +576,26 @@ def test_setup_always_stages_pp_media_under_pp(
     assert dataloader_calls[0]["cp_size"] == cp_size
 
 
+@pytest.mark.parametrize(
+    ("stage0", "expected"),
+    [
+        (SimpleNamespace(consumes_packed_seq_ids=True), True),
+        (SimpleNamespace(consumes_packed_seq_ids=lambda: True), False),
+        (_StageWithoutCPPrepare(), False),
+        (SimpleNamespace(module=SimpleNamespace(consumes_packed_seq_ids=True)), True),
+    ],
+    ids=["declares", "callable-is-not-a-declaration", "silent", "wrapped-declares"],
+)
+def test_setup_hands_the_training_dataloader_the_consumer_declaration(monkeypatch, stage0, expected):
+    """Only an explicit ``True`` on the first model part, unwrapped from a DDP-shaped ``module``, reaches
+    the training ``build``; anything else is passed ``False`` and keeps the dense mask."""
+    dataloader_calls = []
+    _patch_pp_setup_minimals(monkeypatch, cp_size=1, stage0=stage0, dataloader_calls=dataloader_calls)
+    FinetuneRecipeForVLM(_minimal_pp_setup_cfg()).setup()
+
+    assert dataloader_calls[0]["consumes_packed_seq_ids"] is expected
+
+
 # -----------------------------------------------------------------------------
 # val-side wiring (the bug-fix territory)
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
# What does this PR do ?

Skip redundant CPU dense-mask allocation and mask transfers for NEAT VLM packing at
`cp_size=1` when the attention path can consume compact document boundaries.

`VlmDataloaderConfig.build` selects compact `[B, S]` document maps for the existing
`flash_attention_2/3/4` packing integration, or when the model declares
`consumes_packed_seq_ids=True`, regardless of the resolved backend label.
Gemma4-MoE opts in for its vision-aware HF eager/SDPA text path, which rebuilds
full and sliding attention masks from `_packed_seq_ids`.

**Collator benchmark (dense → compact)**

Original measurements retained from this PR: PyTorch 2.10.0+cu130, one CPU thread,
and two synthetic text documents per pack. Each case ran in a separate process.
Collate times are medians of five calls after warm-up; H2D times are medians of
five synchronized copies of the pinned mask.

| Batch × tokens | Collate (ms) | Peak host RSS increase | Mask H2D (ms) |
|---|---:|---:|---:|
| 1 × 3072 | 30.65 → 0.02 | 53.0 → 0.02 MiB | 0.30 → 0.02 |
| 4 × 16384 | 3766 → 0.45 | 3.25 GiB → 0.5 MiB | 19.34 → 0.03 |

The benchmark directly toggled the collator's `materialize_4d_mask` with its
`te` setting. It measured collation and mask copies; it did not run a TE attention
kernel or the model. The consumer-declaration change adds no new performance
measurements. Gemma4 still builds quadratic full/sliding masks on the GPU;
compact inputs do not imply varlen execution or linear GPU memory use.

# Changelog

- Select compact masks through the existing FA packing integration or a model's
  explicit consumer declaration. `_COMPACT_MASK_BACKENDS` contains only FA2/3/4;
  `te` alone does not select compact inputs.
- Add Gemma4's declaration for the active MoE text implementation with
  `enable_moe_block=True`, `use_bidirectional_attention="vision"`, and actual
  HF eager/SDPA dispatch. The shipped Gemma4 26B packing recipe uses HF attention
  despite its `backend.attn: te` label, and receives compact maps through this declaration.
- Read the live model's declaration once in training setup, unwrap one `.module`
  wrapper, and pass a strict boolean to the dataloader's runtime build argument.
- Select the collator mode that also emits `_packed_seq_ids` for single-document
  packs, preserving Gemma4-MoE's sliding-window mask reconstruction.
- Build additive packed masks for Gemma4-MoE eager attention, which adds the mask
  to attention logits; a boolean mask would add `+1/+0` without blocking attention.

# Before your PR is "Ready for review"

- [x] Followed the contributor guidelines.
- [x] Added regression tests.
- [x] Updated the collator documentation.

## TEST

- `pytest -q tests/unit_tests/datasets/vlm/test_vlm_loader.py tests/unit_tests/models/gemma4/test_gemma4_packed_mask_eager.py tests/unit_tests/recipes/test_finetune_vlm_cp_wiring.py`: 78 passed (CPU).
- `ruff format --check` / `ruff check` on `nemo_automodel/components/datasets/vlm/loader.py`, `nemo_automodel/components/models/gemma4_moe/model.py`, `nemo_automodel/recipes/vlm/finetune.py`: passed.

# Additional Information

For CP=1 NEAT packing, non-FA models without a consumer declaration retain their
pre-PR dense input path, including those configured with `te`. This preserves
the old path's limitations: it adds no packing support for those models, no
setup-time rejection, and no guarantee that every TE integration fails on its
first forward.

The declaration is wired into training setup only. Validation dataloader wiring,
CP>1 handling, THD packing, non-packed inputs, and example YAML configurations
remain unchanged.
