### PR TITLE
cp: `fix(checkpoint): 3824` into `r0.6.0`

### DIFF
--- a/nemo_automodel/components/checkpoint/_torch_backports.py
+++ b/nemo_automodel/components/checkpoint/_torch_backports.py
@@ -58,7 +58,12 @@ def apply_patches() -> None:
 def apply_async_checkpoint_patch() -> None:
     """
     Apply stabilization patch for torch.distributed.checkpoint async process executor.
-    This serializes creation of the global background process across concurrent async_save calls.
+
+    This serializes creation of the global background process across concurrent
+    async_save calls and makes its first initialization synchronous. PyTorch
+    otherwise checks for the process on the caller thread but assigns it later on
+    a worker thread, allowing consecutive distributed saves to disagree across
+    ranks about whether process-group initialization is required.
     """
     try:
         ape_mod = importlib.import_module("torch.distributed.checkpoint._async_process_executor")
@@ -85,6 +90,30 @@ def apply_async_checkpoint_patch() -> None:
             except Exception:
                 # Defensive: if staticmethod replacement fails, leave as-is
                 logger.debug("Failed to assign locked _execute_save_impl", exc_info=True)
+
+        ProcessGroupInitInfo = getattr(ape_mod, "_ProcessGroupInitInfo", None)
+        AsyncCheckpointProcess = getattr(ape_mod, "_AsyncCheckpointProcess", None)
+        if (
+            Exec is not None
+            and ProcessGroupInitInfo is not None
+            and AsyncCheckpointProcess is not None
+            and not hasattr(Exec, "_nemo_orig_execute_save")
+        ):
+            Exec._nemo_orig_execute_save = Exec.execute_save
+
+            def _nemo_initialize_checkpoint_process(self, *args, **kwargs):
+                with ape_mod._NEMO_CREATE_LOCK:
+                    if ape_mod._CHECKPOINT_PROCESS is None:
+                        pg_init_info = ProcessGroupInitInfo(kwargs.get("process_group"))
+                        ape_mod._CHECKPOINT_PROCESS = AsyncCheckpointProcess(pg_init_info=pg_init_info)
+                return Exec._nemo_orig_execute_save(self, *args, **kwargs)
+
+            try:
+                Exec.execute_save = _nemo_initialize_checkpoint_process
+                logger.debug("Applied synchronous initialization patch to DCP process executor")
+            except Exception:
+                # Defensive: if method replacement fails, leave as-is
+                logger.debug("Failed to assign patched execute_save", exc_info=True)
 
         ape_mod._NEMO_PATCHED_CREATE_LOCK = True
     except ModuleNotFoundError:

