### PR TITLE
fix: preserve Nemotron router state during HF load

### DIFF
--- a/nemo_automodel/_transformers/model_init.py
+++ b/nemo_automodel/_transformers/model_init.py
@@ -80,6 +80,8 @@ logger = logging.getLogger(__name__)
 # Thread-local: when True, HF's get_init_context must not add torch.device("meta")
 # so that model init runs on real device (used when retrying after "Cannot copy out of meta tensor").
 _hf_meta_device_disabled = threading.local()
+_hf_fp32_contract = threading.local()
+_hf_fp32_contract_lock = threading.RLock()
 
 
 def _get_hf_meta_device_disabled():
@@ -102,12 +104,38 @@ def _filter_meta_device_from_init_context(contexts):
     return [c for c in contexts if not (isinstance(c, torch.device) and getattr(c, "type", None) == "meta")]
 
 
+@contextmanager
+def _apply_hf_fp32_contract(model_cls: type, module_names: tuple[str, ...]):
+    """Temporarily apply an FP32 contract to the concrete class selected by HF."""
+    attr = "_keep_in_fp32_modules_strict"
+    with _hf_fp32_contract_lock:
+        if not module_names:
+            yield
+            return
+
+        # ``__dict__`` distinguishes a class-owned value from an inherited one,
+        # which lets us restore Python's original MRO behavior exactly.
+        had_own_attr = attr in model_cls.__dict__
+        previous = model_cls.__dict__.get(attr)
+        inherited = getattr(model_cls, attr, None)
+        setattr(model_cls, attr, set(inherited or ()) | set(module_names))
+        try:
+            yield
+        finally:
+            if had_own_attr:
+                setattr(model_cls, attr, previous)
+            else:
+                delattr(model_cls, attr)
+
+
 def _patched_get_init_context(cls, *args, **kwargs):
     """Wrapper around PreTrainedModel.get_init_context that strips meta device when requested."""
     original = _patched_get_init_context.__wrapped__
     contexts = original(cls, *args, **kwargs)
     if _get_hf_meta_device_disabled():
-        return _filter_meta_device_from_init_context(contexts)
+        contexts = _filter_meta_device_from_init_context(contexts)
+    module_names = getattr(_hf_fp32_contract, "module_names", ())
+    contexts.append(_apply_hf_fp32_contract(cls, module_names))
     return contexts
 
 
@@ -255,6 +283,39 @@ def _resolve_custom_model_cls_for_config(config):
         return None
 
     return ModelRegistry.resolve_custom_model_cls(arch_name, config)
+
+
+@contextmanager
+def _keep_model_owned_hf_modules_in_fp32(hf_config: object):
+    """Request a model-specific strict FP32 contract during an HF load.
+
+    The request is thread-local. The patched ``get_init_context`` receives the
+    concrete class selected by Transformers, including trust-remote-code model
+    classes, and applies the contract only while that class is constructed.
+    ``post_init`` copies the class contract onto the instance before checkpoint
+    materialization creates the dtype plan.
+
+    Args:
+        hf_config: Hugging Face config used to select the model-owned contract.
+
+    Yields:
+        Control while the model-owned strict FP32 contract is active.
+    """
+    module_names = ModelRegistry.get_force_hf_fp32_module_names(hf_config)
+    if not module_names:
+        yield
+        return
+
+    had_previous = hasattr(_hf_fp32_contract, "module_names")
+    previous = getattr(_hf_fp32_contract, "module_names", ())
+    _hf_fp32_contract.module_names = tuple(dict.fromkeys((*previous, *module_names)))
+    try:
+        yield
+    finally:
+        if had_previous:
+            _hf_fp32_contract.module_names = previous
+        else:
+            del _hf_fp32_contract.module_names
 
 
 def _load_registered_custom_config(pretrained_model_name_or_path, attn_implementation, **kwargs):
