### PR TITLE
fix(loss): scale InfoNCE logits before masking padded negatives

### DIFF
--- a/nemo_automodel/components/loss/infonce.py
+++ b/nemo_automodel/components/loss/infonce.py
@@ -70,14 +70,14 @@ def infonce_loss(
             logits = pos
             target = torch.zeros(batch, device=device, dtype=torch.long)
 
+        logits = logits / temperature
         if neg is not None:
-            sim_qn = torch.einsum("bd,bkd->bk", query, neg)
+            sim_qn = torch.einsum("bd,bkd->bk", query, neg) / temperature
             if hard_negatives_mask is not None:
                 pad = hard_negatives_mask.to(sim_qn.dtype) == 0
                 sim_qn = sim_qn.masked_fill(pad, float("-inf"))
             logits = torch.cat([logits, sim_qn], dim=-1)
 
-        logits = logits / temperature
         return F.cross_entropy(logits, target)
 
     if direction == "q2d":

--- a/tests/unit_tests/loss/test_infonce.py
+++ b/tests/unit_tests/loss/test_infonce.py
@@ -431,6 +431,52 @@ def test_infonce_module_learnable_temperature():
     assert torch.allclose(loss_fn.current_temperature(), torch.tensor(0.05), atol=ATOL)
 
 
+@pytest.mark.parametrize("direction", ["q2d", "symmetric"])
+@pytest.mark.parametrize("in_batch", [False, True])
+@pytest.mark.parametrize("mask_kind", ["all_valid", "ragged", "all_padding"])
+def test_infonce_learnable_temperature_with_masked_negatives(direction, in_batch, mask_kind):
+    torch.manual_seed(42)
+    inputs = [torch.randn(*shape, requires_grad=True) for shape in [(3, 8), (3, 8), (3, 2, 8)]]
+    mask = torch.tensor([[1, 0], [0, 0], [1, 1]], dtype=torch.bool)
+    if mask_kind == "all_valid":
+        mask.fill_(True)
+    elif mask_kind == "all_padding":
+        mask.fill_(False)
+    loss_fn = InfoNCELoss(
+        temperature=0.2,
+        learnable_temperature=True,
+        direction=direction,
+        use_in_batch_negatives=in_batch,
+        cross_device_negatives=False,
+    )
+    reference_inputs = [x.detach().clone().requires_grad_() for x in inputs]
+    log_inv_tau = loss_fn.log_inv_tau.detach().clone().requires_grad_()
+    q, d, negatives = [torch.nn.functional.normalize(x, dim=-1) for x in reference_inputs]
+
+    def reference_side(query, docs, include_negatives):
+        losses = []
+        for i in range(len(query)):
+            candidates = docs if in_batch else docs[i : i + 1]
+            if include_negatives:
+                candidates = torch.cat([candidates, negatives[i, mask[i]]])
+            scores = (candidates @ query[i]) * log_inv_tau.exp()
+            positive = i if in_batch else 0
+            losses.append(torch.logsumexp(scores, dim=0) - scores[positive])
+        return torch.stack(losses).mean()
+
+    expected = reference_side(q, d, True)
+    if direction == "symmetric":
+        expected = (expected + reference_side(d, q, False)) / 2
+    expected.backward()
+    actual = loss_fn(*inputs, hard_negatives_mask=mask)
+    actual.backward()
+
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(loss_fn.log_inv_tau.grad, log_inv_tau.grad)
+    for actual_input, reference_input in zip(inputs, reference_inputs):
+        torch.testing.assert_close(actual_input.grad, reference_input.grad)
+
+
 # ---------------------------------------------------------------------------
 # InfoNCEDistillLoss module
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this PR do ?

Padded hard negatives can produce a finite InfoNCE loss but a NaN gradient for a learned temperature. Their logits are first set to `-inf` and then divided by the temperature, so division backward encounters an infinite operand even though the padded candidate contributes no loss.

Scale positive/in-batch and hard-negative logits before applying the padding mask in both `infonce_loss` and `infonce_distill_loss`. Teacher logits remain detached. The probabilities and embedding gradients are preserved, while infinite mask values stay out of the temperature derivative.

# Changelog

- Keep learned temperature gradients finite for padded negatives in ordinary and distillation InfoNCE.
- Compare losses and student/temperature gradients against per-query references that physically omit padded candidates, including KL, CE and MSE distillation.
- Cover valid q2d/symmetric configurations and fully valid, ragged and fully padded negative sets; preserve the configuration checks added in #3870.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read the contribution guidelines.
- [x] Added regression tests.
- [x] Checked documentation impact; no new API or configuration.

# Additional Information

`pytest --cpu tests/unit_tests/loss/test_infonce.py -q`: 98 passed. Before the distillation fix, 18 of its 27 new cases failed at the temperature-gradient check; the nine fully valid cases already passed. The references independently compare losses and all affected gradients after removing padded candidates.

Changed-file pre-commit checks and `git diff --check` pass. This update was validated on CPU; it does not claim a new distributed or GPU benchmark.
