### PR TITLE
fix(ci): stabilize FlexAttention checkpoint parity

### DIFF
--- a/examples/llm_finetune/gpt_oss/gpt_oss_20b_peft.yaml
+++ b/examples/llm_finetune/gpt_oss/gpt_oss_20b_peft.yaml
@@ -120,9 +120,10 @@ ci:
   recipe_owner: akoumpa
   time: "00:20:00"
   checkpoint_robustness:
-    # PEFT source and reload comparisons consistently sit above the standard
-    # same-implementation envelope while remaining well inside the shared relaxed profile.
-    parity_tolerance_profile: relaxed
+    # Fixed attention makes AutoModel reload exact; source parity also passes standard.
+    # HF adapter reload still needs relaxed (mean KL 0.01998, p95 KL 0.06953).
+    parity_tolerance_profile_overrides:
+      hf_reload: relaxed
     tokenizer_name: openai/gpt-oss-20b
     dataset.num_samples_limit: 500
     validation_dataset.num_samples_limit: 500

--- a/tests/ci_tests/README.md
+++ b/tests/ci_tests/README.md
@@ -154,6 +154,15 @@ harness fails with an actionable error instead of repeating content if a request
 document. Pipeline-parallel runs resize their stage activation buffers to the configured parity length; reduce the
 length only when a model has a documented memory limit.
 
+Parity forwards through AutoModel's shared `FlexAttention` wrapper use static compilation and fixed 64-by-64
+query/key tiles. A separate compiler entry point keeps training's recompilations out of the parity cache budget;
+full-graph compilation raises instead of silently falling back to unfused attention. The trained reference and
+reloaded model therefore use the same attention policy even when training has generalized shapes or autotuned
+different kernels. This temporary override also applies to AutoModel
+source-parity forwards and is restored afterward; training, native resume, other attention backends, and vanilla-HF
+attention retain their normal execution. It improves reload consistency without guaranteeing bitwise equality
+across different topologies or closer agreement with HF. Existing numerical thresholds still apply.
+
 For a diagnosed cross-framework instability, `cross_framework_gate_sequence_length` can gate Phases 0 and 3 on a
 prefix of the same long forward. It does not launch a shorter forward: the harness still runs and reports all
 `parity_sequence_length` tokens, while mean KL, p95 KL, and cosine use the configured prefix for pass/fail. Phase 2,

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -35,11 +35,11 @@ import os
 import sys
 import time
 import traceback
-from collections.abc import Callable
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from dataclasses import dataclass
 from datetime import timedelta
-from functools import wraps
+from functools import cache, wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -51,6 +51,7 @@ import torch
 import torch.distributed as dist
 from torch.distributed.tensor import DTensor
 
