### PR TITLE
fix(data): support Mistral tokenizers in the distillation collator

### DIFF
--- a/nemo_automodel/components/datasets/llm/retrieval_distill_collator.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_distill_collator.py
@@ -213,19 +213,23 @@ class BiEncoderDistillCollator:
         neg_lists_raw = [docs[1:] for docs in doc_lists]
         neg_lists = [[self._apply_passage_prefix(n, pi) for n in negs] for negs, pi in zip(neg_lists_raw, passage_inst)]
 
+        token_type_kwargs = {}
+        if "token_type_ids" in getattr(self.tokenizer, "model_input_names", []):
+            token_type_kwargs["return_token_type_ids"] = False
+
         q_enc = self.tokenizer(
             query_texts,
             max_length=self.q_max_len,
             padding=PaddingStrategy.DO_NOT_PAD,
             truncation=True,
-            return_token_type_ids=False,
+            **token_type_kwargs,
         )
         d_enc = self.tokenizer(
             pos_docs,
             max_length=self.p_max_len,
             padding=PaddingStrategy.DO_NOT_PAD,
             truncation=True,
-            return_token_type_ids=False,
+            **token_type_kwargs,
         )
 
         q_features = [{k: q_enc[k][i] for k in q_enc.keys()} for i in range(len(query_texts))]
@@ -300,7 +304,7 @@ class BiEncoderDistillCollator:
             max_length=self.p_max_len,
             padding=PaddingStrategy.DO_NOT_PAD,
             truncation=True,
