### PR TITLE
fix(loss): handle strided soft cross-entropy inputs

### DIFF
--- a/nemo_automodel/components/loss/triton/soft_cross_entropy.py
+++ b/nemo_automodel/components/loss/triton/soft_cross_entropy.py
@@ -162,17 +162,28 @@ class SoftCrossEntropyFunction(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, logits, target_probs, valid_mask, valid_count):
+        """Flatten soft-CE inputs for kernels with contiguous column and mask access.
+
+        Args:
+            ctx: Autograd context.
+            logits: Tensor of shape [batch, sequence, vocab], possibly strided or
+                expanded. Contiguous inputs may be reused for the backward gradient.
+            target_probs: Tensor of shape [batch, sequence, vocab], possibly strided.
+            valid_mask: Tensor of shape [batch, sequence] containing 0/1 supervision.
+            valid_count: Scalar tensor containing the clamped number of valid positions.
+
+        Returns:
+            Scalar fp32 tensor containing the mean supervised soft cross entropy.
+        """
         B, S, V = logits.shape
         n_rows = B * S
 
-        logits_2d = logits.view(n_rows, V)
-        if logits_2d.stride(-1) != 1:
-            logits_2d = logits_2d.contiguous()
-        target_probs_2d = target_probs.view(n_rows, V)
+        logits_2d = logits.reshape(n_rows, V).contiguous()
+        target_probs_2d = target_probs.reshape(n_rows, V)
         if target_probs_2d.stride(-1) != 1:
             target_probs_2d = target_probs_2d.contiguous()
 
-        mask_1d = valid_mask.view(n_rows)
+        mask_1d = valid_mask.reshape(n_rows).contiguous()
         loss_1d = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
         lse_1d = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
         sump_1d = torch.empty(n_rows, dtype=torch.float32, device=logits.device)

--- a/tests/unit_tests/loss/test_soft_ce_triton.py
+++ b/tests/unit_tests/loss/test_soft_ce_triton.py
@@ -156,3 +156,38 @@ def test_unnormalized_target_forward_and_backward():
 
     torch.testing.assert_close(tri_loss, ref_loss, rtol=1e-4, atol=1e-4)
     torch.testing.assert_close(logits_tri.grad, logits_ref.grad, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize(
+    "layout",
+    ["logits_slice", "targets_slice", "logits_transpose", "targets_transpose", "logits_expand", "mask_slice", "mask_expand"],
+)
+def test_strided_inputs_match_pytorch(dtype, layout):
+    """Sequence views and broadcast masks preserve the soft-label objective."""
+    torch.manual_seed(123)
+    logits, targets, mask = _make_inputs(2, 8, 17, dtype=dtype)
+    if layout == "logits_slice":
+        logits = torch.randn(2, 16, 17, dtype=dtype, device="cuda")[:, :8]
+    elif layout == "targets_slice":
+        targets = torch.softmax(torch.randn(2, 16, 17, device="cuda"), dim=-1).to(dtype)[:, :8]
+    elif layout == "logits_transpose":
+        logits = torch.randn(8, 2, 17, dtype=dtype, device="cuda").transpose(0, 1)
+    elif layout == "targets_transpose":
+        targets = torch.softmax(torch.randn(8, 2, 17, device="cuda"), dim=-1).to(dtype).transpose(0, 1)
+    elif layout == "logits_expand":
+        logits = torch.randn(1, 1, 17, dtype=dtype, device="cuda").expand(2, 8, 17)
+    elif layout == "mask_slice":
+        storage = torch.ones(2, 16, 1, device="cuda")
+        storage[:, ::4] = 0
+        mask = storage[:, ::2]
+    else:
+        mask = torch.tensor([0.0, 1.0], device="cuda").reshape(2, 1, 1).expand(2, 8, 1)
+    logits.requires_grad_(True)
+    reference = logits.detach().clone().requires_grad_(True)
+    expected = _pytorch_reference(reference, targets, mask)
+    expected.backward()
+    actual = fused_soft_cross_entropy(logits, targets, mask)
+    actual.backward()
+    torch.testing.assert_close(actual, expected, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(logits.grad, reference.grad, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
# What does this PR do ?

The fused soft-target cross entropy rejects sequence slices and transposes when flattening them with `view`. Strided float supervision masks can also be read at the wrong offsets, and expanded logits can alias rows during the in-place backward.

Materialize logits and the flattened mask in contiguous storage, and use `reshape` for soft targets. Add comparisons with the PyTorch objective for sliced, transposed and expanded inputs in FP32 and BF16.

All 35 soft-CE GPU tests pass; the 14 new cases fail on the original implementation. A small linear projection also matches a PyTorch reference over three SGD updates per dtype with sliced logits and targets and a strided mask. Full EAGLE training and distributed runs were not exercised.

# Before your PR is "Ready for review"

- [x] Read the contribution guidelines.
- [x] Added regression coverage.
- [x] Checked documentation impact; no new public API or configuration.
