### PR TITLE
ci: drop the redundant -rA PASSES report from test runs

### DIFF
--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -73,6 +73,13 @@ if [[ -n "$MEDIA_EXTRA" ]]; then
     uv pip install ".[$MEDIA_EXTRA]"
 fi
 
+# Report only failures and errors (-rfE), not every passing test (-rA). Because
+# we already run with -s and log_cli=true, each passing test's captured log is
+# streamed live as it runs, which makes the -rA "PASSES" section a verbatim
+# duplicate of output the log already contains. On the CPU unit-test suite that
+# duplicate measured 128s of the job's 900s budget -- on its own enough to push
+# the job past its timeout and into two full retries. Failure tracebacks are
+# controlled by --tb, so they are unaffected.
 coverage run \
     -m pytest \
     --durations 32 \
@@ -80,7 +87,7 @@ coverage run \
     "${TEST_DIRS[@]}" \
     -o log_cli=true \
     -o log_cli_level=INFO \
-    -vs -m "not pleasefixme" --tb=short -rA \
+    -vs -m "not pleasefixme" --tb=short -rfE \
     $SHARD_ARGS \
     $ADDITIONAL_ARGS
 coverage combine -q


### PR DESCRIPTION
## What

`tests/run_test.sh` runs pytest with `-rA`. This switches it to `-rfE`.

## Why

`L0_Unit_Tests_CPU` currently takes **47 minutes and reports no test results at all**. The suite needs ~15.5 min against a 15 min timeout, so every attempt is SIGKILLed and `nick-fields/retry` (`max_attempts: 3`, `retry_on: timeout`) re-runs the whole thing three times:

```
Attempt 1  15:02:11 → 15:17:23   Timeout of 900000ms hit
Attempt 2  15:17:24 → 15:32:36   Timeout of 900000ms hit
Attempt 3  15:32:37 → 15:48:00   Timeout of 900000ms hit
```

Phase breakdown of the last green run ([34414016653](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/34414016653), 851.77 s of pytest) vs. Jul 30 (515.25 s):

| phase | Jul 30 | Sep 9 | Δ |
|---|---:|---:|---:|
| interpreter + plugin import | 9.9 s | 9.0 s | −0.9 s |
| collection | 68.2 s | 76.0 s | +7.8 s |
| test execution | 359.2 s | 645.9 s | +286.7 s |
| **`-rA` PASSES report** | **86.1 s** | **127.6 s** | **+41.5 s** |
| durations + summary | 1.4 s | 1.7 s | +0.3 s |

**The `-rA` section prints nothing new.** We pass `-s` *and* `-o log_cli=true -o log_cli_level=INFO`, so pytest's logging plugin already streams every test's captured log records live as the test runs. `-rA` then re-emits the same records a second time in the end-of-session `PASSES` section. The duplication is directly observable — e.g. in run 34491816167 the message `No clip_grad_norm.max_norm specified` appears 17x in the live region and again 14x in the report; there the section had re-emitted 1.29 MB over 8370 lines and reached only 85.7% of the suite when the job was killed.

`-rfE` keeps failures and errors in the short summary. Tracebacks are controlled by `--tb=short`, so failure output is unchanged. `grep` confirms nothing parses the `PASSED` lines — `-rA` occurs in exactly one place in the repo.

## Effect

Removes ~128 s from every unit-test attempt, taking the CPU job from ~931 s back under the 900 s cap. This also applies to both GPU unit-test shards and every L2 job, since they share `run_test.sh`.

## This is a stopgap

The suite is growing about a minute a week, so ~100 s of headroom buys roughly two weeks:

| | Jul 30 | Sep 9 |
|---|---:|---:|
| tests collected | 11,786 | 13,888 |
| pytest session | 515 s | 852 s |

Test count is up 18% but wall-clock is up 65% — superlinear, because the new tests skew heavily toward multi-rank ones. Comparing the two runs' `--durations` reports, **277 s of the current top-32 (83%) are tests that did not exist on Jul 30**, while the pre-existing heavy tests are flat (12.2→11.2 s, 8.8→8.7 s, 7.2→7.6 s, 5.5→5.6 s, 4.8→4.9 s).

The underlying cost is process spawning: **46% of execution time is in the ~35 files that use `mp.spawn` (53 call sites, 24 of them gloo-only) or `sys.executable`**, from 4.6% of the tests. Each child is a fresh interpreter paying a full `import torch` + `import nemo_automodel` — measured at ~9 s in these same logs. Follow-ups worth doing, in order:

1. Don't retry deterministic timeouts — `retry_on: timeout` with `max_attempts: 3` can never succeed for a suite that reliably overruns; it just triples the cost and delays the signal by 30 min.
2. Reuse worker processes (or use a fork context — the CPU job never initializes CUDA) so the torch import is paid once instead of 53 times.
3. Shard the CPU job the way `L0_Unit_Tests_GPU_{1,2}_of_2` already is. The machinery exists and is unused: `run_test.sh` already accepts `--SHARD_ID/--NUM_SHARDS` and `pytest-shard` is installed.