-            return_token_type_ids=False,
+            **token_type_kwargs,
         )
         n_features = [{k: n_enc[k][i] for k in n_enc.keys()} for i in range(len(flat_negs))]
         n_batch = self.tokenizer.pad(

--- a/tests/unit_tests/datasets/llm/test_retrieval_distill_collator.py
+++ b/tests/unit_tests/datasets/llm/test_retrieval_distill_collator.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import numpy as np
+import pytest
 import torch
 
 from nemo_automodel.components.datasets.llm.retrieval_distill_collator import (
@@ -15,6 +16,7 @@ from nemo_automodel.components.datasets.llm.retrieval_distill_collator import (
 class _TinyTokenizer:
     pad_token = "<pad>"
     pad_token_id = 0
+    model_input_names = ["input_ids", "attention_mask", "token_type_ids"]
 
     def __call__(
         self,
@@ -22,8 +24,9 @@ class _TinyTokenizer:
         max_length=None,
         padding=None,
         truncation=False,
-        return_token_type_ids=False,
+        return_token_type_ids=True,
     ):
+        assert return_token_type_ids is False
         if isinstance(texts, str):
             texts = [texts]
         input_ids = []
@@ -58,6 +61,47 @@ class _TinyTokenizer:
         return {"input_ids": input_ids, "attention_mask": attention_mask}
 
 
+class _TokenizerWithoutTokenTypeIds(_TinyTokenizer):
+    model_input_names = ["input_ids", "attention_mask"]
+
+    def __call__(self, texts, max_length=None, padding=None, truncation=False):
+        return super().__call__(
+            texts,
+            max_length=max_length,
+            padding=padding,
+            truncation=truncation,
+            return_token_type_ids=False,
+        )
+
+
+@pytest.mark.parametrize("tokenizer_file", ["mistral_instruct_tokenizer_240323.model.v3", "tekken_240911.json"])
+def test_distill_collator_with_mistral_common(tokenizer_file):
+    # Mistral's backend is optional; the tokenizers are bundled with mistral-common.
+    mistral_common = pytest.importorskip("mistral_common")
+    from transformers import MistralCommonBackend
+
+    tokenizer = MistralCommonBackend(Path(mistral_common.__file__).parent / "data" / tokenizer_file)
+    tokenizer.pad_token = tokenizer.eos_token
+    collator = BiEncoderDistillCollator(tokenizer=tokenizer, q_max_len=32, p_max_len=32, pad_to_multiple_of=4)
+    batch = [
+        {"question": "what is alpha", "doc_text": ["alpha positive", "alpha hard one", "alpha hard two"]},
+        {"question": "what is beta", "doc_text": ["beta positive", "beta hard one"]},
+    ]
+
+    out = collator(batch)
+
+    assert out["n_mask"].tolist() == [[1, 1], [1, 0]]
+    for i, example in enumerate(batch):
+        for prefix, text in [("q", example["question"]), ("d", example["doc_text"][0])]:
+            expected = tokenizer(text, max_length=32, truncation=True)["input_ids"]
+            actual = out[f"{prefix}_input_ids"][i][out[f"{prefix}_attention_mask"][i].bool()]
+            assert actual.tolist() == expected
+        for j, text in enumerate(example["doc_text"][1:]):
+            expected = tokenizer(text, max_length=32, truncation=True)["input_ids"]
+            actual = out["n_input_ids"][i, j][out["n_attention_mask"][i, j].bool()]
+            assert actual.tolist() == expected
+
+
 def _write_teacher_cache(cache_dir: Path, queries: list[str], docs: list[str], dim: int = 3):
     cache_dir.mkdir(parents=True, exist_ok=True)
 
@@ -83,13 +127,14 @@ def _write_teacher_cache(cache_dir: Path, queries: list[str], docs: list[str], d
     return query_vectors, doc_vectors
 
 
-def test_distill_collator_adds_cached_teacher_embeddings_with_raw_text_lookup(tmp_path: Path):
+@pytest.mark.parametrize("tokenizer_cls", [_TinyTokenizer, _TokenizerWithoutTokenTypeIds])
+def test_distill_collator_adds_cached_teacher_embeddings_with_raw_text_lookup(tmp_path: Path, tokenizer_cls):
     queries = ["what is alpha", "what is beta"]
     docs = ["alpha positive", "alpha hard one", "alpha hard two", "beta positive", "beta hard one"]
     query_vectors, doc_vectors = _write_teacher_cache(tmp_path / "cache", queries, docs)
 
     collator = BiEncoderDistillCollator(
-        tokenizer=_TinyTokenizer(),
+        tokenizer=tokenizer_cls(),
         q_max_len=16,
         p_max_len=16,
         query_prefix="query:",


### PR DESCRIPTION
# What does this PR do ?

`BiEncoderDistillCollator` passes `return_token_type_ids=False` to every tokenizer call. `MistralCommonBackend` does not accept this argument, so retrieval distillation fails while encoding the first query. The regular `BiEncoderCollator` already handles this backend in #3441.

Apply the same convention to queries, positive documents and hard negatives: disable token type IDs explicitly only when the tokenizer advertises them in `model_input_names`.

# Changelog

- Support tokenizer backends without the `return_token_type_ids` argument throughout retrieval distillation collation.
- Extend cached-teacher coverage with a strict tokenizer and verify token contents with the real Mistral SentencePiece and Tekken backends using their bundled vocabularies.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read the contribution guidelines.
- [x] Added necessary regression tests.
- [x] Checked documentation impact; no new API, configuration or dependency requirement.

# Additional Information

`pytest tests/unit_tests/datasets/llm/test_retrieval_distill_collator.py tests/unit_tests/datasets/llm/test_bi_encoder_collator.py -q`: 17 passed with both Transformers 5.3.0 and the current 5.15.1 pin, using mistral-common 1.11.7. The updated distillation tests give 3 failures and 1 pass against the original collator. Ruff 0.16.4, Bandit B614 and `git diff --check` pass on the changed files.

The Mistral tests use local package assets and skip when the optional backend is absent. No GPU or complete retrieval training run was needed or performed. Related #3102 changes backend selection; its distillation configuration still dispatches through AutoTokenizer and does not modify this collator.
