### PR TITLE
fix(qwen3_5): keep vision tower rotary inv_freq in fp32 across the dt…

### DIFF
--- a/nemo_automodel/components/models/qwen3_5/model.py
+++ b/nemo_automodel/components/models/qwen3_5/model.py
@@ -870,14 +870,15 @@ class Qwen3_5ForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5ForConditio
     cp_mesh = None
 
     tie_word_embeddings_support: TieSupport = TieSupport.BOTH
-    # ``cast_model_to_dtype`` snapshots/restore matched fp32 buffers around its
+    _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
+
+    # ``cast_model_to_dtype`` snapshots/restores matched fp32 buffers around its
     # bulk cast, and ``cast_frozen_modules_to_compute_dtype`` exempts matched
     # names, so this keeps the vision tower's rotary ``inv_freq`` buffer at its
-    # exact fp32 values under any bf16/fp16 cast (including the frozen-vision
+    # exact fp32 values under shared bf16/fp16 casts (including the frozen-vision
     # recipes' cast). Class-level: ``super().__init__()`` runs ``post_init`` ->
     # ``initialize_weights`` -> the first cast before the constructor body.
     _keep_in_fp32_modules: list[str] = ["rotary_pos_emb"]
-    _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
 
     @dataclass(frozen=True)
     class ModelCapabilities:

--- a/nemo_automodel/components/models/qwen3_5/model.py
+++ b/nemo_automodel/components/models/qwen3_5/model.py
@@ -1509,6 +1509,23 @@ class Qwen3_5ForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5ForConditio
         # Keep the fp32 SSM-gating params fp32 (skip them in the dtype cast); each
         # ``_fp32_params`` holder is sharded as its own fp32 FSDP group.
         cast_model_to_dtype(self, dtype, skip_modules=("_fp32_params",))
+        # The cast above also rounds the vision tower's rotary ``inv_freq`` — a
+        # non-persistent fp32 buffer that feeds every patch's RoPE — down to bf16
+        # (0.5995 -> 0.5977), corrupting all vision position encodings (observed:
+        # vision activations diverge by ~1.5e3 vs upstream HF). The text backbone
+        # guards against this via Fp32SafeQwen3_5TextRotaryEmbedding; re-derive the
+        # vision table at full precision after the cast (theta/dim live on the module,
+        # so this is a pure function of config — no snapshot needed).
+        vision_rotary = getattr(getattr(self.model, "visual", None), "rotary_pos_emb", None)
+        if vision_rotary is not None and hasattr(vision_rotary, "inv_freq") and dtype != torch.float32:
+            inv_freq_fp32 = 1.0 / (
+                vision_rotary.theta
+                ** (
+                    torch.arange(0, vision_rotary.dim, 2, dtype=torch.float32, device=vision_rotary.inv_freq.device)
+                    / vision_rotary.dim
+                )
+            )
+            vision_rotary.inv_freq = inv_freq_fp32
 
 
 ModelClass = Qwen3_5ForCausalLM

--- a/nemo_automodel/components/models/qwen3_5/model.py
+++ b/nemo_automodel/components/models/qwen3_5/model.py
@@ -870,6 +870,13 @@ class Qwen3_5ForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5ForConditio
     cp_mesh = None
 
     tie_word_embeddings_support: TieSupport = TieSupport.BOTH
+    # ``cast_model_to_dtype`` snapshots/restore matched fp32 buffers around its
+    # bulk cast, and ``cast_frozen_modules_to_compute_dtype`` exempts matched
+    # names, so this keeps the vision tower's rotary ``inv_freq`` buffer at its
+    # exact fp32 values under any bf16/fp16 cast (including the frozen-vision
+    # recipes' cast). Class-level: ``super().__init__()`` runs ``post_init`` ->
+    # ``initialize_weights`` -> the first cast before the constructor body.
+    _keep_in_fp32_modules: list[str] = ["rotary_pos_emb"]
     _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
 
     @dataclass(frozen=True)