+from nemo_automodel.components.attention.flex_attention import FlexAttention
 from nemo_automodel.components.checkpoint.checkpointing import (
     _MODELS_REQUIRING_BUFFER_REINIT,
     _reinit_non_persistent_buffers,
@@ -2112,20 +2113,101 @@ def _get_logits_pp(trainer, input_ids, device) -> torch.Tensor:
     return buf.cpu()
 
 
-def _get_logits(model, input_ids, device, trainer=None) -> torch.Tensor:
-    """Forward pass returning float32 logits on CPU."""
-    if trainer is not None and getattr(trainer, "pp_enabled", False):
-        return _get_logits_pp(trainer, input_ids, device)
+@cache
+def _parity_flex_attention() -> Callable[..., torch.Tensor | tuple[torch.Tensor, torch.Tensor]]:
+    """Compile one static, fixed-tile FlexAttention callable per test process.
 
-    model.eval()
-    ids = torch.tensor([input_ids], device=device)
-    attention_mask = torch.ones_like(ids)
-    with torch.no_grad():
-        out = model(input_ids=ids, attention_mask=attention_mask, use_cache=False)
-        logits = out.logits if hasattr(out, "logits") else out
-        if isinstance(logits, DTensor):
-            logits = logits.full_tensor()
-        return logits.float().cpu()
+    The compiler retains specializations for the parity input geometries for the
+    lifetime of this process. Training continues to use the original callable.
+    """
+    from torch.nn.attention.flex_attention import BlockMask, flex_attention
+
+    # A distinct code object keeps training's recompilations out of the parity
+    # cache budget. Full-graph mode rejects fallback to unfused attention.
+    @torch.compile(dynamic=False, fullgraph=True)
+    def attention(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *,
+        block_mask: BlockMask,
+        scale: float | None = None,
+        enable_gqa: bool = False,
+        return_lse: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        """Run fixed-tile attention through a dedicated compiler entry point.
+
+        Args:
+            q: Tensor of shape [batch, query_heads, query_sequence, head_dim].
+            k: Tensor of shape [batch, kv_heads, key_sequence, head_dim].
+            v: Tensor of shape [batch, kv_heads, key_sequence, value_dim].
+            block_mask: BlockMask describing allowed positions of shape
+                [batch, query_heads, query_sequence, key_sequence].
+            scale: Optional query/key scale; defaults to inverse sqrt(head_dim).
+            enable_gqa: Allow query_heads to be a multiple of kv_heads.
+            return_lse: Also return the attention log-sum-exp for attention sinks.
+
+        Returns:
+            Output of shape [batch, query_heads, query_sequence, value_dim], or
+            that output and log-sum-exp of shape [batch, query_heads, query_sequence].
+        """
+        return flex_attention(
+            q,
+            k,
+            v,
+            block_mask=block_mask,
+            scale=scale,
+            enable_gqa=enable_gqa,
+            return_lse=return_lse,
+            kernel_options={"BLOCK_M": 64, "BLOCK_N": 64},
+        )
+
+    return attention
+
+
+@contextmanager
+def _fixed_flex_attention_for_parity(model_parts: Sequence[torch.nn.Module]) -> Iterator[None]:
+    """Keep shared FlexAttention numerics consistent across parity forwards.
+
+    Training can generalize the compiled shapes and select different tiles from
+    a fresh reload. Fix both policies for reference and candidate forwards; even
+    small attention differences can change MoE routes. The override is local to
+    these serial test forwards and is restored on both success and failure.
+
+    Args:
+        model_parts: Local model parts, including every local pipeline stage.
+            Models using other attention implementations are left untouched.
+
+    Yields:
+        None while the shared FlexAttention callable is temporarily replaced.
+    """
+    if not any(isinstance(module, FlexAttention) for part in model_parts for module in part.modules()):
+        yield
+        return
+    original = FlexAttention.flex_attn
+    FlexAttention.flex_attn = _parity_flex_attention()
+    try:
+        yield
+    finally:
+        FlexAttention.flex_attn = original
+
+
+def _get_logits(model, input_ids, device, trainer=None) -> torch.Tensor:
+    """Run a parity forward and return float32 CPU logits of shape [1, sequence, vocab]."""
+    model_parts = trainer.model_parts if trainer is not None else [model]
+    with _fixed_flex_attention_for_parity(model_parts):
+        if trainer is not None and getattr(trainer, "pp_enabled", False):
+            return _get_logits_pp(trainer, input_ids, device)
+
+        model.eval()
+        ids = torch.tensor([input_ids], device=device)
+        attention_mask = torch.ones_like(ids)
+        with torch.no_grad():
+            out = model(input_ids=ids, attention_mask=attention_mask, use_cache=False)
+            logits = out.logits if hasattr(out, "logits") else out
+            if isinstance(logits, DTensor):
+                logits = logits.full_tensor()
+            return logits.float().cpu()
 
 
 def _reinit_rotary_per_module(model, default_device):

--- a/tests/unit_tests/ci_tests/test_checkpoint_robustness_attention.py
+++ b/tests/unit_tests/ci_tests/test_checkpoint_robustness_attention.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from nemo_automodel.components.attention.flex_attention import FlexAttention
+from tests.functional_tests.checkpoint_robustness import test_checkpoint_robustness_llm as harness
+
+
+class _StubFlexAttention(FlexAttention):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Exercise callable selection without compiling a GPU kernel.
+
+        Args:
+            x: Tensor of shape [batch, sequence, vocab].
+
+        Returns:
+            Tensor of shape [batch, sequence, vocab].
+        """
+        return FlexAttention.flex_attn(x)
+
+
+class _Model(torch.nn.Module):
+    def __init__(self, attention: torch.nn.Module) -> None:
+        super().__init__()
+        self.attention = attention
+
+    def forward(self, input_ids: torch.Tensor, attention_mask: torch.Tensor | None, use_cache: bool) -> torch.Tensor:
+        """Return toy logits through the selected attention module.
+
+        Args:
+            input_ids: Integer tensor of shape [batch, sequence].
+            attention_mask: Tensor of shape [batch, sequence]; unused.
+            use_cache: Unused cache setting.
+
+        Returns:
+            Tensor of shape [batch, sequence, 1].
+        """
+        return self.attention(input_ids.float().unsqueeze(-1))
+
+
+@pytest.mark.parametrize("fail_forward", [False, True])
+def test_parity_attention_is_scoped_to_forward(monkeypatch, fail_forward):
+    original = Mock(side_effect=lambda x: x)
+    parity = Mock(side_effect=RuntimeError("forward failed") if fail_forward else lambda x: x + 1)
+    monkeypatch.setattr(FlexAttention, "flex_attn", original)
+    monkeypatch.setattr(harness, "_parity_flex_attention", lambda: parity)
+    model = _Model(_StubFlexAttention())
+
+    if fail_forward:
+        with pytest.raises(RuntimeError, match="forward failed"):
+            harness._get_logits(model, [1, 2], torch.device("cpu"))
+    else:
+        logits = harness._get_logits(model, [1, 2], torch.device("cpu"))
+        torch.testing.assert_close(logits, torch.tensor([[[2.0], [3.0]]]), rtol=0, atol=0)
+
+    assert FlexAttention.flex_attn is original
+    original.assert_not_called()
+    parity.assert_called_once()
+    # A subsequent ordinary forward must use the original execution policy.
+    output = model(torch.tensor([[1, 2]]), None, False)
+    torch.testing.assert_close(output, torch.tensor([[[1.0], [2.0]]]), rtol=0, atol=0)
+    original.assert_called_once()
+
+
+def test_other_attention_backends_do_not_initialize_parity_kernel(monkeypatch):
+    factory = Mock(side_effect=AssertionError("unexpected FlexAttention compilation"))
+    monkeypatch.setattr(harness, "_parity_flex_attention", factory)
+    model = _Model(torch.nn.Identity())
+
+    logits = harness._get_logits(model, [1, 2], torch.device("cpu"))
+
+    torch.testing.assert_close(logits, torch.tensor([[[1.0], [2.0]]]), rtol=0, atol=0)
+    factory.assert_not_called()
+
+
+def test_parity_attention_covers_later_local_pipeline_parts(monkeypatch):
+    original = FlexAttention.flex_attn
+    parity = Mock()
+    monkeypatch.setattr(harness, "_parity_flex_attention", lambda: parity)
+    first = torch.nn.Identity()
+    trainer = SimpleNamespace(pp_enabled=True, model_parts=[first, _Model(_StubFlexAttention())])
+
+    def pipeline_forward(trainer, input_ids, device):
+        assert FlexAttention.flex_attn is parity
+        return torch.ones(1, len(input_ids), 1)
+
+    monkeypatch.setattr(harness, "_get_logits_pp", pipeline_forward)
+    logits = harness._get_logits(first, [1, 2], torch.device("cpu"), trainer=trainer)
+
+    torch.testing.assert_close(logits, torch.ones(1, 2, 1), rtol=0, atol=0)
+    assert FlexAttention.flex_attn is original


### PR DESCRIPTION
# What does this PR do?

Fix checkpoint parity failures caused by different FlexAttention compilation histories in the trained reference and a fresh AutoModel reload. Identical checkpoint weights can produce different attention outputs, changing MoE routes and exceeding the logit gate. Parity forwards now use static compilation and fixed 64-by-64 tiles through a dedicated compiler entry point.

# Changelog

- Scope the attention override to checkpoint-test parity forwards through AutoModel's shared `FlexAttention` wrapper. Restore the original callable after success or failure, including pipeline-parallel forwards.
- Isolate parity's compilation cache from training and reject silent unfused fallback. Production training and vanilla-HF attention keep their existing execution.
- Restore GPT-OSS 20B PEFT's default `standard` logit profile; retain `relaxed` only for `hf_reload`, whose measured cross-framework discrepancy still exceeds standard. Full fine-tuning and native-resume profiles are unchanged.
- Add regression coverage for restoration, unrelated attention backends, and later local pipeline parts; document the execution policy.

# Validation evidence

**Scoped GPU CI passed on the final pushed commit** `06555289cb0e28d2478c445226317d42701f6cd3`. It built that commit and ran exactly `gpt_oss_20b` and `gpt_oss_20b_peft`, with eight H100 GPUs each. [Job link](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/67387549)

| Scoped CI recipe | AutoModel mean / p95 KL | AutoModel logits bitwise exact | HF mean / p95 KL | Result |
|---|---:|---|---:|---|
| GPT-OSS 20B PEFT | 0 / 0 | Yes | 0.01848220 / 0.05372002 | PASS |
| GPT-OSS 20B full fine-tuning | 0 / 0 | Yes | 0.00132906 / 0.00466887 | PASS |

Both jobs passed their normal 50-step training checks and all six checkpoint phases: source-reference, source-parity, train/save, AutoModel reload, HF reload, and native resume. All six enforced logit gates passed. The recorded profiles are `standard` for both source and AutoModel reload comparisons, `standard` for full-finetune HF reload, and `relaxed` only for PEFT HF reload.

The scope audit examined all 66 shipped checkpoint-robustness recipes. On the tested stack, only these two recipes reach the changed shared wrapper.

<details>
<summary>Additional local GPU and CPU evidence</summary>

A separate eight-H100 run passed all twelve checkpoint phases with the original eight-step configuration and 2,048-token parity document. Both AutoModel reloads were bitwise exact. PEFT HF mean/p95 KL was `0.01997820 / 0.06952501`; full-finetune HF was `0.00133035 / 0.00489038`.

Both source comparisons had mean KL `0.00547423`, p95 KL `0.01818439`, and cosine `0.99937062`, within standard. The original PEFT AutoModel reload failure had p95 KL `0.05857162` against `0.05`.

The local GPU run preceded the recipe-profile tightening; its saved measurements passed all six numerical gates when re-scored with the final recipe's actual policy resolvers. Scoped CI also passed the final committed configuration.

- 126 CPU tests passed, including the new restoration/bypass/pipeline-part tests and existing HF-argument/profile tests.
- Eight BF16 GQA attention cases passed on one H100: head dimensions 64/128/256, tile-boundary lengths, full/sliding causal masks, with/without sinks. Fresh and warmed compiler processes produced bitwise-identical outputs. Against FP64 attention on the same quantized inputs, maximum absolute difference was `0.010241`, within rtol/atol `0.02`.
- Repository Ruff formatting/lint and `git diff --check` passed.

</details>

The PEFT HF exception keeps its existing limits (mean `0.025`, p95 `0.1`, cosine `0.99`); this PR does not increase any threshold. Its scoped-CI HF values are lower than the local run, but these two passing training runs do not establish a complete HF variability envelope.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added necessary tests and documentation.
- [x] Local GPU/CPU validation and lint passed; commit includes DCO signoff.
- [x] Scoped CI passed on the final pushed commit.

# Additional Information

Bitwise reload equality is demonstrated for the tested topology (EP8 / TP1 / CP1 / PP1); this does not guarantee exact logits across different parallel topologies or universally closer agreement with HF.

Fixes [AMINT-317](https://linear.app/nvidia/issue/AMINT-317/kl-divergence-exceeds-allowed-threshold-by-marginal-amount-25percent)
