### PR TITLE
fix(peft): export Nemotron adapters in the Transformers v5 namespace

### DIFF
--- a/nemo_automodel/components/checkpoint/addons.py
+++ b/nemo_automodel/components/checkpoint/addons.py
@@ -562,7 +562,9 @@ def _extract_target_modules(
     # The base method defaults to the identity; legacy adapters that don't
     # subclass StateDictAdapter (e.g. kimivl) skip it, as before.
     if isinstance(adapter, StateDictAdapter):
-        final_target_modules = {adapter.map_peft_target_module_to_hf(name) for name in final_target_modules}
+        final_target_modules = {
+            adapter.map_peft_target_module_to_hf(name, v4_compatible=v4_compatible) for name in final_target_modules
+        }
 
     # Under pipeline parallelism each rank only holds the local stage's layers,
     # so named_modules() above yields layer-specific target names for that stage

--- a/nemo_automodel/components/checkpoint/state_dict_adapter.py
+++ b/nemo_automodel/components/checkpoint/state_dict_adapter.py
@@ -106,7 +106,7 @@ class StateDictAdapter(ABC):
         }
         return list(self.to_hf(shape_only_state, exclude_key_regex=r".*_extra_state.*", quantization=False))
 
-    def map_peft_target_module_to_hf(self, name: str) -> str:
+    def map_peft_target_module_to_hf(self, name: str, *, v4_compatible: bool = False) -> str:
         """Translate a PEFT target-module name to the HuggingFace layout.
 
         adapter_config.json's target_modules are collected from native module
@@ -117,6 +117,7 @@ class StateDictAdapter(ABC):
 
         Args:
             name: A target-module name in native layout.
+            v4_compatible: Whether to target the legacy Transformers v4 layout.
 
         Returns:
             The name in HuggingFace layout. Defaults to the name unchanged.

--- a/nemo_automodel/components/models/kimi_k3/state_dict_adapter.py
+++ b/nemo_automodel/components/models/kimi_k3/state_dict_adapter.py
@@ -194,7 +194,7 @@ class KimiK3StateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter):
         lora = match.group("lora") or ""
         return f"{match.group('prefix')}.mlp.experts.{match.group('expert')}.{projection}{lora}.weight"
 
-    def map_peft_target_module_to_hf(self, name: str) -> str:
+    def map_peft_target_module_to_hf(self, name: str, *, v4_compatible: bool = False) -> str:
         """Convert a native PEFT target-module path to the checkpoint layout.
 
         adapter_config.json's target_modules must name modules that exist in the
@@ -203,6 +203,13 @@ class KimiK3StateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter):
         block_sparse_moe, and the other MoE-owned children (shared_experts,
         routed_expert_*, gate) move from mlp. to block_sparse_moe. as well.
         Dense-layer mlp paths pass through unchanged.
+
+        Args:
+            name: A target-module name in native layout.
+            v4_compatible: Legacy export selection; K3 uses the same module names in both formats.
+
+        Returns:
+            Target-module name in the HF K3 layout.
         """
         # Same segment renames as _native_moe_key_to_hf, but target-module paths
         # can END at the segment (e.g. ...mlp.routed_expert_up_proj), which the

--- a/nemo_automodel/components/models/nemotron_v3/state_dict_adapter.py
+++ b/nemo_automodel/components/models/nemotron_v3/state_dict_adapter.py
@@ -128,12 +128,16 @@ class NemotronV3StateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter
         """Nemotron V3 exposes fused non-gated expert parameters in Transformers v5."""
         return ("mixer.experts.up_proj", "mixer.experts.down_proj")
 
-    def _native_key_to_hf(self, key: str) -> str:
+    def _native_key_to_hf(self, key: str, *, v4_compatible: bool = False) -> str:
         """Normalize a native Nemotron V3 key to its public HF namespace."""
         key = _strip_mamba_fp32_holder_key(key)
+        # Base checkpoints may still use the remote-code backbone namespace.
+        # Default PEFT exports target the built-in Transformers v5 model, whose
+        # modules live under model regardless of the base checkpoint's keys.
+        hf_prefix = "model." if ".lora_" in key and not v4_compatible else self._hf_prefix
         key = re.sub(
             r"^(?P<outer>base_model\.model\.)?model\.",
-            lambda match: f"{match.group('outer') or ''}{self._hf_prefix}",
+            lambda match: f"{match.group('outer') or ''}{hf_prefix}",
             key,
         )
         hf_root = re.escape(self._hf_prefix.rstrip("."))
@@ -141,9 +145,19 @@ class NemotronV3StateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter
         key = re.sub(rf"^{hf_root}\.embed_tokens\.weight$", f"{self._hf_prefix}embeddings.weight", key)
         return key
 
-    def map_peft_target_module_to_hf(self, module_name: str) -> str:
-        """Map native PEFT target modules to the public Nemotron-H namespace."""
-        return self._native_key_to_hf(module_name)
+    def map_peft_target_module_to_hf(self, module_name: str, *, v4_compatible: bool = False) -> str:
+        """Map PEFT targets to the same namespace as the exported adapter weights.
+
+        Args:
+            module_name: A target-module name in native layout.
+            v4_compatible: Preserve the source checkpoint's legacy namespace.
+
+        Returns:
+            Target-module name for the selected HF export format.
+        """
+        if v4_compatible:
+            return self._native_key_to_hf(module_name, v4_compatible=True)
+        return _strip_mamba_fp32_holder_key(module_name)
 
     def _hf_key_to_native(self, key: str) -> str:
         """Normalize a public HF Nemotron V3 key to its native namespace."""
@@ -300,6 +314,7 @@ class NemotronV3StateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter
             List of (fqn, tensor) tuples in HuggingFace format
         """
         exclude_key_regex = kwargs.get("exclude_key_regex", None)