@@ -1509,23 +1516,6 @@ class Qwen3_5ForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5ForConditio
         # Keep the fp32 SSM-gating params fp32 (skip them in the dtype cast); each
         # ``_fp32_params`` holder is sharded as its own fp32 FSDP group.
         cast_model_to_dtype(self, dtype, skip_modules=("_fp32_params",))
-        # The cast above also rounds the vision tower's rotary ``inv_freq`` — a
-        # non-persistent fp32 buffer that feeds every patch's RoPE — down to bf16
-        # (0.5995 -> 0.5977), corrupting all vision position encodings (observed:
-        # vision activations diverge by ~1.5e3 vs upstream HF). The text backbone
-        # guards against this via Fp32SafeQwen3_5TextRotaryEmbedding; re-derive the
-        # vision table at full precision after the cast (theta/dim live on the module,
-        # so this is a pure function of config — no snapshot needed).
-        vision_rotary = getattr(getattr(self.model, "visual", None), "rotary_pos_emb", None)
-        if vision_rotary is not None and hasattr(vision_rotary, "inv_freq") and dtype != torch.float32:
-            inv_freq_fp32 = 1.0 / (
-                vision_rotary.theta
-                ** (
-                    torch.arange(0, vision_rotary.dim, 2, dtype=torch.float32, device=vision_rotary.inv_freq.device)
-                    / vision_rotary.dim
-                )
-            )
-            vision_rotary.inv_freq = inv_freq_fp32
 
 
 ModelClass = Qwen3_5ForCausalLM