@@ -1235,14 +1296,15 @@ def __init_model(
             kwargs["quantization_config"] = quantization_config
             _setup_bnb_loading_kwargs(kwargs)
         if is_pretrained_init:
-            with skip_random_init():
-                model = cls._from_pretrained_parent_class(
-                    pretrained_model_name_or_path,
-                    *model_args,
-                    torch_dtype=torch_dtype,
-                    attn_implementation=attn_implementation,
-                    **kwargs,
-                )
+            with _keep_model_owned_hf_modules_in_fp32(hf_config):
+                with skip_random_init():
+                    model = cls._from_pretrained_parent_class(
+                        pretrained_model_name_or_path,
+                        *model_args,
+                        torch_dtype=torch_dtype,
+                        attn_implementation=attn_implementation,
+                        **kwargs,
+                    )
             if restore_loaded_dtype:
                 _restore_loaded_model_dtype(
                     model,

--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -333,6 +333,15 @@ MODEL_ARCH_MAPPING = OrderedDict(
     ]
 )
 
+# Optional architecture-owned metadata used by the vanilla-HF loading path.
+# Implementation details live in each model package and are imported lazily.
+FORCE_HF_FP32_CONTRACT_MAPPING: Dict[str, Tuple[str, str]] = {
+    "NemotronHForCausalLM": (
+        "nemo_automodel.components.models.nemotron_v3.fp32_contract",
+        "get_force_hf_fp32_module_names",
+    ),
+}
+
 
 # Custom model_type → config class for models that have auto_map in their
 # checkpoint config.json.  Registered eagerly with AutoConfig so that
@@ -556,6 +565,18 @@ class _ModelRegistry:
     def has_retrieval_model(self, arch_name: str) -> bool:
         """Return ``True`` if *arch_name* is a registered retrieval/encoder architecture."""
         return arch_name in self._retrieval_archs
+
+    def get_force_hf_fp32_module_names(self, config: object) -> tuple[str, ...]:
+        """Resolve an architecture-owned FP32 contract for vanilla-HF loading."""
+        architectures = getattr(config, "architectures", None) or ()
+        for architecture in architectures:
+            registration = FORCE_HF_FP32_CONTRACT_MAPPING.get(architecture)
+            if registration is None:
+                continue
+            module_path, function_name = registration
+            function = getattr(importlib.import_module(module_path), function_name)
+            return tuple(function(config))
+        return ()
 
     def register_retrieval(self, arch_name: str) -> None:
         """Mark *arch_name* as a retrieval/encoder architecture."""

--- a/nemo_automodel/components/models/nemotron_v3/fp32_contract.py
+++ b/nemo_automodel/components/models/nemotron_v3/fp32_contract.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Nemotron V3 state that must retain FP32 values in the vanilla-HF layout."""
+
+_FORCE_HF_FP32_MODULE_NAMES = ("e_score_correction_bias",)
+
+
+def get_force_hf_fp32_module_names(hf_config: object) -> tuple[str, ...]:
+    """Return HF-visible FP32 state names for a Nemotron-H checkpoint."""
+    architectures = getattr(hf_config, "architectures", None) or ()
+    if "NemotronHForCausalLM" not in architectures:
+        return ()
+    return _FORCE_HF_FP32_MODULE_NAMES

--- a/tests/unit_tests/_transformers/test_auto_model.py
+++ b/tests/unit_tests/_transformers/test_auto_model.py
@@ -35,10 +35,12 @@ from nemo_automodel._transformers.auto_model import (
 )
 from nemo_automodel._transformers.infrastructure import _apply_peft_and_lower_precision, instantiate_infrastructure
 from nemo_automodel._transformers.model_init import (
+    _apply_hf_fp32_contract,
     _filter_kwargs_for_init,
     _filter_meta_device_from_init_context,
     _get_hf_meta_device_disabled,
     _get_mixin_wrapped_class,
+    _keep_model_owned_hf_modules_in_fp32,
     _patched_get_init_context,
     no_hf_meta_device,
 )
@@ -1222,6 +1224,163 @@ class TestModelMappingKeyErrorFallback:
         assert fake_model.linear.weight.dtype == torch.bfloat16
         # promote(fp32, bf16) == fp32 -> intrinsically-fp32 checkpoint param survives.
         assert fake_model.norm.weight.dtype == torch.float32
+
+    def test_force_hf_pretrained_preserves_model_owned_fp32_value_when_dtype_inspection_fails(self, tmp_path):
+        """The model-owned FP32 contract protects values during the initial Hugging Face load."""
+        from transformers import PretrainedConfig, PreTrainedModel
+
+        from nemo_automodel.components.models.common.utils import cast_frozen_modules_to_compute_dtype
+
+        class TinyConfig(PretrainedConfig):
+            model_type = "force-hf-fp32-contract-test"
+
+        class TinyHFModel(PreTrainedModel):
+            config_class = TinyConfig
+            _keep_in_fp32_modules_strict = ["existing_fp32_state"]
+
+            def __init__(self, config):
+                super().__init__(config)
+                self.router = torch.nn.Linear(2, 2, bias=False)
+                self.router.weight.requires_grad_(False)
+                self.router.register_buffer(
+                    "e_score_correction_bias",
+                    torch.tensor([36.6368637, 37.9461441], dtype=torch.float32),
+                )
+                self.post_init()
+
+        config = TinyConfig()
+        reference_model = TinyHFModel(config)
+        expected_bias = reference_model.router.e_score_correction_bias.detach().clone()
+        reference_model.save_pretrained(tmp_path)
+        previous_contract = TinyHFModel._keep_in_fp32_modules_strict
+
+        cls = self._make_cls({TinyConfig: TinyHFModel})
+        cls._from_pretrained_parent_class = MagicMock(side_effect=TinyHFModel.from_pretrained)
+
+        with (
+            patch("nemo_automodel._transformers.model_init.get_hf_config", return_value=config),
+            patch(
+                "nemo_automodel._transformers.model_init.ModelRegistry.get_force_hf_fp32_module_names",
+                return_value=("e_score_correction_bias",),
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.utils._get_checkpoint_tensor_dtypes",
+                side_effect=FileNotFoundError("simulated incomplete cache"),
+            ),
+            patch(
+                "nemo_automodel._transformers.model_init._get_mixin_wrapped_class",
+                return_value=TinyHFModel,
+            ),
+        ):
+            _, model = _init_model(
+                cls,
+                str(tmp_path),
+                attn_implementation="eager",
+                torch_dtype=torch.bfloat16,
+                quantization_config=None,
+                force_hf=True,
+            )
+
+        cast_frozen_modules_to_compute_dtype(model, torch.bfloat16)
+
+        actual_bias = model.router.e_score_correction_bias
+        assert actual_bias.dtype == torch.float32
+        assert torch.equal(actual_bias, expected_bias)
+        assert model._keep_in_fp32_modules_strict == {
+            "existing_fp32_state",
+            "e_score_correction_bias",
+        }
+        assert TinyHFModel._keep_in_fp32_modules_strict is previous_contract
+
+    def test_force_hf_fp32_contract_restores_target_class_after_exception(self):
+        class TinyHFModel:
+            _keep_in_fp32_modules_strict = ["existing_fp32_state"]
+
+        previous_contract = TinyHFModel._keep_in_fp32_modules_strict
+
+        with pytest.raises(RuntimeError, match="load failed"):
+            with _apply_hf_fp32_contract(TinyHFModel, ("e_score_correction_bias",)):
+                assert TinyHFModel._keep_in_fp32_modules_strict == {
+                    "existing_fp32_state",
+                    "e_score_correction_bias",
+                }
+                raise RuntimeError("load failed")
+
+        assert TinyHFModel._keep_in_fp32_modules_strict is previous_contract
+
+    def test_force_hf_fp32_contract_applies_to_trust_remote_code_class(self, tmp_path):
+        """The contract reaches the concrete class selected from a remote auto_map."""
+        import json
+
+        from safetensors.torch import save_file
+        from transformers import AutoConfig, AutoModelForCausalLM
+
+        (tmp_path / "configuration_tiny.py").write_text(
+            """from transformers import PretrainedConfig
+
+
+class TinyRemoteConfig(PretrainedConfig):
+    model_type = \"tiny_remote_fp32\"
+"""
+        )
+        (tmp_path / "modeling_tiny.py").write_text(
+            """import torch
+from transformers import PreTrainedModel
+
+from .configuration_tiny import TinyRemoteConfig
+
+
+class TinyRemoteForCausalLM(PreTrainedModel):
+    config_class = TinyRemoteConfig
+    _keep_in_fp32_modules_strict = [\"existing_fp32_state\"]
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.router = torch.nn.Linear(2, 2, bias=False)
+        self.router.register_buffer(
+            \"e_score_correction_bias\",
+            torch.zeros(2, dtype=torch.float32),
+        )
+        self.post_init()
+"""
+        )
+        config_dict = {
+            "architectures": ["NemotronHForCausalLM"],
+            "auto_map": {
+                "AutoConfig": "configuration_tiny.TinyRemoteConfig",
+                "AutoModelForCausalLM": "modeling_tiny.TinyRemoteForCausalLM",
+            },
+            "model_type": "tiny_remote_fp32",
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config_dict))
+
+        expected_bias = torch.tensor([36.6368637, 37.9461441], dtype=torch.float32)
+        save_file(
+            {
+                "router.weight": torch.zeros((2, 2), dtype=torch.float32),
+                "router.e_score_correction_bias": expected_bias,
+            },
+            tmp_path / "model.safetensors",
+            metadata={"format": "pt"},
+        )
+
+        config = AutoConfig.from_pretrained(tmp_path, trust_remote_code=True)
+        with _keep_model_owned_hf_modules_in_fp32(config):
+            model = AutoModelForCausalLM.from_pretrained(
+                tmp_path,
+                config=config,
+                trust_remote_code=True,
+                dtype=torch.bfloat16,
+            )
+
+        actual_bias = model.router.e_score_correction_bias
+        assert actual_bias.dtype == torch.float32
+        assert torch.equal(actual_bias, expected_bias)
+        assert model._keep_in_fp32_modules_strict == {
+            "existing_fp32_state",
+            "e_score_correction_bias",
+        }
+        assert type(model).__dict__["_keep_in_fp32_modules_strict"] == ["existing_fp32_state"]
 
     def test_fallback_path_known_config_type(self):
         """Fallback (non-force_hf, no custom model) path: _model_mapping succeeds."""

--- a/tests/unit_tests/components/models/nemotron_v3/test_fp32_contract.py
+++ b/tests/unit_tests/components/models/nemotron_v3/test_fp32_contract.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import types
+
+from nemo_automodel.components.models.nemotron_v3.fp32_contract import get_force_hf_fp32_module_names
+
+
+def test_force_hf_fp32_module_names_are_nemotron_specific():
+    nemotron_config = types.SimpleNamespace(architectures=["NemotronHForCausalLM"])
+    other_config = types.SimpleNamespace(architectures=["OtherForCausalLM"])
+
+    assert get_force_hf_fp32_module_names(nemotron_config) == ("e_score_correction_bias",)
+    assert get_force_hf_fp32_module_names(other_config) == ()


### PR DESCRIPTION
# What does this PR do ?

Preserves Nemotron V3's inference-critical `e_score_correction_bias` in FP32 during Hugging Face `from_pretrained` loads used by `force_hf=true`.

Nemotron V3 creates this MoE router buffer in FP32 and adds it to routing scores immediately before top-k expert selection. The force-HF path could materialize it in BF16 before Automodel's post-load dtype restoration. If checkpoint-dtype inspection later failed, upcasting the buffer restored its dtype but not values already rounded during the initial load.

This change requests the Nemotron-specific FP32 contract before checkpoint materialization. A thread-local request is applied from Transformers' `get_init_context` hook to the concrete class actually selected by Hugging Face, including `trust_remote_code` classes. `post_init` copies the contract onto the model instance before Hugging Face builds its dtype plan, and the class state is restored after construction.

# Changelog

- Keep the HF-visible Nemotron router-bias contract in the Nemotron V3 component.
- Resolve model-owned force-HF contracts lazily through `ModelRegistry` instead of coupling the shared loader to Nemotron.
- Apply it to the actual local or trust-remote-code model class during construction.
- Serialize patched model construction so another thread cannot observe partially modified class state.
- Add exact-value tests for the force-HF path, dynamic `auto_map` dispatch, and class-state cleanup.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? No user-facing API or configuration changes require documentation.

# Validation

Checks run on commit `0cf5b67a`:

- Ruff format and lint on all five changed files
- Python syntax compilation on all five changed files
- `git diff --check`

The focused tests cover:

- exact FP32 checkpoint-value preservation when post-load dtype inspection fails;
- a local `auto_map` + `trust_remote_code=True` model, proving the contract reaches the dynamically selected class;
- preservation of an existing class-owned strict-FP32 contract and exact restoration after both success and failure;
- architecture scoping of the Nemotron-specific contract.

HSG's primary and backup Slurm controllers were unavailable during the final self-review update, so the exact-head container pytest run is pending CI/cluster recovery.

The original FP32-at-load proof of concept was exercised in the NeMo-RL experiment container, followed by a strict 20-step GRPO A/B that changed only the Automodel revision:

| Automodel variant | Mean `train/gen_kl_error` | Min | Max | Step 20 |
| --- | ---: | ---: | ---: | ---: |
| [Unpatched baseline](https://wandb.ai/nvidia/nemo-rl-nanov3-kl-investigation/runs/5xoixngo) | 0.010395 | 0.0079 | 0.0131 | 0.008127 |
| [FP32 contract fix](https://wandb.ai/nvidia/nemo-rl-nanov3-kl-investigation/runs/dma8wtqn) | 0.002340 | 0.0018 | 0.0043 | 0.004094 |

Both runs used the same NeMo-RL commit, vLLM commit, seed, Nano 30B-A3B native-LoRA recipe, 2-node x 4-GPU topology, and ran 20/20 steps without OOM, NaN/Inf, or refit failure. The mean generation KL error decreased by 77.5% (4.4x), and the fixed maximum remained below the baseline minimum.

The experiment used the earlier base-class-scoped proof-of-concept commit `a1bac041`. Self-review subsequently replaced that delivery mechanism with the concrete-class `get_init_context` hook in this PR; therefore the table validates the router-bias FP32 hypothesis, while the exact-head lifecycle behavior is covered by the focused tests above and still requires the pending exact-head run.

# Additional Information

Discovered while validating NVIDIA-NeMo/RL#3964, which makes native LoRA adapter refit the correctness-first default. That change synchronizes only LoRA A/B tensors, so model-owned non-LoRA FP32 state must already match between the trainer and rollout model.
