### PR TITLE
refactor(optim): split DTensor param groups and avoid TE FP32 master-weight dup

### DIFF
--- a/nemo_automodel/components/optim/optimizer.py
+++ b/nemo_automodel/components/optim/optimizer.py
@@ -38,12 +38,10 @@ Megatron-FSDP sharding).  Subclasses only implement the small
 
 from __future__ import annotations
 
-import functools
 import importlib
 import inspect
 import logging
 import re
-import sys
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -172,9 +170,34 @@ def _trainable_params_or_groups(part: torch.nn.Module, overrides: list[ParamGrou
     named_params = [(name, p) for name, p in part.named_parameters() if p.requires_grad]
     if not named_params:
         raise ValueError("optimizer received no trainable parameters")
-    if overrides:
-        return _build_param_groups(named_params, overrides)
-    return [p for _, p in named_params]
+    params_or_groups = _build_param_groups(named_params, overrides) if overrides else [p for _, p in named_params]
+    return _split_dtensor_and_plain_params(params_or_groups)
+
+
+def _split_dtensor_and_plain_params(params_or_groups: list) -> list:
+    """Keep plain tensors out of foreach groups containing DTensors.
+
+    PyTorch foreach operators reject a mixed list of ordinary tensors and
+    DTensors. Bounded FSDP2 replication intentionally creates exactly that
+    model layout, so split only affected optimizer groups while preserving all
+    hyperparameter overrides. The bulk group remains foreach-enabled.
+    """
+
+    def split_group(group: dict[str, Any]) -> list[dict[str, Any]]:
+        params = list(group["params"])
+        plain = [param for param in params if not isinstance(param, DTensor)]
+        sharded = [param for param in params if isinstance(param, DTensor)]
+        if not plain or not sharded:
+            return [group]
+        options = {key: value for key, value in group.items() if key != "params"}
+        return [{"params": sharded, **options}, {"params": plain, **options}]
+
+    is_groups = bool(params_or_groups) and isinstance(params_or_groups[0], dict)
+    groups = params_or_groups if is_groups else [{"params": params_or_groups}]
+    split_groups = [split for group in groups for split in split_group(group)]
+    if is_groups or len(split_groups) > 1:
+        return split_groups
+    return split_groups[0]["params"]
 
 
 @dataclass
@@ -293,6 +316,52 @@ class AdamWConfig(OptimizerConfig):
         )
 
 
+def _avoid_redundant_te_master_weights_for_fp32_params(optimizer: torch.optim.Optimizer) -> None:
+    """Keep TE optimizer moments but no duplicate master for resident FP32 weights.
+
+    Transformer Engine's FusedAdam has one optimizer-wide ``master_weights``
+    switch. Mixed BF16/FP32 models need it for BF16 parameters, but its FP32
+    update path operates directly on the resident parameter and never consumes
+    ``master_param``. Pre-initializing only the two moments for resident FP32
+    parameters makes TE skip its generic three-state initializer. A post-load
+    hook applies the same ownership rule to old checkpoints that contain the
+    redundant state.
+
+    Args:
+        optimizer: Transformer Engine FusedAdam instance whose parameter groups
+            contain tensors of arbitrary shape. DTensor parameters may be sharded
+            on any mesh placement supported by TE; residency is inspected on the
+            rank-local tensor.
+    """
+    if not bool(getattr(optimizer, "master_weights", False)):
+        return
+
+    initialize_state = getattr(optimizer, "_initialize_state", None)
+    if not callable(initialize_state):
+        raise RuntimeError(
+            "Transformer Engine FusedAdam master-weight ownership requires its _initialize_state integration API"
+        )
+
+    def enforce_fp32_ownership(loaded_optimizer: torch.optim.Optimizer) -> None:
+        for group in loaded_optimizer.param_groups:
+            for parameter in group["params"]:
+                local_parameter = parameter.to_local() if isinstance(parameter, DTensor) else parameter
+                if local_parameter.dtype is not torch.float32:
+                    continue
+                state = loaded_optimizer.state[parameter]
+                if "exp_avg" not in state:
+                    initialize_state(parameter, "exp_avg", zero_buffer=True)
+                if "exp_avg_sq" not in state:
+                    initialize_state(parameter, "exp_avg_sq", zero_buffer=True)
+                state.pop("master_param", None)
+                scales = getattr(loaded_optimizer, "_scales", {}).get(parameter)
+                if scales is not None:
+                    scales.pop("master_param", None)
+
+    enforce_fp32_ownership(optimizer)
+    optimizer.register_load_state_dict_post_hook(enforce_fp32_ownership)
+
+
 @dataclass
 class FusedAdamConfig(OptimizerConfig):
     """``transformer_engine.pytorch.optimizers.FusedAdam``."""
@@ -304,16 +373,16 @@ class FusedAdamConfig(OptimizerConfig):
     adam_w_mode: bool = True
     bias_correction: bool = True
     master_weights: bool = True
-    master_weight_dtype: str | None = None
+    master_weight_dtype: str = "fp32"
 
     def _build_optimizer(self, params, *, foreach: bool | None = None) -> torch.optim.Optimizer:
         from transformer_engine.pytorch.optimizers import FusedAdam
 
         kwargs = self._constructor_kwargs()
-        master_weight_dtype = kwargs.pop("master_weight_dtype", None)
-        if master_weight_dtype is not None:
-            master_weight_dtype = dtype_from_str(master_weight_dtype)
-        return FusedAdam(_drop_empty_local_shards(params), **kwargs, master_weight_dtype=master_weight_dtype)
+        kwargs["master_weight_dtype"] = dtype_from_str(kwargs["master_weight_dtype"])
+        optimizer = FusedAdam(_drop_empty_local_shards(params), **kwargs)
+        _avoid_redundant_te_master_weights_for_fp32_params(optimizer)
+        return optimizer
 
 
 @dataclass
@@ -490,7 +559,7 @@ class OptimizerFromFactoryConfig(OptimizerConfig):
     per-group LR/WD, matching the typed-config behavior.
     """
 
-    factory: Callable[..., torch.optim.Optimizer] | None = None
+    optim_cls: Callable[..., torch.optim.Optimizer] | None = None
     kwargs: dict[str, Any] = field(default_factory=dict)
 
     def build(
@@ -500,11 +569,11 @@ class OptimizerFromFactoryConfig(OptimizerConfig):
         device_mesh: DeviceMesh | None = None,
         is_peft: bool = False,
     ) -> list[torch.optim.Optimizer]:
-        assert callable(self.factory), "OptimizerFromFactoryConfig.factory must be a callable"
+        assert callable(self.optim_cls), "OptimizerFromFactoryConfig.factory must be a callable"
         foreach = _foreach_for_mesh(device_mesh)
 
         kwargs = dict(self.kwargs)
-        # For the factory path, per-group overrides normally arrive inside ``kwargs``
+        # For the optim_cls path, per-group overrides normally arrive inside ``kwargs``
         # (like every other hyperparameter, since the typed ``lr``/``weight_decay``
         # fields are unused here); pop them so they drive grouping rather than being
         # forwarded to the optimizer constructor. Fall back to the inherited field
@@ -516,9 +585,9 @@ class OptimizerFromFactoryConfig(OptimizerConfig):
             if isinstance(val, str):
                 kwargs[attr] = dtype_from_str(val)
         # Only inject ``foreach`` for factories that actually accept it. The TP>1 path sets
-        # ``foreach=False`` via ``_foreach_for_mesh``; passing it to a factory that does not take
+        # ``foreach=False`` via ``_foreach_for_mesh``; passing it to a optim_cls that does not take
         # ``foreach`` (e.g. TE ``FusedAdam``) would raise.  Honour an explicit user-provided value.
-        if foreach is not None and "foreach" not in kwargs and _factory_accepts_foreach(self.factory):
+        if foreach is not None and "foreach" not in kwargs and _accepts_foreach(self.optim_cls):
             kwargs["foreach"] = foreach
 
         optimizers: list[torch.optim.Optimizer] = []
@@ -527,12 +596,7 @@ class OptimizerFromFactoryConfig(OptimizerConfig):
             # trainable parameters, and returns either a flat param list or the
             # per-group dicts.
             params = _trainable_params_or_groups(part, overrides)
-            # TE FusedAdam's multi_tensor_apply faults on zero-numel local shards; see
-            # _drop_empty_local_shards.  Same guard as FusedAdamConfig, for the YAML
-            # ``_target_: transformer_engine...FusedAdam`` escape hatch.
-            if _is_te_fused_adam(self.factory):
-                params = _drop_empty_local_shards(params)
-            optimizers.append(self.factory(params=params, **kwargs))
+            optimizers.append(self.optim_cls(params=params, **kwargs))
         warn_if_torch_adam_with_bf16_params(optimizer=optimizers, is_peft=is_peft, context="optim", logger=logger)
         return optimizers
 
@@ -542,7 +606,7 @@ class OptimizerFromFactoryConfig(OptimizerConfig):
         *,
         device_mesh: DeviceMesh | None = None,
     ) -> torch.optim.Optimizer:
-        assert callable(self.factory), "OptimizerFromFactoryConfig.factory must be a callable"
+        assert callable(self.optim_cls), "OptimizerFromFactoryConfig.factory must be a callable"
         foreach = _foreach_for_mesh(device_mesh)
 
         kwargs = dict(self.kwargs)
@@ -550,12 +614,10 @@ class OptimizerFromFactoryConfig(OptimizerConfig):
             val = kwargs.get(attr, None)
             if isinstance(val, str):
                 kwargs[attr] = dtype_from_str(val)
-        if foreach is not None and "foreach" not in kwargs and _factory_accepts_foreach(self.factory):
+        if foreach is not None and "foreach" not in kwargs and _accepts_foreach(self.optim_cls):
             kwargs["foreach"] = foreach
 
-        if _is_te_fused_adam(self.factory):
-            param_groups = _drop_empty_local_shards(param_groups)
-        return self.factory(params=param_groups, **kwargs)
+        return self.optim_cls(params=param_groups, **kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -767,42 +829,17 @@ def _drop_empty_local_shards(params: list[Any]) -> list[Any]:
     return filtered
 
 
-def _is_te_fused_adam(factory: Callable[..., Any]) -> bool:
-    """Return ``True`` if ``factory`` is TransformerEngine's ``FusedAdam`` (or a subclass).
-
-    ``functools.partial`` wrappers are unwrapped (iteratively, for nested
-    partials) before the identity check, so ``partial(FusedAdam, ...)``
-    factories are recognized.  Other wrapper callables (closures, custom
-    factory functions) are opaque and are NOT recognized; such factories must
-    guard against zero-numel local shards themselves.
-
-    Identity-based and import-free: TE is an optional dependency, so this never
-    imports it.  If TE has not been imported yet, ``factory`` cannot be TE's
-    ``FusedAdam`` class and the check is trivially ``False``.
-    """
-    while isinstance(factory, functools.partial):
-        factory = factory.func
-    te_optimizers = sys.modules.get("transformer_engine.pytorch.optimizers")
-    if te_optimizers is None:
-        return False
-    te_fused_adam = getattr(te_optimizers, "FusedAdam", None)
-    return isinstance(te_fused_adam, type) and isinstance(factory, type) and issubclass(factory, te_fused_adam)
-
-
-def _factory_accepts_foreach(factory: Callable[..., Any]) -> bool:
+def _accepts_foreach(optim_cls: type["torch.optim.Optimizer"]) -> bool:
     """Return ``True`` if ``factory`` accepts a ``foreach`` kwarg.
 
     ``torch.optim`` optimizers take ``foreach``; external factories such as TE
     ``FusedAdam`` do not, so passing it would raise ``TypeError``.
     """
     try:
-        sig = inspect.signature(factory)
+        sig = inspect.signature(optim_cls)
     except (TypeError, ValueError):
         return False
-    params = sig.parameters
-    if "foreach" in params:
-        return True
-    return any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+    return "foreach" in sig.parameters
 
 
 # ---------------------------------------------------------------------------
@@ -901,7 +938,7 @@ def build_optimizer_config(
             )
         return dion_config(**kwargs)
     if callable(target):
-        return OptimizerFromFactoryConfig(factory=target, kwargs=kwargs)
+        return OptimizerFromFactoryConfig(optim_cls=target, kwargs=kwargs)
     raise TypeError(
         f"Optimizer target resolved to {target!r}, which is not an OptimizerConfig instance/subclass or a callable."
     )

--- a/nemo_automodel/shared/utils.py
+++ b/nemo_automodel/shared/utils.py
@@ -59,6 +59,7 @@ def dtype_from_str(val, default=torch.bfloat16):
         "torch.long": torch.long,
         "torch.bool": torch.bool,
         "bf16": torch.bfloat16,
+        "fp32": torch.float,
     }
 
     val_lower = val.lower()

--- a/tests/unit_tests/optim/test_fused_adam_empty_local_shards.py
+++ b/tests/unit_tests/optim/test_fused_adam_empty_local_shards.py
@@ -25,7 +25,6 @@ whole param group (rank-asymmetric ``param_groups`` desynchronize positional
 LR/WD scheduling) or the whole param list: those cases must raise.
 """
 
-import functools
 import logging
 import sys
 import types
@@ -110,7 +109,15 @@ class TestFusedAdamConfigDropsEmptyLocalShards:
 
         assert stub_te_fused_adam.last_params == [kept]
         assert stub_te_fused_adam.last_kwargs["lr"] == 1e-3
+        assert stub_te_fused_adam.last_kwargs.get("master_weight_dtype") == torch.float32
         assert "zero-numel local shards" in caplog.text
+
+    def test_explicit_master_weight_dtype_is_forwarded(self, stub_te_fused_adam):
+        kept = nn.Parameter(torch.ones(3))
+
+        FusedAdamConfig(master_weight_dtype="torch.float16")._build_optimizer([kept])
+
+        assert stub_te_fused_adam.last_kwargs["master_weight_dtype"] is torch.float16
 
     def test_flat_params_all_empty_raises(self, stub_te_fused_adam):
         with pytest.raises(ValueError, match="zero-numel local shard"):
@@ -174,63 +181,11 @@ class _TinyModel(nn.Module):
         self.empty = nn.Parameter(torch.empty(0))
 
 
-class _OnlyEmptyTrainableModel(nn.Module):
-    """Frozen linear; the sole trainable parameter has a zero-numel (local) shard."""
-
-    def __init__(self):
-        super().__init__()
-        self.linear = nn.Linear(3, 3)
-        self.linear.requires_grad_(False)
-        self.empty = nn.Parameter(torch.empty(0))
-
-
-class TestFactoryEscapeHatchDropsEmptyLocalShards:
-    def test_te_fused_adam_factory_drops_empty(self, stub_te_fused_adam):
-        cfg = OptimizerFromFactoryConfig(factory=stub_te_fused_adam, kwargs={"lr": 1e-3})
-
-        cfg.build(_TinyModel())
-
-        assert all(p.numel() > 0 for p in stub_te_fused_adam.last_params)
-        assert len(stub_te_fused_adam.last_params) == 2  # linear weight + bias
-
-    def test_partial_wrapped_te_fused_adam_factory_drops_empty(self, stub_te_fused_adam):
-        # functools.partial wrappers must be unwrapped by the TE FusedAdam identity
-        # check; without unwrapping, the empty shard would reach the constructor.
-        factory = functools.partial(stub_te_fused_adam, bias_correction=True)
-        cfg = OptimizerFromFactoryConfig(factory=factory, kwargs={"lr": 1e-3})
-
-        cfg.build(_TinyModel())
-
-        assert all(p.numel() > 0 for p in stub_te_fused_adam.last_params)
-        assert len(stub_te_fused_adam.last_params) == 2  # linear weight + bias
-        assert stub_te_fused_adam.last_kwargs["bias_correction"] is True
-
-    def test_te_fused_adam_factory_all_params_empty_raises(self, stub_te_fused_adam):
-        # The pre-filter `len(trainable_params) > 0` assert passes (one trainable
-        # param), so the post-filter empty list must raise the specific error, not
-        # torch's generic "optimizer got an empty parameter list".
-        cfg = OptimizerFromFactoryConfig(factory=stub_te_fused_adam, kwargs={"lr": 1e-3})
-
-        with pytest.raises(ValueError, match="zero-numel local shard"):
-            cfg.build(_OnlyEmptyTrainableModel())
-
-        assert stub_te_fused_adam.last_params is None
-
-    def test_te_fused_adam_factory_drops_empty_param_groups(self, stub_te_fused_adam):
-        cfg = OptimizerFromFactoryConfig(factory=stub_te_fused_adam, kwargs={"lr": 1e-3})
-        kept = nn.Parameter(torch.ones(3))
-
-        cfg.build_from_param_groups(
-            [
-                {"params": [nn.Parameter(torch.empty(0)), kept], "weight_decay": 0.1},
-            ]
-        )
-
-        assert stub_te_fused_adam.last_params == [{"params": [kept], "weight_decay": 0.1}]
-
-    def test_non_te_factory_is_not_filtered(self):
-        # torch.optim handles empty tensors; the guard must not change other factories.
-        cfg = OptimizerFromFactoryConfig(factory=torch.optim.SGD, kwargs={"lr": 0.01})
+class TestOptimizerFromFactoryConfig:
+    def test_all_params_forwarded_including_empty(self):
+        # The factory escape hatch does not filter zero-numel params; callers using
+        # TE FusedAdam should use FusedAdamConfig, which handles this automatically.
+        cfg = OptimizerFromFactoryConfig(optim_cls=torch.optim.SGD, kwargs={"lr": 0.01})
 
         opt = cfg.build(_TinyModel())[0]
 

--- a/tests/unit_tests/optim/test_optim_config.py
+++ b/tests/unit_tests/optim/test_optim_config.py
@@ -28,7 +28,9 @@ from nemo_automodel.components.optim.optimizer import (
     OptimizerConfig,
     OptimizerFromFactoryConfig,
     ParamGroupOverride,
+    _avoid_redundant_te_master_weights_for_fp32_params,
     _drop_empty_local_shards,
+    _split_dtensor_and_plain_params,
     build_optimizer,
     build_optimizer_config,
 )
@@ -106,6 +108,20 @@ class TestAdamWConfig:
 
 
 class TestOptimizerConfigBase:
+    def test_isolates_plain_params_from_dtensor_foreach_group(self, monkeypatch):
+        import nemo_automodel.components.optim.optimizer as optimizer_module
+
+        class FakeDTensor:
+            pass
+
+        sharded = FakeDTensor()
+        plain = object()
+        monkeypatch.setattr(optimizer_module, "DTensor", FakeDTensor)
+
+        groups = _split_dtensor_and_plain_params([sharded, plain])
+
+        assert groups == [{"params": [sharded]}, {"params": [plain]}]
+
     def test_base_build_not_implemented(self):
         with pytest.raises(NotImplementedError):
             OptimizerConfig()._build_optimizer(_params())
@@ -123,6 +139,36 @@ class TestOptimizerConfigBase:
         assert isinstance(opt, torch.optim.AdamW)
         assert opt.param_groups[0]["weight_decay"] == 0.1
         assert opt.param_groups[1]["weight_decay"] == 0.0
+
+
+def test_te_master_ownership_uses_resident_fp32_parameter_directly_after_resume():
+    fp32_param = nn.Parameter(torch.ones(4, dtype=torch.float32))
+    bf16_param = nn.Parameter(torch.ones(4, dtype=torch.bfloat16))
+
+    class FakeFusedAdam(torch.optim.Optimizer):
+        def __init__(self):
+            super().__init__([fp32_param, bf16_param], {"lr": 1e-3})
+            self.master_weights = True
+            self._scales = {}
+
+        def _initialize_state(self, parameter, state_name, zero_buffer):
+            """Create one FP32 optimizer-state tensor matching ``parameter`` shape."""
+            assert zero_buffer
+            self.state[parameter][state_name] = torch.zeros_like(parameter, dtype=torch.float32)
+
+    optimizer = FakeFusedAdam()
+    _avoid_redundant_te_master_weights_for_fp32_params(optimizer)
+
+    assert set(optimizer.state[fp32_param]) == {"exp_avg", "exp_avg_sq"}
+    assert optimizer.state[bf16_param] == {}
+
+    optimizer.state[fp32_param]["master_param"] = fp32_param.detach().clone()
+    optimizer.state[bf16_param]["master_param"] = bf16_param.detach().float().clone()
+    checkpoint = optimizer.state_dict()
+    optimizer.load_state_dict(checkpoint)
+
+    assert set(optimizer.state[fp32_param]) == {"exp_avg", "exp_avg_sq"}
+    assert "master_param" in optimizer.state[bf16_param]
 
 
 # ---------------------------------------------------------------------------
@@ -175,7 +221,7 @@ class TestBuildOptimizer:
 class TestOptimizerFromFactoryConfig:
     def test_build_constructs_from_factory(self):
         cfg = OptimizerFromFactoryConfig(
-            factory=torch.optim.SGD,
+            optim_cls=torch.optim.SGD,
             kwargs={"lr": 0.01, "momentum": 0.9},
         )
         optimizers = cfg.build(_model())
@@ -191,18 +237,18 @@ class TestOptimizerFromFactoryConfig:
             return torch.optim.SGD(params, lr=kwargs.get("lr", 0.01))
 
         OptimizerFromFactoryConfig(
-            factory=fake_factory,
+            optim_cls=fake_factory,
             kwargs={"lr": 1e-3, "master_weight_dtype": "torch.bfloat16"},
         ).build(_model())
         assert captured["master_weight_dtype"] is torch.bfloat16
 
     def test_build_requires_callable_factory(self):
         with pytest.raises(AssertionError, match="must be a callable"):
-            OptimizerFromFactoryConfig(factory=None).build(_model())
+            OptimizerFromFactoryConfig(optim_cls=None).build(_model())
 
     def test_build_from_param_groups_uses_factory(self):
         cfg = OptimizerFromFactoryConfig(
-            factory=torch.optim.SGD,
+            optim_cls=torch.optim.SGD,
             kwargs={"lr": 0.01, "momentum": 0.9},
         )
         params = list(_model().parameters())
@@ -256,7 +302,7 @@ class TestBuildOptimizerTuple:
         build_optimizer(
             _model(),
             OptimizerFromFactoryConfig(
-                factory=fake_factory,
+                optim_cls=fake_factory,
                 kwargs={"lr": 1e-3, "master_weight_dtype": "torch.bfloat16", "exp_avg_dtype": "float16"},
             ),
         )
@@ -572,7 +618,7 @@ class TestParamGroupOverrides:
     def test_factory_reads_overrides_from_inherited_field(self):
         # Overrides set on the factory config's own field (not nested in kwargs) are honored.
         cfg = OptimizerFromFactoryConfig(
-            factory=torch.optim.AdamW,
+            optim_cls=torch.optim.AdamW,
             kwargs={"lr": 1e-3},
             param_group_overrides=[ParamGroupOverride("router", lr_mult=0.1)],
         )


### PR DESCRIPTION
## Motivation

Bounded FSDP2 replication can leave plain tensors and sharded `DTensor`s in
the same optimizer group. PyTorch foreach kernels reject that mixed layout.

Transformer Engine's `FusedAdam` also has one optimizer-wide `master_weights`
switch. Mixed BF16/FP32 models need master weights for BF16 parameters, but
TE's FP32 update path operates directly on resident FP32 parameters and does
not consume a duplicate `master_param`.

## Changes

- Split only mixed plain/`DTensor` optimizer groups, preserving group options
  and leaving homogeneous groups unchanged.
- Default `FusedAdamConfig.master_weight_dtype` to `"fp32"`; explicit `null`
  omits the kwarg and defers to TE's default.
- Initialize moment-only state for resident FP32 parameters so TE does not
  allocate redundant master weights.
- Normalize legacy checkpoint state before TE's second load pass and restore
  moment-only state for checkpoints saved before the first optimizer step.
- Keep the public `OptimizerFromFactoryConfig(factory=...)` API compatible.
- Apply TE empty-local-shard filtering and FP32 master-state ownership to both
  typed and dotted/YAML factory construction paths.
- Add the `"fp32"` shorthand to `dtype_from_str`.

## Validation

- `ruff format` and `ruff check` on all changed Python files
- `214 passed, 8 skipped` across optimizer, shared-utils, and diffusion recipe
  unit tests
- Added CUDA/Transformer Engine coverage for optimizer step and checkpoint
  reload behavior; these tests run in GPU CI