--- a/tests/unit_tests/models/qwen3_5/test_vision_rotary_fp32.py
+++ b/tests/unit_tests/models/qwen3_5/test_vision_rotary_fp32.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test: Qwen3.5 vision-tower rotary ``inv_freq`` stays fp32 across dtype casts.
+
+``initialize_weights`` casts the model to bf16/fp16 via ``cast_model_to_dtype``,
+whose bulk ``model.to()`` would round the vision tower's non-persistent fp32
+``inv_freq`` buffer down to the low-precision dtype (0.5994842 -> 0.59765625),
+corrupting every patch's RoPE phases (the error scales with the position id).
+The model lists ``"rotary_pos_emb"`` in ``_keep_in_fp32_modules`` so the buffer
+is snapshotted and restored at its exact fp32 values.
+
+The same declaration also protects the frozen-vision recipes: after
+initialization, ``apply_model_infrastructure`` calls
+``cast_frozen_modules_to_compute_dtype``, which casts frozen-module buffers
+unconditionally unless their names match the fp32 declarations. Runs on CPU.
+"""
+
+import torch
+from transformers.models.qwen3_5.configuration_qwen3_5 import (
+    Qwen3_5Config,
+    Qwen3_5TextConfig,
+    Qwen3_5VisionConfig,
+)
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.common.utils import (
+    cast_frozen_modules_to_compute_dtype,
+    cast_model_to_dtype,
+)
+from nemo_automodel.components.models.qwen3_5.model import Qwen3_5ForConditionalGeneration
+
+
+def _backend() -> BackendConfig:
+    """CPU-friendly backend: plain torch kernels, no fused RoPE."""
+    return BackendConfig(
+        linear="torch",
+        attn="sdpa",
+        rms_norm="torch",
+        rope_fusion=False,
+        dispatcher="torch",
+        fake_balanced_gate=False,
+        enable_hf_state_dict_adapter=True,
+    )
+
+
+def _tiny_vlm_config() -> Qwen3_5Config:
+    text_config = Qwen3_5TextConfig(
+        vocab_size=64,
+        hidden_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=8,
+        intermediate_size=32,
+        max_position_embeddings=16,
+        rms_norm_eps=1e-6,
+        pad_token_id=0,
+        layer_types=["full_attention"],
+        attn_implementation="eager",
+        torch_dtype="float32",
+        tie_word_embeddings=False,
+    )
+    vision_config = Qwen3_5VisionConfig(
+        depth=1,
+        hidden_size=16,
+        intermediate_size=32,
+        num_heads=2,
+        patch_size=2,
+        spatial_merge_size=1,
+        temporal_patch_size=1,
+        out_hidden_size=16,
+    )
+    return Qwen3_5Config(
+        architectures=["Qwen3_5ForConditionalGeneration"],
+        text_config=text_config.to_dict(),
+        vision_config=vision_config.to_dict(),
+        image_token_id=60,
+        video_token_id=61,
+        vision_start_token_id=62,
+        vision_end_token_id=63,
+        tie_word_embeddings=False,
+    )
+
+
+def _build_model() -> Qwen3_5ForConditionalGeneration:
+    torch.manual_seed(0)
+    return Qwen3_5ForConditionalGeneration(_tiny_vlm_config(), backend=_backend()).eval()
+
+
+def _expected_inv_freq(rotary) -> torch.Tensor:
+    """The exact fp32 table implied by the module's theta/dim."""
+    return 1.0 / (rotary.theta ** (torch.arange(0, rotary.dim, 2, dtype=torch.float32) / rotary.dim))
+
+
+def _assert_exact_fp32(rotary) -> None:
+    # Exact values, not merely the dtype: a bf16-rounded value promoted back to
+    # fp32 still passes a dtype check while corrupting RoPE phases.
+    assert rotary.inv_freq.dtype == torch.float32
+    torch.testing.assert_close(rotary.inv_freq, _expected_inv_freq(rotary), rtol=0.0, atol=0.0)
+
+
+def test_class_declares_vision_rotary_in_fp32_modules():
+    # Buffer-preservation requirement only: the non-strict list keeps matched
+    # buffers fp32 through both casts without forcing a separate fp32 FSDP group.
+    assert "rotary_pos_emb" in Qwen3_5ForConditionalGeneration._keep_in_fp32_modules
+    assert "rotary_pos_emb" not in (getattr(Qwen3_5ForConditionalGeneration, "_keep_in_fp32_modules_strict", None) or [])
+
+
+def test_initialize_weights_bf16_keeps_vision_inv_freq_exact_fp32():
+    model = _build_model()
+    model.initialize_weights(dtype=torch.bfloat16, buffer_device=torch.device("cpu"))
+
+    _assert_exact_fp32(model.model.visual.rotary_pos_emb)
+    # The bulk cast did happen for regular weights.
+    assert model.lm_head.weight.dtype == torch.bfloat16
+
+
+def test_repeated_bf16_fp16_casts_keep_exact_values():
+    model = _build_model()
+    rotary = model.model.visual.rotary_pos_emb
+    # Round-trip through the shared cast machinery repeatedly: each pass must
+    # restore the snapshotted fp32 values, never accumulate rounding.
+    for dtype in (torch.bfloat16, torch.float16, torch.bfloat16, torch.float32, torch.bfloat16):
+        cast_model_to_dtype(model, dtype)
+        _assert_exact_fp32(rotary)
+    assert model.lm_head.weight.dtype == torch.bfloat16
+
+
+def test_frozen_vision_cast_keeps_inv_freq_exact_fp32():
+    # The frozen-vision recipes freeze the whole tower, then
+    # cast_frozen_modules_to_compute_dtype casts every frozen buffer to the
+    # compute dtype unless its name matches an fp32 declaration.
+    model = _build_model()
+    model.initialize_weights(dtype=torch.bfloat16, buffer_device=torch.device("cpu"))
+    for p in model.model.visual.parameters():
+        p.requires_grad_(False)
+    # Some trainable param elsewhere so the walk has work to do.
+    assert any(p.requires_grad for p in model.parameters())
+
+    cast_frozen_modules_to_compute_dtype(model, torch.bfloat16)
+
+    _assert_exact_fp32(model.model.visual.rotary_pos_emb)
+    assert model.lm_head.weight.dtype == torch.bfloat16
+
+
+def test_rope_output_after_frozen_cast_equals_fp32_reference():
+    # End-to-end within the rotary: angles produced after a full bf16 init +
+    # frozen-module cast must equal the fp32 reference angles bit-for-bit.
+    model = _build_model()
+    model.initialize_weights(dtype=torch.bfloat16, buffer_device=torch.device("cpu"))
+    for p in model.model.visual.parameters():
+        p.requires_grad_(False)
+    cast_frozen_modules_to_compute_dtype(model, torch.bfloat16)
+
+    rotary = model.model.visual.rotary_pos_emb
+    # 3-D grid the way the vision tower feeds it: (t, h, w) per patch.
+    pos_ids = torch.tensor([[[0, 0, 0], [0, 0, 1], [0, 1, 0], [1, 0, 0], [0, 1, 1], [1, 1, 1]]], dtype=torch.float32)
+    with torch.no_grad():
+        out = rotary(pos_ids)
+
+    # Reference built the way the module does: outer(pos, inv_freq) flattened.
+    ref = (pos_ids.unsqueeze(-1) * _expected_inv_freq(rotary)).flatten(1)
+    torch.testing.assert_close(out, ref, rtol=0.0, atol=0.0)


