### PR TITLE
fix(loss): reject InfoNCE directions without candidates to score

### DIFF
--- a/nemo_automodel/components/loss/infonce.py
+++ b/nemo_automodel/components/loss/infonce.py
@@ -22,7 +22,34 @@ def infonce_loss(
     use_in_batch_negatives: bool = True,
     normalize: bool = True,
 ) -> torch.Tensor:
-    """InfoNCE contrastive loss with optional hard negatives."""
+    """InfoNCE contrastive loss with optional hard negatives.
+
+    Args:
+        queries: Tensor of shape [batch, hidden] -- pooled query embeddings.
+        documents: Tensor of shape [batch, hidden] -- pooled embeddings of the
+            positive document for each query, row-aligned with ``queries``.
+        hard_negatives: Optional Tensor of shape [batch, negatives, hidden] --
+            mined negative *documents* for each query. Rows are per-query, so
+            these are candidates for the ``"q2d"`` direction only.
+        hard_negatives_mask: Optional Tensor of shape [batch, negatives] --
+            1 for a real negative, 0 for padding in a ragged batch. Padded
+            columns are scored as ``-inf`` and contribute nothing.
+        temperature: Logit scale divisor; a 0-dim Tensor when it is learned.
+        direction: ``"q2d"``, ``"d2q"``, or ``"symmetric"``.
+        use_in_batch_negatives: Score every query against every document in the
+            batch instead of only its own positive.
+        normalize: L2-normalize the embeddings before scoring.
+
+    Returns:
+        Scalar Tensor: the mean cross-entropy over the batch.
+
+    Raises:
+        ValueError: If the embedding shapes disagree with the layouts above, if
+            ``direction`` is unknown, or if the requested directions have no
+            candidates to score against -- ``use_in_batch_negatives=False``
+            needs ``hard_negatives`` *and* ``direction="q2d"``, because the
+            document-to-query direction can only draw candidates from the batch.
+    """
     if queries.dim() != 2 or documents.dim() != 2:
         raise ValueError(
             f"infonce_loss: queries and documents must be 2-D [B, D]; got queries={tuple(queries.shape)}, "
@@ -51,8 +78,17 @@ def infonce_loss(
                 f"infonce_loss: hard_negatives_mask must be [B, K]; got {tuple(hard_negatives_mask.shape)}"
             )
 
-    if not use_in_batch_negatives and not has_hard_negs:
-        raise ValueError("infonce_loss: no negatives provided")
+    if not use_in_batch_negatives:
+        if not has_hard_negs:
+            raise ValueError("infonce_loss: no negatives provided")
+        if direction != "q2d":
+            raise ValueError(
+                f"infonce_loss: direction={direction!r} scores each document against the other "
+                "queries in the batch, and hard negatives are document-side candidates that "
+                "cannot stand in for them. With use_in_batch_negatives=False that direction has "
+                "no candidates at all and its cross-entropy is identically zero. Set "
+                "use_in_batch_negatives=True or direction='q2d'."
+            )
 
     if normalize:
         q = F.normalize(queries, dim=-1)
@@ -101,7 +137,46 @@ def infonce_distill_loss(
     normalize: bool = True,
     divergence: str = "kl",
 ) -> torch.Tensor:
-    """Soft listwise distillation on InfoNCE candidate sets."""
+    """Soft listwise distillation on InfoNCE candidate sets.
+
+    Builds the same candidate sets as :func:`infonce_loss` for the student and
+    the (detached) teacher, then matches the student's distribution over those
+    candidates to the teacher's.
+
+    Args:
+        student_queries: Tensor of shape [batch, student_hidden].
+        student_documents: Tensor of shape [batch, student_hidden], row-aligned
+            with ``student_queries``.
+        teacher_queries: Tensor of shape [batch, teacher_hidden]. Detached.
+        teacher_documents: Tensor of shape [batch, teacher_hidden], row-aligned
+            with ``teacher_queries``. Detached.
+        student_hard_negatives: Optional Tensor of shape
+            [batch, negatives, student_hidden] -- mined negative *documents*,
+            per query, so they are candidates for ``"q2d"`` only.
+        teacher_hard_negatives: Optional Tensor of shape
+            [batch, negatives, teacher_hidden], aligned with
+            ``student_hard_negatives``. Required when it is given. Detached.
+        hard_negatives_mask: Optional Tensor of shape [batch, negatives] -- 1
+            for a real negative, 0 for padding. Padded columns are scored as
+            ``-inf`` and masked out of the divergence.
+        temperature: Logit scale divisor.
+        direction: ``"q2d"``, ``"d2q"``, or ``"symmetric"``.
+        use_in_batch_negatives: Score every query against every document in the
+            batch instead of only its own positive.
+        normalize: L2-normalize the embeddings before scoring.
+        divergence: ``"kl"``, ``"ce"``, or ``"mse"``.
+
+    Returns:
+        Scalar Tensor: the mean divergence over the batch.
+
+    Raises:
+        ValueError: If the embedding shapes disagree with the layouts above, if
+            ``direction`` or ``divergence`` is unknown, or if the requested
+            directions have no candidates to score against --
+            ``use_in_batch_negatives=False`` needs hard negatives *and*
+            ``direction="q2d"``, because the document-to-query direction can
+            only draw candidates from the batch.
+    """
     if student_queries.dim() != 2 or student_documents.dim() != 2:
         raise ValueError(
             f"infonce_distill_loss: student embeddings must be 2-D [B, D_s]; got queries={tuple(student_queries.shape)}, "
@@ -141,8 +216,18 @@ def infonce_distill_loss(
         if hard_negatives_mask is not None and hard_negatives_mask.shape != (batch, student_hard_negatives.shape[1]):
             raise ValueError("infonce_distill_loss: hard_negatives_mask must be [B, K]")
 
-    if not use_in_batch_negatives and not has_hard_negs:
-        raise ValueError("infonce_distill_loss: no negatives available")
+    if not use_in_batch_negatives:
+        if not has_hard_negs:
+            raise ValueError("infonce_distill_loss: no negatives available")
+        if direction != "q2d":
+            raise ValueError(
+                f"infonce_distill_loss: direction={direction!r} scores each document against the "
+                "other queries in the batch, and hard negatives are document-side candidates that "
+                "cannot stand in for them. With use_in_batch_negatives=False that direction leaves "
+                "a single candidate, so student and teacher distributions are both degenerate and "
+                "the divergence is identically zero. Set use_in_batch_negatives=True or "
+                "direction='q2d'."
+            )
 
     s_q = student_queries.float()
     s_d = student_documents.float()

--- a/tests/unit_tests/loss/test_infonce.py
+++ b/tests/unit_tests/loss/test_infonce.py
@@ -91,6 +91,43 @@ def test_infonce_loss_no_in_batch_with_hard_negatives():
     assert torch.isfinite(loss)
 
 
+@pytest.mark.parametrize("direction", ["d2q", "symmetric"])
+def test_infonce_loss_no_in_batch_rejects_document_side_direction(direction):
+    """``d2q`` can only draw candidates from the batch, so dropping them is not a valid config."""
+    torch.manual_seed(0)
+    q = torch.randn(4, 8)
+    d = torch.randn(4, 8)
+    n = torch.randn(4, 3, 8)
+
+    with pytest.raises(ValueError, match="no candidates at all"):
+        infonce_loss(q, d, hard_negatives=n, direction=direction, use_in_batch_negatives=False)
+
+
+@pytest.mark.parametrize(
+    "direction, use_in_batch_negatives",
+    [("q2d", True), ("q2d", False), ("d2q", True), ("symmetric", True)],
+)
+def test_infonce_loss_accepted_configs_score_real_candidates(direction, use_in_batch_negatives):
+    """Every accepted config must score >1 candidate: a 1-class CE is 0 with no gradient."""
+    torch.manual_seed(0)
+    q = torch.randn(4, 8, requires_grad=True)
+    d = torch.randn(4, 8, requires_grad=True)
+    n = torch.randn(4, 3, 8, requires_grad=True)
+
+    loss = infonce_loss(
+        q,
+        d,
+        hard_negatives=n,
+        direction=direction,
+        use_in_batch_negatives=use_in_batch_negatives,
+    )
+    loss.backward()
+
+    assert loss.item() > 0.0
+    assert q.grad.abs().sum().item() > 0.0
+    assert d.grad.abs().sum().item() > 0.0
+
+
 def test_infonce_loss_without_normalize():
     torch.manual_seed(0)
     q = torch.randn(4, 8)
@@ -398,6 +435,49 @@ def test_distill_loss_no_negatives_error():
         infonce_distill_loss(s_q, s_d, t_q, t_d, use_in_batch_negatives=False)
 
 
+@pytest.mark.parametrize("direction", ["d2q", "symmetric"])
+def test_distill_loss_no_in_batch_rejects_document_side_direction(direction):
+    """The document-to-query candidate set is the batch; without it the divergence is 0."""
+    s_q, s_d, t_q, t_d, s_n, t_n = _distill_inputs()
+
+    with pytest.raises(ValueError, match="a single candidate"):
+        infonce_distill_loss(
+            s_q,
+            s_d,
+            t_q,
+            t_d,
+            student_hard_negatives=s_n,
+            teacher_hard_negatives=t_n,
+            direction=direction,
+            use_in_batch_negatives=False,
+        )
+
+
+@pytest.mark.parametrize(
+    "direction, use_in_batch_negatives",
+    [("q2d", True), ("q2d", False), ("d2q", True), ("symmetric", True)],
+)
+def test_distill_loss_accepted_configs_score_real_candidates(direction, use_in_batch_negatives):
+    """A degenerate 1-candidate set makes both distributions one-hot and the divergence 0."""
+    s_q, s_d, t_q, t_d, s_n, t_n = _distill_inputs(requires_grad=True)
+
+    loss = infonce_distill_loss(
+        s_q,
+        s_d,
+        t_q,
+        t_d,
+        student_hard_negatives=s_n,
+        teacher_hard_negatives=t_n,
+        direction=direction,
+        use_in_batch_negatives=use_in_batch_negatives,
+    )
+    loss.backward()
+
+    assert loss.item() > 0.0
+    assert s_q.grad.abs().sum().item() > 0.0
+    assert s_d.grad.abs().sum().item() > 0.0
+
+
 # ---------------------------------------------------------------------------
 # InfoNCELoss module
 # ---------------------------------------------------------------------------
@@ -410,6 +490,18 @@ def test_infonce_module_forward():
     loss = loss_fn(q, d)
 
     assert torch.isfinite(loss)
+
+
+def test_infonce_module_surfaces_document_side_direction_conflict():
+    """The recipe builds this module straight from YAML, so the config path must fail loudly."""
+    torch.manual_seed(0)
+    loss_fn = InfoNCELoss(direction="symmetric", use_in_batch_negatives=False)
+    q = torch.randn(4, 8)
+    d = torch.randn(4, 8)
+    n = torch.randn(4, 3, 8)
+
+    with pytest.raises(ValueError, match="no candidates at all"):
+        loss_fn(q, d, hard_negatives=n)
 
 
 def test_infonce_module_rejects_nonpositive_temperature():


### PR DESCRIPTION
# What does this PR do ?

Rejects the InfoNCE configurations whose loss is mathematically forced to `0.0`,
instead of training on them silently.

`infonce_loss` / `infonce_distill_loss` accept `direction="d2q"` or
`"symmetric"` together with `use_in_batch_negatives=False`. Hard negatives are
documents mined *per query*, so they are candidates for the query-to-document
direction only, and `_one_direction` correctly passes `None` for the reverse
direction. With in-batch negatives also switched off, that direction is left
with a single candidate column:

```python
pos = (query * doc).sum(dim=-1, keepdim=True)   # [B, 1]
logits = pos
target = torch.zeros(batch, device=device, dtype=torch.long)
...
return F.cross_entropy(logits, target)          # one class -> log(1) == 0
```

The existing guard only caught the case where *no* negatives were passed at all,
so it never fired:

```python
if not use_in_batch_negatives and not has_hard_negs:
    raise ValueError("infonce_loss: no negatives provided")
```

Measured on `main` @ `b1f4031d`, `B=4`, `K=3`, CPU:

| direction | `use_in_batch_negatives` | loss | sum abs grad (queries) | sum abs grad (hard negs) |
|---|---|---:|---:|---:|
| `q2d` | true | 8.986291 | 25.4025 | 4.2906 |
| `q2d` | false | 5.643632 | 17.9486 | 20.5227 |
| `d2q` | true | 5.800508 | 20.0058 | — |
| `d2q` | false | **0.000000** | **0.0000** | — |
| `symmetric` | true | 7.393400 | 20.2241 | 2.1453 |
| `symmetric` | false | 2.821816 | 8.9743 | 10.2613 |

`2.821816 == 5.643632 / 2` exactly — the `d2q` half of `"symmetric"` contributes
literally nothing, so a config asking for a symmetric objective silently gets a
halved one-directional one. `infonce_distill_loss` degenerates identically: the
single-candidate softmax makes the student and the detached teacher
distributions both one-hot, so KL/CE/MSE over them is `0.0` with zero student
gradients.

This is reachable from YAML: `RetrievalDistillBiEncoderRecipe` builds both
modules from `self.cfg.get("infonce_loss")` / `self.cfg.get("infonce_distill_loss")`,
and `direction` and `use_in_batch_negatives` are plain keys on that block (see
`examples/retrieval/distillation/nemotron3_embed_1b_distill.yaml`). The shipped
example is safe; flipping those two keys is not.

## Why reject rather than feed the negatives into `d2q`

Reusing `hard_negatives` for the reverse direction would be numerically wrong,
not just unhelpful: they are *document* embeddings, and the document-to-query
direction needs query-side candidates. The `None` in `_one_direction(d, q, None)`
is correct; the missing piece is that the caller was never told the resulting
candidate set is empty. So the guard is extended instead, in the same place and
the same style as the existing one, and the failure is raised before any work is
done. This matches the precedent already in the recipe:

```python
# Guard against a configured intermediate loss whose layer_pairs are empty
# while the weight is active: hooks would fire but the loss would silently
# short-circuit to zero (contributing no gradient).
```

No behavior changes for any configuration that was producing a real loss.

# Changelog

- `infonce_loss` and `infonce_distill_loss` now raise `ValueError` when
  `use_in_batch_negatives=False` is combined with `direction="d2q"` or
  `"symmetric"`, explaining that the document-to-query direction can only draw
  candidates from the batch and naming both ways out.
- Both functions gained full Google-style docstrings recording the tensor
  layouts (`[batch, hidden]`, `[batch, negatives, hidden]`, `[batch, negatives]`
  masks), the per-query/document-side semantics of `hard_negatives` that make
  the direction restriction necessary, and the `Raises` contract.
- `tests/unit_tests/loss/test_infonce.py`: added the rejection tests for both
  functions and for the `InfoNCELoss` module (the config-driven entry point),
  plus parametrized guards asserting every *accepted* `(direction,
  use_in_batch_negatives)` combination yields a strictly positive loss and
  non-zero input gradients — the invariant the bug violated.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

The only documentation of this contract was the functions' one-line docstrings,
which are expanded here. No user-facing docs or example configs reference the
rejected combination, so nothing else needed updating.

Verified locally: `pytest tests/unit_tests/loss/test_infonce.py` -> 62 passed.
The 5 new rejection tests fail on `main` (`DID NOT RAISE ValueError`) and pass
here. `ruff format --check` / `ruff check` clean. CPU only, no GPU needed.

# Additional Information

- Related to #3869