+        v4_compatible = kwargs.get("v4_compatible", False)
 
         # MTP keys live in their own ``mtp.*`` namespace; route them through
         # the standard expert-split path with the prefix overridden so
@@ -332,10 +347,10 @@ class NemotronV3StateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter
         if expert_result is not None:
             # The shared expert converter preserves the native input prefix for
             # LoRA keys. Route every result through Nemotron's adapter-specific
-            # model -> backbone normalization just like ordinary tensors.
-            result = [(self._native_key_to_hf(key), value) for key, value in expert_result]
+            # normalization for the selected PEFT export format.
+            result = [(self._native_key_to_hf(key, v4_compatible=v4_compatible), value) for key, value in expert_result]
         else:
-            new_fqn = self._native_key_to_hf(fqn)
+            new_fqn = self._native_key_to_hf(fqn, v4_compatible=v4_compatible)
             result = [(new_fqn, _upcast_mamba_fp32_state_tensor(new_fqn, tensor))]
 
         if exclude_key_regex:

--- a/tests/unit_tests/checkpoint/test_addons.py
+++ b/tests/unit_tests/checkpoint/test_addons.py
@@ -413,7 +413,7 @@ class TestExtractTargetModules:
         """
 
         class _RenamingAdapter(_StubStateDictAdapter):
-            def map_peft_target_module_to_hf(self, name):
+            def map_peft_target_module_to_hf(self, name: str, *, v4_compatible: bool = False) -> str:
                 return name.replace(".mlp.experts.", ".block_sparse_moe.experts.")
 
         model = _make_model_with_named_modules(

--- a/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_state_dict_adapter.py
+++ b/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_state_dict_adapter.py
@@ -100,14 +100,18 @@ class TestNemotronV3StateDictAdapter:
         adapter._uses_model_prefix = True
         assert adapter._hf_prefix == "model."
 
-    def test_peft_target_module_mapping_tracks_hf_prefix(self, config, moe_config, backend):
-        """PEFT target-module metadata uses the same public namespace as exported tensors."""
+    def test_peft_target_module_mapping_tracks_export_format(self, config, moe_config, backend):
+        """Default PEFT targets the built-in model; v4 preserves the source namespace."""
         adapter = NemotronV3StateDictAdapter(config, moe_config, backend)
         native_name = "model.layers.0.mixer.in_proj"
 
-        assert adapter.map_peft_target_module_to_hf(native_name) == "backbone.layers.0.mixer.in_proj"
+        assert adapter.map_peft_target_module_to_hf(native_name) == native_name
+        assert (
+            adapter.map_peft_target_module_to_hf(native_name, v4_compatible=True) == "backbone.layers.0.mixer.in_proj"
+        )
         adapter._uses_model_prefix = True
         assert adapter.map_peft_target_module_to_hf(native_name) == native_name
+        assert adapter.map_peft_target_module_to_hf(native_name, v4_compatible=True) == native_name
 
     def test_expert_path_segment_property(self, config, moe_config, backend):
         """Test _expert_path_segment property returns 'mixer.experts'."""
@@ -240,17 +244,32 @@ class TestNemotronV3AdapterDense:
         )
         assert exported[0][0] == "mtp.layers.0.mixer.A_log"
 
-    def test_peft_outer_prefix_round_trip(self, adapter):
-        hf_key = "base_model.model.backbone.layers.0.mixer.in_proj.lora_A.weight"
+    @pytest.mark.parametrize("v4_compatible", [False, True])
+    def test_peft_outer_prefix_round_trip(self, adapter, v4_compatible):
+        prefix = "backbone" if v4_compatible else "model"
+        hf_key = f"base_model.model.{prefix}.layers.0.mixer.in_proj.lora_A.weight"
         native_key = "base_model.model.model.layers.0.mixer.in_proj.lora_A.weight"
         tensor = torch.randn(8, 256)
 
-        exported = adapter.to_hf({native_key: tensor})
+        exported = adapter.to_hf({native_key: tensor}, v4_compatible=v4_compatible)
+        assert adapter._uses_model_prefix is False, "PEFT export must not change the full-checkpoint layout"
         restored = adapter.from_hf(dict(exported))
 
         assert list(exported) == [hf_key]
         assert list(restored) == [native_key]
         torch.testing.assert_close(restored[native_key], tensor)
+
+    def test_legacy_peft_adapter_loads_and_reexports_for_v5(self, adapter):
+        """A saved backbone adapter remains loadable and can be exported to built-in HF."""
+        old_key = "base_model.model.backbone.layers.0.mixer.in_proj.lora_A.weight"
+        tensor = torch.randn(8, 256)
+
+        native = adapter.from_hf({old_key: tensor})
+        exported = adapter.to_hf(native)
+
+        key = "base_model.model.model.layers.0.mixer.in_proj.lora_A.weight"
+        assert set(exported) == {key}
+        torch.testing.assert_close(exported[key], tensor, rtol=0, atol=0)
 
 
 class TestNemotronV3AdapterMTP:
@@ -792,7 +811,7 @@ class TestNemotronV3AdapterMixerExperts:
         result = adapter.convert_single_tensor_to_hf("model.layers.0.mixer.experts.lora_gate_and_up_A", tensor)
 
         keys = {key for key, _ in result}
-        assert keys == {"backbone.layers.0.mixer.experts.base_layer.lora_A.weight"}
+        assert keys == {"model.layers.0.mixer.experts.base_layer.lora_A.weight"}
         assert adapter._v5_peft_target_parameters == ("mixer.experts.up_proj", "mixer.experts.down_proj")
 
     def test_legacy_layout_option_restores_the_pre_flip_suffix(self, config, moe_config, backend):
@@ -804,7 +823,7 @@ class TestNemotronV3AdapterMixerExperts:
         )
 
         keys = {key for key, _ in result}
-        assert keys == {"backbone.layers.0.mixer.experts.base_layer.lora_B.weight"}
+        assert keys == {"model.layers.0.mixer.experts.base_layer.lora_B.weight"}
 
     def test_v4_lora_export_stays_per_expert_for_non_gated_experts(self, config, moe_config, backend):
         """Explicit v4 compatibility retains the per-expert up projection."""

--- a/tests/unit_tests/models/test_moe_peft_v5_state_dict_adapters.py
+++ b/tests/unit_tests/models/test_moe_peft_v5_state_dict_adapters.py
@@ -150,9 +150,6 @@ def _make_adapter_and_state(family: str, rank: int):
         adapter = NemotronV3StateDictAdapter(
             SimpleNamespace(num_hidden_layers=1), moe_config, backend, dtype=torch.float32
         )
-        # This fixture uses Transformers v5's native ``model.*`` hierarchy;
-        # remote-code Nemotron-H checkpoints instead select ``backbone.*``.
-        adapter._uses_model_prefix = True
     expert_path, _ = _FAMILIES[family]
 
     base = f"base_model.model.model.layers.0.{expert_path}"
@@ -164,6 +161,89 @@ def _make_adapter_and_state(family: str, rank: int):
         f"{base}.lora_down_B": torch.randn(moe_config.n_routed_experts, rank, moe_config.dim),
     }
     return adapter, moe_config, state_dict
+
+
+def test_nemotron_linear_adapter_export_loads_into_hf(tmp_path: Path) -> None:
+    """Base checkpoints with backbone keys must export loadable linear adapters.
+
+    Exercise Mamba input, latent projections, shared experts, and lm_head using
+    the real export metadata and PEFT loader. Previously only lm_head loaded:
+    the built-in HF model silently skipped every backbone-prefixed target.
+    """
+    from peft import LoraConfig, PeftModel, get_peft_model_state_dict
+    from safetensors.torch import save_file
+    from transformers.models.nemotron_h.configuration_nemotron_h import NemotronHConfig
+    from transformers.models.nemotron_h.modeling_nemotron_h import NemotronHForCausalLM
+
+    torch.manual_seed(42)
+    config = NemotronHConfig(
+        vocab_size=32,
+        hidden_size=16,
+        layers_block_type=["mamba", "moe"],
+        num_hidden_layers=2,
+        n_routed_experts=2,
+        moe_intermediate_size=12,
+        moe_shared_expert_intermediate_size=12,
+        moe_latent_size=8,
+        num_experts_per_tok=1,
+        n_group=1,
+        topk_group=1,
+        use_mamba_kernels=False,
+        mamba_num_heads=8,
+        mamba_head_dim=4,
+        n_groups=1,
+        ssm_state_size=4,
+        expand=2,
+    )
+    model = NemotronHForCausalLM(config).eval()
+    base_weights = {name: tensor.clone() for name, tensor in model.state_dict().items()}
+    backend = BackendConfig(linear="torch", attn="sdpa", rms_norm="torch")
+    # Ordinary linear adapters are sufficient for the reported failure; the
+    # grouped expert export and merge are exercised by the tests below.
+    adapter = NemotronV3StateDictAdapter(config, None, backend, dtype=torch.float32)
+    model.state_dict_adapter = adapter
+    peft_config = PeftConfig(exclude_modules=["*.out_proj"], dim=2, alpha=2, use_triton=False)
+    apply_lora_to_linear_modules(model, peft_config)
+    with torch.no_grad():
+        for name, parameter in model.named_parameters():
+            if ".lora_" in name:
+                parameter.normal_(std=0.01)
+    state = ModelState(model, is_peft=True)
+    metadata = _get_hf_peft_config(peft_config, state)
+    native_adapter = state.state_dict()
+    exported = adapter.to_hf(dict(native_adapter))
+    # Explicit legacy export must still preserve both backbone-prefixed
+    # target metadata and weight names for remote-code model consumers.
+    legacy_metadata = _get_hf_peft_config(peft_config, state, v4_compatible=True)
+    legacy_exported = adapter.to_hf(dict(native_adapter), v4_compatible=True)
+    assert "backbone.layers.0.mixer.in_proj" in legacy_metadata["target_modules"]
+    legacy_key = "base_model.model.backbone.layers.0.mixer.in_proj.lora_A.weight"
+    torch.testing.assert_close(
+        legacy_exported[legacy_key], exported[legacy_key.replace(".backbone.", ".model.")], rtol=0, atol=0
+    )
+    streamed = dict(
+        item for name, tensor in native_adapter.items() for item in adapter.convert_single_tensor_to_hf(name, tensor)
+    )
+    assert set(streamed) == set(exported)
+    for name in exported:
+        torch.testing.assert_close(streamed[name], exported[name], rtol=0, atol=0)
+    assert adapter._uses_model_prefix is False
+    LoraConfig(**metadata).save_pretrained(tmp_path)
+    save_file(exported, str(tmp_path / "adapter_model.safetensors"))
+
+    hf_model = NemotronHForCausalLM(config).eval()
+    hf_model.load_state_dict(base_weights)
+    loaded = PeftModel.from_pretrained(hf_model, str(tmp_path), key_mapping={}, autocast_adapter_dtype=False)
+    loaded_state = get_peft_model_state_dict(loaded, save_embedding_layers=False)
+    assert set(loaded_state) == set(exported)
+    for name in exported:
+        torch.testing.assert_close(loaded_state[name], exported[name], rtol=0, atol=0)
+
+    input_ids = torch.tensor([[1, 2, 3, 4]])
+    with torch.no_grad():
+        expected_logits = model(input_ids, use_cache=False).logits
+        actual_logits = loaded(input_ids, use_cache=False).logits
+    torch.testing.assert_close(actual_logits, expected_logits, rtol=1e-5, atol=1e-6)
 
 
 def _expected_hf_delta(lora_a: torch.Tensor, lora_b: torch.Tensor, scale: float) -> torch.Tensor:

--- a/tests/unit_tests/models/test_moe_peft_v5_state_dict_adapters.py
+++ b/tests/unit_tests/models/test_moe_peft_v5_state_dict_adapters.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from inspect import unwrap
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -163,7 +164,7 @@ def _make_adapter_and_state(family: str, rank: int):
     return adapter, moe_config, state_dict
 
 
-def test_nemotron_linear_adapter_export_loads_into_hf(tmp_path: Path) -> None:
+def test_nemotron_linear_adapter_export_loads_into_hf(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Base checkpoints with backbone keys must export loadable linear adapters.
 
     Exercise Mamba input, latent projections, shared experts, and lm_head using
@@ -172,8 +173,15 @@ def test_nemotron_linear_adapter_export_loads_into_hf(tmp_path: Path) -> None:
     """
     from peft import LoraConfig, PeftModel, get_peft_model_state_dict
     from safetensors.torch import save_file
