### PR TITLE
fix(loss): apply per-token gradients in parallel cross entropy

### DIFF
--- a/nemo_automodel/components/loss/triton/te_cross_entropy.py
+++ b/nemo_automodel/components/loss/triton/te_cross_entropy.py
@@ -260,6 +260,7 @@ def element_mul_kernel(
     grad_output_ptr,
     n_cols,
     BLOCK_SIZE: tl.constexpr,
+    PER_ROW: tl.constexpr = False,
 ):
     """
     This function multiplies each element of the tensor pointed by X_ptr with the value pointed by grad_output_ptr.
@@ -268,7 +269,8 @@ def element_mul_kernel(
     Parameters:
     X_ptr: Pointer to the input tensor.
     X_stride (int): The stride of the input tensor.
-    grad_output_ptr: Pointer to the gradient output value.
+    grad_output_ptr: Pointer to a scalar or contiguous [tokens] upstream gradient.
+    PER_ROW: Whether the upstream gradient has one entry per token.
     n_cols (int): The number of columns in the input tensor.
     BLOCK_SIZE (int): The block size for Triton operations.
     """
@@ -279,7 +281,7 @@ def element_mul_kernel(
     X_ptr += program_id * X_stride
 
     # Load the gradient output value
-    grad_output = tl.load(grad_output_ptr)
+    grad_output = tl.load(grad_output_ptr + program_id if PER_ROW else grad_output_ptr)
 
     # Perform the element-wise multiplication
     for i in range(0, n_cols, BLOCK_SIZE):
@@ -371,7 +373,17 @@ def cross_entropy_forward(
 
 
 def cross_entropy_backward(_input: torch.Tensor, grad_output: torch.Tensor):
-    """Backward implementation of cross entropy loss kernel"""
+    """Scale the saved CE gradient by its upstream gradient in place.
+
+    Args:
+        _input: Tensor of shape [batch, sequence, local_vocab] holding the saved
+            gradient; each row must be contiguous. Updated in place.
+        grad_output: Scalar tensor for reduced loss, or tensor of shape
+            [batch, sequence] for unreduced loss. May be noncontiguous.
+
+    Returns:
+        Tensor of shape [batch, sequence, local_vocab], aliasing ``_input``.
+    """
     if not HAVE_TRITON:
         raise ImportError(MISSING_TRITON_MSG)
 
@@ -387,9 +399,10 @@ def cross_entropy_backward(_input: torch.Tensor, grad_output: torch.Tensor):
         element_mul_kernel[(n_rows,)](
             _input,
             _input.stride(-2),
-            grad_output,
+            grad_output.contiguous(),
             V,
             BLOCK_SIZE=BLOCK_SIZE,
+            PER_ROW=grad_output.numel() != 1,
             num_warps=32,
         )
 

--- a/tests/functional_tests/llm_pretrain_and_kd/loss/run_te_parallel_ce_dtensor.py
+++ b/tests/functional_tests/llm_pretrain_and_kd/loss/run_te_parallel_ce_dtensor.py
@@ -35,7 +35,7 @@ import sys
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
-from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Shard
 
@@ -69,6 +69,62 @@ def _init_distributed() -> None:
     dist.init_process_group(backend="nccl")
     local_rank = int(os.environ.get("LOCAL_RANK", "0"))
     torch.cuda.set_device(local_rank)
+
+
+def _test_backward(tp_mesh: DeviceMesh, dtype: torch.dtype) -> None:
+    """Compare weighted CE gradients and a projection update with a full-vocab reference."""
+    world_size = tp_mesh.size()
+    rank = tp_mesh.get_local_rank()
+    device = torch.device("cuda", torch.cuda.current_device())
+    vocab_size, hidden_size = 128, 32
+    vocab_local = vocab_size // world_size
+    shard = slice(rank * vocab_local, (rank + 1) * vocab_local)
+    cases = [
+        ("none", "transposed"),
+        ("none", "contiguous"),
+        ("none", "expanded"),
+        ("mean", "scalar"),
+        ("sum", "scalar"),
+    ]
+    for reduction, layout in cases:
+        torch.manual_seed(6789)
+        inputs = torch.randn(2, 8, hidden_size, device=device, dtype=dtype)
+        full_weight = torch.randn(vocab_size, hidden_size, device=device, dtype=dtype) * 0.1
+        reference_weight = full_weight.float().clone().requires_grad_()
+        local_weight = full_weight[shard].clone().requires_grad_()
+        labels = torch.randint(0, vocab_size, (2, 8), device=device)
+        labels[0, 3] = -100
+        labels[1, 6] = -100
+        reference_logits = F.linear(inputs.float(), reference_weight)
+        reference_loss = F.cross_entropy(
+            reference_logits.reshape(-1, vocab_size), labels.reshape(-1), reduction=reduction
+        )
+        local_logits = F.linear(inputs, local_weight)
+        logits_dt = DTensor.from_local(local_logits, tp_mesh, [Shard(-1)], run_check=True)
+        actual_loss = TEParallelCrossEntropy(reduction=reduction)(logits_dt, labels)
+        if reduction == "none":
+            reference_loss = reference_loss.reshape(2, 8)
+            # A transposed, nonuniform upstream gradient with a zero first weight.
+            weights = (torch.arange(16, device=device, dtype=torch.float32) / 16).reshape(8, 2).t()
+            if layout == "contiguous":
+                weights = weights.contiguous()
+            elif layout == "expanded":
+                weights = torch.tensor(0.375, device=device).expand(2, 8)
+        else:
+            weights = torch.tensor(0.375, device=device)
+        reference_loss.backward(weights)
+        actual_loss.backward(weights)
+        rtol, atol = (2e-4, 2e-5) if dtype == torch.float32 else (2e-2, 2e-2)
+        torch.testing.assert_close(actual_loss, reference_loss, rtol=rtol, atol=atol)
+        torch.testing.assert_close(local_weight.grad.float(), reference_weight.grad[shard], rtol=rtol, atol=atol)
+        actual_norm_sq = local_weight.grad.float().square().sum()
+        dist.all_reduce(actual_norm_sq, group=tp_mesh.get_group())
+        torch.testing.assert_close(actual_norm_sq.sqrt(), reference_weight.grad.norm(), rtol=rtol, atol=atol)
+        actual_updated = local_weight.detach().float() - 0.1 * local_weight.grad.float()
+        reference_updated = reference_weight.detach()[shard] - 0.1 * reference_weight.grad[shard]
+        torch.testing.assert_close(actual_updated, reference_updated, rtol=rtol, atol=atol)
+        if rank == 0:
+            print(f"PASS: backward TP{world_size} {dtype} {reduction=} {layout=}")
 
 
 def main() -> int:
@@ -141,12 +197,15 @@ def main() -> int:
             print("PASS: DTensor + TEParallelCrossEntropy matches reference")
         else:
             print(
-                "FAIL: Loss mismatch\n"
-                f"  ref_loss={ref_loss.item()}\n"
-                f"  te_loss={te_loss.item()}\n",
+                f"FAIL: Loss mismatch\n  ref_loss={ref_loss.item()}\n  te_loss={te_loss.item()}\n",
                 file=sys.stderr,
             )
 
+    for test_dtype in (torch.float32, torch.bfloat16):
+        _test_backward(tp_mesh, test_dtype)
+    if rank == 0:
+        print("PASS: weighted and reduced CE gradients, global norm and projection update match reference")
+    dist.destroy_process_group()
     return 0 if all_ok else 1
 
 


### PR DESCRIPTION
# What does this PR do ?

`TEParallelCrossEntropy(reduction="none")` currently scales every token gradient by the first element of `grad_output`. A weighted token loss therefore produces incorrect parameter gradients; if its first weight is zero, every gradient becomes zero even when other tokens contribute to the loss.

Read the upstream gradient for each row when the loss is unreduced, materializing noncontiguous upstream gradients before the kernel call. Reduced losses and the soft-CE caller retain scalar scaling.

The existing two-GPU DTensor functional test now compares weighted and reduced losses, vocabulary-sharded projection gradients, their global norm, and an equivalent SGD update with a full-vocabulary PyTorch reference. FP32/BF16 cover transposed, contiguous and expanded weights, plus mean/sum reductions. The same ten cases pass with TP1, and all 21 existing soft-CE tests pass. The unmodified kernel fails the first weighted-gradient comparison. Complete trainer runs, multi-node and DP/CP/PP combinations were not exercised.

# Before your PR is "Ready for review"

- [x] Read the contribution guidelines.
- [x] Added regression coverage.
- [x] Checked documentation impact; no new public API or configuration.
