### PR TITLE
fix(vlm): drop removed freeze_embeddings from Nemotron 3.5 Super VL recipes

### DIFF
--- a/examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_cord_v2_peft.yaml
+++ b/examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_cord_v2_peft.yaml
@@ -101,7 +101,6 @@ distributed:
     reshard_after_forward: true
 
 freeze_config:
-  freeze_embeddings: true
   freeze_vision_tower: true
   freeze_audio_tower: true
   freeze_language_model: false

--- a/examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_tulu3_packed_cp8_100steps.yaml
+++ b/examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_tulu3_packed_cp8_100steps.yaml
@@ -76,7 +76,6 @@ distributed:
     reshard_after_forward: true
 
 freeze_config:
-  freeze_embeddings: true
   freeze_vision_tower: true
   freeze_audio_tower: true
   freeze_language_model: false

--- a/examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_tulu3_text_100steps.yaml
+++ b/examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_tulu3_text_100steps.yaml
@@ -80,7 +80,6 @@ distributed:
     reshard_after_forward: true
 
 freeze_config:
-  freeze_embeddings: true
   freeze_vision_tower: true
   freeze_audio_tower: true
   freeze_language_model: false


### PR DESCRIPTION
## Summary

`FreezeConfig` stopped accepting `freeze_embeddings` in #3681, but the three Nemotron 3.5 Super VL recipes merged in #3801 still set it, so they fail at config validation:

```
ValueError: freeze_config has unsupported option(s) ['freeze_embeddings']
```

This removes the key from `nemotron_3_5_super_vl_cord_v2_peft.yaml`, `nemotron_3_5_super_vl_tulu3_text_100steps.yaml` and `nemotron_3_5_super_vl_tulu3_packed_cp8_100steps.yaml`. The option was a no-op for this model family (`apply_parameter_freezing` ignored it), so trainability is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)