+    from transformers.models.nemotron_h import modeling_nemotron_h
     from transformers.models.nemotron_h.configuration_nemotron_h import NemotronHConfig
     from transformers.models.nemotron_h.modeling_nemotron_h import NemotronHForCausalLM
+
+    # Transformers prefers installed causal-conv1d/mamba-ssm kernels even on
+    # CPU. Use its real PyTorch reference functions for this no-cache forward;
+    # use_mamba_kernels=False does not control this newer dispatch path.
+    for name in ("causal_conv1d_fn", "mamba2_chunk_scan"):
+        monkeypatch.setattr(modeling_nemotron_h, name, unwrap(getattr(modeling_nemotron_h, name)))
 
     torch.manual_seed(42)
     config = NemotronHConfig(
@@ -188,7 +196,6 @@ def test_nemotron_linear_adapter_export_loads_into_hf(tmp_path: Path) -> None:
         num_experts_per_tok=1,
         n_group=1,
         topk_group=1,
-        use_mamba_kernels=False,
         mamba_num_heads=8,
         mamba_head_dim=4,
         n_groups=1,


### PR DESCRIPTION
# What does this PR do ?

Fixes [AMINT-330: Missing PEFT adapter weights in checkpoint causing AssertionError](https://linear.app/nvidia/issue/AMINT-330/missing-peft-adapter-weights-in-checkpoint-causing-assertionerror).

Fix Nemotron PEFT exports from base checkpoints that use `backbone.*` names so they load into the built-in Transformers v5 model. Previously, the adapter weights and `target_modules` retained `backbone.*`, while the receiving model exposed `model.*`; PEFT loaded only the matching `lm_head` adapters and omitted the affected Mamba, latent-projection, and shared-expert adapters.

# Changelog

- Export modern Nemotron adapter weights and target metadata under `model.*`, independently of the original base checkpoint namespace.
- Preserve the existing namespace for full checkpoints and explicit `v4_compatible=True` adapter exports. Forward that existing option through the model-owned target-module mapping hook.
- Add a real tiny-model HF PEFT reload regression checking all saved tensors exactly, matching forward logits, bulk/streaming export agreement, and legacy export preservation. Exercise the existing Nemotron expert-merge test without forcing the source checkpoint prefix.
- Select the upstream PyTorch Mamba reference functions within the CPU regression test so installed optional CUDA kernels do not override its CPU execution.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? Updated API docstrings; no user configuration change.

# Additional Information

Validation: **82 passed, no skips** across:

```
tests/unit_tests/models/test_moe_peft_v5_state_dict_adapters.py
tests/unit_tests/models/nemotron_v3/test_nemotron_v3_state_dict_adapter.py
tests/unit_tests/checkpoint/test_addons.py
tests/unit_tests/models/kimi_k3/test_state_dict_adapter.py
```

CPU validation: initially Python 3.12, Torch 2.10.0+cu130, Transformers 5.15.1, PEFT 0.20.0. Repeated in the staged September 11 CI image with Torch 2.14.0a0+4fdf77b940.nv26.08, Transformers 5.15.1, PEFT 0.20.0, and real `causal-conv1d`/`mamba-ssm` installed: the original test reproduced `Expected x.is_cuda() to be true`, and the corrected test passed with **all 82 focused tests**. Exact tensor reload and forward equivalence assertions are retained. Real expert reload/merge coverage includes Nemotron, MiniMax, and Qwen3 MoE. Repository-wide Ruff formatting/lint and `git diff --check` pass; commits include DCO signoff.

Scoped CI rerun: **Passed — all six checkpoint robustness phases.** [Original Nemotron Super PEFT job](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/435543220) ([pipeline 67379306](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/67379306)), testing commit `97874c8a9601e79b9c392059172e6c08a753f287`. The run targeted only `nemotron_super_v3_hellaswag_peft` on EOS (8 H100 GPUs), with an x86 AutoModel build. Source load reference, source load parity, train/save, AutoModel reload, HF reload, and resume each reported `PASS` with exit code 0.

The subsequent CPU kernel-selection correction changes only the unit test; production code is identical to the scoped run's revision.

Broader PEFT export cleanup and shared consumer-level regression coverage are tracked separately in #3867.