--- a/tests/unit_tests/checkpoint/test_torch_backports.py
+++ b/tests/unit_tests/checkpoint/test_torch_backports.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import Future
+from types import SimpleNamespace
+
+import pytest
+
+from nemo_automodel.components.checkpoint import _torch_backports
+
+
+def test_async_checkpoint_patch_initializes_daemon_before_save(monkeypatch: pytest.MonkeyPatch) -> None:
+    call_order: list[str] = []
+    expected_process_group = object()
+    save_future: Future[None] = Future()
+
+    class FakeProcessGroupInitInfo:
+        def __init__(self, received_process_group: object) -> None:
+            assert received_process_group is expected_process_group
+            call_order.append("process_group_info")
+
+    class FakeAsyncCheckpointProcess:
+        def __init__(self, *, pg_init_info: FakeProcessGroupInitInfo) -> None:
+            assert isinstance(pg_init_info, FakeProcessGroupInitInfo)
+            call_order.append("checkpoint_process")
+
+    class FakeExecutor:
+        @staticmethod
+        def _execute_save_impl() -> None:
+            return None
+
+        def execute_save(self, *, process_group: object) -> Future[None]:
+            assert process_group is expected_process_group
+            assert async_process_executor._CHECKPOINT_PROCESS is not None
+            call_order.append("execute_save")
+            return save_future
+
+    async_process_executor = SimpleNamespace(
+        _CHECKPOINT_PROCESS=None,
+        _ProcessGroupInitInfo=FakeProcessGroupInitInfo,
+        _AsyncCheckpointProcess=FakeAsyncCheckpointProcess,
+        _ProcessBasedAsyncCheckpointExecutor=FakeExecutor,
+    )
+    monkeypatch.setattr(
+        _torch_backports.importlib,
+        "import_module",
+        lambda _: async_process_executor,
+    )
+    _torch_backports.apply_async_checkpoint_patch()
+
+    assert FakeExecutor().execute_save(process_group=expected_process_group) is save_future
+    assert not save_future.done()
+    assert call_order == ["process_group_info", "checkpoint_process", "execute_save"]
+
+
+def test_async_checkpoint_patch_propagates_initialization_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    initialization_error = RuntimeError("daemon initialization failed")
+    original_called = False
+    save_future: Future[None] = Future()
+
+    class FakeProcessGroupInitInfo:
+        def __init__(self, process_group: object | None) -> None:
+            assert process_group is None
+
+    class FakeAsyncCheckpointProcess:
+        def __init__(self, *, pg_init_info: FakeProcessGroupInitInfo) -> None:
+            raise initialization_error
+
+    class FakeExecutor:
+        @staticmethod
+        def _execute_save_impl() -> None:
+            return None
+
+        def execute_save(self) -> Future[None]:
+            nonlocal original_called
+            original_called = True
+            return save_future
+
+    async_process_executor = SimpleNamespace(
+        _CHECKPOINT_PROCESS=None,
+        _ProcessGroupInitInfo=FakeProcessGroupInitInfo,
+        _AsyncCheckpointProcess=FakeAsyncCheckpointProcess,
+        _ProcessBasedAsyncCheckpointExecutor=FakeExecutor,
+    )
+    monkeypatch.setattr(
+        _torch_backports.importlib,
+        "import_module",
+        lambda _: async_process_executor,
+    )
+    _torch_backports.apply_async_checkpoint_patch()
+
+    with pytest.raises(RuntimeError, match="daemon initialization failed"):
+        FakeExecutor().execute_save()
+    assert not original_called
+
+
+def test_async_checkpoint_patch_initializes_daemon_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    initialization_started = threading.Event()
+    finish_initialization = threading.Event()
+    save_future: Future[None] = Future()
+    initialization_count = 0
+    returned_futures: list[Future[None]] = []
+
+    class FakeProcessGroupInitInfo:
+        def __init__(self, process_group: object | None) -> None:
+            assert process_group is None
+
+    class FakeAsyncCheckpointProcess:
+        def __init__(self, *, pg_init_info: FakeProcessGroupInitInfo) -> None:
+            nonlocal initialization_count
+            initialization_count += 1
+            initialization_started.set()
+            assert finish_initialization.wait(timeout=1)
+
+    class FakeExecutor:
+        @staticmethod
+        def _execute_save_impl() -> None:
+            return None
+
+        def execute_save(self) -> Future[None]:
+            return save_future
+
+    async_process_executor = SimpleNamespace(
+        _CHECKPOINT_PROCESS=None,
+        _ProcessGroupInitInfo=FakeProcessGroupInitInfo,
+        _AsyncCheckpointProcess=FakeAsyncCheckpointProcess,
+        _ProcessBasedAsyncCheckpointExecutor=FakeExecutor,
+    )
+    monkeypatch.setattr(
+        _torch_backports.importlib,
+        "import_module",
+        lambda _: async_process_executor,
+    )
+    _torch_backports.apply_async_checkpoint_patch()
+
+    def call_patched_execute_save() -> None:
+        returned_futures.append(FakeExecutor().execute_save())
+
+    callers = [threading.Thread(target=call_patched_execute_save) for _ in range(2)]
+    for caller in callers:
+        caller.start()
+    try:
+        assert initialization_started.wait(timeout=1)
+    finally:
+        finish_initialization.set()
+        for caller in callers:
+            caller.join(timeout=1)
+
+    assert initialization_count == 1
+    assert returned_futures == [save_future, save_future]
+    assert async_process_executor._CHECKPOINT_PROCESS is not None


### PR DESCRIPTION
Cherry-pick of #3824 into `r0.6.0`.

# What does this PR do ?

Prevents consecutive process-based async checkpoint saves from taking different daemon-initialization collective paths across ranks.

PyTorch checks `_CHECKPOINT_PROCESS` on the caller thread but assigns it later on a worker thread. AutoModel submits model and optimizer checkpoints consecutively, so rank-local worker scheduling can cause some ranks to skip the optimizer initialization broadcast while other ranks enter it. This leaves the two rank sets waiting in different collectives.

This downstream stabilization makes only the first daemon initialization synchronous. Checkpoint staging and upload remain asynchronous.

# Changelog

- Wrap the process executor's first `execute_save()` call so it returns only after the rank-local checkpoint daemon has been assigned.
- Propagate daemon initialization failures instead of waiting indefinitely.
- Preserve the existing local creation lock and asynchronous checkpoint upload behavior.
- Add focused unit coverage for initialization waiting and failure propagation.

# Validation

- Cherry-pick applied cleanly with `git cherry-pick -x`; both touched files are byte-identical to `main` after the pick.
- Validation performed on the original PR: `ruff check` / `ruff format --check` clean, and `pytest tests/unit_tests/checkpoint/` passed (369 passed, 19 skipped).