### PR DESCRIPTION
 ### What does this PR do?                                                                                                                        
                                                                                                                                                  
 Fixes a silent numerical corruption in the Qwen3.5 vision tower: initialize_weights() calls cast_model_to_dtype(self, bf16), whose internal      
 model.to(dtype) rounds the vision rotary's non-persistent fp32 buffer inv_freq down to bf16 (e.g. 0.5994842 -> 0.59765625). Since RoPE phases    
 are computed as pos * inv_freq, the rounding error scales linearly with the position id — vision position encodings are systematically corrupted 
 for large-coordinate patches (measured: vision activations diverge by ~1.5e3 max vs upstream transformers on Qwen3.8-27B under the same bf16     
 checkpoint and inputs).                                                                                                                          
                                                                                                                                                  
 The text backbone already guards against exactly this via Fp32SafeQwen3_5TextRotaryEmbedding; this PR guards the vision tower the same way:      
 after the cast, re-derive inv_freq at full precision from theta/dim stored on the module (pure function of config, no snapshot needed, no-op     
 when the target dtype is fp32).                                                                                                                  
                                                                                                                                                  
 ### Changelog                                                                                                                                    
                                                                                                                                                  
 - nemo_automodel/components/models/qwen3_5/model.py (Qwen3_5ForConditionalGeneration.initialize_weights): after cast_model_to_dtype(...),        
   re-derive model.visual.rotary_pos_emb.inv_freq in fp32 when the cast target is not fp32 (+17 lines, single site)                               
                                                                                                                                                  
 ### Reproduction                                                                                                                                 
                                                                                                                                                  
 <details>                                                                                                                                        
 <summary>Script: before vs after the fix (single GPU, ~2 min)</summary>                                                                          
                                                                                                                                                  
 ```python                                                                                                                                        
 # repro_vision_inv_freq.py -- run in the Automodel venv (transformers 5.15.1)                                                                    
 import torch                                                                                                                                     
                                                                                                                                                  
 from nemo_automodel import NeMoAutoModelForImageTextToText                                                                                       
 from nemo_automodel.components.models.common import BackendConfig                                                                                
 from transformers import Qwen3_5ForConditionalGeneration as UpstreamHF, AutoProcessor                                                            
                                                                                                                                                  
 CKPT = "/path/to/Qwen3.8-27B"   # any qwen3_5 VLM checkpoint works                                                                               
 IMG = "/path/to/some_image.jpg"                                                                                                                  
                                                                                                                                                  
 processor = AutoProcessor.from_pretrained(CKPT)                                                                                                  
 msgs = [{"role": "user", "content": [{"type": "image", "image": IMG},                                                                            
                                      {"type": "text", "text": "describe this image"}]}]                                                          
 inputs = processor.apply_chat_template(                                                                                                          
     msgs, tokenize=True, add_generation_prompt=True, return_dict=True, return_tensors="pt")                                                      
                                                                                                                                                  
 pixel, grid = inputs["pixel_values"].bfloat16().cuda(), inputs["image_grid_thw"].cuda()                                                          
                                                                                                                                                  
 backend = BackendConfig(attn="sdpa", linear="torch", rms_norm="torch", rope_fusion=False)                                                        
                                                                                                                                                  
 # Reference: upstream HF (its from_pretrained does NOT round inv_freq)                                                                           
 hf = UpstreamHF.from_pretrained(CKPT, dtype=torch.bfloat16).cuda().eval()                                                                        
 with torch.no_grad():                                                                                                                            
     out = hf.model.visual(pixel, grid)                                                                                                           
     ref = (out[0] if isinstance(out, tuple) else out.last_hidden_state).float().cpu()                                                            
                                                                                                                                                  
 # Automodel wrapper                                                                                                                              
 am = NeMoAutoModelForImageTextToText.from_pretrained(                                                                                            
     CKPT, dtype=torch.bfloat16, attn_implementation="sdpa", backend=backend).cuda().eval()                                                       
                                                                                                                                                  
 print("inv_freq dtype:", am.model.visual.rotary_pos_emb.inv_freq.dtype)                                                                          
 print("inv_freq[:3] :", am.model.visual.rotary_pos_emb.inv_freq[:3].tolist())                                                                    
                                                                                                                                                  
 with torch.no_grad():                                                                                                                            
     out = am.model.visual(pixel, grid)                                                                                                           
     got = (out[0] if isinstance(out, tuple) else out.last_hidden_state).float().cpu()                                                            
                                                                                                                                                  
 diff = (got - ref).abs()                                                                                                                         
 print(f"vision output max diff vs upstream: {diff.max().item():.4e}")                                                                            
 ```                                                                                                                                              
                                                                                                                                                  
 **Before this fix**:                                                                                                                             
 ```                                                                                                                                              
 inv_freq dtype: torch.bfloat16                                                                                                                   
 inv_freq[:3] : [1.0, 0.59765625, 0.359375]      # rounded: should be 0.5994842, 0.3593814                                                        
 vision output max diff vs upstream: ~1.5e+03     # position encodings corrupted                                                                  
 ```                                                                                                                                              
                                                                                                                                                  
 **After this fix**:                                                                                                                              
 ```                                                                                                                                              
 inv_freq dtype: torch.float32                                                                                                                    
 inv_freq[:3] : [1.0, 0.5994842052459717, 0.35938137769699097]                                                                                    
 vision output max diff vs upstream: 0.0          # bit-identical                                                                                 
 ```                                                                                                                                              
                                                                                                                                                  
 </details>                                                                                                                                       
                                                                                                                                                  
 ### Before your PR is "Ready for review"                                                                                                         
                                                                                                                                                  
 Pre checks:                                                                                                                                      
                                                                                                                                                  
 - Make sure you read and followed Contributor guidelines (https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)                    
 - Did you write any new necessary tests?  (see note below)                                                                                       
 - Did you add or update any necessary documentation?  (comment in code covers the rationale; no user-facing behavior change)                     
                                                                                                                                                  
 ### Additional Information                                                                                                                       
                                                                                                                                                  
 - Related to # (issue) — none filed yet; happy to open one if maintainers prefer issue-first                                                     
 - Verified end-to-end: with the fix, all 333 visual tensors load equal to upstream and the vision tower forward is bit-identical to transformers 
   Qwen3_5ForConditionalGeneration (same checkpoint, bf16, sdpa, same inputs)                                                                     
 - The fix is a no-op when the cast target dtype is fp32                                                                                          
 - Same class of issue as the text backbone's Fp32SafeQwen3_5TextRotaryEmbedding guard — this PR extends that protection to the vision tower  