### PR TITLE
fix(tests): drop the shadowed TestKimiK25VLForConditionalGenerationForward

### DIFF
--- a/tests/unit_tests/models/kimi_k25_vl/test_kimi_k25_vl_model.py
+++ b/tests/unit_tests/models/kimi_k25_vl/test_kimi_k25_vl_model.py
@@ -270,43 +270,6 @@ class TestKimiK25VLModelInputsEmbeds:
                 raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
 
-class TestKimiK25VLForConditionalGenerationForward:
-    """Tests for KimiK25VLForConditionalGeneration.forward signature."""
-
-    def test_forward_signature_vlm_params(self):
-        """Test forward signature includes VLM-specific parameters."""
-        sig = inspect.signature(KimiK25VLForConditionalGeneration.forward)
-        params = list(sig.parameters.keys())
-
-        # Standard LM params
-        assert "input_ids" in params
-        assert "attention_mask" in params
-        assert "position_ids" in params
-        assert "inputs_embeds" in params
-        assert "labels" in params
-
-        # VLM-specific params
-        assert "pixel_values" in params
-        assert "grid_thws" in params
-        assert "target_seq_length" in params
-
-    def test_forward_signature_optional_params(self):
-        """Test forward signature has expected optional parameters."""
-        sig = inspect.signature(KimiK25VLForConditionalGeneration.forward)
-
-        optional_params = [
-            "past_key_values",
-            "use_cache",
-            "output_attentions",
-            "output_hidden_states",
-            "return_dict",
-            "padding_mask",
-        ]
-
-        for param in optional_params:
-            assert param in sig.parameters, f"forward should accept {param} parameter"
-
-
 class TestKimiK25VLRegistration:
     """Tests for KimiK25VL registration with transformers."""
 


### PR DESCRIPTION
## What

`tests/unit_tests/models/kimi_k25_vl/test_kimi_k25_vl_model.py` declares `TestKimiK25VLForConditionalGenerationForward` **twice at module level** — L273 and L1446. The second binding wins, so the first class is dead and pytest never collects its two tests:

- `test_forward_signature_vlm_params`
- `test_forward_signature_optional_params`

```
$ python -m pyflakes tests/unit_tests/models/kimi_k25_vl/test_kimi_k25_vl_model.py
...:1446:1: redefinition of unused 'TestKimiK25VLForConditionalGenerationForward' from line 273
```

## Why it is safe to just delete it

The surviving class's `test_forward_signature_complete` is a strict superset of both dead tests. Comparing the asserted parameter names:

| dead test | asserts | not covered by `test_forward_signature_complete` |
|---|---|---|
| `test_forward_signature_vlm_params` | `input_ids, attention_mask, position_ids, inputs_embeds, labels, pixel_values, grid_thws, target_seq_length` | *(none)* |
| `test_forward_signature_optional_params` | `past_key_values, use_cache, output_attentions, output_hidden_states, return_dict, padding_mask` | *(none)* |

`test_forward_signature_complete` checks all 14 of those plus `self` and `kwargs`. So this removes 37 lines of unreachable code with **zero** change in what is actually asserted about `KimiK25VLForConditionalGeneration.forward`.

## Why no linter caught it

Two independent blind spots:

1. `pyproject.toml` has `[tool.ruff] exclude = ["tests/"]`, so ruff never looks at this file.
2. `F811` (redefinition) is not in `[tool.ruff.lint] select` either, so it would not be reported even without the exclude.

## Verification

- `ast` module-level name census: `{'TestKimiK25VLForConditionalGenerationForward': 2}` before, no duplicates after; class count 30 -> 29.
- `pyflakes` before/after: the `redefinition of unused ...` line is the only difference; the remaining 9 pre-existing warnings are unchanged.
- `ruff==0.16.4` (the pinned `.pre-commit-config.yaml` rev) with the repo `pyproject.toml`, run with the `tests/` exclude bypassed so it actually inspects the file: **identical** output before and after (`Found 9 errors.`), and the `ruff format --diff` output is byte-for-byte the same 110 lines before and after, none of it inside the removed region.
- Module-level `import inspect` stays used by other tests (lines 211, 229, 1302, 1321, 1413, 1452, 1590 in the original), so no import becomes dead.

If you would rather keep the two tests, the alternative is to rename one of the classes instead — happy to switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
