### PR TITLE
cp: `feat(vlm): add Nemotron 3.5 Super VL (3801)` into `r0.6.0`

### DIFF
--- a/docs/fern/versions/nightly.yml
+++ b/docs/fern/versions/nightly.yml
@@ -263,6 +263,8 @@ navigation:
             path: ../../model-coverage/omni/microsoft/phi4-multimodal.mdx
           - page: "Nemotron-Omni"
             path: ../../model-coverage/omni/nvidia/nemotron-omni.mdx
+          - page: "Nemotron 3.5 Super VL"
+            path: ../../model-coverage/omni/nvidia/nemotron-3-5-super-vl.mdx
       - section: "Diffusion Language Models"
         slug: dllm
         contents:

--- a/docs/model-coverage/omni/nvidia/nemotron-3-5-super-vl.mdx
+++ b/docs/model-coverage/omni/nvidia/nemotron-3-5-super-vl.mdx
@@ -1,0 +1,82 @@
+---
+title: "Nemotron 3.5 Super VL"
+description: ""
+slug: model-coverage/omni/nvidia/nemotron-3-5-super-vl
+---
+[NVIDIA-Nemotron-3.5-Super-midtrain-67B-vision-pretrained](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Super-midtrain-67B-vision-pretrained)
+pairs a "Nemotron Super" NemotronH (hybrid Mamba-2 + Attention) MoE language
+backbone with a RADIO v2.5-H vision encoder, sharing its `NemotronH_Omni_Reasoning_V3`
+architecture and vision stack with [Nemotron-3-Nano-Omni](/model-coverage/omni/nvidia/nemotron-omni).
+This midtrain checkpoint is vision-pretrained only (`sound_config` is absent, so
+there is no audio encoder / audio inputs are not supported on this checkpoint).
+
+<Info>
+
+| | |
+|---|---|
+| **Task** | Multimodal (Text·Image) |
+| **Architecture** | `NemotronH_Omni_Reasoning_V3` |
+| **Parameters** | 121B total (MoE, 512 routed experts, 22 active per token; 124B with the MTP head) |
+| **HF Org** | [nvidia](https://huggingface.co/nvidia) |
+
+</Info>
+
+## Available Models
+
+- **NVIDIA-Nemotron-3.5-Super-midtrain-67B-vision-pretrained**: 121B total (MoE), vision-pretrained, no audio encoder
+
+## Architecture
+
+- `NemotronH_Omni_Reasoning_V3` — reuses the same `NemotronOmniForConditionalGeneration`
+  wrapper, vision tower, and state-dict adapter as `NemotronH_Nano_Omni_Reasoning_V3`;
+  only the LLM sub-config scale differs (Super vs. Nano). The `sound_encoder` /
+  `sound_projection` submodules are constructed only when the checkpoint's
+  `sound_config` is present, so this checkpoint loads with audio disabled.
+
+## Example Recipes
+
+| Recipe | Dataset | Description |
+|---|---|---|
+| [nemotron_3_5_super_vl_tulu3_text_100steps.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_tulu3_text_100steps.yaml) | Tulu-3 | Full SFT, text-only (vision/audio towers frozen and unused) |
+| [nemotron_3_5_super_vl_tulu3_packed_cp8_100steps.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_tulu3_packed_cp8_100steps.yaml) | Tulu-3 (packed, THD) | Context-parallel parity test, `cp_size=8`; text-only packs (`inject_fake_images: false`) |
+| [nemotron_3_5_super_vl_cord_v2_peft.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_cord_v2_peft.yaml) | CORD-v2 | LoRA (rank 64) on the LLM linear projections, base model frozen — receipt image → structured field tokens; single node |
+
+### LoRA on CORD-v2
+
+`nemotron_3_5_super_vl_cord_v2_peft.yaml` fine-tunes the model on CORD-v2 receipt field extraction
+(the same task as the [NemotronOmni CORD-v2 guide](/recipes-e2e-examples/nemotron-omni)) with LoRA adapters
+instead of full SFT. Because the base weights are frozen there are no fp32 master weights or optimizer
+states for them, so the 121B model trains on a single node of 8 H100 (`cp_size 1`, `ep_size 8`) instead of the
+4 nodes full SFT needs.
+
+| | |
+|---|---|
+| LoRA targets | 272 linear projections: Mamba `in_proj`/`out_proj`, attention `q/k/v/o_proj`, MoE `fc1/fc2_latent_proj` and shared experts (routed experts, vision tower, projector, `lm_head` frozen) |
+| Trainable parameters | 177M (0.15%), rank 64, alpha 128; TE `FusedAdam` with fp32 master weights, lr 2e-4 |
+| Peak memory | 38.8 GiB/GPU |
+| Adapter checkpoint | 355 MB (`adapter_model.safetensors` + `adapter_config.json`) |
+| Training | 400 steps (global batch 8, 4 epochs of the 800 training receipts) in 13 min on one node; train loss 0.51 → 0.01 |
+| Validation loss | 0.041 / 0.039 / 0.043 / 0.040 at steps 99 / 199 / 299 / 399 |
+| Field extraction (first 20 validation receipts, greedy, adapter merged into the base model) | step 199 (`LOWEST_VAL`): 8/20 exact match, mean similarity 0.954 (median 0.997), 20/20 structured outputs |
+
+## Try with NeMo AutoModel
+
+**1. Clone and install from source** ([full instructions](/get-started/installation)):
+
+```bash
+git clone https://github.com/NVIDIA-NeMo/Automodel.git
+cd Automodel
+uv sync --locked --all-groups --all-extras --extra vlm-media
+```
+
+**2. Run a recipe** from inside the repo — LoRA on CORD-v2 on a single node (adapter-only checkpoints, ~39 GiB/GPU):
+
+```bash
+uv run automodel examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_cord_v2_peft.yaml --nproc-per-node 8
+```
+
+The Tulu-3 text recipe runs on 4 nodes:
+
+```bash
+uv run automodel examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_tulu3_text_100steps.yaml --nnodes 4 --nproc-per-node 8
+```

--- a/examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_cord_v2_peft.yaml
+++ b/examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_cord_v2_peft.yaml
@@ -1,0 +1,157 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Nemotron 3.5 Super VL LoRA fine-tuning on CORD-v2 receipt field extraction
+# (receipt image -> structured `<s_menu><s_nm>...` token sequence, as in the
+# NemotronOmni CORD-v2 guide). The base model stays frozen and LoRA adapters
+# (rank 64, alpha 128) are trained on the LLM linear projections (Mamba in/out
+# projections, attention q/k/v/o, MoE latent projections and shared experts);
+# the vision tower, vision projector and lm_head are excluded.
+#
+# Sizing: with the base weights frozen there are no fp32 master weights or
+# optimizer states for the base model, so the recipe fits on a single node of
+# 8 H100 (~39 GiB/GPU): 512 experts -> ep_size 8; global_batch_size 8 with
+# cp_size 1 gives dp=8 -> one sample per rank per optimizer step. Checkpoints
+# hold the adapter weights only (adapter_model.safetensors + adapter_config.json).
+#
+# Run:
+#   automodel examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_cord_v2_peft.yaml --nproc-per-node 8
+
+recipe: FinetuneRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 8
+  local_batch_size: 1
+  ckpt_every_steps: 400
+  val_every_steps: 100
+  max_steps: 400
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: nvidia/NVIDIA-Nemotron-3.5-Super-midtrain-67B-vision-pretrained
+  trust_remote_code: true
+  num_nextn_predict_layers: 0
+  torch_dtype: torch.bfloat16
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: te
+    linear: te
+    rms_norm: torch_fp32
+    rope_fusion: false
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: true
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  match_all_linear: false
+  exclude_modules:
+    - "*vision_tower*"
+    - "*vision_model*"
+    - "*vision_projector*"
+    - "*audio*"
+    - "*sound*"
+    - "*lm_head*"
+    - "*mlp1*"
+  dim: 64
+  alpha: 128
+  use_triton: true
+
+processor:
+  _target_: transformers.AutoProcessor.from_pretrained
+  pretrained_model_name_or_path: nvidia/NVIDIA-Nemotron-3.5-Super-midtrain-67B-vision-pretrained
+  trust_remote_code: true
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: vlm_checkpoints/nemotron_3_5_super_vl_cord_v2_peft
+  model_save_format: safetensors
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  # cp_size 1 -> dp 8 on 8 GPUs -> one 1-sample microbatch per rank per optimizer step.
+  cp_size: 1
+  pp_size: 1
+  ep_size: 8
+  sequence_parallel: false
+  activation_checkpointing: true
+  reshard_after_forward: true
+  moe:
+    reshard_after_forward: true
+
+freeze_config:
+  freeze_embeddings: true
+  freeze_vision_tower: true
+  freeze_audio_tower: true
+  freeze_language_model: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_cord_v2_dataset
+  path_or_dataset: naver-clova-ix/cord-v2
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 0
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.nemotron_omni_collate_fn
+    max_length: 4096
+  drop_last: true
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_cord_v2_dataset
+  path_or_dataset: naver-clova-ix/cord-v2
+  split: validation
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 1
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.nemotron_omni_collate_fn
+    max_length: 4096
+
+wandb:
+  enable: false
+  entity: Nemo-automodel
+  project: huiyingl_workspace
+  name: nemotron_3_5_super_vl_cord_v2_peft
+
+optimizer:
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+  lr: 2e-4
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+  master_weights: true
+  store_param_remainders: true
+  exp_avg_dtype: torch.bfloat16
+  exp_avg_sq_dtype: torch.bfloat16
+
+ci:
+  recipe_owner: HuiyingLi
+  nodes: 1
+  time: "01:00:00"
+  max_steps: 2

--- a/examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_tulu3_packed_cp8_100steps.yaml
+++ b/examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_tulu3_packed_cp8_100steps.yaml
@@ -1,0 +1,143 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Nemotron 3.5 Super VL packed-sequence SFT with context parallelism: cp_size=8.
+# Text-only Tulu-3 packed into 8192-token THD rows (real tokens, no fake images);
+# each row is sharded to 1024 tokens/rank through the packed THD path of the
+# NemotronH hybrid Mamba+Attention MoE backbone. 512 experts -> ep_size 32.
+#
+# world = tp1 * cp8 * pp1 * dp4 = 32 (4 nodes x 8 GPUs); ep32 = dp*cp.
+#
+# Run (4 nodes):
+#   automodel examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_tulu3_packed_cp8_100steps.yaml --nproc-per-node 8 --nnodes 4
+
+recipe: FinetuneRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 32
+  local_batch_size: 1
+  ckpt_every_steps: 100000
+  val_every_steps: 100000
+  max_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1234
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: nvidia/NVIDIA-Nemotron-3.5-Super-midtrain-67B-vision-pretrained
+  trust_remote_code: true
+  num_nextn_predict_layers: 0
+  torch_dtype: torch.bfloat16
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: te
+    linear: te
+    rms_norm: torch_fp32
+    rope_fusion: false
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: true
+
+processor:
+  _target_: transformers.AutoProcessor.from_pretrained
+  pretrained_model_name_or_path: nvidia/NVIDIA-Nemotron-3.5-Super-midtrain-67B-vision-pretrained
+  trust_remote_code: true
+
+checkpoint:
+  enabled: false
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 8
+  pp_size: 1
+  ep_size: 32
+  sequence_parallel: false
+  activation_checkpointing: true
+  reshard_after_forward: true
+  moe:
+    reshard_after_forward: true
+
+freeze_config:
+  freeze_embeddings: true
+  freeze_vision_tower: true
+  freeze_audio_tower: true
+  freeze_language_model: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_tulu3_dataset
+  path_or_dataset: allenai/tulu-3-sft-mixture
+  split: train
+  # Truncate over-long samples instead of substituting a random other sample
+  # (keeps every rank of a CP/TP group on identical packs).
+  truncate: true
+  # Tulu-3 is text-only. The VLM pipeline otherwise injects a fake 512x512 image
+  # into every sample (~245 <image> tokens + a vision-tower forward per sample).
+  inject_fake_images: false
+
+# THD packing: real Tulu-3 tokens fill each 8192-token row (8192 divisible by 2*cp=16).
+# packing_format: thd (not the "neat" default) is required for this hybrid Mamba+MoE
+# backbone: "neat" packing builds a dense block-causal mask / per-token seq_idx
+# convention meant for plain transformer attention, which nemotron_v3's Mamba mixer
+# does not understand (it reads a document-boundary attention_mask, not a dense mask).
+# "thd" wires qkv_format=thd + real cu_seqlens end to end instead.
+packed_sequence:
+  pretokenize: true
+  packing_format: thd
+  max_length: 8192
+  pack_size: 8192
+  collate_max_length: 8192
+  packing_ratio: 0.9
+  drop_long_samples: true
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 0
+  drop_last: true
+  shuffle: false
+
+optimizer:
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+  betas: [0.9, 0.95]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0.01
+  master_weights: true
+  store_param_remainders: true
+  exp_avg_dtype: torch.bfloat16
+  exp_avg_sq_dtype: torch.bfloat16
+
+lr_scheduler:
+  lr_decay_style: constant
+
+wandb:
+  enable: false
+  entity: Nemo-automodel
+  project: huiyingl_workspace
+  name: nemotron_3_5_super_vl_tulu3_packed_cp8_100steps
+
+ci:
+  recipe_owner: HuiyingLi
+  nodes: 4
+  time: "01:00:00"
+  max_steps: 2

--- a/examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_tulu3_text_100steps.yaml
+++ b/examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_tulu3_text_100steps.yaml
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Nemotron 3.5 Super VL (vision-pretrained checkpoint, architectures =
+# NemotronH_Omni_Reasoning_V3: a "Nemotron Super" NemotronH hybrid
+# Mamba+Attention MoE LLM backbone + the Nemotron Omni RADIO vision head)
+# text-only SFT on Tulu-3.
+#
+# Loaded through NeMoAutoModelForImageTextToText (the full omni checkpoint --
+# vision tower included) with the vision/audio towers frozen and a text-only
+# dataset (make_tulu3_dataset emits conversations with no image entries), so
+# only the "Nemotron Super" LLM half is ever exercised in the forward/backward
+# pass, isolating LLM-only convergence.
+#
+# Run:
+#   automodel examples/vlm_finetune/nemotron_3_5_super_vl/nemotron_3_5_super_vl_tulu3_text_100steps.yaml --nproc-per-node 8 --nnodes 4
+
+recipe: FinetuneRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 32
+  local_batch_size: 1
+  ckpt_every_steps: 100000
+  val_every_steps: 20
+  max_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1234
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: nvidia/NVIDIA-Nemotron-3.5-Super-midtrain-67B-vision-pretrained
+  trust_remote_code: true
+  num_nextn_predict_layers: 0
+  torch_dtype: torch.bfloat16
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: te
+    linear: te
+    rms_norm: torch_fp32
+    rope_fusion: false
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: true
+
+processor:
+  _target_: transformers.AutoProcessor.from_pretrained
+  pretrained_model_name_or_path: nvidia/NVIDIA-Nemotron-3.5-Super-midtrain-67B-vision-pretrained
+  trust_remote_code: true
+
+checkpoint:
+  enabled: false
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 32
+  sequence_parallel: false
+  activation_checkpointing: true
+  reshard_after_forward: true
+  moe:
+    reshard_after_forward: true
+
+freeze_config:
+  freeze_embeddings: true
+  freeze_vision_tower: true
+  freeze_audio_tower: true
+  freeze_language_model: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_tulu3_dataset
+  path_or_dataset: allenai/tulu-3-sft-mixture
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 0
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.nemotron_omni_collate_fn
+    max_length: 2048
+  drop_last: true
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_tulu3_dataset
+  path_or_dataset: allenai/tulu-3-sft-mixture
+  split: "train[:128]"
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 1
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.nemotron_omni_collate_fn
+    max_length: 2048
+
+wandb:
+  enable: false
+  entity: Nemo-automodel
+  project: huiyingl_workspace
+  name: nemotron_3_5_super_vl_tulu3_text_100steps
+
+optimizer:
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+  betas: [0.9, 0.95]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0.01
+  master_weights: true
+  store_param_remainders: true
+  exp_avg_dtype: torch.bfloat16
+  exp_avg_sq_dtype: torch.bfloat16
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 1.0e-6
+
+ci:
+  recipe_owner: HuiyingLi
+  nodes: 4
+  time: "01:00:00"
+  max_steps: 2

--- a/nemo_automodel/_transformers/capabilities.py
+++ b/nemo_automodel/_transformers/capabilities.py
@@ -191,11 +191,14 @@ class ModelSupports:
             "cp",
             "ep",
             "sequence_packing",
+            "mtp_cp",
+            "mtp_cp_pp",
             "cp_vision_frame_sharding",
             "gradient_checkpointing",
             "generate",
         )
         flags = ", ".join("{}={}".format(name, getattr(self, "supports_" + name)) for name in names)
+        flags += ", mtp_enabled={}".format(self.mtp_enabled)
         flags += ", is_custom_model={}".format(self.is_custom_model)
         return "ModelSupports({})".format(flags)
 
@@ -297,6 +300,30 @@ class ModelSupports:
         except AttributeError:
             return False
         return capabilities.supports_thd
+
+    @property
+    def supports_mtp_cp(self) -> bool:
+        """Model owns a verified MTP training path under context parallelism."""
+        try:
+            capabilities = query_capabilities(self._model)
+        except AttributeError:
+            return False
+        return capabilities.supports_mtp_cp
+
+    @property
+    def supports_mtp_cp_pp(self) -> bool:
+        """Model owns a verified MTP training path with both CP and PP."""
+        try:
+            capabilities = query_capabilities(self._model)
+        except AttributeError:
+            return False
+        return capabilities.supports_mtp_cp_pp
+
+    @property
+    def mtp_enabled(self) -> bool:
+        """Whether MTP is active for this configured model instance."""
+        mtp_config = getattr(self._model, "mtp_config", None)
+        return bool(getattr(mtp_config, "enabled", False))
 
     @property
     def supports_cp_vision_frame_sharding(self) -> bool:

--- a/nemo_automodel/_transformers/model_capabilities.py
+++ b/nemo_automodel/_transformers/model_capabilities.py
@@ -55,6 +55,8 @@ class ModelCapabilities:
         supports_pp: Pipeline parallelism.
         supports_ep: Expert parallelism (MoE).
         supports_thd: THD packed-sequence inputs.
+        supports_mtp_cp: MTP training with context parallelism.
+        supports_mtp_cp_pp: MTP training with context and pipeline parallelism.
         supports_cp_vision_frame_sharding: Frame-level vision-tower sharding over
             context-parallel ranks.
     """
@@ -64,6 +66,8 @@ class ModelCapabilities:
     supports_pp: bool = False
     supports_ep: bool = False
     supports_thd: bool = False
+    supports_mtp_cp: bool = False
+    supports_mtp_cp_pp: bool = False
     supports_cp_vision_frame_sharding: bool = False
 
 
@@ -82,6 +86,8 @@ def _to_canonical(caps_obj) -> ModelCapabilities:
         supports_pp=bool(caps_obj.supports_pp),
         supports_ep=bool(caps_obj.supports_ep),
         supports_thd=bool(getattr(caps_obj, "supports_thd", False)),
+        supports_mtp_cp=bool(getattr(caps_obj, "supports_mtp_cp", False)),
+        supports_mtp_cp_pp=bool(getattr(caps_obj, "supports_mtp_cp_pp", False)),
         supports_cp_vision_frame_sharding=bool(getattr(caps_obj, "supports_cp_vision_frame_sharding", False)),
     )
 

--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -196,6 +196,13 @@ MODEL_ARCH_MAPPING = OrderedDict(
             ),
         ),
         (
+            "NemotronH_Omni_Reasoning_V3",
+            (
+                "nemo_automodel.components.models.nemotron_omni.model",
+                "NemotronOmniForConditionalGeneration",
+            ),
+        ),
+        (
             "NemotronParseForConditionalGeneration",
             ("nemo_automodel.components.models.nemotron_parse.model", "NemotronParseForConditionalGeneration"),
         ),

--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -1339,6 +1339,25 @@ def default_collate_fn(
     return batch
 
 
+def _merge_media_values(values: list[Any]) -> torch.Tensor | list[Any]:
+    """Merge fixed-shape patch tensors or preserve variable-resolution media lists."""
+    if not values:
+        raise ValueError("Media merge requires at least one value.")
+    if all(isinstance(value, torch.Tensor) for value in values):
+        return torch.cat(values, dim=0).to(torch.bfloat16)
+    # At least one pack carries variable-resolution media as a list: flatten
+    # every pack to one tensor per image (a stacked [N, ...] tensor splits along dim 0).
+    flat = []
+    for value in values:
+        if isinstance(value, torch.Tensor):
+            flat.extend(value.to(torch.bfloat16))
+        elif isinstance(value, (list, tuple)):
+            flat.extend(item.to(torch.bfloat16) if isinstance(item, torch.Tensor) else item for item in value)
+        else:
+            raise TypeError(f"VLM media values must be tensors or lists, got {type(value).__name__}.")
+    return flat
+
+
 def pad_collate_fn(
     examples: Sequence[Dict[str, Any]],
     processor,
@@ -1426,7 +1445,7 @@ def pad_collate_fn(
     for key in ("pixel_values", "pixel_values_videos"):
         tensors = [ex[key] for ex in examples if key in ex and ex[key] is not None]
         if tensors:
-            batch[key] = torch.cat(tensors, dim=0).to(torch.bfloat16)
+            batch[key] = _merge_media_values(tensors)
 
     # Per-sample image counts from image_grid_thw shapes (before concat)
     image_grid_per_sample = [
@@ -1582,7 +1601,7 @@ def neat_packed_vlm_collater(
     for key in ("pixel_values", "pixel_values_videos"):
         tensors = [x[key] for x in batch if key in x and x[key] is not None]
         if tensors:
-            result[key] = torch.cat(tensors, dim=0).to(torch.bfloat16)
+            result[key] = _merge_media_values(tensors)
 
     for key in ("image_grid_thw", "image_position_ids", "video_grid_thw", "second_per_grid_ts"):
         tensors = [x[key] for x in batch if key in x and x[key] is not None]
@@ -1721,7 +1740,7 @@ def packed_sequence_thd_vlm_collater(
     for key in ("pixel_values", "pixel_values_videos"):
         tensors = [x[key] for x in batch if key in x and x[key] is not None]
         if tensors:
-            result[key] = torch.cat(tensors, dim=0).to(torch.bfloat16)
+            result[key] = _merge_media_values(tensors)
 
     for key in ("image_grid_thw", "image_position_ids", "video_grid_thw", "second_per_grid_ts"):
         tensors = [x[key] for x in batch if key in x and x[key] is not None]

--- a/nemo_automodel/components/datasets/vlm/datasets.py
+++ b/nemo_automodel/components/datasets/vlm/datasets.py
@@ -46,6 +46,21 @@ from nemo_automodel.components.datasets.vlm.utils import (
 logger = logging.getLogger(__name__)
 
 
+def _replacement_rng(idx: int) -> random.Random:
+    """Per-sample RNG for picking a substitute when sample ``idx`` is unusable.
+
+    Seeded from the ORIGINAL sample index only, so every rank (and every
+    dp/cp world size) that materializes sample ``idx`` substitutes the same
+    replacement. Drawing from the process-global ``random`` instead made the
+    substitute rank-dependent: ranks whose global RNG stream had advanced
+    differently (e.g. the per-node dataset-building rank) picked a different
+    document, so context-parallel ranks in one CP group ended up with
+    different packs / ``cu_seqlens`` for the same microbatch -- corrupting the
+    ring-attention gradient accumulation (inf/nan or silently wrong dk/dv).
+    """
+    return random.Random(0x9E3779B9 + 2654435761 * int(idx))
+
+
 @dataclass
 class RdrDatasetConfig:
     """Construction-time configuration for the RDR dataset."""
@@ -1376,6 +1391,7 @@ class PreTokenizedDatasetWrapper(torch.utils.data.Dataset):
         return len(self.dataset)
 
     def __getitem__(self, idx):
+        rng = _replacement_rng(idx)
         from nemo_automodel.components.datasets.vlm.collate_fns import (
             _extract_media_from_conversations,
             build_labels_from_template,
@@ -1454,7 +1470,7 @@ class PreTokenizedDatasetWrapper(torch.utils.data.Dataset):
                             seq_len,
                             self.max_length,
                         )
-                        idx = random.randint(0, len(self.dataset) - 1)
+                        idx = rng.randint(0, len(self.dataset) - 1)
                         continue
 
                 # Build labels BEFORE truncation so the full assistant text
@@ -1489,7 +1505,7 @@ class PreTokenizedDatasetWrapper(torch.utils.data.Dataset):
                         idx,
                         mismatch,
                     )
-                    idx = random.randint(0, len(self.dataset) - 1)
+                    idx = rng.randint(0, len(self.dataset) - 1)
                     continue
 
                 output = {
@@ -1525,7 +1541,7 @@ class PreTokenizedDatasetWrapper(torch.utils.data.Dataset):
                     self.max_retries,
                     e,
                 )
-                idx = random.randint(0, len(self.dataset) - 1)
+                idx = rng.randint(0, len(self.dataset) - 1)
 
         raise RuntimeError(f"Failed to load a valid sample after {self.max_retries} retries")
 
@@ -1554,6 +1570,7 @@ class RobustDatasetWrapper(torch.utils.data.Dataset):
         return len(self.dataset)
 
     def __getitem__(self, idx):
+        rng = _replacement_rng(idx)
         from nemo_automodel.components.datasets.vlm.fake_image import (
             _conversation_has_media,
             inject_fake_image_into_conversation,
@@ -1572,7 +1589,7 @@ class RobustDatasetWrapper(torch.utils.data.Dataset):
                 return example
             except Exception as e:
                 logger.warning(f"Error loading sample {idx}: {e}. Retrying with a different sample.")
-                idx = random.randint(0, len(self.dataset) - 1)
+                idx = rng.randint(0, len(self.dataset) - 1)
         raise RuntimeError(f"Failed to load a valid sample after {self.max_retries} retries")
 
     def robust_collate(self, collate_fn):

--- a/nemo_automodel/components/datasets/vlm/neat_packing_vlm.py
+++ b/nemo_automodel/components/datasets/vlm/neat_packing_vlm.py
@@ -385,7 +385,7 @@ def _build_packed_vlm_sample(
     seq_lens: list[int] = []
     seq_lens_padded: list[int] = []
 
-    pixel_values_list: list[torch.Tensor] = []
+    pixel_values_list: list[torch.Tensor | list[torch.Tensor]] = []
     image_grid_thw_list: list[torch.Tensor] = []
     image_position_ids_list: list[torch.Tensor] = []
     pixel_values_videos_list: list[torch.Tensor] = []
@@ -455,7 +455,20 @@ def _build_packed_vlm_sample(
     else:
         packed["position_ids"] = torch.tensor(all_position_ids_1d, dtype=torch.long)
 
-    packed["pixel_values"] = torch.cat(pixel_values_list, dim=0) if pixel_values_list else None
+    if pixel_values_list and all(isinstance(value, torch.Tensor) for value in pixel_values_list):
+        if all(value.shape[1:] == pixel_values_list[0].shape[1:] for value in pixel_values_list):
+            packed["pixel_values"] = torch.cat(pixel_values_list, dim=0)
+        else:
+            # Variable-resolution images (e.g. dynamic-resolution processors): keep
+            # one tensor per image; the THD collater and the model's feature
+            # extractor accept the list form.
+            packed["pixel_values"] = [image for value in pixel_values_list for image in value]
+    elif pixel_values_list and all(isinstance(value, (list, tuple)) for value in pixel_values_list):
+        packed["pixel_values"] = [item for value in pixel_values_list for item in value]
+    elif pixel_values_list:
+        raise TypeError("Packed VLM pixel_values must be consistently tensors or variable-resolution lists.")
+    else:
+        packed["pixel_values"] = None
     packed["image_grid_thw"] = torch.cat(image_grid_thw_list, dim=0) if image_grid_thw_list else None
     packed["image_position_ids"] = torch.cat(image_position_ids_list, dim=0) if image_position_ids_list else None
     packed["pixel_values_videos"] = torch.cat(pixel_values_videos_list, dim=0) if pixel_values_videos_list else None

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -536,8 +536,23 @@ class NemotronHParallelizationStrategy(ParallelizationStrategy):
         cp_mesh = device_mesh["cp"] if "cp" in device_mesh.mesh_dim_names else None
         if cp_mesh is not None and cp_mesh.size() > 1:
             cp_group = cp_mesh.get_group()
+            cp_global_ranks = torch.distributed.get_process_group_ranks(cp_group)
+            cp_layers = list(layers)
+            mtp_module = getattr(model, "mtp", None)
+            mtp_layers = getattr(mtp_module, "layers", None)
+            mtp_cp_enabled = model.supports.mtp_enabled
+            parallelizer_utils.reject_unsupported_mtp_cp_pp(model)
+            parallelizer_utils.reject_unsupported_mtp_cp(model)
+            if mtp_cp_enabled and mtp_layers is None:
+                raise RuntimeError(
+                    "MTP is enabled but model.mtp.layers is unavailable; cannot configure context parallelism for MTP"
+                )
+            if mtp_cp_enabled and mtp_layers is not None:
+                # MTP blocks live outside the backbone container but execute
+                # the same attention/Mamba CP collectives.
+                cp_layers.extend(mtp_layers)
 
-            for layer in layers:
+            for layer in cp_layers:
                 if hasattr(layer, "block_type") and layer.block_type == "mamba":
                     from nemo_automodel.components.distributed.context_parallel.mamba import MambaContextParallel
 
@@ -557,7 +572,7 @@ class NemotronHParallelizationStrategy(ParallelizationStrategy):
                     if isinstance(attn_module, DotProductAttention):
                         attn_module.set_context_parallel_group(
                             cp_group,
-                            torch.distributed.get_process_group_ranks(cp_group),
+                            cp_global_ranks,
                             torch.cuda.Stream(),
                             cp_comm_type="p2p",
                         )

--- a/nemo_automodel/components/distributed/parallelizer_utils.py
+++ b/nemo_automodel/components/distributed/parallelizer_utils.py
@@ -35,6 +35,26 @@ from nemo_automodel.shared.torch_patches import (
 UniformSubtreeItem = Union[Tuple[nn.Module, torch.dtype], Tuple[str, nn.Module, torch.dtype]]
 
 
+def reject_unsupported_mtp_cp(model: nn.Module) -> None:
+    """Reject enabled MTP when the model has not declared CP support."""
+    if model.supports.mtp_enabled and not model.supports.supports_mtp_cp:
+        raise RuntimeError(f"{type(model).__name__} does not support MTP with context parallelism")
+
+
+def reject_unsupported_mtp_cp_pp(model: nn.Module) -> None:
+    """Reject MTP+CP on every trimmed pipeline stage before CP collectives."""
+    is_pp_stage_fn = getattr(model, "_is_pipeline_parallel_stage", None)
+    if (
+        model.supports.mtp_enabled
+        and not model.supports.supports_mtp_cp_pp
+        and callable(is_pp_stage_fn)
+        and is_pp_stage_fn()
+    ):
+        raise NotImplementedError(
+            "MTP with context and pipeline parallelism is not supported; use PP size 1 or CP size 1"
+        )
+
+
 def configure_fsdp_unused_param_reduction(module: nn.Module) -> int:
     """Reduce zero gradients for FSDP parameters unused on a local CP rank.
 

--- a/nemo_automodel/components/loss/mtp.py
+++ b/nemo_automodel/components/loss/mtp.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Optional
 
@@ -34,6 +35,7 @@ def calculate_mtp_loss(
     *,
     mtp_per_depth_h: list[torch.Tensor] | None = None,
     mtp_per_depth_logits: list[torch.Tensor] | None = None,
+    mtp_per_depth_targets: Sequence[torch.Tensor] | None = None,
     labels: torch.Tensor,
     model: nn.Module,
     scaling_factor: float = 0.1,
@@ -53,9 +55,20 @@ def calculate_mtp_loss(
     Args:
         loss_fn: Configured per-token loss class (same instance the main
             path uses).
-        mtp_per_depth_h: Per-depth hidden states from the model's MTP head,
-            one ``[B, S, H]`` tensor per depth.
-        labels: Original (unshifted) labels.
+        mtp_per_depth_h: Per-depth hidden-state tensors of shape
+            ``[batch, sequence, hidden]``, or ``[1, tokens, hidden]`` for a
+            flattened THD-packed stream.
+        mtp_per_depth_logits: Per-depth logit tensors of shape
+            ``[batch, sequence, vocab]``, or ``[1, tokens, vocab]`` for a
+            flattened THD-packed stream.
+        mtp_per_depth_targets: Optional precomputed target tensors, one per
+            MTP depth, with the same local shape and token layout as ``labels``.
+            Context-parallel callers must shift and boundary-mask them in global
+            sequence order before applying the model input shard. These targets
+            are authoritative: this function cannot infer or repair global
+            packed-sequence boundaries from a rank-local CP shard.
+        labels: Original unshifted label tensor of shape ``[batch, sequence]``
+            or ``[tokens]`` for a flattened THD-packed stream.
         model: The wrapped model; used to fetch the shared LM head when the
             loss class needs materialized logits (non-FusedLinearCE path).
         scaling_factor: Coefficient applied to the summed per-depth CE.
@@ -95,6 +108,20 @@ def calculate_mtp_loss(
         mtp_outputs = [h.squeeze(0) if (h.dim() == 3 and h.shape[0] == 1) else h for h in mtp_outputs]
 
     D = len(mtp_outputs)
+    if mtp_per_depth_targets is not None:
+        if cu_seqlens is not None or seq_idx is not None:
+            raise ValueError("mtp_per_depth_targets cannot be combined with cu_seqlens or seq_idx")
+        if len(mtp_per_depth_targets) != D:
+            raise ValueError(
+                f"Expected {D} mtp_per_depth_targets for {D} MTP outputs, got {len(mtp_per_depth_targets)}"
+            )
+        for depth, targets in enumerate(mtp_per_depth_targets, start=1):
+            if targets.shape != labels.shape:
+                raise ValueError(
+                    f"MTP depth {depth} target shape {tuple(targets.shape)} does not match "
+                    f"labels shape {tuple(labels.shape)}"
+                )
+
     cur_labels = labels
     total = mtp_outputs[0].new_zeros(())
 
@@ -139,18 +166,21 @@ def calculate_mtp_loss(
             )
 
     for k, mtp_output in enumerate(mtp_outputs):
-        cur_labels = roll_tensor(cur_labels, shifts=-1, dim=-1)
-        masked = cur_labels.clone()
-        n_invalid = min(k + 1, masked.shape[-1])
-        masked[..., -n_invalid:] = ignore_index
+        if mtp_per_depth_targets is None:
+            cur_labels = roll_tensor(cur_labels, shifts=-1, dim=-1)
+            masked = cur_labels.clone()
+            n_invalid = min(k + 1, masked.shape[-1])
+            masked[..., -n_invalid:] = ignore_index
 
-        # Mask labels whose rolled source (position t+k+1) lives in a
-        # different sub-seq than position t — predictions across sub-seq
-        # boundaries are nonsensical.
-        if seq_idx is not None:
-            rolled_seq_idx = roll_tensor(seq_idx, shifts=-(k + 1), dim=-1)
-            cross_seq = rolled_seq_idx != seq_idx
-            masked = torch.where(cross_seq, torch.full_like(masked, ignore_index), masked)
+            # Mask labels whose rolled source (position t+k+1) lives in a
+            # different sub-seq than position t — predictions across sub-seq
+            # boundaries are nonsensical.
+            if seq_idx is not None:
+                rolled_seq_idx = roll_tensor(seq_idx, shifts=-(k + 1), dim=-1)
+                cross_seq = rolled_seq_idx != seq_idx
+                masked = torch.where(cross_seq, torch.full_like(masked, ignore_index), masked)
+        else:
+            masked = mtp_per_depth_targets[k]
 
         if mtp_per_depth_logits is not None:
             if isinstance(loss_fn, FusedLinearCrossEntropy):

--- a/nemo_automodel/components/models/common/mtp/__init__.py
+++ b/nemo_automodel/components/models/common/mtp/__init__.py
@@ -26,14 +26,20 @@ keys) lives in the model's own package.
 
 from nemo_automodel.components.models.common.mtp.mtp import (
     MTPConfig,
+    MTPContextParallelInputs,
     MTPModule,
     get_mtp_loss_scaling_factor,
+    prepare_mtp_context_parallel_inputs,
     roll_tensor,
+    shift_packed_tensor,
 )
 
 __all__ = [
     "MTPConfig",
+    "MTPContextParallelInputs",
     "MTPModule",
     "get_mtp_loss_scaling_factor",
+    "prepare_mtp_context_parallel_inputs",
     "roll_tensor",
+    "shift_packed_tensor",
 ]

--- a/nemo_automodel/components/models/common/mtp/mtp.py
+++ b/nemo_automodel/components/models/common/mtp/mtp.py
@@ -16,11 +16,36 @@
 
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from dataclasses import dataclass
 from typing import Callable
 
 import torch
 import torch.nn as nn
+
+
+@dataclass(frozen=True)
+class MTPContextParallelInputs:
+    """Globally shifted MTP tensors prepared before context-parallel sharding.
+
+    Attributes:
+        input_ids: Per-depth token IDs of shape ``[batch, sequence]`` in global
+            sequence order.
+        position_ids: Per-depth position IDs in global sequence order. Standard
+            positions have shape ``[batch, sequence]``; multi-axis RoPE uses
+            ``[axes, batch, sequence]``.
+        targets: Per-depth loss targets of shape ``[batch, sequence]`` in global
+            sequence order, with invalid positions set to the loss ignore index.
+        valid_masks: Per-depth masks of shape ``[batch, sequence]`` identifying
+            positions whose future token remains in the same packed sequence.
+        position_ids_seq_dim: Sequence dimension of each position-ID tensor.
+    """
+
+    input_ids: tuple[torch.LongTensor, ...]
+    position_ids: tuple[torch.LongTensor, ...]
+    targets: tuple[torch.LongTensor, ...]
+    valid_masks: tuple[torch.BoolTensor, ...]
+    position_ids_seq_dim: int
 
 
 def roll_tensor(t: torch.Tensor, shifts: int = -1, dim: int = -1) -> torch.Tensor:
@@ -49,6 +74,264 @@ def roll_tensor(t: torch.Tensor, shifts: int = -1, dim: int = -1) -> torch.Tenso
         idx = torch.arange(0, n, device=t.device)
     rolled = rolled.index_fill(dim, idx, 0)
     return rolled
+
+
+def shift_packed_tensor(
+    tensor: torch.Tensor,
+    *,
+    depth: int,
+    seq_idx: torch.Tensor | None = None,
+    fill_value: float | int = 0,
+    batch_dim: int = 0,
+    seq_dim: int = 1,
+) -> torch.Tensor:
+    """Shift a token-aligned tensor left without crossing sequence boundaries.
+
+    Args:
+        tensor: Token-aligned tensor in global sequence order. Its batch and
+            sequence axes are selected by ``batch_dim`` and ``seq_dim``.
+        depth: Number of future-token positions to shift; must be positive.
+        seq_idx: Optional sequence IDs of shape ``[batch, sequence]``. Tokens
+            whose shifted source has a different ID are filled.
+        fill_value: Scalar used for trailing and cross-sequence positions.
+        batch_dim: Batch dimension in ``tensor``.
+        seq_dim: Sequence dimension in ``tensor``.
+
+    Returns:
+        Tensor with the same shape, dtype, and device as ``tensor``. The output
+        owns independent storage and positions without a valid future source
+        contain ``fill_value``.
+    """
+    if tensor.dim() < 2:
+        raise ValueError(f"tensor must have batch and sequence dimensions, got {tuple(tensor.shape)}")
+    if depth <= 0:
+        raise ValueError(f"depth must be positive, got {depth}")
+    batch_dim %= tensor.dim()
+    seq_dim %= tensor.dim()
+    if batch_dim == seq_dim:
+        raise ValueError("batch_dim and seq_dim must be different")
+    token_shape = (tensor.shape[batch_dim], tensor.shape[seq_dim])
+    if seq_idx is not None and seq_idx.shape != token_shape:
+        raise ValueError(f"seq_idx shape {tuple(seq_idx.shape)} must match tensor token shape {token_shape}")
+
+    shifted = torch.roll(tensor, shifts=-depth, dims=seq_dim)
+    sequence = tensor.shape[seq_dim]
+    positions = torch.arange(sequence, device=tensor.device)
+    valid = (positions + depth < sequence).unsqueeze(0).expand(tensor.shape[batch_dim], -1)
+    if seq_idx is not None:
+        shifted_seq_idx = torch.roll(seq_idx, shifts=-depth, dims=1)
+        valid = valid & (shifted_seq_idx == seq_idx)
+    valid_shape = [1] * tensor.dim()
+    valid_shape[batch_dim] = tensor.shape[batch_dim]
+    valid_shape[seq_dim] = sequence
+    valid = valid.reshape(valid_shape)
+    return torch.where(valid, shifted, torch.as_tensor(fill_value, dtype=tensor.dtype, device=tensor.device))
+
+
+def _packed_seq_ids_from_padded_lengths(
+    seq_lens_padded: torch.Tensor,
+    *,
+    batch_size: int,
+    seq_len: int,
+    device: torch.device,
+) -> torch.LongTensor:
+    """Expand padded packed-sequence lengths into token-aligned sequence IDs.
+
+    Args:
+        seq_lens_padded: Tensor of shape [batch, num_sequences] or
+            [num_sequences] for a single batch row. Negative entries are
+            unused sentinels; nonnegative entries are materialized sequence
+            lengths including padding.
+        batch_size: Expected batch dimension of the returned tensor.
+        seq_len: Expected materialized token count in each batch row.
+        device: Device for the returned token-aligned IDs.
+
+    Returns:
+        Sequence-ID tensor of shape [batch, sequence] on device.
+    """
+    if seq_lens_padded.dim() == 1:
+        seq_lens_padded = seq_lens_padded.unsqueeze(0)
+    if seq_lens_padded.dim() != 2 or seq_lens_padded.shape[0] != batch_size:
+        raise ValueError(
+            "seq_lens_padded must have shape [batch, num_sequences], "
+            f"got {tuple(seq_lens_padded.shape)} for batch size {batch_size}"
+        )
+
+    seq_idx = torch.zeros((batch_size, seq_len), dtype=torch.long, device=device)
+    for batch_idx, row in enumerate(seq_lens_padded):
+        lengths = row.to(device=device, dtype=torch.long).clamp_min(0)
+        sequence_ids = torch.arange(1, row.numel() + 1, dtype=torch.long, device=device)
+        try:
+            seq_idx[batch_idx] = torch.repeat_interleave(sequence_ids, lengths, output_size=seq_len)
+        except RuntimeError as exc:
+            raise ValueError(
+                f"seq_lens_padded row {batch_idx} must cover exactly the input sequence length {seq_len}"
+            ) from exc
+    return seq_idx
+
+
+def _packed_seq_ids_from_batch(
+    batch: MutableMapping[str, object],
+    *,
+    input_ids: torch.Tensor,
+) -> torch.LongTensor | None:
+    """Normalize supported packed-boundary metadata to token-aligned IDs.
+
+    Args:
+        batch: Unsharded batch. Optional seq_idx or _packed_seq_ids tensors
+            have shape [batch, sequence] (or [sequence] when batch is one).
+            seq_lens_padded has shape [batch, num_sequences].
+            cu_seqlens_padded or cu_seqlens contains flattened cumulative
+            boundaries of shape [num_sequences + 1] with optional negative
+            sentinels.
+        input_ids: Global token-ID tensor of shape [batch, sequence] whose
+            materialized token layout defines the expected output shape.
+
+    Returns:
+        Sequence-ID tensor of shape [batch, sequence] on the input device,
+        or None when the batch has no packed-boundary metadata.
+    """
+    seq_idx = batch.get("seq_idx")
+    if not isinstance(seq_idx, torch.Tensor):
+        seq_idx = batch.get("_packed_seq_ids")
+    if isinstance(seq_idx, torch.Tensor):
+        if seq_idx.dim() == 1 and input_ids.shape[0] == 1:
+            seq_idx = seq_idx.unsqueeze(0)
+        if seq_idx.shape != input_ids.shape:
+            raise ValueError(
+                f"packed sequence IDs must match input_ids, got {tuple(seq_idx.shape)} and {tuple(input_ids.shape)}"
+            )
+        return seq_idx.to(device=input_ids.device)
+
+    seq_lens_padded = batch.get("seq_lens_padded")
+    if isinstance(seq_lens_padded, torch.Tensor):
+        return _packed_seq_ids_from_padded_lengths(
+            seq_lens_padded,
+            batch_size=input_ids.shape[0],
+            seq_len=input_ids.shape[1],
+            device=input_ids.device,
+        )
+
+    # Padded boundaries describe the materialized token layout. Real
+    # cu_seqlens alone are safe only when the materialized layout is unpadded.
+    cu_seqlens = batch.get("cu_seqlens_padded")
+    uses_unpadded_boundaries = not isinstance(cu_seqlens, torch.Tensor)
+    if uses_unpadded_boundaries:
+        cu_seqlens = batch.get("cu_seqlens")
+    if not isinstance(cu_seqlens, torch.Tensor):
+        return None
+    if input_ids.shape[0] != 1:
+        raise ValueError("cu_seqlens MTP boundary metadata requires batch size 1")
+
+    cu_seqlens = cu_seqlens.reshape(-1)
+    cu_seqlens = cu_seqlens[cu_seqlens >= 0].to(device=input_ids.device)
+    if cu_seqlens.numel() < 2:
+        return None
+    if uses_unpadded_boundaries and bool(cu_seqlens[-1] != input_ids.shape[1]):
+        raise ValueError(
+            "cu_seqlens cannot describe a padded materialized MTP token layout: "
+            f"its final boundary must equal input sequence length {input_ids.shape[1]}; "
+            "provide cu_seqlens_padded"
+        )
+    positions = torch.arange(input_ids.shape[1], device=input_ids.device)
+    return torch.searchsorted(cu_seqlens[1:].contiguous(), positions, right=True).unsqueeze(0)
+
+
+def prepare_mtp_context_parallel_inputs(
+    batch: MutableMapping[str, object],
+    *,
+    num_depths: int,
+    ignore_index: int = -100,
+) -> MTPContextParallelInputs:
+    """Prepare global future-token tensors before context-parallel sharding.
+
+    Each MTP depth is shifted in global sequence order before CP partitions the
+    token axis. Packed boundaries are preserved, so no future token, position,
+    or target crosses from one document into another. Missing or shared
+    position IDs are materialized in batch so the main model and MTP heads are
+    subsequently sharded from the same global source.
+
+    Args:
+        batch: Mutable unsharded batch. input_ids and labels are tensors of
+            shape [batch, sequence]. Optional position_ids has shape
+            [batch, sequence], shared shape [1, sequence], or multi-axis RoPE
+            shape [axes, batch, sequence]. Packed boundaries may use the tensor layouts documented by
+            _packed_seq_ids_from_batch.
+        num_depths: Number of MTP future-token depths; must be positive.
+        ignore_index: Fill value for invalid targets at trailing and packed
+            boundary positions.
+
+    Returns:
+        Per-depth input IDs, position IDs, targets, and validity masks. Token
+        tensors have global shape [batch, sequence] and independent storage;
+        targets without a valid same-sequence future token contain ignore_index.
+    """
+    if num_depths <= 0:
+        raise ValueError(f"num_depths must be positive, got {num_depths}")
+
+    input_ids = batch.get("input_ids")
+    labels = batch.get("labels")
+    if not isinstance(input_ids, torch.Tensor) or not isinstance(labels, torch.Tensor):
+        raise ValueError("MTP with context parallelism requires tensor input_ids and labels")
+    if input_ids.dim() != 2 or labels.shape != input_ids.shape:
+        raise ValueError(
+            "MTP with context parallelism requires input_ids and labels with matching "
+            f"[batch, sequence] shapes, got {tuple(input_ids.shape)} and {tuple(labels.shape)}"
+        )
+
+    position_ids = batch.get("position_ids")
+    if position_ids is None:
+        position_ids = (
+            torch.arange(input_ids.shape[1], device=input_ids.device)
+            .unsqueeze(0)
+            .expand(input_ids.shape[0], -1)
+            .contiguous()
+        )
+        batch["position_ids"] = position_ids
+    elif (
+        isinstance(position_ids, torch.Tensor)
+        and position_ids.dim() == 2
+        and position_ids.shape == (1, input_ids.shape[1])
+    ):
+        position_ids = position_ids.expand(input_ids.shape[0], -1).contiguous()
+        batch["position_ids"] = position_ids
+    elif (
+        isinstance(position_ids, torch.Tensor) and position_ids.dim() == 3 and position_ids.shape[1:] == input_ids.shape
+    ):
+        pass
+    elif not isinstance(position_ids, torch.Tensor) or position_ids.shape != input_ids.shape:
+        position_shape = tuple(position_ids.shape) if isinstance(position_ids, torch.Tensor) else type(position_ids)
+        raise ValueError(
+            f"MTP position_ids must be a tensor matching input_ids, got {position_shape} and {tuple(input_ids.shape)}"
+        )
+
+    position_batch_dim = 1 if position_ids.dim() == 3 else 0
+    position_seq_dim = 2 if position_ids.dim() == 3 else 1
+    seq_idx = _packed_seq_ids_from_batch(batch, input_ids=input_ids)
+    depths = tuple(range(1, num_depths + 1))
+    return MTPContextParallelInputs(
+        input_ids=tuple(shift_packed_tensor(input_ids, depth=depth, seq_idx=seq_idx) for depth in depths),
+        position_ids=tuple(
+            shift_packed_tensor(
+                position_ids,
+                depth=depth,
+                seq_idx=seq_idx,
+                batch_dim=position_batch_dim,
+                seq_dim=position_seq_dim,
+            )
+            for depth in depths
+        ),
+        targets=tuple(
+            shift_packed_tensor(labels, depth=depth, seq_idx=seq_idx, fill_value=ignore_index) for depth in depths
+        ),
+        valid_masks=tuple(
+            shift_packed_tensor(
+                torch.ones_like(input_ids, dtype=torch.bool), depth=depth, seq_idx=seq_idx, fill_value=False
+            )
+            for depth in depths
+        ),
+        position_ids_seq_dim=position_seq_dim,
+    )
 
 
 def get_mtp_loss_scaling_factor(model: nn.Module, default: float = 0.1) -> float:
@@ -174,19 +457,25 @@ class MTPModule(nn.Module):
         hidden_states: torch.Tensor,
         *,
         input_ids: torch.LongTensor | None = None,
+        input_ids_per_depth: tuple[torch.LongTensor, ...] | None = None,
         embed_fn: Callable[[torch.LongTensor], torch.Tensor] | None = None,
         embed_inputs: tuple[torch.Tensor, ...] | None = None,
         position_ids: torch.LongTensor | None = None,
+        position_ids_per_depth: tuple[torch.LongTensor, ...] | None = None,
         **block_kwargs,
     ) -> list[torch.Tensor]:
         """Iterate over MTP depths and return per-depth hidden states.
 
-        Two mutually-exclusive input modes:
+        Three mutually-exclusive input modes:
 
         * **Single-rank / first-stage PP** (default): pass ``input_ids`` plus
           ``embed_fn``. The module rolls ``input_ids`` cumulatively left by 1
           per depth and applies ``embed_fn`` to produce the future-token
           embedding for that depth.
+        * **Context parallel**: pass ``input_ids_per_depth`` plus ``embed_fn``.
+          Each tensor is globally shifted and then sharded into the local CP
+          token layout, so this module embeds it directly without a rank-local
+          roll.
         * **Final-stage PP / multimodal**: pass ``embed_inputs`` (a tuple of
           pre-rolled per-depth embeddings, length ``num_depths``). Used when
           the last PP stage no longer owns ``embed_tokens``, or for multimodal
@@ -197,37 +486,98 @@ class MTPModule(nn.Module):
 
         Args:
             hidden_states: Output of the main model's final norm (``h_0``);
-                shape matches the model's residual stream.
-            input_ids: Token ids ``[B, S]`` (or ``[T]`` in THD). Rolled
+                tensor of shape ``[batch, sequence, hidden]`` or
+                ``[tokens, hidden]`` for THD.
+            input_ids: Token ids of shape ``[batch, sequence]`` (or
+                ``[tokens]`` in THD). Rolled
                 cumulatively left by 1 per depth. Mutually exclusive with
-                ``embed_inputs``.
+                ``input_ids_per_depth`` and ``embed_inputs``.
+            input_ids_per_depth: Optional tuple of ``num_depths`` pre-shifted
+                token-ID tensors. Each has local CP shape
+                ``[batch, sequence]`` or ``[tokens]`` and is embedded directly
+                with ``embed_fn``. Requires ``position_ids_per_depth``.
             embed_fn: Callable applied to rolled ``input_ids`` to produce the
                 future-token embedding (typically the model's input embedding
                 layer). Required when ``input_ids`` is supplied.
             embed_inputs: Optional tuple of ``num_depths`` pre-computed
-                future-token embeddings, one per depth in MTP order.
-                Mutually exclusive with ``input_ids``/``embed_fn``.
+                future-token embeddings, each of shape
+                ``[batch, sequence, hidden]`` or ``[tokens, hidden]``.
+                Mutually exclusive with ``input_ids``/
+                ``input_ids_per_depth``/``embed_fn``.
             position_ids: Position ids matching ``input_ids``. When supplied,
                 rolled cumulatively per depth in lockstep with ``input_ids``
                 (so slot ``t`` carries the original position of the rolled
                 token) and forwarded to each sublayer via ``block_kwargs``.
                 Required for RoPE-using sublayers; ignored by sublayers that
                 don't consume it.
+            position_ids_per_depth: Optional tuple of ``num_depths``
+                pre-computed future-token position tensors. Each tensor has
+                shape ``[batch, sequence]``, ``[axes, batch, sequence]`` for
+                multi-axis RoPE, or ``[tokens]`` for THD. When supplied, these
+                tensors are forwarded directly instead of rolling rank-local
+                ``position_ids``. Use this when context parallelism has already sharded the sequence.
+                Required with ``input_ids_per_depth`` and incompatible with
+                rank-local ``input_ids`` rolling.
             **block_kwargs: Forwarded to each sublayer's ``__call__`` (e.g.
                 ``attention_mask``).
 
         Returns:
-            List of length ``num_depths`` containing the hidden state
-            produced at each depth.
+            List of length ``num_depths`` containing hidden states of shape
+            ``[batch, sequence, hidden]`` or ``[tokens, hidden]``.
         """
         if embed_inputs is not None:
-            if input_ids is not None or embed_fn is not None:
-                raise ValueError("embed_inputs is mutually exclusive with input_ids/embed_fn")
+            if input_ids is not None or input_ids_per_depth is not None or embed_fn is not None:
+                raise ValueError("embed_inputs is mutually exclusive with input_ids/input_ids_per_depth/embed_fn")
             if len(embed_inputs) != self.num_depths:
                 raise ValueError(f"embed_inputs length {len(embed_inputs)} does not match num_depths {self.num_depths}")
+        elif input_ids_per_depth is not None:
+            if input_ids is not None or embed_fn is None:
+                raise ValueError("input_ids_per_depth requires embed_fn and is mutually exclusive with input_ids")
+            if len(input_ids_per_depth) != self.num_depths:
+                raise ValueError(
+                    f"input_ids_per_depth length {len(input_ids_per_depth)} does not match num_depths {self.num_depths}"
+                )
         else:
             if input_ids is None or embed_fn is None:
-                raise ValueError("MTPModule.forward requires either embed_inputs or (input_ids, embed_fn)")
+                raise ValueError(
+                    "MTPModule.forward requires embed_inputs, (input_ids_per_depth, embed_fn), or (input_ids, embed_fn)"
+                )
+        if input_ids_per_depth is not None and position_ids_per_depth is None:
+            raise ValueError("input_ids_per_depth and position_ids_per_depth must be provided together")
+        if input_ids is not None and position_ids_per_depth is not None:
+            raise ValueError(
+                "position_ids_per_depth cannot be combined with rank-local input_ids rolling; "
+                "provide input_ids_per_depth or precomputed embed_inputs"
+            )
+        if position_ids_per_depth is not None:
+            if len(position_ids_per_depth) != self.num_depths:
+                raise ValueError(
+                    f"position_ids_per_depth length {len(position_ids_per_depth)} "
+                    f"does not match num_depths {self.num_depths}"
+                )
+            if position_ids is not None:
+                expected_position_shape = position_ids.shape
+                expected_position_source = "base position_ids"
+            elif input_ids is not None:
+                expected_position_shape = input_ids.shape
+                expected_position_source = "input_ids"
+            elif input_ids_per_depth is not None:
+                expected_position_shape = input_ids_per_depth[0].shape
+                expected_position_source = "input_ids_per_depth token shape"
+            else:
+                expected_position_shape = embed_inputs[0].shape[:-1]
+                expected_position_source = "embed_inputs token shape"
+            for depth, depth_position_ids in enumerate(position_ids_per_depth, start=1):
+                position_shape_matches = depth_position_ids.shape == expected_position_shape
+                if len(expected_position_shape) == 2:
+                    position_shape_matches = position_shape_matches or (
+                        depth_position_ids.dim() == 3 and depth_position_ids.shape[1:] == expected_position_shape
+                    )
+                if not position_shape_matches:
+                    raise ValueError(
+                        f"MTP depth {depth} position_ids shape {tuple(depth_position_ids.shape)} "
+                        f"does not match {expected_position_source} {tuple(expected_position_shape)}"
+                    )
 
         num_iterations = self.num_depths
         num_sublayers_per_depth = self.pattern_length
@@ -238,18 +588,25 @@ class MTPModule(nn.Module):
         for depth in range(num_iterations):
             if embed_inputs is not None:
                 decoder_input = embed_inputs[depth]
+            elif input_ids_per_depth is not None:
+                decoder_input = embed_fn(input_ids_per_depth[depth])
             else:
                 cur_input_ids = roll_tensor(cur_input_ids, shifts=-1, dim=-1)
                 decoder_input = embed_fn(cur_input_ids)
-            if cur_position_ids is not None:
+            if position_ids_per_depth is not None:
+                depth_position_ids = position_ids_per_depth[depth]
+            elif cur_position_ids is not None:
                 cur_position_ids = roll_tensor(cur_position_ids, shifts=-1, dim=-1)
+                depth_position_ids = cur_position_ids
+            else:
+                depth_position_ids = None
 
             physical_depth = 0 if use_repeated else depth
             for sublayer_idx in range(num_sublayers_per_depth):
                 sublayer = self.layers[physical_depth * num_sublayers_per_depth + sublayer_idx]
                 kwargs = dict(block_kwargs)
-                if cur_position_ids is not None:
-                    kwargs["position_ids"] = cur_position_ids
+                if depth_position_ids is not None:
+                    kwargs["position_ids"] = depth_position_ids
                 if sublayer_idx == 0:
                     kwargs["embed_input"] = decoder_input
                 hidden_states = sublayer(hidden_states, **kwargs)

--- a/nemo_automodel/components/models/nemotron_omni/model.py
+++ b/nemo_automodel/components/models/nemotron_omni/model.py
@@ -252,6 +252,13 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
     """
 
     tie_word_embeddings_support: TieSupport = TieSupport.UNTIED_ONLY
+    # Same fp32 keep-list as NemotronHForCausalLM: ``cast_model_to_dtype`` reads these
+    # attributes from the *outermost* module, so without them the wrapper-level cast in
+    # ``initialize_weights`` turns the router's ``e_score_correction_bias`` buffers into
+    # bf16. The checkpoint stores them in fp32 (values ~3.97 +- 0.024, none bf16-exact) and
+    # the bf16 rounding (ulp 0.0156 at 4.0) is larger than the sigmoid routing margins, so
+    # top-k expert selection diverged from the HF reference on ~85% of tokens.
+    _keep_in_fp32_modules_strict = ["e_score_correction_bias", "_fp32_params"]
     # CP submesh, installed by the MoE parallelizer's apply_cp when context
     # parallelism is active; None means the forward embeds and shards nothing for CP.
     cp_mesh = None
@@ -264,6 +271,9 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
         supports_cp: bool = True
         supports_pp: bool = False
         supports_ep: bool = True
+        # MTP under CP delegates to the NemotronV3 LM's globally-prepared per-depth
+        # targets (prepare_mtp_inputs_for_cp) sharded by the same sharder as the inputs.
+        supports_mtp_cp: bool = True
 
     @classmethod
     def from_config(
@@ -369,14 +379,40 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
         from timm.layers.config import set_fused_attn as _timm_set_fused_attn
 
         _timm_set_fused_attn(False)
-        self.vision_model = AutoModel.from_config(vision_config, trust_remote_code=True)
+        # Resolve RadioModel directly from THIS checkpoint's own remote-code module rather
+        # than through the generic `AutoModel.from_config(..., trust_remote_code=True)`
+        # factory. That factory dispatches on `model_type` ("radio") through a *global*
+        # registry: with multiple RADIO/omni checkpoints' remote code cached under the same
+        # $HF_HOME (each with its own "radio" registration -- e.g. a legacy timm-based
+        # implementation for NemotronH_Nano_Omni_Reasoning_V3 vs. the newer
+        # transformers-native embeddings/encoder RadioModel some checkpoints ship, such as
+        # NemotronH_Omni_Reasoning_V3), whichever module happened to register "radio" first
+        # in this process wins -- nondeterministically resolving the wrong class/module tree
+        # for the checkpoint actually being loaded. Explicit dynamic-module resolution is
+        # deterministic and always matches the checkpoint's own weights.
+        try:
+            from transformers.dynamic_module_utils import get_class_from_dynamic_module
+
+            radio_model_cls = get_class_from_dynamic_module("modeling_radio.RadioModel", config.name_or_path)
+            self.vision_model = radio_model_cls(vision_config)
+        except (ImportError, OSError, AttributeError):
+            # Checkpoints that don't ship a "modeling_radio.RadioModel" module/class under
+            # this exact name/path fall back to the generic, registry-based resolution.
+            self.vision_model = AutoModel.from_config(vision_config, trust_remote_code=True)
         _timm_set_fused_attn(True)  # Restore default for any subsequent timm usage
         # WAR for transformers issue 38358
         if hasattr(self.vision_model, "model") and hasattr(self.vision_model.model, "_init_weights"):
             self.vision_model.model._initialize_weights = self.vision_model.model._init_weights
-        # Make preprocessor external (required by RADIO)
+        # Make preprocessor external (required by RADIO): the image processor already
+        # normalizes pixel values, so the model-side input conditioner must become an
+        # Identity -- exactly what the checkpoint's own NemotronH_Omni_Reasoning_V3.__init__
+        # does. Legacy checkpoints expose it under `radio_model`; the transformers-native
+        # RadioModel exposes it directly. Leaving it active normalizes twice and corrupts
+        # the vision features (RADIO output cosine ~0.32 vs the HF reference).
         if hasattr(self.vision_model, "radio_model"):
             self.vision_model.radio_model.make_preprocessor_external()
+        elif hasattr(self.vision_model, "make_preprocessor_external"):
+            self.vision_model.make_preprocessor_external()
 
         # 3D patch projector for temporally-packed video frames. Only present when the
         # checkpoint ships a `patch_generator.video_embedder` weight (i.e. v3+).
@@ -388,6 +424,26 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
                 out_features=pg.embed_dim,
                 bias=False,
             )
+
+        # The native RadioModel's RadioLayerScale always creates a learnable
+        # `lambda1` parameter, even when `layerscale_value == 1.0` (a pure
+        # multiplicative no-op: `x * 1.0 == x`). Checkpoints trained with
+        # layerscale disabled (this value) never save these tensors, so
+        # checkpoint loading would otherwise fail with a spurious "missing key"
+        # error for a parameter whose only correct value is the identity.
+        # Replacing with nn.Identity() is exact (not an approximation) and
+        # removes both the memory and the checkpoint-key requirement.
+        if hasattr(self.vision_model, "encoder") and getattr(vision_config, "layerscale_value", None) == 1.0:
+            num_replaced = 0
+            for layer in self.vision_model.encoder.layer:
+                if hasattr(layer, "layer_scale1"):
+                    layer.layer_scale1 = nn.Identity()
+                    num_replaced += 1
+                if hasattr(layer, "layer_scale2"):
+                    layer.layer_scale2 = nn.Identity()
+                    num_replaced += 1
+            if num_replaced:
+                logger.info(f"NemotronOmni: Replaced {num_replaced} no-op RADIO layer_scale modules with nn.Identity()")
 
         self.vision_model = self.vision_model.to(dtype)
 
@@ -482,6 +538,16 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
                 moe_config=self.language_model.model.moe_config,
                 backend=self.backend,
                 dtype=dtype,
+                # Checkpoints whose remote code ships the transformers-native RadioModel
+                # (embeddings/encoder module tree, e.g. NemotronH_Omni_Reasoning_V3) save
+                # weights under the older timm-style `radio_model.model.blocks` naming and
+                # need the same key-rename + fused-QKV split transformers itself applies via
+                # `register_checkpoint_conversion_mapping("radio", ...)` during
+                # `from_pretrained`. Checkpoints whose remote code ships the legacy
+                # `radio_model`-wrapped class (identified by `hasattr(self.vision_model,
+                # "radio_model")`, e.g. NemotronH_Nano_Omni_Reasoning_V3) already match the
+                # checkpoint's native layout and need no remap.
+                vision_uses_native_radio=not hasattr(self.vision_model, "radio_model"),
             )
             logger.info("NemotronOmni: State dict adapter created")
 
@@ -573,14 +639,20 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
             x = x.permute(0, 2, 1, 3).contiguous()
         return x
 
-    def extract_feature(self, pixel_values: torch.Tensor) -> torch.Tensor:
+    def extract_feature(self, pixel_values: "torch.Tensor | list[torch.Tensor]") -> "torch.Tensor | list[torch.Tensor]":
         """Extract vision features from pixel values through RADIO + projector.
 
         Args:
-            pixel_values: Image tensors [num_tiles, C, H, W]
+            pixel_values: Image tensors [num_tiles, C, H, W], or a list of
+                per-image tensors ([C, H, W] or [num_tiles, C, H, W]) when the
+                batch mixes resolutions and cannot be stacked. The collate fn
+                (`nemotron_omni_collate_fn`) emits the list form whenever the
+                dataset is variable-resolution and `local_batch_size > 1`.
 
         Returns:
-            Vision embeddings [num_tiles, num_tokens, llm_hidden_size]
+            Vision embeddings [num_tiles, num_tokens, llm_hidden_size], or, for
+            list input, one such tensor per list element. Each element keeps its
+            own `num_tokens` because that depends on the image resolution.
         """
         # Force vision model to eval mode for deterministic spectral reparam.
         # RADIO uses spectral reparameterization with power iteration that is
@@ -589,13 +661,28 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
         # reproducible outputs.
         was_training = self.vision_model.training
         self.vision_model.eval()
+        try:
+            if isinstance(pixel_values, (list, tuple)):
+                # RADIO only accepts a dense (B, C, H, W) tensor, so variable
+                # resolutions have to be run one at a time.
+                return [self._extract_feature_dense(pv[None] if pv.dim() == 3 else pv) for pv in pixel_values]
+            return self._extract_feature_dense(pixel_values)
+        finally:
+            if was_training:
+                self.vision_model.train()
+
+    def _extract_feature_dense(self, pixel_values: torch.Tensor) -> torch.Tensor:
+        """RADIO + pixel-shuffle + projector for one dense [B, C, H, W] batch."""
         vit_embeds = self.vision_model(pixel_values).features
-        if was_training:
-            self.vision_model.train()
         vit_embeds = vit_embeds.to(dtype=torch.bfloat16)
 
         # Patch grid comes from input dims so non-square dynamic-res tiles also work.
-        patch_size = self.vision_model.radio_model.model.patch_generator.patch_size
+        # Native RadioModel (embeddings/encoder tree) exposes `patch_size` directly; the
+        # legacy `radio_model`-wrapped class only has it nested under patch_generator.
+        if hasattr(self.vision_model, "radio_model"):
+            patch_size = self.vision_model.radio_model.model.patch_generator.patch_size
+        else:
+            patch_size = self.vision_model.patch_size
         B, _, H, W = pixel_values.shape
         h = H // patch_size
         w = W // patch_size
@@ -779,6 +866,24 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
     # Context parallelism pre-processing
     # ------------------------------------------------------------------
 
+    @property
+    def mtp(self):
+        """The LM's MTP head (so the MoE parallelizer / FSDP block iteration find its MoE sublayers)."""
+        return getattr(self.language_model, "mtp", None)
+
+    @property
+    def mtp_config(self):
+        """MTP head configuration of the wrapped NemotronV3 LM (drives ``supports.mtp_enabled``)."""
+        return getattr(self.language_model, "mtp_config", None)
+
+    def prepare_mtp_inputs_for_cp(self, batch: dict[str, Any], *, ignore_index: int = -100):
+        """Globally ordered MTP future-token inputs/targets, prepared before CP sharding.
+
+        Delegates to the NemotronV3 LM (the batch is still the full text-token stream;
+        media placeholders are ordinary tokens at this stage).
+        """
+        return self.language_model.prepare_mtp_inputs_for_cp(batch, ignore_index=ignore_index)
+
     def prepare_model_inputs_for_cp(
         self,
         batch: dict[str, Any],
@@ -801,13 +906,76 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
                 sequence]``); left intact.
             num_chunks: Accepted for hook-signature parity; unused (round-robin CP).
         """
-        del batch, num_chunks
+        del num_chunks
+        if batch.get("qkv_format") == "thd":
+            # Packed THD: defer to the framework TE THD sharder, which partitions
+            # input_ids/labels/position_ids per document (tex.thd_get_partitioned_indices)
+            # before embedding -- the layout TE's THD CP attention and the Mamba CP
+            # helpers require. Media inputs stay full-length; record which GLOBAL
+            # positions are media placeholders so forward can pick this rank's
+            # slice of the encoder features (see _select_local_media_features).
+            input_ids = batch.get("input_ids")
+            if input_ids is None:
+                return {}
+            flat = input_ids.reshape(-1)
+            prepared = {"_nemotron_omni_global_image_mask": flat == self.img_context_token_id}
+            if self.sound_context_token_id is not None:
+                prepared["_nemotron_omni_global_sound_mask"] = flat == self.sound_context_token_id
+            return prepared
         return {
             "cp_sharder": ContextParallelSharder(
                 shard_batch=shard_batch_aux_only,
                 local_token_global_indices=round_robin_local_indices,
             )
         }
+
+    @staticmethod
+    def _select_local_media_features(
+        features: torch.Tensor,
+        global_mask: torch.Tensor,
+        local_selected: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        """Pick this CP rank's slice of full-sequence media features (packed THD CP).
+
+        The framework TE THD sharder hands forward an ``input_ids`` shard (TE's
+        per-document partition) while the media encoders ran on every image /
+        clip, so ``features`` is ordered by GLOBAL placeholder position. Map each
+        local token to its global position, then to its feature row.
+
+        Args:
+            features: Tensor of shape [num_global_media_tokens, hidden], ordered by
+                media-placeholder position in the global packed sequence.
+            global_mask: Boolean Tensor of shape [global_tokens], flattened from the
+                global packed sequence, with true entries at media placeholders.
+            local_selected: Boolean Tensor of shape [local_tokens], with true entries
+                at media placeholders in this rank's TE THD partition.
+            cu_seqlens: Int32 Tensor of shape [num_documents + 1] containing cumulative
+                unpadded document boundaries for the global packed sequence.
+            cp_size: Number of context-parallel ranks.
+            cp_rank: This rank's zero-based index in the context-parallel group.
+
+        Returns:
+            Tensor of shape [num_local_media_tokens, hidden] containing this rank's
+            media-feature rows in local placeholder order.
+        """
+        import transformer_engine_torch as tex  # noqa: PLC0415
+
+        cu = cu_seqlens.to(dtype=torch.int32)
+        local_indices = tex.thd_get_partitioned_indices(cu, int(cu[-1].item()), cp_size, cp_rank).to(torch.long)
+        local_selected = local_selected.reshape(-1)
+        if local_indices.numel() != local_selected.numel():
+            raise ValueError(
+                f"NemotronOmni packed CP: {local_indices.numel()} partition indices for "
+                f"{local_selected.numel()} local tokens."
+            )
+        feature_index_by_token = global_mask.reshape(-1).to(device=local_indices.device, dtype=torch.long).cumsum(0) - 1
+        local_feature_indices = feature_index_by_token.index_select(0, local_indices)[
+            local_selected.to(local_indices.device)
+        ]
+        return features.index_select(0, local_feature_indices.to(features.device))
 
     def forward(
         self,
@@ -843,7 +1011,7 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
             pixel_values: Image pixel values [num_tiles, C, H, W]
             input_ids: Input token IDs [batch, seq_len]
             attention_mask: Attention mask [batch, seq_len]
-            position_ids: Position IDs (unused, for API compat)
+            position_ids: Position IDs (ignored by the RoPE-free backbone; forwarded to the MTP head)
             image_flags: Flags indicating real images vs padding [num_tiles, 1]
             labels: Token IDs for loss computation [batch, seq_len]
             inputs_embeds: Pre-computed input embeddings (optional)
@@ -873,6 +1041,40 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
         # context_parallel sharded the tensors). In that case skip the embed +
         # multimodal-replacement block entirely; the shards are already correct.
         _embeds_pre_built = inputs_embeds is not None
+        # Packed THD under CP: input_ids arrive already partitioned per document by
+        # the framework TE THD sharder (cu_seqlens/cp_size/cp_rank come with it);
+        # media features must be narrowed to this rank's placeholders.
+        _global_image_mask = kwargs.pop("_nemotron_omni_global_image_mask", None)
+        _global_sound_mask = kwargs.pop("_nemotron_omni_global_sound_mask", None)
+        _thd_cp = (
+            kwargs.get("qkv_format") == "thd"
+            and kwargs.get("cu_seqlens") is not None
+            and int(kwargs.get("cp_size", 1)) > 1
+        )
+
+        def _local_media(
+            features: torch.Tensor,
+            global_mask: torch.Tensor | None,
+            selected: torch.Tensor,
+        ) -> torch.Tensor:
+            """Select local packed-THD media rows when context parallelism is active.
+
+            Args:
+                features: Tensor of shape [num_global_media_tokens, hidden].
+                global_mask: Optional Boolean Tensor of shape [global_tokens] marking
+                    media placeholders in the global packed sequence.
+                selected: Boolean Tensor of shape [local_tokens] marking media
+                    placeholders in this rank's local sequence.
+
+            Returns:
+                Tensor of shape [num_local_media_tokens, hidden] for packed THD CP,
+                or ``features`` unchanged outside that path.
+            """
+            if not _thd_cp or global_mask is None:
+                return features
+            return self._select_local_media_features(
+                features, global_mask, selected, kwargs["cu_seqlens"], int(kwargs["cp_size"]), int(kwargs["cp_rank"])
+            )
 
         # Get text embeddings
         if inputs_embeds is None:
@@ -893,16 +1095,17 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
         # When both are None (or pixel_values is None), we skip image
         # injection and run the LM path on text embeddings only.
         if not _embeds_pre_built and pixel_values is not None and imgs_sizes is not None:
-            B, N, C = inputs_embeds.shape
-            inputs_embeds = inputs_embeds.reshape(B * N, C)
-            input_ids_flat = input_ids.reshape(B * N)
+            _embeds_shape = inputs_embeds.shape  # [B, N, C] or THD-flattened [T, C]
+            C = _embeds_shape[-1]
+            inputs_embeds = inputs_embeds.reshape(-1, C)
+            input_ids_flat = input_ids.reshape(-1)
             selected = input_ids_flat == self.img_context_token_id
 
             # Vision/audio encoders are not CP-sharded; suspend the ring dispatcher
             # so their non-causal attention is not intercepted by the CP ring SDPA.
             with cp_dispatcher_suspended(self.cp_mesh):
                 vit_embeds = self.extract_feature_dynamic(pixel_values, imgs_sizes)
-            vit_embeds = vit_embeds.reshape(-1, C)
+            vit_embeds = _local_media(vit_embeds.reshape(-1, C), _global_image_mask, selected)
 
             if torch.distributed.is_initialized() and torch.distributed.get_rank() == 0:
                 logger.info(
@@ -923,17 +1126,26 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
                 n_token = int(selected.sum().item())
                 inputs_embeds[selected] = inputs_embeds[selected] * 0.0 + vit_embeds[:n_token]
 
-            inputs_embeds = inputs_embeds.reshape(B, N, C)
-        elif not _embeds_pre_built and pixel_values is not None and image_flags is not None:
-            image_flags = image_flags.squeeze(-1)
+            inputs_embeds = inputs_embeds.reshape(_embeds_shape)
+        elif not _embeds_pre_built and pixel_values is not None:
+            if image_flags is None:
+                # Packed samples carry pixel_values without tile flags: every image is real.
+                n_imgs = len(pixel_values) if isinstance(pixel_values, (list, tuple)) else pixel_values.shape[0]
+                image_flags = torch.ones(n_imgs, dtype=torch.long, device=inputs_embeds.device)
+            image_flags = image_flags.reshape(-1)
 
-            B, N, C = inputs_embeds.shape
-            inputs_embeds = inputs_embeds.reshape(B * N, C)
-            input_ids_flat = input_ids.reshape(B * N)
+            _embeds_shape = inputs_embeds.shape  # [B, N, C] or THD-flattened [T, C]
+            C = _embeds_shape[-1]
+            B = _embeds_shape[0] if inputs_embeds.dim() == 3 else 1
+            inputs_embeds = inputs_embeds.reshape(-1, C)
+            input_ids_flat = input_ids.reshape(-1)
 
             selected = input_ids_flat == self.img_context_token_id
 
-            vit_batch_size = pixel_values.shape[0]
+            # Mixed-resolution batches arrive as a list of per-image tensors
+            # (they cannot be stacked), so there is no leading batch dim.
+            pv_is_list = isinstance(pixel_values, (list, tuple))
+            vit_batch_size = len(pixel_values) if pv_is_list else pixel_values.shape[0]
             with cp_dispatcher_suspended(self.cp_mesh):
                 vit_embeds = self.extract_feature(pixel_values)
 
@@ -941,11 +1153,18 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
                 logger.info(
                     f"NemotronOmni: dynamic ViT batch size: {vit_batch_size}, "
                     f"images per sample: {vit_batch_size / B}, "
-                    f"dynamic token length: {N}"
+                    f"tokens: {inputs_embeds.shape[0]}"
                 )
 
             # Filter by image_flags (1 = real image, 0 = padding)
-            vit_embeds = vit_embeds[image_flags == 1]
+            if pv_is_list:
+                # Token count per image varies with resolution, so the features
+                # can't be stacked — select then concatenate along the token dim.
+                kept = [e.reshape(-1, C) for e, flag in zip(vit_embeds, image_flags.tolist()) if flag == 1]
+                vit_embeds = torch.cat(kept, dim=0) if kept else vit_embeds[0].new_zeros((0, C))
+            else:
+                vit_embeds = vit_embeds[image_flags == 1]
+            vit_embeds = _local_media(vit_embeds.reshape(-1, C), _global_image_mask, selected)
 
             try:
                 inputs_embeds[selected] = inputs_embeds[selected] * 0.0 + vit_embeds.reshape(-1, C)
@@ -959,19 +1178,21 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
                 n_token = selected.sum()
                 inputs_embeds[selected] = inputs_embeds[selected] * 0.0 + vit_embeds[:n_token]
 
-            inputs_embeds = inputs_embeds.reshape(B, N, C)
+            inputs_embeds = inputs_embeds.reshape(_embeds_shape)
 
         # Image and video both expand to `img_context_token_id` in the prompt, so a
         # single sample can carry only one of `pixel_values` / `pixel_values_videos`.
         if not _embeds_pre_built and pixel_values_videos is not None:
             assert pixel_values is None, "pixel_values and pixel_values_videos are mutually exclusive"
-            B_v, N_v, C_v = inputs_embeds.shape
-            inputs_embeds = inputs_embeds.reshape(B_v * N_v, C_v)
-            video_selected = input_ids.reshape(B_v * N_v) == self.img_context_token_id
+            _embeds_shape_v = inputs_embeds.shape
+            C_v = _embeds_shape_v[-1]
+            inputs_embeds = inputs_embeds.reshape(-1, C_v)
+            video_selected = input_ids.reshape(-1) == self.img_context_token_id
             with cp_dispatcher_suspended(self.cp_mesh):
                 video_embeds = self.extract_video_feature(pixel_values_videos)
-            inputs_embeds[video_selected] = inputs_embeds[video_selected] * 0.0 + video_embeds.reshape(-1, C_v)
-            inputs_embeds = inputs_embeds.reshape(B_v, N_v, C_v)
+            video_embeds = _local_media(video_embeds.reshape(-1, C_v), _global_image_mask, video_selected)
+            inputs_embeds[video_selected] = inputs_embeds[video_selected] * 0.0 + video_embeds
+            inputs_embeds = inputs_embeds.reshape(_embeds_shape_v)
 
         # --- Sound/audio token replacement ---
         has_sound = (
@@ -981,9 +1202,10 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
             and self.sound_context_token_id is not None
         )
         if has_sound:
-            B_s, N_s, C_s = inputs_embeds.shape
-            inputs_embeds = inputs_embeds.reshape(B_s * N_s, C_s)
-            input_ids_flat_sound = input_ids.reshape(B_s * N_s)
+            _embeds_shape_s = inputs_embeds.shape
+            C_s = _embeds_shape_s[-1]
+            inputs_embeds = inputs_embeds.reshape(-1, C_s)
+            input_ids_flat_sound = input_ids.reshape(-1)
 
             sound_selected = input_ids_flat_sound == self.sound_context_token_id
             num_sound_tokens = sound_selected.sum().item()
@@ -998,7 +1220,7 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
                 # Extract and project sound features
                 with cp_dispatcher_suspended(self.cp_mesh):
                     sound_embeds = self.extract_sound_feature(sound_features, sound_attention_mask)
-                sound_embeds_flat = sound_embeds.reshape(-1, C_s)
+                sound_embeds_flat = _local_media(sound_embeds.reshape(-1, C_s), _global_sound_mask, sound_selected)
 
                 if torch.distributed.is_initialized() and torch.distributed.get_rank() == 0:
                     logger.info(
@@ -1023,7 +1245,40 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
 
                 del sound_embeds, sound_embeds_flat
 
-            inputs_embeds = inputs_embeds.reshape(B_s, N_s, C_s)
+            inputs_embeds = inputs_embeds.reshape(_embeds_shape_s)
+
+        # packed_sequence_thd_vlm_collater / packed_sequence_thd_collater emit
+        # seq_lens/seq_lens_padded (not cu_seqlens): the generic TE-THD CP sharder
+        # that would normally derive cu_seqlens (thd_utils.process_input_for_thd)
+        # never runs for this model, since prepare_model_inputs_for_cp's aux-only
+        # sharder takes priority once CP is active. Without cu_seqlens, TE's
+        # DotProductAttention falls back to its constructor-default qkv_format
+        # ("bshd") and rejects the THD-squeezed 2D/3D q/k/v downstream. Derive the
+        # GLOBAL (pre-CP-shard) cu_seqlens here so TE's ring/P2P CP attention -
+        # configured on this model's attention layers via MoE parallelizer's
+        # apply_cp (block.self_attn) - gets real sequence-boundary metadata.
+        if kwargs.get("qkv_format") == "thd" and "cu_seqlens" not in kwargs and "seq_lens" in kwargs:
+            _seq_lens = kwargs.pop("seq_lens")
+            _seq_lens_padded = kwargs.pop("seq_lens_padded", None)
+            _seq_lens_flat = _seq_lens.reshape(-1)
+            _valid_seq_lens = _seq_lens_flat[_seq_lens_flat != -1000].to(torch.int32)
+            _cu_seqlens = torch.cat(
+                [torch.zeros(1, dtype=torch.int32, device=_valid_seq_lens.device), _valid_seq_lens.cumsum(0)]
+            ).to(torch.int32)
+            kwargs["cu_seqlens"] = _cu_seqlens
+            if _seq_lens_padded is not None:
+                _seq_lens_padded_flat = _seq_lens_padded.reshape(-1)
+                _valid_seq_lens_padded = _seq_lens_padded_flat[_seq_lens_padded_flat != -1000].to(torch.int32)
+                _cu_seqlens_padded = torch.cat(
+                    [
+                        torch.zeros(1, dtype=torch.int32, device=_valid_seq_lens_padded.device),
+                        _valid_seq_lens_padded.cumsum(0),
+                    ]
+                ).to(torch.int32)
+                if not torch.equal(_cu_seqlens_padded, _cu_seqlens):
+                    kwargs["cu_seqlens_padded"] = _cu_seqlens_padded
+            if _cu_seqlens.numel() > 1:
+                kwargs["max_seqlen"] = (_cu_seqlens[1:] - _cu_seqlens[:-1]).max().to(torch.int32)
 
         # Context-parallel: keep this rank's round-robin chunk pair of the freshly
         # embedded + spliced full sequence (aux streams aligned by
@@ -1031,16 +1286,40 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
         # pre-embed and stays differentiable. Skipped when inputs_embeds is pre-sharded.
         cp_size = self.cp_mesh.size() if self.cp_mesh is not None else 1
         if cp_size > 1 and not _embeds_pre_built:
-            inputs_embeds, _, _ = shard_sequence_for_cp_round_robin(self.cp_mesh, inputs_embeds, seq_dim=1)
+            if not _thd_cp:
+                # BSHD: ring-SDPA / all-gather CP uses the whole-row head-tail layout.
+                # (Packed THD is already this rank's per-document shard: the framework
+                # TE THD sharder partitioned input_ids before embedding.)
+                inputs_embeds, _, _ = shard_sequence_for_cp_round_robin(self.cp_mesh, inputs_embeds, seq_dim=1)
+            # shard_sequence_for_cp_round_robin only shards inputs_embeds; a THD/packed
+            # attention_mask (still the pre-shard, full-length seq_idx/padding tensor)
+            # would now mismatch the sharded sequence length. qkv_format="thd" (set by
+            # packed_sequence_thd_vlm_collater / packed_sequence_thd_collater) plus
+            # seq_lens/seq_lens_padded already fully describe packing structure, so drop
+            # the stale mask rather than let it desync the THD-vs-BSHD branch in the
+            # LLM's attention layers.
+            if kwargs.get("qkv_format") == "thd" or "cu_seqlens" in kwargs or "cu_seqlens_q" in kwargs:
+                attention_mask = None
 
         # Forward through the LLM. ``logits_to_keep`` gates the lm_head projection
         # (0 -> all positions; N -> last N) and ``output_hidden_states`` makes the
         # returned NemotronHCausalLMOutputWithPast carry the final, full-sequence
         # decoder hidden states (consumed by fused linear cross-entropy / cut-CE).
-        outputs = self.language_model(
-            input_ids=None,  # We pass inputs_embeds instead
+        kwargs.pop("seq_lens", None)
+        kwargs.pop("seq_lens_padded", None)
+        # Context-parallel MTP: the recipe supplies globally shifted per-depth token ids
+        # (prepare_mtp_inputs_for_cp) sharded like the inputs. The LM receives
+        # inputs_embeds from us, so hand it per-depth EMBEDDINGS instead (text-token
+        # embeddings; media placeholders keep their placeholder embedding).
+        mtp_per_depth_input_ids = kwargs.pop("mtp_per_depth_input_ids", None)
+        mtp_embed_inputs: tuple = ()
+        if mtp_per_depth_input_ids is not None:
+            embed = self.language_model.get_input_embeddings()
+            mtp_embed_inputs = tuple(embed(ids) for ids in mtp_per_depth_input_ids)
+        lm_kwargs = dict(
             inputs_embeds=inputs_embeds,
             attention_mask=attention_mask,
+            position_ids=position_ids,  # unused by the RoPE-free backbone; consumed by the MTP head
             labels=labels,
             use_cache=use_cache,
             output_hidden_states=output_hidden_states,
@@ -1048,6 +1327,11 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
             logits_to_keep=logits_to_keep,
             **kwargs,
         )
+        if mtp_embed_inputs:
+            # NemotronV3 takes the per-depth MTP embeddings as positional varargs after input_ids.
+            outputs = self.language_model(None, *mtp_embed_inputs, **lm_kwargs)
+        else:
+            outputs = self.language_model(input_ids=None, **lm_kwargs)  # inputs_embeds carry the tokens
 
         return outputs
 

--- a/nemo_automodel/components/models/nemotron_omni/state_dict_adapter.py
+++ b/nemo_automodel/components/models/nemotron_omni/state_dict_adapter.py
@@ -94,6 +94,85 @@ _VISION_PROJ_CUSTOM_TO_HF = {v: k for k, v in _VISION_PROJ_HF_TO_CUSTOM.items()}
 # Sound projector: Keys are identical between HF and custom
 # sound_projection.norm.weight, sound_projection.linear1.weight, sound_projection.linear2.weight
 
+# Vision encoder (RADIO), legacy checkpoint -> transformers-native RadioModel.
+#
+# Checkpoints whose remote code ships the transformers-native RadioModel
+# (`embeddings`/`encoder` module tree -- e.g. NemotronH_Omni_Reasoning_V3) still save
+# weights under the older timm-style "radio_model.model.blocks" naming with a fused QKV
+# projection. transformers applies the equivalent rename + QKV split automatically during
+# `from_pretrained` via `register_checkpoint_conversion_mapping("radio", ...)`
+# (see the checkpoint's `modeling_radio.py`); nemo_automodel's checkpoint loading bypasses
+# `from_pretrained`, so the same mapping is replicated here. Order matters: prefixes are
+# matched most-specific-first via ``str.replace`` on the sub-key (after stripping the
+# "vision_model." prefix), mirroring the checkpoint's own ``WeightRenaming`` list.
+_RADIO_LEGACY_TO_NATIVE_RENAMES: list[tuple[str, str]] = [
+    ("radio_model.model.patch_generator.video_embedder", "embeddings.video_patch_projection"),
+    ("radio_model.model.patch_generator.embedder", "embeddings.patch_projection"),
+    ("radio_model.model.patch_generator.pos_embed", "embeddings.position_embedding"),
+    ("radio_model.model.patch_generator.cls_token.token", "embeddings.cls_register_token"),
+    ("radio_model.model.blocks", "encoder.layer"),
+    ("attn.proj", "attention.output.dense"),
+    ("radio_model.input_conditioner", "input_conditioner"),
+    ("radio_model.summary_idxs", "summary_idxs"),
+]
+_RADIO_NATIVE_TO_LEGACY_RENAMES: list[tuple[str, str]] = [(new, old) for old, new in _RADIO_LEGACY_TO_NATIVE_RENAMES]
+# attn.qkv.{weight,bias} (fused) <-> attention.attention.{query,key,value}.{weight,bias},
+# chunked/concatenated along dim 0 in query, key, value order.
+_RADIO_QKV_SPLIT_TARGETS = ("attention.attention.query", "attention.attention.key", "attention.attention.value")
+
+
+def _rename_radio_key(sub_key: str, renames: list[tuple[str, str]]) -> str:
+    """Apply every matching rename in order (chained), not just the first match.
+
+    E.g. "radio_model.model.blocks.0.attn.proj.weight" needs both the
+    "radio_model.model.blocks" -> "encoder.layer" AND "attn.proj" -> "attention.output.dense"
+    renames applied in sequence.
+    """
+    for old, new in renames:
+        if old in sub_key:
+            sub_key = sub_key.replace(old, new, 1)
+    return sub_key
+
+
+def _radio_legacy_to_native(sub_key: str, value: torch.Tensor) -> list[tuple[str, torch.Tensor]]:
+    """Rename one legacy ("radio_model.model.blocks...") RADIO sub-key to the native layout.
+
+    Returns a list because a fused ``attn.qkv`` tensor splits into three (query/key/value).
+    The general rename chain (e.g. "radio_model.model.blocks" -> "encoder.layer") is applied
+    first so it composes with the "attn.qkv" -> query/key/value split that follows.
+    """
+    renamed = _rename_radio_key(sub_key, _RADIO_LEGACY_TO_NATIVE_RENAMES)
+    if "attn.qkv" in renamed:
+        chunks = value.chunk(3, dim=0)
+        return [
+            (renamed.replace("attn.qkv", target, 1), chunk) for target, chunk in zip(_RADIO_QKV_SPLIT_TARGETS, chunks)
+        ]
+    return [(renamed, value)]
+
+
+def _radio_native_to_legacy(vision_sub_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Inverse of :func:`_radio_legacy_to_native`: native RadioModel sub-keys -> legacy checkpoint keys.
+
+    ``attention.attention.{query,key,value}`` triplets are concatenated back into a single
+    fused ``attn.qkv`` tensor (query, key, value order along dim 0). The qkv-target ->
+    "attn.qkv" placeholder substitution happens before the general rename chain, so
+    "encoder.layer" still gets reverse-renamed to "radio_model.model.blocks" for qkv keys too.
+    """
+    result: dict[str, torch.Tensor] = {}
+    qkv_groups: dict[str, dict[str, torch.Tensor]] = {}
+    for sub_key, value in vision_sub_dict.items():
+        matched_target = next((t for t in _RADIO_QKV_SPLIT_TARGETS if t in sub_key), None)
+        if matched_target is not None:
+            group_key = _rename_radio_key(
+                sub_key.replace(matched_target, "attn.qkv", 1), _RADIO_NATIVE_TO_LEGACY_RENAMES
+            )
+            qkv_groups.setdefault(group_key, {})[matched_target] = value
+        else:
+            result[_rename_radio_key(sub_key, _RADIO_NATIVE_TO_LEGACY_RENAMES)] = value
+    for group_key, parts in qkv_groups.items():
+        result[group_key] = torch.cat([parts[t] for t in _RADIO_QKV_SPLIT_TARGETS], dim=0)
+    return result
+
 
 class NemotronOmniStateDictAdapter(StateDictAdapter):
     """State dict adapter for NemotronOmni (NemotronH_Nano_Omni_Reasoning_V3) models.
@@ -105,6 +184,20 @@ class NemotronOmniStateDictAdapter(StateDictAdapter):
     and MoE expert merging) and handles vision/audio components directly.
     """
 
+    @property
+    def supports_write_through_checkpoint_load(self) -> bool:
+        """Whether the embedded language adapter and all wrapper renames preserve storage.
+
+        False when the vision tower needs the native-RadioModel remap: the fused
+        ``attn.qkv`` <-> split query/key/value conversion changes tensor cardinality
+        (1 checkpoint tensor <-> 3 module tensors), which `convert_single_tensor_to_hf`
+        cannot do correctly one tensor at a time.
+        """
+        # r0.6.0 predates the language adapter direct-load capability flag.
+        return getattr(self._llm_adapter, "supports_write_through_checkpoint_load", False) and not getattr(
+            self, "vision_uses_native_radio", False
+        )
+
     def __init__(
         self,
         config,
@@ -112,6 +205,7 @@ class NemotronOmniStateDictAdapter(StateDictAdapter):
         moe_config: MoEConfig,
         backend: BackendConfig,
         dtype: torch.dtype = torch.bfloat16,
+        vision_uses_native_radio: bool = False,
     ):
         """Initialize the state dict adapter.
 
@@ -121,12 +215,18 @@ class NemotronOmniStateDictAdapter(StateDictAdapter):
             moe_config: MoE configuration
             backend: Backend configuration
             dtype: Target dtype
+            vision_uses_native_radio: Whether the vision tower is the transformers-native
+                RadioModel (embeddings/encoder module tree), requiring the legacy
+                "radio_model.model.blocks" checkpoint keys to be renamed and their fused
+                QKV split. False for the legacy `radio_model`-wrapped vision class, whose
+                checkpoint keys already match the module tree as-is.
         """
         self.config = config
         self.llm_config = llm_config
         self.moe_config = moe_config
         self.backend = backend
         self.dtype = dtype
+        self.vision_uses_native_radio = vision_uses_native_radio
 
         # Create the LLM state dict adapter (handles expert merging etc.)
         self._llm_adapter = NemotronV3StateDictAdapter(
@@ -174,9 +274,14 @@ class NemotronOmniStateDictAdapter(StateDictAdapter):
         for key in list(hf_state_dict.keys()):
             value = hf_state_dict.pop(key)
 
-            # 1. Vision model keys (pass through as-is)
+            # 1. Vision model keys (pass through as-is, or remap legacy RADIO naming)
             if key.startswith("vision_model."):
-                result[key] = value
+                sub_key = key[len("vision_model.") :]
+                if self.vision_uses_native_radio:
+                    for new_sub_key, new_value in _radio_legacy_to_native(sub_key, value):
+                        result[f"vision_model.{new_sub_key}"] = new_value
+                else:
+                    result[key] = value
                 debug_counts["vision_model"] += 1
 
             # 2. Vision projector keys (mlp1.* -> vision_projector.*)
@@ -272,6 +377,7 @@ class NemotronOmniStateDictAdapter(StateDictAdapter):
         """
         hf_result = {}
         llm_state_dict = {}
+        vision_state_dict = {}
 
         for fqn in list(state_dict.keys()):
             tensor = state_dict.pop(fqn)
@@ -279,9 +385,9 @@ class NemotronOmniStateDictAdapter(StateDictAdapter):
             if exclude_key_regex and re.match(exclude_key_regex, fqn):
                 continue
 
-            # Vision model (pass through)
+            # Vision model (pass through, or remap back to legacy RADIO naming)
             if fqn.startswith("vision_model."):
-                hf_result[fqn] = tensor
+                vision_state_dict[fqn[len("vision_model.") :]] = tensor
 
             # Vision projector (custom -> HF)
             elif fqn.startswith("vision_projector."):
@@ -314,6 +420,14 @@ class NemotronOmniStateDictAdapter(StateDictAdapter):
         for key, value in converted_llm.items():
             hf_result[f"language_model.{key}"] = value
 
+        # Convert vision keys back to the checkpoint's own naming (remap for native RadioModel,
+        # pass through otherwise) and re-add "vision_model." prefix
+        converted_vision = (
+            _radio_native_to_legacy(vision_state_dict) if self.vision_uses_native_radio else vision_state_dict
+        )
+        for key, value in converted_vision.items():
+            hf_result[f"vision_model.{key}"] = value
+
         return hf_result
 
     def convert_single_tensor_to_hf(self, fqn: str, tensor: Any, **kwargs) -> list[tuple[str, Any]]:
@@ -329,9 +443,13 @@ class NemotronOmniStateDictAdapter(StateDictAdapter):
         """
         exclude_key_regex = kwargs.get("exclude_key_regex", None)
 
-        # Vision model (pass through)
+        # Vision model (pass through, or rename for native RadioModel checkpoints)
         if fqn.startswith("vision_model."):
-            new_fqn = fqn
+            if self.vision_uses_native_radio:
+                sub_key = fqn[len("vision_model.") :]
+                new_fqn = f"vision_model.{_rename_radio_key(sub_key, _RADIO_NATIVE_TO_LEGACY_RENAMES)}"
+            else:
+                new_fqn = fqn
 
         # Vision projector
         elif fqn.startswith("vision_projector."):

--- a/nemo_automodel/components/models/nemotron_v3/layers.py
+++ b/nemo_automodel/components/models/nemotron_v3/layers.py
@@ -386,7 +386,13 @@ class NemotronV3Mamba2Mixer(nn.Module):
             dt_limit_kwargs = {} if self.time_step_limit == (0.0, float("inf")) else {"dt_limit": self.time_step_limit}
 
             if self.cp is not None:
-                cu_seqlens_cp = kwargs.get("cu_seqlens")
+                # ``MambaContextParallel`` uses a non-None ``cu_seqlens`` to
+                # select its packed 2D THD transport. SDPA/flex attention
+                # keeps qkv_format="thd" inputs in 3D BSHD, where the CP
+                # transport must instead reorder along the sequence dimension.
+                # Keep global cu_seqlens above for constructing seq_idx, but
+                # only pass it to the transport for genuinely squeezed THD.
+                cu_seqlens_cp = kwargs.get("cu_seqlens") if squeezed else None
                 # CP reorder helpers expect 2D [T, H] when cu_seqlens is provided (THD format).
                 # The mixer unsqueezes 2D input to [1, T, H] above, so squeeze back for CP methods.
                 if squeezed and cu_seqlens_cp is not None:

--- a/nemo_automodel/components/models/nemotron_v3/model.py
+++ b/nemo_automodel/components/models/nemotron_v3/model.py
@@ -28,6 +28,10 @@ from nemo_automodel.components.models.common import (
     initialize_linear_module,
     initialize_rms_norm_module,
 )
+from nemo_automodel.components.models.common.mtp import (
+    MTPContextParallelInputs,
+    prepare_mtp_context_parallel_inputs,
+)
 from nemo_automodel.components.models.common.tie_word_embeddings import (
     TieSupport,
     reject_unsupported_tie_word_embeddings,
@@ -304,6 +308,7 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
         supports_cp: bool = True
         supports_pp: bool = True
         supports_ep: bool = True
+        supports_mtp_cp: bool = True
 
     @classmethod
     def from_config(
@@ -557,6 +562,41 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
             embeds.append(self.model.embed_tokens(cur_input_ids))
         return tuple(embeds)
 
+    def prepare_mtp_inputs_for_cp(
+        self,
+        batch: dict[str, Any],
+        *,
+        ignore_index: int = -100,
+    ) -> MTPContextParallelInputs | None:
+        """Prepare global MTP futures before context-parallel sharding.
+
+        The recipe calls this hook while ``batch`` is still in global sequence
+        order. It shifts future-token IDs, positions, and loss targets without
+        crossing packed-sequence boundaries. The recipe then shards each tensor
+        with the same :class:`ContextParallelSharder` instance as the main
+        inputs, avoiding both rank-local rolls and an all-gather.
+
+        Args:
+            batch: Unsharded model batch containing ``input_ids`` and ``labels``
+                with shape ``[batch, sequence]``. Missing ``position_ids`` are
+                synthesized in global order. ``seq_idx``, ``_packed_seq_ids``,
+                raw ``seq_lens_padded``, or ``cu_seqlens`` may describe
+                packed-sequence boundaries.
+            ignore_index: Fill value for invalid MTP loss targets.
+
+        Returns:
+            Globally ordered tensors for every enabled MTP depth, or ``None``
+            when MTP is disabled.
+        """
+        if not self.mtp_config.enabled:
+            return None
+
+        return prepare_mtp_context_parallel_inputs(
+            batch,
+            num_depths=self.mtp_config.num_layers,
+            ignore_index=ignore_index,
+        )
+
     def customize_pipeline_stage_modules(
         self,
         module_names_per_stage: list[list[str]],
@@ -635,6 +675,8 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
         use_cache: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
+        mtp_per_depth_input_ids: tuple[torch.LongTensor, ...] | None = None,
+        mtp_per_depth_position_ids: tuple[torch.LongTensor, ...] | None = None,
         padding_mask: Optional[torch.Tensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         output_hidden_states: Optional[bool] = None,
@@ -673,6 +715,16 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
             use_cache: Whether to return ``past_key_values`` for subsequent steps.
             cache_position: Token position indices for cache updates.
             position_ids: Position IDs (forwarded into MTP sublayer kwargs).
+            mtp_per_depth_input_ids: Optional globally shifted future-token IDs,
+                one tensor per MTP depth. Each tensor has shape [batch,
+                sequence], or [tokens] for THD, matching the local CP layout.
+                When supplied, MTP embeds these tensors directly instead of
+                rolling rank-local ``input_ids``.
+            mtp_per_depth_position_ids: Optional pre-computed future-token
+                position IDs, one tensor per MTP depth. Each tensor has shape
+                [batch, sequence], or [tokens] for THD, matching the local CP
+                layout of ``position_ids``. When supplied, MTP consumes these
+                tensors directly instead of rolling rank-local positions.
             padding_mask: Padding mask ``[B, S]`` used by the THD squeeze helper
                 and as the MoE / mamba 2D mask source.
             logits_to_keep: If > 0, only compute logits for the last
@@ -700,6 +752,18 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
         has_lm_head = self.lm_head is not None
         mtp_depth = int(getattr(self.mtp_config, "num_layers", 0) or 0)
         pp_mtp_enabled = is_pp_stage and self.mtp_config.enabled
+        # CP shards are not contiguous sequence slices. MTP therefore cannot
+        # derive future-token embeddings or positions by rolling rank-local
+        # tensors; callers must provide both globally shifted tensors.
+        mtp_active = self.mtp is not None and self.training
+        cp_size = int(kwargs.get("cp_size", 1) or 1)
+        if cp_size > 1 and mtp_active:
+            precomputed_token_sources = int(bool(mtp_embed_inputs)) + int(mtp_per_depth_input_ids is not None)
+            if precomputed_token_sources != 1 or mtp_per_depth_position_ids is None:
+                raise ValueError(
+                    "Context-parallel MTP requires exactly one of precomputed per-depth embeddings or input IDs, "
+                    "together with per-depth position IDs"
+                )
 
         # Neat-packed SDPA: convert _packed_seq_ids (1-based [B,S] int, 0=pad)
         # to mamba's seq_idx and derive a 2D padding_mask. The neat collater
@@ -786,7 +850,7 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
         # MTP head: last PP stage in training only. Other stages / eval emit
         # placeholder empties below so the tuple arity stays 1 + D.
         mtp_per_depth_h: list[torch.Tensor] | None = None
-        if self.mtp is not None and self.training:
+        if mtp_active:
             mtp_attention_mask = (
                 causal_mask_mapping.get("full_attention") if causal_mask_mapping is not None else attention_mask
             )
@@ -830,6 +894,8 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
             # tensors for the same reason.
             mtp_hidden = hidden_states
             mtp_embeds_for_call = tuple(mtp_embed_inputs) if mtp_embed_inputs else ()
+            mtp_input_ids_for_call = mtp_per_depth_input_ids
+            mtp_position_ids_for_call = mtp_per_depth_position_ids
             # SALM / multimodal: when inputs_embeds (pre-fused audio+text) are present
             # and no PP embeddings were provided, pre-roll them per depth so audio
             # positions carry the correct audio embedding rather than embed_fn(padding_id).
@@ -842,18 +908,40 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
                     cur_emb = roll_tensor(cur_emb, shifts=-1, dim=-2)
                     salm_embed_inputs.append(cur_emb)
                 mtp_embeds_for_call = tuple(salm_embed_inputs)
-            if is_thd:
+            if squeeze_for_thd:
                 if mtp_hidden.dim() == 3 and mtp_hidden.shape[0] == 1:
                     mtp_hidden = mtp_hidden.squeeze(0)
                 mtp_embeds_for_call = tuple(
                     e.squeeze(0) if (e.dim() == 3 and e.shape[0] == 1) else e for e in mtp_embeds_for_call
                 )
+                if mtp_input_ids_for_call is not None:
+                    mtp_input_ids_for_call = tuple(
+                        ids.squeeze(0) if (ids.dim() == 2 and ids.shape[0] == 1) else ids
+                        for ids in mtp_input_ids_for_call
+                    )
+                if mtp_position_ids_for_call is not None:
+                    mtp_position_ids_for_call = tuple(
+                        p.squeeze(0) if (p.dim() == 2 and p.shape[0] == 1) else p for p in mtp_position_ids_for_call
+                    )
+            if mtp_position_ids_for_call is not None:
+                mtp_kwargs["position_ids_per_depth"] = mtp_position_ids_for_call
+
+            if mtp_embeds_for_call and mtp_input_ids_for_call is not None:
+                raise ValueError("MTP per-depth input IDs cannot be combined with pre-computed embeddings")
 
             if mtp_embeds_for_call:
                 # Final PP stage: embeddings produced upstream.
                 mtp_per_depth_h = self.mtp(
                     hidden_states=mtp_hidden,
                     embed_inputs=mtp_embeds_for_call,
+                    **mtp_kwargs,
+                )
+            elif mtp_input_ids_for_call is not None:
+                # Context parallel: IDs were shifted globally, then sharded.
+                mtp_per_depth_h = self.mtp(
+                    hidden_states=mtp_hidden,
+                    input_ids_per_depth=mtp_input_ids_for_call,
+                    embed_fn=self.model.embed_tokens,
                     **mtp_kwargs,
                 )
             else:
@@ -864,7 +952,7 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
                     embed_fn=self.model.embed_tokens,
                     **mtp_kwargs,
                 )
-            if is_thd and mtp_per_depth_h is not None:
+            if squeeze_for_thd and mtp_per_depth_h is not None:
                 mtp_per_depth_h = [h.unsqueeze(0) if h.dim() == 2 else h for h in mtp_per_depth_h]
         elif pp_mtp_enabled and has_lm_head:
             # Eval, or no MTP on this rank — emit empties to keep tuple arity.

--- a/nemo_automodel/components/models/qwen3_5_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/model.py
@@ -75,7 +75,13 @@ from nemo_automodel.components.distributed.cp_vision_frame_shard import (
 )
 from nemo_automodel.components.models.common import BackendConfig, initialize_linear_module
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
-from nemo_automodel.components.models.common.mtp import MTPConfig, MTPModule, roll_tensor
+from nemo_automodel.components.models.common.mtp import (
+    MTPConfig,
+    MTPContextParallelInputs,
+    MTPModule,
+    prepare_mtp_context_parallel_inputs,
+    roll_tensor,
+)
 from nemo_automodel.components.models.common.tie_word_embeddings import (
     TieSupport,
     reject_unsupported_tie_word_embeddings,
@@ -336,6 +342,36 @@ def _rolled_embed_inputs(inputs_embeds: torch.Tensor, num_depths: int) -> tuple[
         cur = roll_tensor(cur, shifts=-1, dim=-2)
         embed_inputs.append(cur)
     return tuple(embed_inputs)
+
+
+def _mask_mtp_embed_inputs(
+    embed_inputs: tuple[torch.Tensor, ...],
+    valid_masks: tuple[torch.BoolTensor, ...],
+) -> tuple[torch.Tensor, ...]:
+    """Zero invalid future-token embeddings in the local CP layout.
+
+    Args:
+        embed_inputs: Per-depth embeddings of shape ``[batch, sequence, hidden]``.
+        valid_masks: Per-depth masks of shape ``[batch, sequence]`` in the same
+            local CP token layout as ``embed_inputs``.
+
+    Returns:
+        Per-depth embeddings of shape ``[batch, sequence, hidden]`` with invalid
+        trailing or packed-boundary positions set to zero.
+    """
+    if len(embed_inputs) != len(valid_masks):
+        raise ValueError(
+            f"MTP embed depth count {len(embed_inputs)} does not match valid-mask count {len(valid_masks)}"
+        )
+    masked = []
+    for depth, (embed_input, valid_mask) in enumerate(zip(embed_inputs, valid_masks), start=1):
+        if valid_mask.shape != embed_input.shape[:-1]:
+            raise ValueError(
+                f"MTP depth {depth} valid-mask shape {tuple(valid_mask.shape)} "
+                f"does not match embedding token shape {tuple(embed_input.shape[:-1])}"
+            )
+        masked.append(embed_input.masked_fill(~valid_mask.bool().unsqueeze(-1), 0))
+    return tuple(masked)
 
 
 class Qwen3_5MoeMTPSublayer(Qwen3_5MoeBlock):
@@ -759,6 +795,7 @@ class Qwen3_5MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         supports_cp: bool = True
         supports_pp: bool = True
         supports_ep: bool = True
+        supports_mtp_cp: bool = True
 
     @classmethod
     def from_config(
@@ -859,6 +896,25 @@ class Qwen3_5MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
     def set_output_embeddings(self, new_embeddings: nn.Module) -> None:
         self.lm_head = new_embeddings
 
+    def prepare_mtp_inputs_for_cp(self, batch: dict[str, Any], *, ignore_index: int = -100) -> MTPContextParallelInputs:
+        """Prepare text-model future-token streams before CP sharding.
+
+        Args:
+            batch: Full-sequence batch whose ``input_ids``, ``labels``, and
+                optional ``position_ids`` tensors have shape ``[batch, sequence]``.
+            ignore_index: Fill value for invalid targets at trailing and packed
+                document-boundary positions.
+
+        Returns:
+            Global per-depth token IDs, position IDs, targets, and validity masks.
+            Token tensors have shape ``[batch, sequence]``.
+        """
+        return prepare_mtp_context_parallel_inputs(
+            batch,
+            num_depths=self.mtp_config.num_layers,
+            ignore_index=ignore_index,
+        )
+
     def forward(
         self,
         input_ids: torch.Tensor | None = None,
@@ -867,6 +923,8 @@ class Qwen3_5MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         past_key_values: Any | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
         labels: torch.LongTensor | None = None,
+        mtp_per_depth_input_ids: tuple[torch.LongTensor, ...] | None = None,
+        mtp_per_depth_position_ids: tuple[torch.LongTensor, ...] | None = None,
         use_cache: bool | None = None,
         logits_to_keep: int | torch.Tensor = 0,
         output_hidden_states: bool | None = None,
@@ -891,6 +949,10 @@ class Qwen3_5MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
                 ``[batch, sequence, hidden]``.
             labels: Optional labels of shape ``[batch, sequence]``. Accepted for
                 Hugging Face compatibility; loss is computed outside this model.
+            mtp_per_depth_input_ids: Optional globally shifted then CP-sharded
+                token IDs, one tensor of shape ``[batch, sequence]`` per depth.
+            mtp_per_depth_position_ids: Optional globally shifted then CP-sharded
+                positions, one tensor of shape ``[batch, sequence]`` per depth.
             use_cache: Whether to use a KV cache; ``True`` is unsupported.
             logits_to_keep: ``0`` to project every position, a positive integer
                 to keep the last positions, or indices of shape
@@ -945,7 +1007,22 @@ class Qwen3_5MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
                 device=source_embeds.device,
                 cache_position=cache_position,
             )
-            if input_ids is None:
+            if mtp_per_depth_input_ids is not None:
+                if mtp_per_depth_position_ids is None:
+                    raise ValueError("Qwen3.5-MoE MTP per-depth token IDs require per-depth position IDs")
+                mtp_per_depth_h = self.mtp(
+                    hidden_states,
+                    input_ids_per_depth=mtp_per_depth_input_ids,
+                    embed_fn=self.model.embed_tokens,
+                    position_ids_per_depth=mtp_per_depth_position_ids,
+                    attention_mask=attention_mask,
+                    padding_mask=padding_mask,
+                    rotary_emb=self.model.rotary_emb,
+                    **kwargs,
+                )
+            elif int(kwargs.get("cp_size", 1) or 1) > 1:
+                raise ValueError("Context-parallel Qwen3.5-MoE MTP requires precomputed per-depth inputs and positions")
+            elif input_ids is None:
                 mtp_per_depth_h = self.mtp(
                     hidden_states,
                     embed_inputs=_rolled_embed_inputs(source_embeds, self.mtp.num_depths),
@@ -1043,6 +1120,7 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
         supports_pp: bool = True
         supports_ep: bool = True
         supports_thd: bool = False
+        supports_mtp_cp: bool = True
         supports_cp_vision_frame_sharding: bool = True
 
     @classmethod
@@ -1325,6 +1403,30 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
             **promoted,
         }
 
+    def prepare_mtp_inputs_for_cp(self, batch: dict[str, Any], *, ignore_index: int = -100) -> MTPContextParallelInputs:
+        """Prepare Qwen VLM future-token streams before CP sharding.
+
+        Call this after :meth:`prepare_model_inputs_for_cp` has materialized
+        full-sequence mRoPE positions.
+
+        Args:
+            batch: Full-sequence batch whose ``input_ids`` and ``labels`` tensors
+                have shape ``[batch, sequence]`` and whose ``position_ids`` tensor
+                has shape ``[axes, batch, sequence]``.
+            ignore_index: Fill value for invalid targets at trailing and packed
+                document-boundary positions.
+
+        Returns:
+            Global per-depth token IDs, mRoPE position IDs, targets, and validity
+            masks. Token tensors have shape ``[batch, sequence]`` and position
+            tensors have shape ``[axes, batch, sequence]``.
+        """
+        return prepare_mtp_context_parallel_inputs(
+            batch,
+            num_depths=self.mtp_config.num_layers,
+            ignore_index=ignore_index,
+        )
+
     def _embed_and_splice_for_cp(
         self,
         input_ids: torch.Tensor,
@@ -1439,6 +1541,9 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
         padding_mask: torch.Tensor | None = None,
         inputs_embeds: torch.Tensor | None = None,
         cache_position: torch.Tensor | None = None,
+        mtp_per_depth_input_ids: tuple[torch.LongTensor, ...] | None = None,
+        mtp_per_depth_position_ids: tuple[torch.LongTensor, ...] | None = None,
+        mtp_per_depth_valid_masks: tuple[torch.BoolTensor, ...] | None = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         output_hidden_states: Optional[bool] = None,
         **kwargs: Any,
@@ -1457,6 +1562,14 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
             inputs_embeds: Optional embeddings of shape
                 ``[batch, sequence, hidden]``.
             cache_position: Optional token positions of shape ``[sequence]``.
+            mtp_per_depth_input_ids: Optional globally shifted then CP-sharded
+                token IDs, one tensor of shape ``[batch, sequence]`` per depth.
+            mtp_per_depth_position_ids: Optional globally shifted then CP-sharded
+                mRoPE positions, one tensor of shape
+                ``[axes, batch, sequence]`` per depth.
+            mtp_per_depth_valid_masks: Optional CP-sharded masks, one tensor of
+                shape ``[batch, sequence]`` per depth, where ``True`` marks a
+                valid same-document future token.
             logits_to_keep: Number of trailing logits to retain, or indices of
                 shape ``[kept_sequence]``.
             output_hidden_states: Whether to expose final decoder states for the
@@ -1541,6 +1654,33 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
         # the packed contiguous shard or the ordinary round-robin chunk pair.
         # Auxiliary streams and mRoPE positions already use the matching layout.
         cp_size = self.cp_mesh.size() if self.cp_mesh is not None else 1
+        mtp_embed_inputs = None
+        if (
+            cp_size <= 1
+            and self.mtp is not None
+            and self.training
+            and inputs_embeds is None
+            and input_ids is not None
+            and not torch.is_floating_point(input_ids)
+            and has_media_tokens
+            and (
+                (isinstance(pixel_values, torch.Tensor) and pixel_values.numel() > 0)
+                or (isinstance(pixel_values_videos, torch.Tensor) and pixel_values_videos.numel() > 0)
+            )
+        ):
+            # MTP predicts from the same fused text/vision embedding stream as
+            # the backbone. Re-embedding media placeholder IDs would silently
+            # discard the continuous image/video features on the CP1 reference.
+            inputs_embeds = self._embed_and_splice_for_cp(
+                input_ids,
+                pixel_values=pixel_values,
+                pixel_values_videos=pixel_values_videos,
+                image_grid_thw=image_grid_thw,
+                video_grid_thw=video_grid_thw,
+            )
+            input_ids = None
+            for media_key in ("pixel_values", "pixel_values_videos", "image_grid_thw", "video_grid_thw"):
+                kwargs.pop(media_key, None)
         if cp_size > 1 and inputs_embeds is None and input_ids is not None and not torch.is_floating_point(input_ids):
             is_first_stage = getattr(self.model.language_model, "embed_tokens", None) is not None
             is_last_stage = getattr(self, "lm_head", None) is not None
@@ -1559,7 +1699,30 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
                 )
                 from nemo_automodel.components.distributed.blockdiag_cp import current_blockdiag_cp_state
 
-                if current_blockdiag_cp_state() is not None:
+                uses_blockdiag_cp = current_blockdiag_cp_state() is not None
+                if self.mtp is not None and self.training:
+                    if (
+                        mtp_per_depth_input_ids is None
+                        or mtp_per_depth_position_ids is None
+                        or mtp_per_depth_valid_masks is None
+                    ):
+                        raise ValueError(
+                            "Context-parallel Qwen3.5-MoE MTP requires precomputed per-depth inputs, positions, and masks"
+                        )
+                    rolled_embed_inputs = _rolled_embed_inputs(inputs_embeds, self.mtp.num_depths)
+                    if uses_blockdiag_cp:
+                        mtp_embed_inputs = tuple(
+                            shard_sequence_for_cp_contiguous(self.cp_mesh, embed_input, seq_dim=1)[0]
+                            for embed_input in rolled_embed_inputs
+                        )
+                    else:
+                        mtp_embed_inputs = tuple(
+                            shard_sequence_for_cp_round_robin(self.cp_mesh, embed_input, seq_dim=1)[0]
+                            for embed_input in rolled_embed_inputs
+                        )
+                    mtp_embed_inputs = _mask_mtp_embed_inputs(mtp_embed_inputs, mtp_per_depth_valid_masks)
+
+                if uses_blockdiag_cp:
                     inputs_embeds, _, _ = shard_sequence_for_cp_contiguous(self.cp_mesh, inputs_embeds, seq_dim=1)
                 else:
                     inputs_embeds, _, _ = shard_sequence_for_cp_round_robin(self.cp_mesh, inputs_embeds, seq_dim=1)
@@ -1608,7 +1771,19 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
                     "mm_token_type_ids",
                 }
             }
-            if input_ids is None:
+            if mtp_embed_inputs is not None:
+                mtp_per_depth_h = self.mtp(
+                    hidden_states,
+                    embed_inputs=mtp_embed_inputs,
+                    position_ids_per_depth=mtp_per_depth_position_ids,
+                    attention_mask=attention_mask,
+                    padding_mask=padding_mask,
+                    rotary_emb=language_model.rotary_emb,
+                    **mtp_kwargs,
+                )
+            elif cp_size > 1:
+                raise ValueError("Context-parallel Qwen3.5-MoE MTP requires globally prepared per-depth inputs")
+            elif input_ids is None:
                 mtp_per_depth_h = self.mtp(
                     hidden_states,
                     embed_inputs=_rolled_embed_inputs(source_embeds, self.mtp.num_depths),

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -870,7 +870,12 @@ class MoE(nn.Module):
         y = self.experts(x_latent, token_mask, weights, indices)
 
         if self.fc2_latent_proj is not None:
-            y = self.fc2_latent_proj(y)
+            # ``self.experts`` is its own FSDP unit; an ``output_dtype`` in the FSDP
+            # MixedPrecisionPolicy (NeMo-RL uses float32) casts its output above the
+            # block's compute dtype, and TE/torch linears reject an input dtype that
+            # differs from the (param_dtype-cast) weight. Re-enter the compute dtype
+            # of the latent input before the back-projection.
+            y = self.fc2_latent_proj(y.to(x_latent.dtype))
         if z is not None:
             y = y + z
         return y.view(shape)

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -1012,6 +1012,8 @@ def parallelize_model(
 
     cp_enabled = cp_axis_name is not None and world_mesh[cp_axis_name].size() > 1
     if cp_enabled:
+        parallelizer_utils.reject_unsupported_mtp_cp_pp(model)
+        parallelizer_utils.reject_unsupported_mtp_cp(model)
         apply_cp(model, world_mesh[cp_axis_name])
 
     ep_enabled = ep_axis_name is not None and moe_mesh is not None and moe_mesh[ep_axis_name].size() > 1

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -1019,14 +1019,39 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             )
             for k, v in batch.items()
         }
+        model = self.model_parts[0] if hasattr(self, "model_parts") else None
+        mtp_cp_enabled = not self.pp_enabled and self._get_cp_group_size() > 1 and model.supports.mtp_enabled
+        mtp_cp_inputs = None
+        if mtp_cp_enabled:
+            if not model.supports.supports_mtp_cp:
+                raise NotImplementedError(
+                    f"{type(model).__name__} declares supports_mtp_cp=False; "
+                    "MTP target preparation for context parallelism is unavailable"
+                )
+            mtp_cp_inputs = model.prepare_mtp_inputs_for_cp(
+                batch,
+                ignore_index=self.cfg.mtp.ignore_index,
+            )
         cp_sharder = ContextParallelSharder(
-            self.model_parts[0] if hasattr(self, "model_parts") else None,
+            model,
             self.device_mesh,
             batch,
             padding_token_id=self.tokenizer.pad_token_id if self.tokenizer else 0,
             num_chunks=self.pp.pp_batch_size // self.pp.pp_microbatch_size if self.pp_enabled else 1,
         )
         train_ctx, batch = cp_sharder.shard(batch)
+        mtp_per_depth_targets = None
+        if mtp_cp_inputs is not None:
+            batch["mtp_per_depth_input_ids"] = tuple(
+                cp_sharder.shard_token_tensor(ids, seq_dim=1, fill=0) for ids in mtp_cp_inputs.input_ids
+            )
+            batch["mtp_per_depth_position_ids"] = tuple(
+                cp_sharder.shard_token_tensor(ids, seq_dim=1, fill=0) for ids in mtp_cp_inputs.position_ids
+            )
+            mtp_per_depth_targets = tuple(
+                cp_sharder.shard_token_tensor(targets, seq_dim=1, fill=self.cfg.mtp.ignore_index)
+                for targets in mtp_cp_inputs.targets
+            )
         labels = batch.pop("labels")
         fp8_ctx = self.te_fp8.maybe_te_autocast() if self.te_fp8 is not None else nullcontext()
 
@@ -1127,6 +1152,11 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                 mtp_per_depth_logits = getattr(out, "mtp_per_depth_logits", None)
                 if mtp_per_depth_h is not None or mtp_per_depth_logits is not None:
                     mtp_cfg = self.cfg.mtp
+                    if self._get_cp_group_size() > 1 and mtp_per_depth_targets is None:
+                        raise NotImplementedError(
+                            f"{type(model).__name__} produced MTP outputs under context parallelism "
+                            "without globally prepared targets"
+                        )
                     scaling_factor = (
                         mtp_cfg.scaling_factor if mtp_cfg.scaling_factor is not None else out.mtp_loss_scaling_factor
                     )
@@ -1134,13 +1164,14 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                         self.loss_fn,
                         mtp_per_depth_h=mtp_per_depth_h,
                         mtp_per_depth_logits=mtp_per_depth_logits,
+                        mtp_per_depth_targets=mtp_per_depth_targets,
                         labels=labels,
                         model=model,
                         scaling_factor=scaling_factor,
                         num_label_tokens=num_label_tokens,
                         ignore_index=mtp_cfg.ignore_index,
                         # mask cross-boundary MTP label rolls in THD packing (matches the PP path)
-                        cu_seqlens=batch.get("cu_seqlens"),
+                        cu_seqlens=None if mtp_per_depth_targets is not None else batch.get("cu_seqlens"),
                         lm_weight=shared_lm_weight,
                         **loss_distributed_kwargs,
                     )

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -882,7 +882,36 @@ class FinetuneRecipeForVLM(BaseRecipe):
             padding_token_id=_padding_id,
             invoke_pre_embed=True,
         )
+        model = self.model_parts[0]
+        mtp_cp_enabled = _cp_active and not self.pp_enabled and model.supports.mtp_enabled
+        mtp_cp_inputs = None
+        if mtp_cp_enabled:
+            if not model.supports.supports_mtp_cp:
+                raise NotImplementedError(
+                    f"{type(model).__name__} declares supports_mtp_cp=False; "
+                    "MTP target preparation for context parallelism is unavailable"
+                )
+            mtp_cp_inputs = model.prepare_mtp_inputs_for_cp(
+                batch,
+                ignore_index=self.cfg.mtp.ignore_index,
+            )
         train_ctx, batch = cp_sharder.shard(batch)
+        mtp_per_depth_targets = None
+        if mtp_cp_inputs is not None:
+            batch["mtp_per_depth_input_ids"] = tuple(
+                cp_sharder.shard_token_tensor(ids, seq_dim=1, fill=0) for ids in mtp_cp_inputs.input_ids
+            )
+            batch["mtp_per_depth_position_ids"] = tuple(
+                cp_sharder.shard_token_tensor(ids, seq_dim=mtp_cp_inputs.position_ids_seq_dim, fill=0)
+                for ids in mtp_cp_inputs.position_ids
+            )
+            batch["mtp_per_depth_valid_masks"] = tuple(
+                cp_sharder.shard_token_tensor(mask, seq_dim=1, fill=False) for mask in mtp_cp_inputs.valid_masks
+            )
+            mtp_per_depth_targets = tuple(
+                cp_sharder.shard_token_tensor(targets, seq_dim=1, fill=self.cfg.mtp.ignore_index)
+                for targets in mtp_cp_inputs.targets
+            )
         labels = batch.pop("labels")
 
         if self.pp_enabled:
@@ -960,6 +989,8 @@ class FinetuneRecipeForVLM(BaseRecipe):
                 mtp_per_depth_h = getattr(out, "mtp_per_depth_h", None)
                 mtp_per_depth_logits = getattr(out, "mtp_per_depth_logits", None)
                 if mtp_per_depth_h is not None or mtp_per_depth_logits is not None:
+                    if _cp_active and mtp_per_depth_targets is None:
+                        raise RuntimeError("MTP with context parallelism requires globally prepared per-depth targets")
                     mtp_cfg = self.cfg.mtp
                     scaling_factor = (
                         mtp_cfg.scaling_factor if mtp_cfg.scaling_factor is not None else out.mtp_loss_scaling_factor
@@ -968,6 +999,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
                         self.loss_fn,
                         mtp_per_depth_h=mtp_per_depth_h,
                         mtp_per_depth_logits=mtp_per_depth_logits,
+                        mtp_per_depth_targets=mtp_per_depth_targets,
                         labels=labels,
                         model=model,
                         scaling_factor=scaling_factor,
@@ -975,6 +1007,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
                         ignore_index=mtp_cfg.ignore_index,
                         lm_weight=shared_lm_weight,
                         grad_reduce_group=grad_reduce_group,
+                        cu_seqlens=None if mtp_per_depth_targets is not None else batch.get("cu_seqlens"),
                     )
 
                 # Joint base + drafter co-training (Gemma4WithDrafter and

--- a/tests/functional_tests/context_parallel/run_hybrid_nemotron_v3_cp.py
+++ b/tests/functional_tests/context_parallel/run_hybrid_nemotron_v3_cp.py
@@ -16,13 +16,15 @@
 """End-to-end hybrid NemotronV3 CP test.
 
 Validates that a hybrid model with interleaved attention and mamba layers
-produces matching outputs/gradients between CP=1 and CP=2 across four
+produces matching outputs/gradients between CP=1 and CP=N across six
 configurations:
 
   Config 1 (bshd_te):        3D BSHD input, TE p2p CP, DualChunkSwap
   Config 2 (thd_te):         2D THD input, TE p2p CP, DualChunkSwap, cu_seqlens
   Config 3 (thd_te_packed):  2D THD input, TE p2p CP, multi-sequence packing, seq_idx
   Config 4 (bshd_sdpa):      3D BSHD input, DTensor context_parallel(), SDPA backend
+  Config 5 (thd_te_mtp):     packed THD MTP loss, activations, gradients, optimizer step
+  Config 6 (bshd_sdpa_mtp):  packed BSHD SDPA MTP-Mamba loss and gradient parity
 
 Usage:
     torchrun --nproc_per_node=2 tests/functional_tests/context_parallel/run_hybrid_nemotron_v3_cp.py
@@ -33,6 +35,8 @@ import sys
 
 import torch
 import torch.distributed as dist
+
+from nemo_automodel.components.models.common.mtp import shift_packed_tensor
 
 
 def dual_chunk_swap_unsplit(chunks_per_rank, cp_size, seq_dim=1):
@@ -62,7 +66,7 @@ class MockHybridConfig:
     values that avoid errors without activating MoE layers.
     """
 
-    def __init__(self):
+    def __init__(self, cp_size=2):
         # Attention config
         self.num_attention_heads = 8
         self.num_key_value_heads = 4
@@ -72,10 +76,13 @@ class MockHybridConfig:
         self.attention_dropout = 0.0
 
         # Mamba config
-        self.mamba_num_heads = 8
+        # Preserve the established 8-head CP=2/4 test topology. Odd CP sizes
+        # need a synthetic divisible topology to exercise the generic MTP path.
+        uses_default_mamba_topology = 8 % cp_size == 0
+        self.mamba_num_heads = 8 if uses_default_mamba_topology else 2 * cp_size
         self.mamba_head_dim = 32
         self.ssm_state_size = 16
-        self.n_groups = 2  # must be >= cp_size for non-replicated mode
+        self.n_groups = 2 if uses_default_mamba_topology else cp_size
         self.chunk_size = 256
         self.conv_kernel = 4
         self.use_conv_bias = True
@@ -104,14 +111,22 @@ class MockHybridConfig:
         self.mlp_hidden_act = "silu"
 
         # MoE config fields
-        self.n_routed_experts = 1
-        self.num_experts_per_tok = 1
+        self.n_routed_experts = 4
+        self.num_experts_per_tok = 2
         self.n_group = 1
         self.topk_group = 1
         self.routed_scaling_factor = 1.0
         self.moe_intermediate_size = self.intermediate_size
         self.norm_topk_prob = False
         self.moe_shared_expert_intermediate_size = self.intermediate_size
+
+        # MTP config: one native Nemotron depth (attention + MoE).
+        self.num_nextn_predict_layers = 1
+        self.mtp_hybrid_override_pattern = "*E"
+
+    def to_dict(self):
+        """Return the config fields expected by the Hugging Face-compatible wrapper."""
+        return vars(self)
 
 
 def _create_baseline_model(config, backend, device):
@@ -142,7 +157,8 @@ def _wire_te_cp(model, cp_group, config):
 
     from nemo_automodel.components.distributed.context_parallel.mamba import MambaContextParallel
 
-    for layer in model.layers.values():
+    layers = model.layers.values() if hasattr(model.layers, "values") else model.layers
+    for layer in layers:
         if layer.block_type == "mamba":
             mixer = layer.mixer
             mixer.cp = MambaContextParallel(
@@ -173,7 +189,8 @@ def _wire_sdpa_cp(model, cp_group):
     """
     from nemo_automodel.components.distributed.context_parallel.mamba import MambaContextParallel
 
-    for layer in model.layers.values():
+    layers = model.layers.values() if hasattr(model.layers, "values") else model.layers
+    for layer in layers:
         if layer.block_type == "mamba":
             mixer = layer.mixer
             mixer.cp = MambaContextParallel(
@@ -549,28 +566,560 @@ def run_bshd_sdpa(rank, world_size, device, config):
     )
 
 
+# ---------------------------------------------------------------------------
+# Config 5: THD + TE + packed MTP
+# ---------------------------------------------------------------------------
+def _gather_te_partition(local_tensor, local_indices, full_tokens, cp_group):
+    """Restore a tensor sharded with TE packed-CP indices to global order.
+
+    Args:
+        local_tensor: Per-rank tensor of shape [local_tokens, ...].
+        local_indices: Tensor of shape [local_tokens] containing global positions.
+        full_tokens: Global packed-token count.
+        cp_group: Context-parallel process group.
+
+    Returns:
+        Tensor of shape [full_tokens, ...] in global packed-token order.
+    """
+    cp_size = dist.get_world_size(group=cp_group)
+    gathered_tensors = [torch.empty_like(local_tensor) for _ in range(cp_size)]
+    gathered_indices = [torch.empty_like(local_indices) for _ in range(cp_size)]
+    dist.all_gather(gathered_tensors, local_tensor.contiguous(), group=cp_group)
+    dist.all_gather(gathered_indices, local_indices.contiguous(), group=cp_group)
+    output = local_tensor.new_empty((full_tokens, *local_tensor.shape[1:]))
+    for indices, tensor in zip(gathered_indices, gathered_tensors):
+        output.index_copy_(0, indices.to(torch.long), tensor)
+    return output
+
+
+def _create_mtp_model(config, backend, device):
+    """Create a synchronized causal LM with its native Nemotron MTP head."""
+    from nemo_automodel.components.models.nemotron_v3.model import NemotronHForCausalLM
+
+    model = NemotronHForCausalLM(config, backend=backend).to(device=device, dtype=torch.bfloat16)
+    model.initialize_weights(buffer_device=device, dtype=torch.bfloat16)
+    model.train()
+    for parameter in model.parameters():
+        dist.broadcast(parameter.data, src=0)
+    return model
+
+
+def run_thd_te_mtp(rank, world_size, device, config):
+    """Config 5: packed THD MTP CP=1/CP=N numerical training parity."""
+    import transformer_engine.pytorch  # noqa: F401
+    import transformer_engine_torch as tex
+    from torch.distributed.device_mesh import init_device_mesh
+
+    from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
+    from nemo_automodel.components.loss.mtp import calculate_mtp_loss
+    from nemo_automodel.components.models.common import BackendConfig
+
+    backend = BackendConfig(
+        linear="torch",
+        attn="te",
+        rms_norm="torch",
+        experts="torch",
+        dispatcher="torch",
+        fake_balanced_gate=False,
+        enable_hf_state_dict_adapter=False,
+    )
+    model_baseline = _create_mtp_model(config, backend, device)
+
+    # Two unequal documents expose both packed-document boundaries and TE's
+    # head/tail CP partition boundaries. Each length remains divisible by
+    # 2 * CP, so unequal sequence lengths must still contribute the same
+    # aggregate token count to every rank.
+    # TE's DualChunkSwap needs each packed sequence divisible by 2 * CP.
+    # Keeping 32 aggregate tokens per rank also gives every tested size the
+    # same amount of local work (12 from the first document, 20 from the second).
+    seq_len_a = 12 * world_size
+    seq_len_b = 20 * world_size
+    total_len = seq_len_a + seq_len_b
+    cu_seqlens = torch.tensor([0, seq_len_a, total_len], dtype=torch.int32, device=device)
+    seq_idx = torch.repeat_interleave(
+        torch.arange(2, dtype=torch.int32, device=device),
+        torch.tensor([seq_len_a, seq_len_b], device=device),
+    )
+    position_ids = torch.cat([torch.arange(seq_len_a, device=device), torch.arange(seq_len_b, device=device)])
+
+    torch.manual_seed(2026)
+    input_ids = torch.randint(0, config.vocab_size, (1, total_len), device=device)
+    dist.broadcast(input_ids, src=0)
+
+    # SALM labels are already next-token targets. MTP depth 1 therefore needs
+    # one additional global shift, with the final two positions in each
+    # document ignored.
+    seq_idx_batched = seq_idx.unsqueeze(0)
+    labels_full = shift_packed_tensor(input_ids, depth=1, seq_idx=seq_idx_batched, fill_value=-100).squeeze(0)
+    mtp_inputs_full = model_baseline.prepare_mtp_inputs_for_cp(
+        {
+            "input_ids": input_ids,
+            "labels": labels_full.unsqueeze(0),
+            "position_ids": position_ids.unsqueeze(0),
+            "seq_idx": seq_idx.unsqueeze(0),
+        }
+    )
+    assert mtp_inputs_full is not None
+    mtp_input_ids_full = mtp_inputs_full.input_ids[0]
+    assert mtp_inputs_full.position_ids is not None
+    mtp_position_ids_full = mtp_inputs_full.position_ids[0]
+    mtp_targets_full = mtp_inputs_full.targets[0].squeeze(0)
+    torch.testing.assert_close(
+        mtp_targets_full,
+        shift_packed_tensor(labels_full.unsqueeze(0), depth=1, seq_idx=seq_idx_batched, fill_value=-100).squeeze(0),
+        rtol=0,
+        atol=0,
+    )
+    num_label_tokens = int((labels_full != -100).sum().item())
+    max_seqlen = torch.tensor(max(seq_len_a, seq_len_b), dtype=torch.int32, device=device)
+
+    output_baseline = model_baseline(
+        input_ids,
+        position_ids=position_ids,
+        mtp_per_depth_input_ids=(mtp_input_ids_full,),
+        mtp_per_depth_position_ids=(mtp_position_ids_full,),
+        qkv_format="thd",
+        cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen,
+        cp_rank=0,
+        cp_size=1,
+    )
+    mtp_hidden_baseline = output_baseline.mtp_per_depth_h[0].squeeze(0)
+    loss_fn = MaskedCrossEntropy(reduction="sum")
+    mtp_loss_baseline = calculate_mtp_loss(
+        loss_fn,
+        mtp_per_depth_h=output_baseline.mtp_per_depth_h,
+        mtp_per_depth_targets=(mtp_targets_full,),
+        labels=labels_full,
+        model=model_baseline,
+        scaling_factor=1.0,
+        num_label_tokens=num_label_tokens,
+    )
+    mtp_loss_baseline.backward()
+
+    selected_names = (
+        "model.embed_tokens.weight",
+        "lm_head.weight",
+        "mtp.layers.0.eh_proj.weight",
+        "mtp.layers.0.mixer.q_proj.weight",
+    )
+    baseline_params = dict(model_baseline.named_parameters())
+    baseline_grads = {name: baseline_params[name].grad.detach().clone() for name in selected_names}
+    baseline_before_step = {name: baseline_params[name].detach().clone() for name in selected_names}
+
+    model_cp = _create_mtp_model(config, backend, device)
+    model_cp.load_state_dict(model_baseline.state_dict())
+    model_cp.zero_grad(set_to_none=True)
+    cp_mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("cp",))
+    cp_group = cp_mesh["cp"].get_group()
+    _wire_te_cp(model_cp.model, cp_group, config)
+    _wire_te_cp(model_cp.mtp, cp_group, config)
+
+    local_indices = tex.thd_get_partitioned_indices(cu_seqlens, total_len, world_size, rank).to(torch.long)
+    local_token_count = torch.tensor(local_indices.numel(), dtype=torch.int64, device=device)
+    token_counts = [torch.empty_like(local_token_count) for _ in range(world_size)]
+    dist.all_gather(token_counts, local_token_count, group=cp_group)
+    token_counts = [int(count.item()) for count in token_counts]
+    if len(set(token_counts)) != 1:
+        raise AssertionError(f"TE packed CP assigned unequal aggregate token counts across ranks: {token_counts}")
+    if token_counts[0] != total_len // world_size:
+        raise AssertionError(
+            f"TE packed CP assigned {token_counts[0]} tokens per rank; expected {total_len // world_size}"
+        )
+    mtp_inputs_cp = model_cp.prepare_mtp_inputs_for_cp(
+        {
+            "input_ids": input_ids,
+            "labels": labels_full.unsqueeze(0),
+            "position_ids": position_ids.unsqueeze(0),
+            "seq_idx": seq_idx.unsqueeze(0),
+        }
+    )
+    assert mtp_inputs_cp is not None
+    assert mtp_inputs_cp.position_ids is not None
+    input_ids_local = input_ids.reshape(-1).index_select(0, local_indices)
+    mtp_input_ids_local = mtp_inputs_cp.input_ids[0].reshape(-1).index_select(0, local_indices)
+    position_ids_local = position_ids.index_select(0, local_indices)
+    mtp_position_ids_local = mtp_inputs_cp.position_ids[0].reshape(-1).index_select(0, local_indices)
+    labels_local = labels_full.index_select(0, local_indices)
+    mtp_targets_local = mtp_inputs_cp.targets[0].reshape(-1).index_select(0, local_indices)
+
+    output_cp = model_cp(
+        input_ids_local,
+        position_ids=position_ids_local,
+        mtp_per_depth_input_ids=(mtp_input_ids_local,),
+        mtp_per_depth_position_ids=(mtp_position_ids_local,),
+        qkv_format="thd",
+        cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen,
+        cp_rank=rank,
+        cp_size=world_size,
+    )
+    mtp_loss_cp = calculate_mtp_loss(
+        loss_fn,
+        mtp_per_depth_h=output_cp.mtp_per_depth_h,
+        mtp_per_depth_targets=(mtp_targets_local,),
+        labels=labels_local,
+        model=model_cp,
+        scaling_factor=1.0,
+        num_label_tokens=num_label_tokens,
+    )
+    mtp_loss_cp.backward()
+
+    mtp_hidden_cp = _gather_te_partition(
+        output_cp.mtp_per_depth_h[0].squeeze(0).detach(),
+        local_indices,
+        total_len,
+        cp_group,
+    )
+    logits_cp = _gather_te_partition(
+        output_cp.logits.squeeze(0).detach(),
+        local_indices,
+        total_len,
+        cp_group,
+    )
+    targets_cp = _gather_te_partition(mtp_targets_local, local_indices, total_len, cp_group)
+    mtp_loss_cp_global = mtp_loss_cp.detach().clone()
+    dist.all_reduce(mtp_loss_cp_global, op=dist.ReduceOp.SUM, group=cp_group)
+
+    for parameter in model_cp.parameters():
+        if parameter.grad is not None:
+            dist.all_reduce(parameter.grad, op=dist.ReduceOp.SUM, group=cp_group)
+
+    cp_params = dict(model_cp.named_parameters())
+
+    logits_baseline = output_baseline.logits.squeeze(0).detach()
+    if rank == 0:
+        logits_diff = (logits_cp - logits_baseline).abs()
+        hidden_diff = (mtp_hidden_cp - mtp_hidden_baseline.detach()).abs()
+        logits_cosine = torch.nn.functional.cosine_similarity(
+            logits_cp.float().flatten(), logits_baseline.float().flatten(), dim=0
+        )
+        hidden_cosine = torch.nn.functional.cosine_similarity(
+            mtp_hidden_cp.float().flatten(), mtp_hidden_baseline.detach().float().flatten(), dim=0
+        )
+        print("\n" + "=" * 70)
+        print("Config: thd_te_mtp - packed Nemotron MTP training parity")
+        print("=" * 70)
+        print(f"Targets: exact global reconstruction = {torch.equal(targets_cp, mtp_targets_full)}")
+        print(
+            f"Backbone logits diff - mean: {logits_diff.mean().item():.6f}, "
+            f"max: {logits_diff.max().item():.6f}, cosine: {logits_cosine.item():.8f}"
+        )
+        print(
+            f"MTP hidden diff - mean: {hidden_diff.mean().item():.6f}, "
+            f"max: {hidden_diff.max().item():.6f}, cosine: {hidden_cosine.item():.8f}"
+        )
+        print(f"MTP loss: CP={mtp_loss_cp_global.item():.6f}, baseline={mtp_loss_baseline.detach().item():.6f}")
+        for name in selected_names:
+            grad_diff = (cp_params[name].grad - baseline_grads[name]).abs()
+            print(f"Grad {name} - mean: {grad_diff.mean().item():.6f}, max: {grad_diff.max().item():.6f}")
+    try:
+        torch.testing.assert_close(targets_cp, mtp_targets_full, rtol=0, atol=0)
+        torch.testing.assert_close(
+            logits_cp,
+            logits_baseline,
+            rtol=2e-2,
+            atol=5e-2,
+            msg="CP backbone logits differ from CP=1",
+        )
+        torch.testing.assert_close(
+            mtp_hidden_cp,
+            mtp_hidden_baseline.detach(),
+            rtol=2e-2,
+            # BF16 P2P accumulation error grows slightly with CP rank count;
+            # loss and gradient parity below provide stricter end-result checks.
+            atol=1.25e-1,
+            msg="CP MTP hidden states differ from CP=1",
+        )
+        torch.testing.assert_close(
+            mtp_loss_cp_global,
+            mtp_loss_baseline.detach(),
+            rtol=2e-2,
+            atol=3e-2,
+            msg="global CP MTP loss differs from CP=1",
+        )
+        for name in selected_names:
+            torch.testing.assert_close(
+                cp_params[name].grad,
+                baseline_grads[name],
+                rtol=5e-2,
+                atol=1e-2,
+                msg=f"CP MTP gradient differs for {name}",
+            )
+
+        learning_rate = 0.25
+        torch.optim.SGD(model_baseline.parameters(), lr=learning_rate).step()
+        torch.optim.SGD(model_cp.parameters(), lr=learning_rate).step()
+        for name in selected_names:
+            before = baseline_before_step[name].float()
+            baseline_update = baseline_params[name].detach().float() - before
+            cp_update = cp_params[name].detach().float() - before
+            if not torch.count_nonzero(baseline_update):
+                raise AssertionError(f"baseline optimizer did not update {name}")
+            if not torch.count_nonzero(cp_update):
+                raise AssertionError(f"CP optimizer did not update {name}")
+            if rank == 0:
+                update_diff = (cp_update - baseline_update).abs()
+                print(
+                    f"Update {name} - mean diff: {update_diff.mean().item():.6f}, "
+                    f"max diff: {update_diff.max().item():.6f}"
+                )
+            # Compare update vectors, not final BF16 parameters. The old
+            # parameter atol (5e-2) exactly equaled learning_rate * old grad_atol
+            # (0.25 * 2e-1). The update atol below is also stricter than
+            # learning_rate * current grad_atol (0.25 * 1e-2 = 2.5e-3).
+            torch.testing.assert_close(
+                cp_update,
+                baseline_update,
+                rtol=5e-2,
+                atol=2e-3,
+                msg=f"CP optimizer update differs for {name}",
+            )
+    except AssertionError as error:
+        if rank == 0:
+            print(f"  thd_te_mtp: FAILED - {error}")
+        return 1
+
+    if rank == 0:
+        print("  PASSED")
+        print("=" * 70)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Config 6: BSHD + SDPA + packed MTP Mamba
+# ---------------------------------------------------------------------------
+def run_bshd_sdpa_mtp(rank, world_size, device, config):
+    """Packed BSHD MTP-Mamba CP=1/CP=N loss and gradient parity."""
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor.experimental import context_parallel
+    from torch.distributed.tensor.experimental._attention import context_parallel_unshard, set_rotate_method
+    from torch.nn.attention import SDPBackend, sdpa_kernel
+
+    from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
+    from nemo_automodel.components.loss.mtp import calculate_mtp_loss
+    from nemo_automodel.components.models.common import BackendConfig
+    from nemo_automodel.components.models.common.mtp import shift_packed_tensor
+
+    config.mtp_hybrid_override_pattern = "M"
+    backend = BackendConfig(
+        linear="torch",
+        attn="sdpa",
+        rms_norm="torch",
+        experts="torch",
+        dispatcher="torch",
+        fake_balanced_gate=False,
+        enable_hf_state_dict_adapter=False,
+    )
+    model_baseline = _create_mtp_model(config, backend, device)
+
+    seq_len_a = seq_len_b = 32 * world_size
+    total_len = seq_len_a + seq_len_b
+    cu_seqlens = torch.tensor([0, seq_len_a, total_len], dtype=torch.int32, device=device)
+    seq_idx = torch.repeat_interleave(
+        torch.arange(2, dtype=torch.long, device=device),
+        torch.tensor([seq_len_a, seq_len_b], device=device),
+    ).unsqueeze(0)
+    position_ids = torch.cat(
+        [torch.arange(seq_len_a, device=device), torch.arange(seq_len_b, device=device)]
+    ).unsqueeze(0)
+
+    torch.manual_seed(2027)
+    input_ids = torch.randint(0, config.vocab_size, (1, total_len), device=device)
+    dist.broadcast(input_ids, src=0)
+    labels_full = shift_packed_tensor(input_ids, depth=1, seq_idx=seq_idx, fill_value=-100)
+    raw_packed_batch = {
+        "input_ids": input_ids,
+        "labels": labels_full,
+        "position_ids": position_ids,
+        "seq_lens": torch.tensor([[seq_len_a, seq_len_b]], device=device),
+        "seq_lens_padded": torch.tensor([[seq_len_a, seq_len_b]], device=device),
+    }
+    mtp_inputs_full = model_baseline.prepare_mtp_inputs_for_cp(raw_packed_batch)
+    assert mtp_inputs_full is not None
+    assert mtp_inputs_full.position_ids is not None
+    mtp_input_ids_full = mtp_inputs_full.input_ids[0]
+    mtp_position_ids_full = mtp_inputs_full.position_ids[0]
+    mtp_targets_full = mtp_inputs_full.targets[0]
+    num_label_tokens = int((labels_full != -100).sum().item())
+
+    with sdpa_kernel([SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION]):
+        output_baseline = model_baseline(
+            input_ids,
+            position_ids=position_ids,
+            mtp_per_depth_input_ids=(mtp_input_ids_full,),
+            mtp_per_depth_position_ids=(mtp_position_ids_full,),
+            qkv_format="thd",
+            cu_seqlens=cu_seqlens,
+            cp_rank=0,
+            cp_size=1,
+        )
+        loss_fn = MaskedCrossEntropy(reduction="sum")
+        mtp_loss_baseline = calculate_mtp_loss(
+            loss_fn,
+            mtp_per_depth_h=output_baseline.mtp_per_depth_h,
+            mtp_per_depth_targets=(mtp_targets_full,),
+            labels=labels_full,
+            model=model_baseline,
+            scaling_factor=1.0,
+            num_label_tokens=num_label_tokens,
+        )
+        mtp_loss_baseline.backward()
+
+    selected_names = (
+        "model.embed_tokens.weight",
+        "lm_head.weight",
+        "mtp.layers.0.mixer.in_proj.weight",
+    )
+    baseline_params = dict(model_baseline.named_parameters())
+    baseline_grads = {name: baseline_params[name].grad.detach().clone() for name in selected_names}
+
+    model_cp = _create_mtp_model(config, backend, device)
+    model_cp.load_state_dict(model_baseline.state_dict())
+    model_cp.zero_grad(set_to_none=True)
+    cp_mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("cp",))
+    cp_group = cp_mesh["cp"].get_group()
+    _wire_sdpa_cp(model_cp.model, cp_group)
+    _wire_sdpa_cp(model_cp.mtp, cp_group)
+    set_rotate_method("allgather")
+
+    mtp_inputs_cp = model_cp.prepare_mtp_inputs_for_cp(
+        {
+            "input_ids": input_ids,
+            "labels": labels_full,
+            "position_ids": position_ids,
+            "seq_lens": raw_packed_batch["seq_lens"],
+            "seq_lens_padded": raw_packed_batch["seq_lens_padded"],
+        }
+    )
+    assert mtp_inputs_cp is not None
+    assert mtp_inputs_cp.position_ids is not None
+
+    input_ids_cp = input_ids.clone()
+    position_ids_cp = position_ids.clone()
+    labels_cp = labels_full.clone()
+    mtp_input_ids_cp = mtp_inputs_cp.input_ids[0].clone()
+    mtp_position_ids_cp = mtp_inputs_cp.position_ids[0].clone()
+    mtp_targets_cp = mtp_inputs_cp.targets[0].clone()
+    cp_buffers = [
+        input_ids_cp,
+        position_ids_cp,
+        labels_cp,
+        mtp_input_ids_cp,
+        mtp_position_ids_cp,
+        mtp_targets_cp,
+    ]
+    cp_ctx = context_parallel(
+        cp_mesh,
+        buffers=cp_buffers,
+        buffer_seq_dims=[1] * len(cp_buffers),
+        no_restore_buffers=set(cp_buffers),
+    )
+
+    with sdpa_kernel([SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION]):
+        with cp_ctx:
+            output_cp = model_cp(
+                input_ids_cp,
+                position_ids=position_ids_cp,
+                mtp_per_depth_input_ids=(mtp_input_ids_cp,),
+                mtp_per_depth_position_ids=(mtp_position_ids_cp,),
+                qkv_format="thd",
+                cu_seqlens=cu_seqlens,
+                cp_rank=rank,
+                cp_size=world_size,
+            )
+            mtp_loss_cp = calculate_mtp_loss(
+                loss_fn,
+                mtp_per_depth_h=output_cp.mtp_per_depth_h,
+                mtp_per_depth_targets=(mtp_targets_cp,),
+                labels=labels_cp,
+                model=model_cp,
+                scaling_factor=1.0,
+                num_label_tokens=num_label_tokens,
+            )
+            mtp_loss_cp.backward()
+
+    logits_cp, mtp_hidden_cp, targets_cp = context_parallel_unshard(
+        cp_mesh,
+        [
+            output_cp.logits.detach(),
+            output_cp.mtp_per_depth_h[0].detach(),
+            mtp_targets_cp,
+        ],
+        seq_dims=[1, 1, 1],
+    )
+    mtp_loss_cp_global = mtp_loss_cp.detach().clone()
+    dist.all_reduce(mtp_loss_cp_global, op=dist.ReduceOp.SUM, group=cp_group)
+    for parameter in model_cp.parameters():
+        if parameter.grad is not None:
+            dist.all_reduce(parameter.grad, op=dist.ReduceOp.SUM, group=cp_group)
+
+    cp_params = dict(model_cp.named_parameters())
+    logits_baseline = output_baseline.logits.detach()
+    mtp_hidden_baseline = output_baseline.mtp_per_depth_h[0].detach()
+
+    if rank == 0:
+        print("\n" + "=" * 70)
+        print("Config: bshd_sdpa_mtp - packed SDPA MTP-Mamba training parity")
+        print("=" * 70)
+        print(f"Targets: exact global reconstruction = {torch.equal(targets_cp, mtp_targets_full)}")
+        print(f"MTP loss: CP={mtp_loss_cp_global.item():.6f}, baseline={mtp_loss_baseline.detach().item():.6f}")
+        print(f"Backbone logits max diff: {(logits_cp - logits_baseline).abs().max().item():.6f}")
+        print(f"MTP hidden max diff: {(mtp_hidden_cp - mtp_hidden_baseline).abs().max().item():.6f}")
+
+    try:
+        torch.testing.assert_close(targets_cp, mtp_targets_full, rtol=0, atol=0)
+        torch.testing.assert_close(logits_cp, logits_baseline, rtol=2e-2, atol=5e-2)
+        torch.testing.assert_close(mtp_hidden_cp, mtp_hidden_baseline, rtol=2e-2, atol=1.25e-1)
+        torch.testing.assert_close(mtp_loss_cp_global, mtp_loss_baseline.detach(), rtol=2e-2, atol=3e-2)
+        for name in selected_names:
+            torch.testing.assert_close(
+                cp_params[name].grad,
+                baseline_grads[name],
+                rtol=1e-1,
+                atol=2e-1,
+                msg=f"CP MTP gradient differs for {name}",
+            )
+    except AssertionError as error:
+        if rank == 0:
+            print(f"  bshd_sdpa_mtp: FAILED - {error}")
+        return 1
+
+    if rank == 0:
+        print("  PASSED")
+        print("=" * 70)
+    return 0
+
+
 def main():
     init_distributed()
     rank = dist.get_rank()
     world_size = dist.get_world_size()
     device = torch.device(f"cuda:{rank}")
 
-    if world_size != 2:
+    if world_size < 2:
         if rank == 0:
-            print(f"ERROR: This test requires exactly 2 GPUs, got {world_size}", file=sys.stderr)
+            print(f"ERROR: This test requires at least 2 GPUs, got {world_size}", file=sys.stderr)
         sys.exit(1)
 
     torch.manual_seed(42)
     torch.cuda.manual_seed_all(42)
 
-    config = MockHybridConfig()
+    config = MockHybridConfig(cp_size=world_size)
 
     configs = {
         "bshd_te": lambda: run_bshd_te(rank, world_size, device, config),
         "thd_te": lambda: run_thd_te(rank, world_size, device, config),
         "thd_te_packed": lambda: run_thd_te_packed(rank, world_size, device, config),
         "bshd_sdpa": lambda: run_bshd_sdpa(rank, world_size, device, config),
+        "thd_te_mtp": lambda: run_thd_te_mtp(rank, world_size, device, config),
+        "bshd_sdpa_mtp": lambda: run_bshd_sdpa_mtp(rank, world_size, device, config),
     }
+    requested_config = os.environ.get("NEMOTRON_CP_TEST_CONFIG")
+    if requested_config:
+        if requested_config not in configs:
+            raise ValueError(f"Unknown NEMOTRON_CP_TEST_CONFIG={requested_config!r}; choose from {tuple(configs)}")
+        configs = {requested_config: configs[requested_config]}
 
     results = {}
     for name, fn in configs.items():

--- a/tests/functional_tests/context_parallel/run_qwen3_5_moe_mtp_cp_parity.py
+++ b/tests/functional_tests/context_parallel/run_qwen3_5_moe_mtp_cp_parity.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Two-GPU CP1/CP2 loss parity for Qwen3.5-MoE VLM with MTP.
+
+Run:
+    torchrun --standalone --nproc-per-node=2 \
+        tests/functional_tests/context_parallel/run_qwen3_5_moe_mtp_cp_parity.py
+"""
+
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch.distributed.device_mesh import init_device_mesh
+from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import Qwen3_5MoeConfig, Qwen3_5MoeTextConfig
+
+from nemo_automodel.components.distributed.context_parallel import ContextParallelSharder
+from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
+from nemo_automodel.components.loss.mtp import calculate_mtp_loss
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.qwen3_5_moe.model import Qwen3_5MoeForConditionalGeneration
+from nemo_automodel.components.moe.parallelizer import apply_cp
+
+
+def _config() -> Qwen3_5MoeConfig:
+    """Build a four-backbone-layer, one-MTP-depth Qwen VLM config."""
+    text = Qwen3_5MoeTextConfig(
+        vocab_size=128,
+        hidden_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        intermediate_size=128,
+        moe_intermediate_size=32,
+        shared_expert_intermediate_size=32,
+        num_experts=4,
+        num_experts_per_tok=2,
+        max_position_embeddings=128,
+        rms_norm_eps=1e-6,
+        pad_token_id=0,
+        layer_types=["full_attention", "linear_attention"] * 2,
+        mtp_num_hidden_layers=1,
+        torch_dtype="bfloat16",
+    )
+    vision = {
+        "depth": 1,
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "num_heads": 4,
+        "in_channels": 3,
+        "patch_size": 2,
+        "spatial_merge_size": 1,
+        "temporal_patch_size": 1,
+        "out_hidden_size": 64,
+        "num_position_embeddings": 16,
+    }
+    config = Qwen3_5MoeConfig(text_config=text.to_dict(), vision_config=vision)
+    config.image_token_id = 120
+    config.video_token_id = 121
+    config.vision_start_token_id = 122
+    config.vision_end_token_id = 123
+    return config
+
+
+def _backend() -> BackendConfig:
+    """Use torch modules and SDPA so the test exercises PyTorch CP transport."""
+    return BackendConfig(
+        linear="torch",
+        attn="sdpa",
+        rms_norm="torch",
+        experts="torch",
+        dispatcher="torch",
+        fake_balanced_gate=False,
+        enable_hf_state_dict_adapter=False,
+    )
+
+
+def _losses(
+    model: Qwen3_5MoeForConditionalGeneration,
+    logits: torch.Tensor,
+    mtp_hidden: list[torch.Tensor],
+    labels: torch.Tensor,
+    mtp_targets: tuple[torch.Tensor, ...],
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return base, scaled-MTP, and total losses over global-order tensors."""
+    valid_tokens = int((labels != -100).sum().item())
+    base_loss = (
+        F.cross_entropy(
+            logits.float().reshape(-1, logits.shape[-1]),
+            labels.reshape(-1),
+            ignore_index=-100,
+            reduction="sum",
+        )
+        / valid_tokens
+    )
+    mtp_loss = calculate_mtp_loss(
+        MaskedCrossEntropy(ignore_index=-100),
+        mtp_per_depth_h=mtp_hidden,
+        mtp_per_depth_targets=mtp_targets,
+        labels=labels,
+        model=model,
+        scaling_factor=model.mtp_config.loss_scaling_factor,
+        num_label_tokens=valid_tokens,
+        ignore_index=-100,
+    )
+    return base_loss, mtp_loss, base_loss + mtp_loss
+
+
+def main() -> None:
+    """Compare recipe-shaped CP2 execution with the same model at CP1."""
+    dist.init_process_group("nccl")
+    rank, world = dist.get_rank(), dist.get_world_size()
+    if world != 2:
+        raise RuntimeError(f"This parity test requires exactly 2 GPUs, got {world}")
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+
+    torch.manual_seed(1234)
+    model = Qwen3_5MoeForConditionalGeneration(_config(), backend=_backend()).to(device)
+    model.initialize_weights(buffer_device=device, dtype=torch.bfloat16)
+    model.train()
+    for parameter in model.parameters():
+        dist.broadcast(parameter.data, src=0)
+    for buffer in model.buffers():
+        dist.broadcast(buffer.data, src=0)
+
+    sequence = 32
+    torch.manual_seed(5678)
+    input_ids = torch.randint(2, 100, (1, sequence), device=device)
+    input_ids[0, 4] = model.config.vision_start_token_id
+    input_ids[0, 5:9] = model.config.image_token_id
+    input_ids[0, 9] = model.config.vision_end_token_id
+    pixel_values = torch.randn(4, 12, device=device, dtype=torch.bfloat16)
+    image_grid_thw = torch.tensor([[1, 2, 2]], device=device, dtype=torch.long)
+    for tensor in (input_ids, pixel_values, image_grid_thw):
+        dist.broadcast(tensor, src=0)
+    labels = torch.roll(input_ids, shifts=-1, dims=1)
+    labels[:, -1] = -100
+
+    reference_batch = {
+        "input_ids": input_ids.clone(),
+        "labels": labels.clone(),
+        "pixel_values": pixel_values.clone(),
+        "image_grid_thw": image_grid_thw.clone(),
+    }
+    reference_prepared = model.prepare_model_inputs_for_cp(reference_batch)
+    reference_batch["position_ids"] = reference_prepared["position_ids"]
+    reference_mtp = model.prepare_mtp_inputs_for_cp(reference_batch, ignore_index=-100)
+    with torch.no_grad():
+        reference_output = model(
+            input_ids=reference_batch["input_ids"],
+            position_ids=reference_batch["position_ids"],
+            pixel_values=reference_batch["pixel_values"],
+            image_grid_thw=reference_batch["image_grid_thw"],
+        )
+        reference_losses = _losses(
+            model,
+            reference_output.logits,
+            reference_output.mtp_per_depth_h,
+            labels,
+            reference_mtp.targets,
+        )
+
+    mesh = init_device_mesh("cuda", (world,), mesh_dim_names=("cp",))
+    apply_cp(model, mesh["cp"])
+    cp_batch = {
+        "input_ids": input_ids.clone(),
+        "labels": labels.clone(),
+        "pixel_values": pixel_values.clone(),
+        "image_grid_thw": image_grid_thw.clone(),
+    }
+    sharder = ContextParallelSharder(model, mesh, cp_batch)
+    cp_mtp = model.prepare_mtp_inputs_for_cp(cp_batch, ignore_index=-100)
+    train_ctx, cp_batch = sharder.shard(cp_batch)
+    local_mtp_input_ids = tuple(sharder.shard_token_tensor(ids, seq_dim=1, fill=0) for ids in cp_mtp.input_ids)
+    local_mtp_position_ids = tuple(
+        sharder.shard_token_tensor(ids, seq_dim=cp_mtp.position_ids_seq_dim, fill=0) for ids in cp_mtp.position_ids
+    )
+    local_mtp_valid_masks = tuple(
+        sharder.shard_token_tensor(mask, seq_dim=1, fill=False) for mask in cp_mtp.valid_masks
+    )
+    local_mtp_targets = tuple(sharder.shard_token_tensor(targets, seq_dim=1, fill=-100) for targets in cp_mtp.targets)
+    cp_batch.update(
+        {
+            "mtp_per_depth_input_ids": local_mtp_input_ids,
+            "mtp_per_depth_position_ids": local_mtp_position_ids,
+            "mtp_per_depth_valid_masks": local_mtp_valid_masks,
+        }
+    )
+    cp_batch.pop("labels")
+    with torch.no_grad(), train_ctx():
+        cp_output = model(**cp_batch)
+
+    gathered_logits = sharder.gather_token_tensor(cp_output.logits, seq_dim=1, trim=True)
+    gathered_mtp_hidden = [
+        sharder.gather_token_tensor(hidden, seq_dim=1, trim=True) for hidden in cp_output.mtp_per_depth_h
+    ]
+    gathered_mtp_targets = tuple(
+        sharder.gather_token_tensor(targets, seq_dim=1, trim=True) for targets in local_mtp_targets
+    )
+    gathered_mtp_input_ids = tuple(
+        sharder.gather_token_tensor(ids, seq_dim=1, trim=True) for ids in local_mtp_input_ids
+    )
+    gathered_mtp_position_ids = tuple(
+        sharder.gather_token_tensor(ids, seq_dim=cp_mtp.position_ids_seq_dim, trim=True)
+        for ids in local_mtp_position_ids
+    )
+
+    for actual, expected in zip(gathered_mtp_input_ids, reference_mtp.input_ids):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    for actual, expected in zip(gathered_mtp_position_ids, reference_mtp.position_ids):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    for actual, expected in zip(gathered_mtp_targets, reference_mtp.targets):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    cp_losses = _losses(model, gathered_logits, gathered_mtp_hidden, labels, gathered_mtp_targets)
+    names = ("base", "mtp", "total")
+    differences = [
+        abs(cp.detach().item() - reference.detach().item()) for cp, reference in zip(cp_losses, reference_losses)
+    ]
+    tolerance = 5e-2
+    for name, reference, cp, difference in zip(names, reference_losses, cp_losses, differences):
+        if rank == 0:
+            print(f"{name}: cp1={reference.detach().item():.8f} cp2={cp.detach().item():.8f} abs_diff={difference:.3e}")
+        if difference >= tolerance:
+            raise AssertionError(f"{name} loss parity failed: abs_diff={difference:.3e} >= {tolerance:.3e}")
+
+    dist.barrier()
+    if rank == 0:
+        print("RESULT: PASS (Qwen3.5-MoE MTP CP1/CP2 input and loss parity)")
+    dist.destroy_process_group()
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/_transformers/test_model_capabilities.py
+++ b/tests/unit_tests/_transformers/test_model_capabilities.py
@@ -230,6 +230,8 @@ def test_query_returns_canonical_type_for_static_class():
     assert caps.supports_cp is False
     assert caps.supports_ep is False
     assert caps.supports_thd is True
+    assert caps.supports_mtp_cp is False
+    assert caps.supports_mtp_cp_pp is False
     assert caps.supports_cp_vision_frame_sharding is False
 
 

--- a/tests/unit_tests/_transformers/test_registry.py
+++ b/tests/unit_tests/_transformers/test_registry.py
@@ -500,6 +500,29 @@ def test_deepseek_v4_in_custom_config_registrations():
     assert cls_name == "DeepseekV4Config"
 
 
+def test_nemotron_h_omni_reasoning_v3_registered_in_arch_mapping():
+    """NemotronH_Omni_Reasoning_V3 (Super-scale omni checkpoints) must be registered.
+
+    Reuses the same NemotronOmniForConditionalGeneration wrapper as the Nano-scale
+    NemotronH_Nano_Omni_Reasoning_V3 checkpoints: the model class is config-driven
+    (LLM scale, presence of sound_config) rather than hardcoded to one checkpoint
+    size.
+    """
+    from nemo_automodel._transformers.registry import MODEL_ARCH_MAPPING
+
+    assert "NemotronH_Omni_Reasoning_V3" in MODEL_ARCH_MAPPING, (
+        "NemotronH_Omni_Reasoning_V3 missing from MODEL_ARCH_MAPPING. "
+        "nvidia/NVIDIA-Nemotron-3.5-Super-midtrain-67B-vision-pretrained (and other "
+        "Super-scale omni checkpoints) declare this architecture and need it routed "
+        "to the in-tree model implementation."
+    )
+    module_path, cls_name = MODEL_ARCH_MAPPING["NemotronH_Omni_Reasoning_V3"]
+    assert module_path == "nemo_automodel.components.models.nemotron_omni.model"
+    assert cls_name == "NemotronOmniForConditionalGeneration"
+    # Same target class as the Nano variant -- one implementation, two architecture keys.
+    assert MODEL_ARCH_MAPPING["NemotronH_Omni_Reasoning_V3"] == MODEL_ARCH_MAPPING["NemotronH_Nano_Omni_Reasoning_V3"]
+
+
 def test_all_model_folders_registered_in_auto_map():
     """Every model folder with a model.py must have at least one entry in MODEL_ARCH_MAPPING.
 

--- a/tests/unit_tests/datasets/vlm/test_collate_fns.py
+++ b/tests/unit_tests/datasets/vlm/test_collate_fns.py
@@ -3304,3 +3304,15 @@ def test_thd_vlm_collater_empty_batch():
     from nemo_automodel.components.datasets.vlm.collate_fns import packed_sequence_thd_vlm_collater
 
     assert packed_sequence_thd_vlm_collater([]) == {}
+
+
+def test_merge_media_values_flattens_mixed_tensor_and_list_packs():
+    from nemo_automodel.components.datasets.vlm.collate_fns import _merge_media_values
+
+    stacked = torch.randn(2, 3, 8, 8)  # one pack with uniform images
+    ragged = [torch.randn(3, 12, 4), torch.randn(3, 6, 6)]  # another pack with variable resolution
+    merged = _merge_media_values([stacked, ragged])
+
+    assert isinstance(merged, list)
+    assert [tuple(v.shape) for v in merged] == [(3, 8, 8), (3, 8, 8), (3, 12, 4), (3, 6, 6)]
+    assert all(v.dtype == torch.bfloat16 for v in merged)

--- a/tests/unit_tests/datasets/vlm/test_datasets.py
+++ b/tests/unit_tests/datasets/vlm/test_datasets.py
@@ -2007,3 +2007,85 @@ class TestPreTokenizedDatasetWrapperInjectFakeImages:
         )
 
         assert wrapper.inject_fake_images is False
+
+
+class _LengthByTextProcessor:
+    """Processor whose token count depends on the rendered text: ``LONG`` -> 10 tokens
+    (over the test max_length), anything else -> 4 tokens whose ids encode the sample."""
+
+    def apply_chat_template(self, conversations, tokenize=False):
+        return [conversations[0][0]["content"][0]["text"]]
+
+    def __call__(self, **kwargs):
+        import torch
+
+        text = kwargs["text"][0]
+        if text == "LONG":
+            ids = list(range(100, 110))
+        else:
+            ids = [int(text)] * 4
+        return {
+            "input_ids": torch.tensor([ids]),
+            "attention_mask": torch.ones(1, len(ids), dtype=torch.long),
+        }
+
+
+class TestPreTokenizedDatasetWrapperReplacementDeterminism:
+    """Over-long (or otherwise unusable) samples are replaced by a substitute chosen
+    from a per-sample RNG, never from the process-global ``random`` state.
+
+    Regression test: with the global RNG, ranks whose ``random`` stream had
+    advanced differently (e.g. the per-node dataset-building rank) substituted a
+    different document, so context-parallel ranks of one CP group saw different
+    packs / ``cu_seqlens`` for the same microbatch and TE's ring-attention gradient
+    accumulation produced inf/nan (or silently wrong) dk/dv.
+    """
+
+    def _stub_pipeline(self, monkeypatch):
+        import torch
+
+        import nemo_automodel.components.datasets.vlm.collate_fns as collate_fns
+        import nemo_automodel.components.datasets.vlm.fake_image as fake_image
+
+        monkeypatch.setattr(ds, "_preload_media", lambda example, processor, **kw: example)
+        monkeypatch.setattr(ds, "_build_video_metadata", lambda conversation: None)
+        monkeypatch.setattr(fake_image, "_conversation_has_media", lambda conversation: False)
+        monkeypatch.setattr(collate_fns, "_extract_media_from_conversations", lambda conversations: ([], []))
+        monkeypatch.setattr(
+            collate_fns,
+            "build_labels_from_template",
+            lambda input_ids, conversations, processor: torch.zeros_like(input_ids),
+        )
+
+    def _make_dataset(self, n=64):
+        def conv(text):
+            return {
+                "conversation": [
+                    {"role": "user", "content": [{"type": "text", "text": text}]},
+                    {"role": "assistant", "content": [{"type": "text", "text": "ok"}]},
+                ]
+            }
+
+        return [conv("LONG")] + [conv(str(i)) for i in range(1, n)]
+
+    def test_substitute_is_independent_of_global_random_state(self, monkeypatch):
+        import random
+
+        self._stub_pipeline(monkeypatch)
+        wrapper = ds.PreTokenizedDatasetWrapper(
+            self._make_dataset(), _LengthByTextProcessor(), max_length=4, truncate=False, inject_fake_images=False
+        )
+
+        random.seed(1)
+        first = wrapper[0]["input_ids"].tolist()
+        random.seed(2)
+        second = wrapper[0]["input_ids"].tolist()
+        random.seed(3)
+        third = wrapper[0]["input_ids"].tolist()
+
+        assert first != list(range(100, 110)), "the over-long sample must have been replaced"
+        assert first == second == third, "the substitute must not depend on the process-global RNG state"
+
+    def test_different_samples_get_different_substitute_streams(self):
+        draws = {ds._replacement_rng(idx).randint(0, 10**9) for idx in range(32)}
+        assert len(draws) > 1

--- a/tests/unit_tests/datasets/vlm/test_neat_packing_vlm.py
+++ b/tests/unit_tests/datasets/vlm/test_neat_packing_vlm.py
@@ -565,3 +565,54 @@ def test_compute_mrope_position_ids_passes_sample_mm_token_type_ids_through():
 
     assert pos.shape == (3, 4)
     assert captured["mm"].tolist() == [[0, 1, 1, 0]]
+
+
+class TestVariableResolutionImagePacking:
+    def test_mismatched_image_shapes_are_kept_as_per_image_list(self):
+        samples = [
+            {
+                "input_ids": torch.tensor([1, 2]),
+                "labels": torch.tensor([10, 20]),
+                "pixel_values": torch.randn(2, 3, 8, 8),  # two 8x8 images
+            },
+            {
+                "input_ids": torch.tensor([3]),
+                "labels": torch.tensor([30]),
+                "pixel_values": torch.randn(1, 3, 12, 4),  # one 12x4 image
+            },
+        ]
+        result = _build_packed_vlm_sample(samples, pack_size=4, padding_idx=0)
+
+        assert isinstance(result["pixel_values"], list)
+        assert [tuple(v.shape) for v in result["pixel_values"]] == [(3, 8, 8), (3, 8, 8), (3, 12, 4)]
+
+    @pytest.mark.parametrize("collater", ["neat_packed_vlm_collater", "packed_sequence_thd_vlm_collater"])
+    def test_variable_resolution_packs_reach_training_collater(self, collater):
+        """Packing and collation preserve image order, values, and token boundaries."""
+        from nemo_automodel.components.datasets.vlm import collate_fns
+
+        images = [torch.full((1, 3, 8, 8), 1.0), torch.full((1, 3, 12, 4), 2.0)]
+        samples = [
+            {"input_ids": torch.tensor([i + 1]), "labels": torch.tensor([i + 11]), "pixel_values": image}
+            for i, image in enumerate(images)
+        ]
+        ragged = _build_packed_vlm_sample(samples, pack_size=4, padding_idx=0)
+        uniform = _build_packed_vlm_sample(samples[:1], pack_size=4, padding_idx=0)
+
+        batch = getattr(collate_fns, collater)([ragged, uniform], padding_idx=0, max_length=4)
+
+        assert batch["input_ids"].tolist() == [[1, 2, 0, 0], [1, 0, 0, 0]]
+        assert batch["labels"].tolist() == [[11, 12, -100, -100], [11, -100, -100, -100]]
+        assert isinstance(batch["pixel_values"], list)
+        assert len(batch["pixel_values"]) == 3
+        for actual, expected in zip(batch["pixel_values"], [images[0][0], images[1][0], images[0][0]]):
+            torch.testing.assert_close(actual, expected.to(torch.bfloat16), rtol=0, atol=0)
+
+    def test_matching_image_shapes_still_concatenate(self):
+        samples = [
+            {"input_ids": torch.tensor([1]), "labels": torch.tensor([10]), "pixel_values": torch.randn(2, 3, 8, 8)},
+            {"input_ids": torch.tensor([2]), "labels": torch.tensor([20]), "pixel_values": torch.randn(1, 3, 8, 8)},
+        ]
+        result = _build_packed_vlm_sample(samples, pack_size=4, padding_idx=0)
+        assert isinstance(result["pixel_values"], torch.Tensor)
+        assert tuple(result["pixel_values"].shape) == (3, 3, 8, 8)

--- a/tests/unit_tests/distributed/test_parallelization_strategies.py
+++ b/tests/unit_tests/distributed/test_parallelization_strategies.py
@@ -15,8 +15,9 @@
 """Tests for the parallelization strategy pattern."""
 
 import logging
+import sys
 from abc import ABC
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -81,6 +82,18 @@ class MockNemotronHModel(nn.Module):
 
     def __init__(self):
         super().__init__()
+
+        class MockSupports:
+            def __init__(self, model):
+                self.model = model
+                self.supports_mtp_cp = True
+                self.supports_mtp_cp_pp = False
+
+            @property
+            def mtp_enabled(self):
+                return bool(getattr(getattr(self.model, "mtp_config", None), "enabled", False))
+
+        self.supports = MockSupports(self)
         self.config = SimpleNamespace(
             num_attention_heads=8,
             num_key_value_heads=8,
@@ -459,6 +472,201 @@ class TestNemotronHParallelizationStrategy:
         """Test that NemotronHParallelizationStrategy can be instantiated."""
         assert isinstance(strategy, NemotronHParallelizationStrategy)
         assert isinstance(strategy, ParallelizationStrategy)
+
+    @pytest.mark.parametrize("mtp_enabled", [True, False])
+    def test_configures_only_enabled_mtp_attention_and_mamba_for_cp(
+        self,
+        strategy,
+        mock_device_mesh,
+        nemotron_model,
+        monkeypatch,
+        mtp_enabled,
+    ):
+        """The strategy installs CP collectives only on enabled MTP blocks."""
+        mesh, dp_replicate_mesh, dp_shard_mesh, tp_mesh = mock_device_mesh
+        cp_group = object()
+        cp_mesh = MagicMock()
+        cp_mesh.size.return_value = 2
+        cp_mesh.get_group.return_value = cp_group
+        mesh.mesh_dim_names = ("dp_replicate", "dp_shard_cp", "cp", "tp")
+        mesh.__getitem__.side_effect = lambda key: {
+            "dp_replicate": dp_replicate_mesh,
+            "dp_shard_cp": dp_shard_mesh,
+            "cp": cp_mesh,
+            "tp": tp_mesh,
+            ("dp_replicate", "dp_shard_cp"): dp_shard_mesh,
+        }[key]
+
+        class FakeDotProductAttention(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.set_context_parallel_group = MagicMock()
+
+        attention_module = FakeDotProductAttention()
+        attention_layer = nn.Module()
+        attention_layer.block_type = "attention"
+        attention_layer.mixer = nn.Module()
+        attention_layer.mixer.attn_module = attention_module
+        attention_module_2 = FakeDotProductAttention()
+        attention_layer_2 = nn.Module()
+        attention_layer_2.block_type = "attention"
+        attention_layer_2.mixer = nn.Module()
+        attention_layer_2.mixer.attn_module = attention_module_2
+
+        mamba_layer = nn.Module()
+        mamba_layer.block_type = "mamba"
+        mamba_layer.mixer = nn.Module()
+        mamba_layer.mixer.num_heads = 8
+        mamba_layer.mixer.head_dim = 16
+        mamba_layer.mixer.n_groups = 2
+        mamba_layer.mixer.ssm_state_size = 64
+
+        nemotron_model.mtp_config = SimpleNamespace(enabled=mtp_enabled)
+        nemotron_model.mtp = nn.Module()
+        nemotron_model.mtp.layers = nn.ModuleList([attention_layer, attention_layer_2, mamba_layer])
+
+        transformer_engine = ModuleType("transformer_engine")
+        transformer_engine.__path__ = []
+        transformer_engine_pytorch = ModuleType("transformer_engine.pytorch")
+        transformer_engine_pytorch.__path__ = []
+        transformer_engine_attention = ModuleType("transformer_engine.pytorch.attention")
+        transformer_engine_attention.DotProductAttention = FakeDotProductAttention
+        monkeypatch.setitem(sys.modules, "transformer_engine", transformer_engine)
+        monkeypatch.setitem(sys.modules, "transformer_engine.pytorch", transformer_engine_pytorch)
+        monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.attention", transformer_engine_attention)
+
+        from nemo_automodel.components.distributed.context_parallel import mamba as mamba_module
+
+        mamba_cp = object()
+        mamba_cp_ctor = MagicMock(return_value=mamba_cp)
+        monkeypatch.setattr(mamba_module, "MambaContextParallel", mamba_cp_ctor)
+        cp_ranks = [0, 1]
+        get_cp_ranks = MagicMock(return_value=cp_ranks)
+        cp_stream = object()
+        monkeypatch.setattr(parallelizer_mod.torch.distributed, "get_process_group_ranks", get_cp_ranks)
+        monkeypatch.setattr(parallelizer_mod.torch.cuda, "Stream", lambda: cp_stream)
+        monkeypatch.setattr(parallelizer_mod, "fully_shard", lambda model, **_kwargs: model)
+        monkeypatch.setattr(
+            parallelizer_mod.parallelizer_utils,
+            "fully_shard_by_dtype",
+            lambda model, **_kwargs: model,
+        )
+
+        strategy.parallelize(model=nemotron_model, device_mesh=mesh)
+
+        if not mtp_enabled:
+            attention_module.set_context_parallel_group.assert_not_called()
+            attention_module_2.set_context_parallel_group.assert_not_called()
+            mamba_cp_ctor.assert_not_called()
+            assert not hasattr(mamba_layer.mixer, "cp")
+            return
+
+        attention_module.set_context_parallel_group.assert_called_once_with(
+            cp_group,
+            cp_ranks,
+            cp_stream,
+            cp_comm_type="p2p",
+        )
+        attention_module_2.set_context_parallel_group.assert_called_once_with(
+            cp_group,
+            cp_ranks,
+            cp_stream,
+            cp_comm_type="p2p",
+        )
+        get_cp_ranks.assert_called_once_with(cp_group)
+        mamba_cp_ctor.assert_called_once_with(
+            cp_group=cp_group,
+            num_heads=8,
+            head_dim=16,
+            n_groups=2,
+            d_state=64,
+            mixer=mamba_layer.mixer,
+        )
+        assert mamba_layer.mixer.cp is mamba_cp
+
+    def test_cp_mtp_pipeline_stage_raises_explicit_unsupported_topology(
+        self,
+        strategy,
+        mock_device_mesh,
+        nemotron_model,
+        monkeypatch,
+    ):
+        """Every trimmed PP stage must fail before stage-specific CP wiring."""
+        mesh, dp_replicate_mesh, dp_shard_mesh, tp_mesh = mock_device_mesh
+        cp_group = object()
+        cp_mesh = MagicMock()
+        cp_mesh.size.return_value = 2
+        cp_mesh.get_group.return_value = cp_group
+        mesh.mesh_dim_names = ("dp_replicate", "dp_shard_cp", "cp", "tp")
+        mesh.__getitem__.side_effect = lambda key: {
+            "dp_replicate": dp_replicate_mesh,
+            "dp_shard_cp": dp_shard_mesh,
+            "cp": cp_mesh,
+            "tp": tp_mesh,
+            ("dp_replicate", "dp_shard_cp"): dp_shard_mesh,
+        }[key]
+        nemotron_model.mtp_config = SimpleNamespace(enabled=True)
+        nemotron_model.mtp = None
+        nemotron_model._is_pipeline_parallel_stage = lambda: True
+        monkeypatch.setattr(parallelizer_mod.torch.distributed, "get_process_group_ranks", lambda _group: [0, 1])
+
+        with pytest.raises(NotImplementedError, match="MTP with context and pipeline parallelism"):
+            strategy.parallelize(model=nemotron_model, device_mesh=mesh)
+
+    def test_cp_raises_when_enabled_mtp_layers_are_unavailable(
+        self,
+        strategy,
+        mock_device_mesh,
+        nemotron_model,
+        monkeypatch,
+    ):
+        mesh, dp_replicate_mesh, dp_shard_mesh, tp_mesh = mock_device_mesh
+        cp_group = object()
+        cp_mesh = MagicMock()
+        cp_mesh.size.return_value = 2
+        cp_mesh.get_group.return_value = cp_group
+        mesh.mesh_dim_names = ("dp_replicate", "dp_shard_cp", "cp", "tp")
+        mesh.__getitem__.side_effect = lambda key: {
+            "dp_replicate": dp_replicate_mesh,
+            "dp_shard_cp": dp_shard_mesh,
+            "cp": cp_mesh,
+            "tp": tp_mesh,
+            ("dp_replicate", "dp_shard_cp"): dp_shard_mesh,
+        }[key]
+        nemotron_model.mtp_config = SimpleNamespace(enabled=True)
+        nemotron_model.mtp = nn.Module()
+        monkeypatch.setattr(parallelizer_mod.torch.distributed, "get_process_group_ranks", lambda _group: [0, 1])
+
+        with pytest.raises(RuntimeError, match=r"MTP is enabled but model\.mtp\.layers is unavailable"):
+            strategy.parallelize(model=nemotron_model, device_mesh=mesh)
+
+    def test_cp_rejects_enabled_mtp_without_capability(
+        self,
+        strategy,
+        mock_device_mesh,
+        nemotron_model,
+        monkeypatch,
+    ):
+        mesh, dp_replicate_mesh, dp_shard_mesh, tp_mesh = mock_device_mesh
+        cp_mesh = MagicMock()
+        cp_mesh.size.return_value = 2
+        cp_mesh.get_group.return_value = object()
+        mesh.mesh_dim_names = ("dp_replicate", "dp_shard_cp", "cp", "tp")
+        mesh.__getitem__.side_effect = lambda key: {
+            "dp_replicate": dp_replicate_mesh,
+            "dp_shard_cp": dp_shard_mesh,
+            "cp": cp_mesh,
+            "tp": tp_mesh,
+            ("dp_replicate", "dp_shard_cp"): dp_shard_mesh,
+        }[key]
+        nemotron_model.mtp_config = SimpleNamespace(enabled=True)
+        nemotron_model.mtp = nn.Module()
+        nemotron_model.mtp.layers = nn.ModuleList([nn.Module()])
+        nemotron_model.supports.supports_mtp_cp = False
+        monkeypatch.setattr(parallelizer_mod.torch.distributed, "get_process_group_ranks", lambda _group: [0, 1])
+
+        with pytest.raises(RuntimeError, match="does not support MTP with context parallelism"):
+            strategy.parallelize(model=nemotron_model, device_mesh=mesh)
 
     def test_sequence_parallel_not_supported(self, strategy, mock_device_mesh, nemotron_model):
         """Test that sequence parallelism raises assertion error."""

--- a/tests/unit_tests/distributed/test_parallelizer_utils.py
+++ b/tests/unit_tests/distributed/test_parallelizer_utils.py
@@ -31,11 +31,40 @@ from nemo_automodel.components.distributed.parallelizer_utils import (
     fully_shard_by_dtype,
     get_internal_fsdp_mp_policy,
     iter_maximal_uniform_dtype_subtrees,
+    reject_unsupported_mtp_cp,
+    reject_unsupported_mtp_cp_pp,
 )
 from nemo_automodel.shared.torch_patches import (
     patch_fsdp_uniform_reduce_dtype,
     patch_fsdp_unused_param_reduction,
 )
+
+
+def test_reject_unsupported_mtp_cp_pp_allows_disabled_model():
+    model = nn.Linear(2, 2)
+    model.supports = SimpleNamespace(mtp_enabled=False, supports_mtp_cp_pp=False)
+    reject_unsupported_mtp_cp_pp(model)
+
+
+def test_reject_unsupported_mtp_cp_rejects_enabled_unsupported_model():
+    model = nn.Module()
+    model.mtp_config = SimpleNamespace(enabled=True)
+    model.supports = SimpleNamespace(mtp_enabled=True, supports_mtp_cp=False)
+
+    with pytest.raises(RuntimeError, match="does not support MTP with context parallelism"):
+        reject_unsupported_mtp_cp(model)
+
+
+def test_reject_unsupported_mtp_cp_allows_supported_or_disabled_model():
+    model = nn.Module()
+    model.mtp_config = SimpleNamespace(enabled=True)
+    model.supports = SimpleNamespace(mtp_enabled=True, supports_mtp_cp=True)
+    reject_unsupported_mtp_cp(model)
+
+    model.mtp_config.enabled = False
+    model.supports.mtp_enabled = False
+    model.supports.supports_mtp_cp = False
+    reject_unsupported_mtp_cp(model)
 
 
 def test_configure_fsdp_unused_param_reduction_uses_public_fsdp_api(monkeypatch):

--- a/tests/unit_tests/distributed/test_strategy_integration.py
+++ b/tests/unit_tests/distributed/test_strategy_integration.py
@@ -52,6 +52,11 @@ class MockNemotronModel(nn.Module):
         )
         self.backbone = nn.Module()
         self.backbone.layers = nn.ModuleList([self._create_layer() for _ in range(2)])
+        self.supports = SimpleNamespace(
+            mtp_enabled=False,
+            supports_mtp_cp=False,
+            supports_mtp_cp_pp=False,
+        )
         self.__class__.__name__ = "NemotronHForCausalLM"
 
     def _create_layer(self):

--- a/tests/unit_tests/loss/test_mtp_cross_boundary.py
+++ b/tests/unit_tests/loss/test_mtp_cross_boundary.py
@@ -111,6 +111,78 @@ def _run_capture(
     return cap.captured_labels
 
 
+def test_precomputed_targets_preserve_global_shift_after_context_parallel_sharding():
+    """CP-local targets are consumed directly instead of rolled in local order."""
+    labels = torch.tensor([10, 12, 21, 23], dtype=torch.long)
+    mtp_per_depth_h = [torch.zeros((4, 3), requires_grad=True) for _ in range(2)]
+    precomputed_targets = [
+        torch.tensor([11, IGNORE, 22, IGNORE]),
+        torch.tensor([12, IGNORE, 23, IGNORE]),
+    ]
+    cap = _CaptureLoss()
+
+    with mock.patch("nemo_automodel.components.loss.mtp.calculate_loss", side_effect=lambda loss_fn, **kw: cap(**kw)):
+        calculate_mtp_loss(
+            loss_fn=mock.MagicMock(),
+            mtp_per_depth_h=mtp_per_depth_h,
+            mtp_per_depth_targets=precomputed_targets,
+            labels=labels,
+            model=mock.MagicMock(),
+            scaling_factor=1.0,
+        )
+
+    assert len(cap.captured_labels) == 2
+    for actual, expected in zip(cap.captured_labels, precomputed_targets):
+        torch.testing.assert_close(actual, expected)
+
+
+def test_precomputed_target_count_must_match_mtp_depth():
+    labels = torch.zeros(4, dtype=torch.long)
+
+    with pytest.raises(ValueError, match="Expected 2 mtp_per_depth_targets"):
+        calculate_mtp_loss(
+            loss_fn=mock.MagicMock(),
+            mtp_per_depth_h=[torch.zeros(4, 3), torch.zeros(4, 3)],
+            mtp_per_depth_targets=[torch.zeros(4, dtype=torch.long)],
+            labels=labels,
+            model=mock.MagicMock(),
+        )
+
+
+def test_precomputed_target_shape_must_match_local_labels():
+    labels = torch.zeros(4, dtype=torch.long)
+
+    with pytest.raises(ValueError, match="target shape .* does not match labels shape"):
+        calculate_mtp_loss(
+            loss_fn=mock.MagicMock(),
+            mtp_per_depth_h=[torch.zeros(4, 3)],
+            mtp_per_depth_targets=[torch.zeros(5, dtype=torch.long)],
+            labels=labels,
+            model=mock.MagicMock(),
+        )
+
+
+@pytest.mark.parametrize(
+    "sequence_metadata",
+    [
+        {"cu_seqlens": torch.tensor([0, 4], dtype=torch.int32)},
+        {"seq_idx": torch.zeros(4, dtype=torch.long)},
+    ],
+)
+def test_precomputed_targets_are_mutually_exclusive_with_sequence_metadata(sequence_metadata):
+    labels = torch.zeros(4, dtype=torch.long)
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        calculate_mtp_loss(
+            loss_fn=mock.MagicMock(),
+            mtp_per_depth_h=[torch.zeros(4, 3)],
+            mtp_per_depth_targets=[torch.zeros(4, dtype=torch.long)],
+            labels=labels,
+            model=mock.MagicMock(),
+            **sequence_metadata,
+        )
+
+
 def test_cross_boundary_masked_via_seq_idx_1d():
     """Two 4-token sub-seqs in an 8-token packed sample. With seq_idx supplied
     directly, depth-0 must mask position 3 (rolls into sub-seq 1); depth-1 must

--- a/tests/unit_tests/models/common/test_mtp_rolling.py
+++ b/tests/unit_tests/models/common/test_mtp_rolling.py
@@ -26,10 +26,17 @@ covered separately by ``tests/unit_tests/loss/test_mtp_cross_boundary.py``.
 
 from __future__ import annotations
 
+import pytest
 import torch
 import torch.nn as nn
 
-from nemo_automodel.components.models.common.mtp.mtp import MTPConfig, MTPModule, roll_tensor
+from nemo_automodel.components.models.common.mtp.mtp import (
+    MTPConfig,
+    MTPModule,
+    prepare_mtp_context_parallel_inputs,
+    roll_tensor,
+    shift_packed_tensor,
+)
 
 
 class _RecordingSublayer(nn.Module):
@@ -192,6 +199,89 @@ def test_precomputed_embed_inputs_path_skips_token_rolling():
         assert got_pos == expected_pos, f"depth {depth}: position_ids rolling expected on embed_inputs path"
 
 
+def test_precomputed_input_ids_skip_rank_local_rolling():
+    """CP callers can embed globally shifted IDs already in local shard order."""
+    mtp = _build_module(num_depths=2, pattern_length=1)
+    local_input_ids_per_depth = (
+        torch.tensor([2, 3, 8, 0], dtype=torch.long),
+        torch.tensor([3, 4, 0, 0], dtype=torch.long),
+    )
+    local_position_ids_per_depth = (
+        torch.tensor([1, 2, 7, 0], dtype=torch.long),
+        torch.tensor([2, 3, 0, 0], dtype=torch.long),
+    )
+    hidden = torch.zeros(4, 3)
+
+    mtp(
+        hidden,
+        input_ids_per_depth=local_input_ids_per_depth,
+        embed_fn=_embed_fn_identity,
+        position_ids_per_depth=local_position_ids_per_depth,
+    )
+
+    for depth in range(2):
+        got_ids = mtp.layers[depth].calls[0]["embed_input"].squeeze(-1).to(torch.long)
+        torch.testing.assert_close(got_ids, local_input_ids_per_depth[depth])
+
+
+def test_precomputed_input_ids_require_precomputed_position_ids():
+    mtp = _build_module(num_depths=2, pattern_length=1)
+
+    with pytest.raises(ValueError, match="input_ids_per_depth and position_ids_per_depth must be provided together"):
+        mtp(
+            torch.zeros(4, 3),
+            input_ids_per_depth=(torch.arange(4), torch.arange(4)),
+            embed_fn=_embed_fn_identity,
+        )
+
+
+def test_precomputed_position_ids_skip_rank_local_rolling():
+    """CP callers can provide globally shifted positions in local shard order."""
+    mtp = _build_module(num_depths=2, pattern_length=1)
+    embeddings = (torch.full((4, 3), 11.0), torch.full((4, 3), 22.0))
+    local_position_ids = torch.tensor([0, 1, 6, 7], dtype=torch.long)
+    position_ids_per_depth = (
+        torch.tensor([1, 2, 7, 8], dtype=torch.long),
+        torch.tensor([2, 3, 8, 9], dtype=torch.long),
+    )
+    hidden = torch.zeros(4, 3)
+
+    mtp(
+        hidden,
+        embed_inputs=embeddings,
+        position_ids=local_position_ids,
+        position_ids_per_depth=position_ids_per_depth,
+    )
+
+    for depth in range(2):
+        torch.testing.assert_close(mtp.layers[depth].calls[0]["embed_input"], embeddings[depth])
+        torch.testing.assert_close(mtp.layers[depth].calls[0]["position_ids"], position_ids_per_depth[depth])
+
+
+def test_precomputed_position_ids_reject_rank_local_token_rolling():
+    mtp = _build_module(num_depths=2, pattern_length=1)
+
+    with pytest.raises(ValueError, match="cannot be combined with rank-local input_ids rolling"):
+        mtp(
+            torch.zeros(4, 3),
+            input_ids=torch.arange(4),
+            embed_fn=_embed_fn_identity,
+            position_ids_per_depth=(torch.arange(4), torch.arange(4)),
+        )
+
+
+def test_precomputed_position_id_count_must_match_depth():
+    mtp = _build_module(num_depths=2, pattern_length=1)
+
+    with pytest.raises(ValueError, match="position_ids_per_depth length 1 does not match num_depths 2"):
+        mtp(
+            torch.zeros(4, 3),
+            embed_inputs=(torch.zeros(4, 3), torch.zeros(4, 3)),
+            position_ids=torch.arange(4),
+            position_ids_per_depth=(torch.arange(4),),
+        )
+
+
 def test_trailing_positions_zero_after_roll():
     """The roll is left-shift with trailing zeros (not wrap-around). At depth
     k, the last ``k+1`` slots of the rolled tensor are zero — these are the
@@ -211,3 +301,189 @@ def test_trailing_positions_zero_after_roll():
         )
         # The remaining prefix should match the original IDs shifted by n_trailing.
         assert ids[:-n_trailing] == input_ids[n_trailing:].tolist()
+
+
+def test_precomputed_position_id_shape_checked_without_base_positions():
+    mtp = _build_module(num_depths=2, pattern_length=1)
+    embeddings = (torch.zeros(4, 3), torch.zeros(4, 3))
+
+    with pytest.raises(ValueError, match=r"MTP depth 2 position_ids shape \(1, 4\).*token shape \(4,\)"):
+        mtp(
+            torch.zeros(4, 3),
+            embed_inputs=embeddings,
+            position_ids_per_depth=(torch.arange(4), torch.arange(4).unsqueeze(0)),
+        )
+
+
+def test_shift_packed_tensor_masks_trailing_and_cross_sequence_positions():
+    values = torch.tensor([[10, 11, 12, 20, 21, 22]])
+    seq_idx = torch.tensor([[0, 0, 0, 1, 1, 1]])
+
+    depth_1 = shift_packed_tensor(values, depth=1, seq_idx=seq_idx, fill_value=-1)
+    depth_2 = shift_packed_tensor(values, depth=2, seq_idx=seq_idx, fill_value=-1)
+
+    assert depth_1.tolist() == [[11, 12, -1, 21, 22, -1]]
+    assert depth_2.tolist() == [[12, -1, -1, 22, -1, -1]]
+
+
+def test_shift_packed_tensor_supports_trailing_feature_dimensions():
+    values = torch.arange(12).reshape(1, 3, 4)
+    shifted = shift_packed_tensor(values, depth=1, fill_value=-1)
+
+    assert torch.equal(shifted[:, :2], values[:, 1:])
+    assert shifted[:, -1].tolist() == [[-1, -1, -1, -1]]
+
+
+class TestMTPContextParallelPreparation:
+    @staticmethod
+    def _prepare(batch, *, num_depths=2):
+        return prepare_mtp_context_parallel_inputs(
+            batch,
+            num_depths=num_depths,
+            ignore_index=-100,
+        )
+
+    def test_prepares_all_depths_in_global_packed_order(self):
+        batch = {
+            "input_ids": torch.tensor([[10, 11, 12, 20, 21, 22]]),
+            "labels": torch.tensor([[11, 12, -100, 21, 22, -100]]),
+            "position_ids": torch.tensor([[0, 1, 2, 0, 1, 2]]),
+            "_packed_seq_ids": torch.tensor([[1, 1, 1, 2, 2, 2]]),
+        }
+
+        prepared = self._prepare(batch)
+
+        assert [tensor.tolist() for tensor in prepared.input_ids] == [
+            [[11, 12, 0, 21, 22, 0]],
+            [[12, 0, 0, 22, 0, 0]],
+        ]
+        assert [tensor.tolist() for tensor in prepared.position_ids] == [
+            [[1, 2, 0, 1, 2, 0]],
+            [[2, 0, 0, 2, 0, 0]],
+        ]
+        assert [tensor.tolist() for tensor in prepared.targets] == [
+            [[12, -100, -100, 22, -100, -100]],
+            [[-100, -100, -100, -100, -100, -100]],
+        ]
+        assert [tensor.tolist() for tensor in prepared.valid_masks] == [
+            [[True, True, False, True, True, False]],
+            [[True, False, False, True, False, False]],
+        ]
+        assert prepared.position_ids_seq_dim == 1
+
+    def test_multi_axis_positions_shift_on_the_sequence_axis(self):
+        batch = {
+            "input_ids": torch.tensor([[10, 11, 12, 13]]),
+            "labels": torch.tensor([[11, 12, 13, -100]]),
+            "position_ids": torch.tensor(
+                [
+                    [[0, 1, 2, 3]],
+                    [[10, 11, 12, 13]],
+                    [[20, 21, 22, 23]],
+                ]
+            ),
+        }
+
+        prepared = self._prepare(batch, num_depths=1)
+
+        assert prepared.position_ids_seq_dim == 2
+        assert prepared.position_ids[0].tolist() == [
+            [[1, 2, 3, 0]],
+            [[11, 12, 13, 0]],
+            [[21, 22, 23, 0]],
+        ]
+        assert prepared.valid_masks[0].tolist() == [[True, True, True, False]]
+
+    def test_raw_thd_lengths_mask_boundaries_before_sharding(self):
+        batch = {
+            "input_ids": torch.tensor([[10, 11, 12, 20, 21, 22]]),
+            "labels": torch.tensor([[11, 12, -100, 21, 22, -100]]),
+            "position_ids": torch.tensor([[0, 1, 2, 0, 1, 2]]),
+            "seq_lens": torch.tensor([[3, 3, -1000]]),
+            "seq_lens_padded": torch.tensor([[3, 3, -1000]]),
+        }
+
+        prepared = self._prepare(batch, num_depths=1)
+
+        assert prepared.input_ids[0].tolist() == [[11, 12, 0, 21, 22, 0]]
+        assert prepared.position_ids[0].tolist() == [[1, 2, 0, 1, 2, 0]]
+        assert prepared.targets[0].tolist() == [[12, -100, -100, 22, -100, -100]]
+
+    def test_seq_lens_padded_must_cover_materialized_layout(self):
+        batch = {
+            "input_ids": torch.tensor([[10, 11, 12, 20, 21, 22]]),
+            "labels": torch.tensor([[11, 12, -100, 21, 22, -100]]),
+            "seq_lens_padded": torch.tensor([[2, 2, -1000]]),
+        }
+
+        with pytest.raises(ValueError, match="must cover exactly the input sequence length 6"):
+            self._prepare(batch, num_depths=1)
+
+    def test_missing_position_ids_are_synthesized_globally_before_sharding(self):
+        batch = {
+            "input_ids": torch.tensor([[10, 11, 12, 13, 14, 15]]),
+            "labels": torch.tensor([[11, 12, 13, 14, 15, -100]]),
+        }
+
+        prepared = self._prepare(batch, num_depths=1)
+
+        assert batch["position_ids"].tolist() == [[0, 1, 2, 3, 4, 5]]
+        assert prepared.position_ids[0].tolist() == [[1, 2, 3, 4, 5, 0]]
+
+    def test_cu_seqlens_padded_preserves_inter_sequence_padding(self):
+        batch = {
+            "input_ids": torch.tensor([[10, 11, 12, 0, 20, 21, 22, 0]]),
+            "labels": torch.tensor([[11, 12, -100, -100, 21, 22, -100, -100]]),
+            "cu_seqlens": torch.tensor([0, 3, 6], dtype=torch.int32),
+            "cu_seqlens_padded": torch.tensor([0, 4, 8], dtype=torch.int32),
+        }
+
+        prepared = self._prepare(batch, num_depths=1)
+
+        assert prepared.input_ids[0].tolist() == [[11, 12, 0, 0, 21, 22, 0, 0]]
+        assert prepared.targets[0].tolist() == [[12, -100, -100, -100, 22, -100, -100, -100]]
+
+    def test_shared_position_ids_expand_to_batch_before_shifting(self):
+        batch = {
+            "input_ids": torch.tensor([[10, 11, 12, 13], [20, 21, 22, 23]]),
+            "labels": torch.tensor([[11, 12, 13, -100], [21, 22, 23, -100]]),
+            "position_ids": torch.tensor([[0, 1, 2, 3]]),
+        }
+
+        prepared = self._prepare(batch, num_depths=1)
+
+        assert batch["position_ids"].tolist() == [[0, 1, 2, 3], [0, 1, 2, 3]]
+        assert prepared.position_ids[0].tolist() == [[1, 2, 3, 0], [1, 2, 3, 0]]
+
+    def test_cu_seqlens_masks_boundaries_and_ignores_padding_sentinels(self):
+        batch = {
+            "input_ids": torch.tensor([[10, 11, 12, 20, 21, 22]]),
+            "labels": torch.tensor([[11, 12, -100, 21, 22, -100]]),
+            "cu_seqlens": torch.tensor([[0, 3, 6, -1000]]),
+        }
+
+        prepared = self._prepare(batch, num_depths=1)
+
+        assert prepared.input_ids[0].tolist() == [[11, 12, 0, 21, 22, 0]]
+        assert prepared.position_ids[0].tolist() == [[1, 2, 0, 4, 5, 0]]
+        assert prepared.targets[0].tolist() == [[12, -100, -100, 22, -100, -100]]
+
+    def test_unpadded_cu_seqlens_rejects_padded_materialized_layout(self):
+        batch = {
+            "input_ids": torch.tensor([[10, 11, 12, 0, 20, 21, 22, 0]]),
+            "labels": torch.tensor([[11, 12, -100, -100, 21, 22, -100, -100]]),
+            "cu_seqlens": torch.tensor([0, 3, 6], dtype=torch.int32),
+        }
+
+        with pytest.raises(ValueError, match="provide cu_seqlens_padded"):
+            self._prepare(batch, num_depths=1)
+
+    def test_rejects_nonpositive_depth_count(self):
+        with pytest.raises(ValueError, match="num_depths must be positive"):
+            self._prepare(
+                {
+                    "input_ids": torch.tensor([[10, 11]]),
+                    "labels": torch.tensor([[11, -100]]),
+                },
+                num_depths=0,
+            )

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_cp.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_cp.py
@@ -28,6 +28,7 @@ do not load the 30B real model.
 
 from __future__ import annotations
 
+import sys
 from types import SimpleNamespace
 
 import torch
@@ -148,6 +149,53 @@ def test_prepare_model_inputs_for_cp_is_sharder_only():
     assert sharder.local_token_global_indices is round_robin_local_indices
     # nothing consumed: input_ids / media stay for the forward
     assert batch["input_ids"] is input_ids and "pixel_values" in batch
+
+
+def test_prepare_model_inputs_for_cp_records_global_media_masks_for_thd():
+    """Packed THD defers sharding and records global image/sound placeholder masks."""
+    model = _make_omni_stub()
+    input_ids = torch.tensor([[1, IMG_TOKEN_ID, SOUND_TOKEN_ID, 4]])
+
+    out = model.prepare_model_inputs_for_cp({"input_ids": input_ids, "qkv_format": "thd"})
+
+    assert set(out) == {"_nemotron_omni_global_image_mask", "_nemotron_omni_global_sound_mask"}
+    assert out["_nemotron_omni_global_image_mask"].tolist() == [False, True, False, False]
+    assert out["_nemotron_omni_global_sound_mask"].tolist() == [False, False, True, False]
+
+
+def test_select_local_media_features_maps_global_placeholders_to_local_rows(monkeypatch):
+    """The local THD token order selects the matching global media-feature rows."""
+
+    def _partition_indices(
+        cu_seqlens: torch.Tensor,
+        total_tokens: int,
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        """Return a fixed Tensor of shape [local_tokens] for one global THD sequence."""
+        assert cu_seqlens.tolist() == [0, 8]
+        assert (total_tokens, cp_size, cp_rank) == (8, 2, 0)
+        return torch.tensor([0, 1, 6, 7])
+
+    monkeypatch.setitem(
+        sys.modules,
+        "transformer_engine_torch",
+        SimpleNamespace(thd_get_partitioned_indices=_partition_indices),
+    )
+    features = torch.tensor([[10.0], [20.0], [30.0], [40.0]])
+    global_mask = torch.tensor([False, True, True, False, False, True, True, False])
+    local_selected = torch.tensor([False, True, True, False])
+
+    local = NemotronOmniForConditionalGeneration._select_local_media_features(
+        features,
+        global_mask,
+        local_selected,
+        torch.tensor([0, 8], dtype=torch.int32),
+        cp_size=2,
+        cp_rank=0,
+    )
+
+    torch.testing.assert_close(local, torch.tensor([[10.0], [40.0]]))
 
 
 def test_forward_text_only_embeds():

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_mtp_plumbing.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_mtp_plumbing.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NemotronOmni exposes the wrapped NemotronV3 LM's MTP head to the recipe.
+
+The recipe decides whether to compute the MTP loss from ``model.supports.mtp_enabled``
+(reads ``model.mtp_config``) and, under context parallelism, requires
+``supports_mtp_cp`` plus ``prepare_mtp_inputs_for_cp``. The omni wrapper delegates
+all three to its language model.
+"""
+
+from types import SimpleNamespace
+
+from nemo_automodel.components.models.nemotron_omni.model import NemotronOmniForConditionalGeneration
+
+
+def _bare_omni_with_lm(lm):
+    model = NemotronOmniForConditionalGeneration.__new__(NemotronOmniForConditionalGeneration)
+    # nn.Module.__setattr__ needs the module machinery; bypass it for a stub LM.
+    object.__setattr__(model, "language_model", lm)
+    return model
+
+
+def test_mtp_config_and_cp_prep_delegate_to_language_model():
+    calls = []
+
+    def prepare(batch, *, ignore_index=-100):
+        calls.append((batch, ignore_index))
+        return "prepared"
+
+    lm = SimpleNamespace(mtp_config=SimpleNamespace(enabled=True, num_layers=1), prepare_mtp_inputs_for_cp=prepare)
+    model = _bare_omni_with_lm(lm)
+
+    assert model.mtp_config.enabled is True
+    assert model.prepare_mtp_inputs_for_cp({"input_ids": None}, ignore_index=-7) == "prepared"
+    assert calls == [({"input_ids": None}, -7)]
+
+
+def test_mtp_config_absent_when_language_model_has_none():
+    model = _bare_omni_with_lm(SimpleNamespace())
+    assert model.mtp_config is None
+
+
+def test_declares_mtp_cp_support():
+    assert NemotronOmniForConditionalGeneration.ModelCapabilities().supports_mtp_cp is True

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_state_dict_adapter.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_state_dict_adapter.py
@@ -42,6 +42,7 @@ def adapter():
     a.moe_config = MagicMock()
     a.backend = MagicMock()
     a.dtype = torch.bfloat16
+    a.vision_uses_native_radio = False
     # Echo input keys through unchanged — lets us verify *only* the
     # NemotronOmni-side key handling without depending on NemotronV3 internals.
     a._llm_adapter = MagicMock()
@@ -222,3 +223,78 @@ def test_mapping_tables_are_inverses():
     for hf_key, custom_key in _VISION_PROJ_HF_TO_CUSTOM.items():
         assert _VISION_PROJ_CUSTOM_TO_HF[custom_key] == hf_key
     assert len(_VISION_PROJ_HF_TO_CUSTOM) == len(_VISION_PROJ_CUSTOM_TO_HF)
+
+
+# ---------------------------------------------------------------------------
+# Native RadioModel remap (NemotronH_Omni_Reasoning_V3 / Super-scale omni)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def native_adapter():
+    """Adapter configured for a checkpoint whose vision tower is the native RadioModel."""
+    a = NemotronOmniStateDictAdapter.__new__(NemotronOmniStateDictAdapter)
+    a.config = MagicMock()
+    a.llm_config = MagicMock()
+    a.moe_config = MagicMock()
+    a.backend = MagicMock()
+    a.dtype = torch.bfloat16
+    a.vision_uses_native_radio = True
+    a._llm_adapter = MagicMock()
+    a._llm_adapter.from_hf.side_effect = lambda sd, **kwargs: dict(sd)
+    a._llm_adapter.to_hf.side_effect = lambda sd, **kwargs: dict(sd)
+    a._llm_adapter.convert_single_tensor_to_hf.side_effect = lambda fqn, tensor, **kwargs: [(fqn, tensor)]
+    return a
+
+
+def test_from_hf_renames_legacy_radio_keys_to_native(native_adapter):
+    """Legacy ``radio_model.model.blocks``/``patch_generator`` keys remap to the native tree."""
+    hf_sd = {
+        "vision_model.radio_model.model.blocks.0.norm1.weight": torch.zeros(2),
+        "vision_model.radio_model.model.blocks.0.attn.proj.weight": torch.zeros(2, 2),
+        "vision_model.radio_model.model.patch_generator.cls_token.token": torch.zeros(1),
+        "vision_model.radio_model.input_conditioner.norm_mean": torch.zeros(3),
+    }
+    out = native_adapter.from_hf(dict(hf_sd))
+
+    assert "vision_model.encoder.layer.0.norm1.weight" in out
+    assert "vision_model.encoder.layer.0.attention.output.dense.weight" in out
+    assert "vision_model.embeddings.cls_register_token" in out
+    assert "vision_model.input_conditioner.norm_mean" in out
+    assert not any("radio_model" in k for k in out)
+
+
+def test_from_hf_splits_fused_qkv_for_native_radio(native_adapter):
+    """A fused ``attn.qkv`` tensor splits into three native query/key/value tensors."""
+    qkv = torch.arange(9 * 2, dtype=torch.float32).reshape(9, 2)  # 3 chunks of 3 rows each
+    hf_sd = {"vision_model.radio_model.model.blocks.0.attn.qkv.weight": qkv}
+    out = native_adapter.from_hf(dict(hf_sd))
+
+    q_key = "vision_model.encoder.layer.0.attention.attention.query.weight"
+    k_key = "vision_model.encoder.layer.0.attention.attention.key.weight"
+    v_key = "vision_model.encoder.layer.0.attention.attention.value.weight"
+    assert q_key in out and k_key in out and v_key in out
+    assert torch.equal(out[q_key], qkv[0:3])
+    assert torch.equal(out[k_key], qkv[3:6])
+    assert torch.equal(out[v_key], qkv[6:9])
+
+
+def test_native_radio_round_trip(native_adapter):
+    """from_hf -> to_hf recovers the original legacy keys, shapes, and values (incl. fused qkv)."""
+    hf_sd = {
+        "vision_model.radio_model.model.blocks.0.norm1.weight": torch.randn(4),
+        "vision_model.radio_model.model.blocks.0.attn.qkv.weight": torch.randn(9, 4),
+        "vision_model.radio_model.model.patch_generator.pos_embed": torch.randn(2, 4),
+    }
+    custom_sd = native_adapter.from_hf(dict(hf_sd))
+    round_tripped = native_adapter.to_hf(dict(custom_sd))
+
+    assert set(round_tripped) == set(hf_sd)
+    for key, value in hf_sd.items():
+        assert torch.equal(round_tripped[key], value)
+
+
+def test_supports_write_through_checkpoint_load_false_for_native_radio(native_adapter):
+    """Native RadioModel's fused-qkv split changes cardinality; write-through must be disabled."""
+    native_adapter._llm_adapter.supports_write_through_checkpoint_load = True
+    assert native_adapter.supports_write_through_checkpoint_load is False

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_var_res_tiles.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_var_res_tiles.py
@@ -1,0 +1,239 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for the tile-based vision path on mixed-resolution batches.
+
+`nemotron_omni_collate_fn` cannot stack images of differing resolutions, so it
+hands `forward()` a *list* of per-image tensors instead of a dense
+[num_tiles, C, H, W] tensor. That happens for any variable-resolution dataset
+(e.g. CORD-V2) as soon as `local_batch_size > 1`. The vision tower and LM are
+mocked so these tests stay CPU-only and don't need RADIO weights.
+"""
+
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from nemo_automodel.components.models.nemotron_omni.model import (
+    NemotronOmniForConditionalGeneration,
+)
+
+
+class _StubVisionModel(nn.Module):
+    """Dense-only vision tower, matching HF RADIO: it accepts a single
+    [B, C, H, W] tensor and returns (H//p)*(W//p) patch features per image."""
+
+    def __init__(self, patch_size: int, c_feat: int):
+        super().__init__()
+        self.patch_size = patch_size
+        self.c_feat = c_feat
+        self.dummy = nn.Parameter(torch.zeros(1))
+        self.received_shapes: list[tuple[int, int, int]] = []
+        # extract_feature reads the patch size off this attribute chain.
+        self.radio_model = SimpleNamespace(
+            model=SimpleNamespace(patch_generator=SimpleNamespace(patch_size=patch_size))
+        )
+
+    def forward(self, x: torch.Tensor):
+        assert isinstance(x, torch.Tensor), "RADIO only accepts a dense tensor"
+        b, _, h, w = x.shape
+        self.received_shapes.append((b, h, w))
+        length = (h // self.patch_size) * (w // self.patch_size)
+        # Fill with a per-resolution marker so callers can verify which image's
+        # features landed in which slot. Values stay exact in bfloat16.
+        return SimpleNamespace(features=torch.full((b, length, self.c_feat), _marker(h, w), dtype=torch.float32))
+
+
+def _marker(h: int, w: int) -> float:
+    """Small, bfloat16-exact value identifying an (h, w) image."""
+    return float((h // 8) * 10 + (w // 8))
+
+
+class _IdentityProjector(nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x
+
+
+class _StubLM(nn.Module):
+    """Mocks just enough of NemotronV3ForCausalLM for forward() to run."""
+
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.captured_inputs_embeds: torch.Tensor | None = None
+        self.embed = nn.Embedding(32, hidden_size)
+
+    def get_input_embeddings(self):
+        return self.embed
+
+    def forward(self, *, inputs_embeds=None, **kwargs):
+        self.captured_inputs_embeds = inputs_embeds.detach().clone()
+        from transformers.modeling_outputs import CausalLMOutputWithPast
+
+        return CausalLMOutputWithPast(loss=None, logits=inputs_embeds)
+
+
+def _make_model_stub(*, patch_size=2, downsample_ratio=0.5, c_feat=16, img_token_id=18, hidden=64):
+    """Bare NemotronOmniForConditionalGeneration with only the attributes the
+    tile-based path touches. Skips the heavy __init__ (RADIO + LM)."""
+    self = object.__new__(NemotronOmniForConditionalGeneration)
+    nn.Module.__init__(self)
+    self.patch_size = patch_size
+    self.downsample_ratio = downsample_ratio
+    self.img_context_token_id = img_token_id
+    self.ps_version = "v2"
+    self.vision_model = _StubVisionModel(patch_size, c_feat)
+    self.vision_projector = _IdentityProjector()
+    self.language_model = _StubLM(hidden_size=hidden)
+    return self
+
+
+def _num_tokens(h: int, w: int, patch_size: int = 2, downsample_ratio: float = 0.5) -> int:
+    """Image-slot embeddings produced for an (h, w) image by the tile path."""
+    return int((h // patch_size) * downsample_ratio) * int((w // patch_size) * downsample_ratio)
+
+
+# ---------------------------------------------------------------------------
+# extract_feature
+# ---------------------------------------------------------------------------
+
+
+def test_extract_feature_accepts_list_of_variable_shaped_tensors():
+    """The collate fn emits a list when resolutions differ; extract_feature must
+    run the (dense-only) vision tower once per image and keep the per-image
+    token counts, which depend on resolution."""
+    model = _make_model_stub()
+
+    pixel_values = [torch.zeros(3, 8, 8), torch.zeros(3, 8, 16), torch.zeros(3, 16, 8)]
+    out = model.extract_feature(pixel_values)
+
+    assert isinstance(out, list) and len(out) == 3
+    assert model.vision_model.received_shapes == [(1, 8, 8), (1, 8, 16), (1, 16, 8)]
+    assert [tuple(o.shape) for o in out] == [
+        (1, _num_tokens(8, 8), 64),
+        (1, _num_tokens(8, 16), 64),
+        (1, _num_tokens(16, 8), 64),
+    ]
+    assert all(o.dtype == torch.bfloat16 for o in out)
+
+
+def test_extract_feature_dense_input_is_unchanged():
+    """Uniform-resolution batches still take the stacked-tensor path."""
+    model = _make_model_stub()
+
+    out = model.extract_feature(torch.zeros(2, 3, 8, 8))
+
+    assert isinstance(out, torch.Tensor)
+    assert tuple(out.shape) == (2, _num_tokens(8, 8), 64)
+    # A single dense call, not one per image.
+    assert model.vision_model.received_shapes == [(2, 8, 8)]
+
+
+def test_extract_feature_list_restores_train_mode():
+    """The vision tower is force-evaled for deterministic spectral reparam; the
+    original mode must be restored, on the list path too."""
+    model = _make_model_stub()
+    model.vision_model.train()
+
+    model.extract_feature([torch.zeros(3, 8, 8), torch.zeros(3, 8, 16)])
+
+    assert model.vision_model.training, "train mode should be restored"
+
+
+# ---------------------------------------------------------------------------
+# forward() tile-based branch
+# ---------------------------------------------------------------------------
+
+
+def test_forward_tile_branch_handles_mixed_resolution_list():
+    """Regression: `vit_batch_size = pixel_values.shape[0]` raised
+    AttributeError ('list' object has no attribute 'shape') for any
+    variable-resolution batch with local_batch_size > 1."""
+    img, txt = 18, 5
+    model = _make_model_stub(img_token_id=img, hidden=64)
+
+    sizes = [(8, 8), (8, 16), (16, 8)]
+    n_img_tokens = sum(_num_tokens(h, w) for h, w in sizes)
+    assert n_img_tokens == 20
+
+    # 2 samples; image slots split 12 / 8 across the batch, padded with text.
+    seq = 14
+    input_ids = torch.full((2, seq), txt, dtype=torch.long)
+    input_ids[0, 1:13] = img
+    input_ids[1, 2:10] = img
+    assert int((input_ids == img).sum()) == n_img_tokens
+
+    pixel_values = [torch.zeros(3, h, w) for h, w in sizes]
+    image_flags = torch.ones(len(sizes), 1, dtype=torch.long)
+
+    text_mask = input_ids != img
+    pre_scatter = model.language_model.get_input_embeddings()(input_ids)
+    expected_text = pre_scatter[text_mask].clone()
+
+    model(input_ids=input_ids, pixel_values=pixel_values, image_flags=image_flags)
+
+    final = model.language_model.captured_inputs_embeds
+    assert final is not None
+    assert final.shape == (2, seq, 64)
+    # Each image was run separately at its own resolution.
+    assert model.vision_model.received_shapes == [(1, 8, 8), (1, 8, 16), (1, 16, 8)]
+    # Text positions untouched.
+    torch.testing.assert_close(final[text_mask], expected_text.to(final.dtype))
+    # Image slots hold each image's features, in order and un-truncated. A
+    # partial scatter is silently caught-and-warned in forward(), so assert on
+    # the values rather than just "something changed".
+    expected_img = torch.cat([torch.full((_num_tokens(h, w) * 64,), _marker(h, w)) for h, w in sizes])
+    torch.testing.assert_close(final[~text_mask].flatten().float(), expected_img)
+
+
+def test_forward_tile_branch_list_respects_image_flags():
+    """image_flags=0 marks padding images; on the list path those must be
+    dropped per image rather than by indexing a stacked tensor."""
+    img, txt = 18, 5
+    model = _make_model_stub(img_token_id=img, hidden=64)
+
+    # Only the first two images are real: 4 + 8 = 12 image slots.
+    sizes = [(8, 8), (8, 16), (16, 8)]
+    image_flags = torch.tensor([[1], [1], [0]], dtype=torch.long)
+    n_img_tokens = _num_tokens(8, 8) + _num_tokens(8, 16)
+
+    seq = 14
+    input_ids = torch.full((1, seq), txt, dtype=torch.long)
+    input_ids[0, 1 : 1 + n_img_tokens] = img
+    assert int((input_ids == img).sum()) == 12
+
+    pixel_values = [torch.zeros(3, h, w) for h, w in sizes]
+
+    text_mask = input_ids != img
+    pre_scatter = model.language_model.get_input_embeddings()(input_ids)
+    expected_text = pre_scatter[text_mask].clone()
+
+    model(input_ids=input_ids, pixel_values=pixel_values, image_flags=image_flags)
+
+    final = model.language_model.captured_inputs_embeds
+    assert final.shape == (1, seq, 64)
+    torch.testing.assert_close(final[text_mask], expected_text.to(final.dtype))
+    # Only the two flagged images contribute; the (16, 8) marker must not appear.
+    expected_img = torch.cat([torch.full((_num_tokens(h, w) * 64,), _marker(h, w)) for h, w in sizes[:2]])
+    torch.testing.assert_close(final[~text_mask].flatten().float(), expected_img)
+
+
+def test_forward_tile_branch_single_image_list_synthesizes_one_flag():
+    """A one-image variable-resolution pack works when image_flags is absent."""
+    img, txt = 18, 5
+    model = _make_model_stub(img_token_id=img, hidden=64)
+
+    input_ids = torch.tensor([[txt, img, img, img, img, txt]])
+    pixel_values = [torch.zeros(3, 8, 8)]
+
+    model(input_ids=input_ids, pixel_values=pixel_values)
+
+    final = model.language_model.captured_inputs_embeds
+    assert final is not None
+    assert final.shape == (1, 6, 64)
+    torch.testing.assert_close(final[0, 1:5].float(), torch.full((4, 64), _marker(8, 8)))

--- a/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_layers.py
+++ b/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_layers.py
@@ -709,6 +709,81 @@ class TestMambaMixerSeqIdxConstruction:
         assert seq_idx[0, :8].tolist() == [0] * 8
         assert seq_idx[0, 8:].tolist() == [1] * 8
 
+    def test_cp_bshd_uses_sequence_transport_while_preserving_packed_seq_idx(self, monkeypatch, config):
+        """BSHD packing metadata must not select the CP helper's 2D THD path."""
+        import sys
+        import types
+
+        from nemo_automodel.components.models.nemotron_v3.layers import NemotronV3Mamba2Mixer
+
+        mixer = NemotronV3Mamba2Mixer(config, layer_idx=0)
+        calls: dict[str, object] = {}
+
+        class FakeCP:
+            cp_size = 2
+            n_groups_local = mixer.n_groups
+
+            def pre_conv_ssm(self, tensor, *, cu_seqlens=None):
+                calls["pre_cu_seqlens"] = cu_seqlens
+                calls["pre_shape"] = tensor.shape
+                return tensor
+
+            def post_conv_ssm(self, tensor, *, cu_seqlens=None):
+                calls["post_cu_seqlens"] = cu_seqlens
+                return tensor
+
+            @staticmethod
+            def get_A_log(tensor):
+                return tensor
+
+            @staticmethod
+            def get_dt_bias(tensor):
+                return tensor
+
+            @staticmethod
+            def get_D(tensor):
+                return tensor
+
+            def get_conv1d_weight(self):
+                return mixer.conv1d.weight.squeeze(1)
+
+            def get_conv1d_bias(self):
+                return mixer.conv1d.bias
+
+        def fake_kernel(projected_states, *args, **kwargs):
+            del args
+            calls["seq_idx"] = kwargs["seq_idx"]
+            return projected_states[..., : mixer.intermediate_size]
+
+        for name in ("mamba_ssm", "mamba_ssm.ops", "mamba_ssm.ops.triton"):
+            if name not in sys.modules:
+                monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+        fake_ssd = types.ModuleType("mamba_ssm.ops.triton.ssd_combined")
+        fake_ssd.mamba_split_conv1d_scan_combined = fake_kernel
+        monkeypatch.setitem(sys.modules, "mamba_ssm.ops.triton.ssd_combined", fake_ssd)
+
+        class GateIdentity(torch.nn.Module):
+            def forward(self, tensor, gate=None):
+                del gate
+                return tensor
+
+        mixer.norm = GateIdentity()
+        mixer.cp = FakeCP()
+        hidden_states = torch.randn(1, 8, config.hidden_size)
+        cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)
+
+        output = mixer(hidden_states, cu_seqlens=cu_seqlens)
+
+        assert output.shape == hidden_states.shape
+        assert calls["pre_shape"] == mixer.in_proj(hidden_states).shape
+        assert calls["pre_cu_seqlens"] is None
+        assert calls["post_cu_seqlens"] is None
+        # The local BSHD shard has 8 positions, while CP=2 transport presents
+        # 16 positions to the kernel. cu_seqlens describes 8 real packed tokens;
+        # searchsorted assigns the trailing 8 CP-padding positions the sentinel
+        # sequence ID immediately after the two real documents.
+        assert calls["seq_idx"].tolist() == [[0] * 4 + [1] * 4 + [2] * 8]
+
     def test_bshd_b_gt_1_passes_through_upstream_seq_idx(self, monkeypatch, config):
         """If seq_idx is supplied upstream (e.g. via _packed_seq_ids), the
         construction path must NOT override it — neat-packing semantics."""

--- a/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_pp_mtp.py
+++ b/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_pp_mtp.py
@@ -295,7 +295,14 @@ class TestPPForward:
 
         activation = torch.zeros(1, 4, cfg.hidden_size, dtype=torch.bfloat16)
         mtp_embed = torch.randn(1, 4, cfg.hidden_size, dtype=torch.bfloat16)
-        out = model(activation, mtp_embed)
+        position_ids = torch.arange(4).unsqueeze(0)
+        mtp_position_ids = (torch.tensor([[1, 2, 3, 0]]),)
+        out = model(
+            activation,
+            mtp_embed,
+            position_ids=position_ids,
+            mtp_per_depth_position_ids=mtp_position_ids,
+        )
 
         assert isinstance(out, tuple)
         assert len(out) == 3  # (logits, mtp_per_depth_h[0], seq_idx)
@@ -305,8 +312,115 @@ class TestPPForward:
         # NOT via the input_ids/embed_fn path.
         assert "embed_inputs" in captured
         torch.testing.assert_close(captured["embed_inputs"][0], mtp_embed)
+        torch.testing.assert_close(captured["position_ids_per_depth"][0], mtp_position_ids[0])
         assert captured.get("input_ids") is None
         assert captured.get("embed_fn") is None
+
+    @pytest.mark.parametrize("missing", ["embeddings", "position_ids"])
+    def test_context_parallel_requires_paired_mtp_embeddings_and_positions(self, backend, missing):
+        model, cfg = _make_model(
+            backend,
+            mtp_layers=1,
+            mtp_layers_block_type=["attention", "moe"],
+        )
+        model.train()
+
+        def fake_inner(self, input_ids, **kwargs):
+            del self, kwargs
+            source = input_ids if input_ids is not None else inputs_embeds
+            return torch.ones(source.shape[0], source.shape[1], cfg.hidden_size, dtype=torch.bfloat16)
+
+        inputs_embeds = torch.zeros(1, 4, cfg.hidden_size, dtype=torch.bfloat16)
+        model.model.forward = types.MethodType(fake_inner, model.model)
+        mtp_embed_inputs = () if missing == "embeddings" else (inputs_embeds.clone(),)
+        mtp_position_ids = None if missing == "position_ids" else (torch.tensor([[1, 2, 3, 0]]),)
+
+        with pytest.raises(ValueError, match="requires exactly one of precomputed per-depth embeddings or input IDs"):
+            model(
+                None,
+                *mtp_embed_inputs,
+                inputs_embeds=inputs_embeds,
+                position_ids=torch.arange(4).unsqueeze(0),
+                mtp_per_depth_position_ids=mtp_position_ids,
+                cp_size=2,
+            )
+
+    def test_context_parallel_accepts_pre_sharded_mtp_input_ids(self, backend):
+        model, cfg = _make_model(
+            backend,
+            mtp_layers=1,
+            mtp_layers_block_type=["attention", "moe"],
+        )
+        model.train()
+        captured = {}
+
+        def fake_inner(self, input_ids, **kwargs):
+            del self, kwargs
+            return torch.ones(input_ids.shape[0], input_ids.shape[1], cfg.hidden_size, dtype=torch.bfloat16)
+
+        def fake_mtp_forward(self, **kwargs):
+            captured.update(kwargs)
+            return [kwargs["hidden_states"].clone()]
+
+        model.model.forward = types.MethodType(fake_inner, model.model)
+        model.mtp.forward = types.MethodType(fake_mtp_forward, model.mtp)
+
+        input_ids = torch.tensor([[10, 11, 20, 21]])
+        mtp_input_ids = (torch.tensor([[11, 12, 21, 0]]),)
+        position_ids = torch.tensor([[0, 1, 0, 1]])
+        mtp_position_ids = (torch.tensor([[1, 2, 1, 0]]),)
+
+        out = model(
+            input_ids,
+            position_ids=position_ids,
+            mtp_per_depth_input_ids=mtp_input_ids,
+            mtp_per_depth_position_ids=mtp_position_ids,
+            cp_size=2,
+        )
+
+        assert out.mtp_per_depth_h is not None
+        torch.testing.assert_close(captured["input_ids_per_depth"][0], mtp_input_ids[0])
+        torch.testing.assert_close(captured["position_ids_per_depth"][0], mtp_position_ids[0])
+        assert captured.get("input_ids") is None
+
+    def test_sdpa_thd_keeps_mtp_tensors_batched(self, backend):
+        model, cfg = _make_model(
+            backend,
+            mtp_layers=1,
+            mtp_layers_block_type=["attention", "moe"],
+        )
+        model.train()
+        model.model.embed_tokens = None
+        captured = {}
+
+        def fake_inner(self, input_ids, **kwargs):
+            del self, kwargs
+            return torch.ones(input_ids.shape[0], input_ids.shape[1], cfg.hidden_size, dtype=torch.bfloat16)
+
+        def fake_mtp_forward(self, **kwargs):
+            captured.update(kwargs)
+            return [kwargs["hidden_states"].clone()]
+
+        model.model.forward = types.MethodType(fake_inner, model.model)
+        model.mtp.forward = types.MethodType(fake_mtp_forward, model.mtp)
+
+        activation = torch.zeros(1, 4, cfg.hidden_size, dtype=torch.bfloat16)
+        mtp_embed = torch.randn(1, 4, cfg.hidden_size, dtype=torch.bfloat16)
+        position_ids = torch.arange(4).unsqueeze(0)
+        mtp_position_ids = (torch.tensor([[1, 2, 3, 0]]),)
+
+        model(
+            activation,
+            mtp_embed,
+            position_ids=position_ids,
+            mtp_per_depth_position_ids=mtp_position_ids,
+            qkv_format="thd",
+        )
+
+        assert captured["hidden_states"].shape == (1, 4, cfg.hidden_size)
+        assert captured["embed_inputs"][0].shape == (1, 4, cfg.hidden_size)
+        assert captured["position_ids"].shape == (1, 4)
+        assert captured["position_ids_per_depth"][0].shape == (1, 4)
 
     def test_final_stage_eval_emits_placeholders(self, backend):
         """In eval mode, the last stage keeps the (1 + D + seq_idx) tuple arity."""

--- a/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_mtp.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_mtp.py
@@ -73,6 +73,39 @@ def _backend():
 
 
 class TestQwen3_5MoeMTP:
+    def test_vlm_declares_mtp_cp_and_prepares_multi_axis_inputs(self):
+        model = Qwen3_5MoeForConditionalGeneration(_tiny_vl_config(mtp_num_hidden_layers=1), backend=_backend())
+        batch = {
+            "input_ids": torch.tensor([[10, 11, 20, 21]]),
+            "labels": torch.tensor([[11, 12, 21, 22]]),
+            "position_ids": torch.tensor(
+                [
+                    [[0, 1, 0, 1]],
+                    [[10, 11, 20, 21]],
+                    [[30, 31, 40, 41]],
+                ]
+            ),
+            "_packed_seq_ids": torch.tensor([[0, 0, 1, 1]]),
+        }
+
+        prepared = model.prepare_mtp_inputs_for_cp(batch, ignore_index=-100)
+
+        assert model.ModelCapabilities().supports_mtp_cp
+        assert prepared.position_ids_seq_dim == 2
+        torch.testing.assert_close(prepared.input_ids[0], torch.tensor([[11, 0, 21, 0]]))
+        torch.testing.assert_close(
+            prepared.position_ids[0],
+            torch.tensor(
+                [
+                    [[1, 0, 1, 0]],
+                    [[11, 0, 21, 0]],
+                    [[31, 0, 41, 0]],
+                ]
+            ),
+        )
+        torch.testing.assert_close(prepared.targets[0], torch.tensor([[12, -100, 22, -100]]))
+        torch.testing.assert_close(prepared.valid_masks[0], torch.tensor([[True, False, True, False]]))
+
     def test_moe_mtp_builds_full_attention_moe_block(self):
         model = Qwen3_5MoeForConditionalGeneration(_tiny_vl_config(mtp_num_hidden_layers=1), backend=_backend())
 

--- a/tests/unit_tests/moe/test_latent_projection.py
+++ b/tests/unit_tests/moe/test_latent_projection.py
@@ -166,6 +166,44 @@ class TestMoELatentProjectionForward:
             experts_input = mock_experts.call_args[0][0]
             assert experts_input.shape[-1] == moe_config.moe_latent_size
 
+    def test_fc2_latent_proj_accepts_float32_expert_output(self, moe_config, backend_config):
+        """Test back-projection re-enters bf16 after an FSDP-style fp32 expert output."""
+        moe_config.moe_latent_size = 64
+        moe_config.n_shared_experts = 0
+        moe = MoE(moe_config, backend_config)
+
+        batch_size, seq_len = 2, 3
+        x = torch.randn(batch_size, seq_len, moe_config.dim, dtype=torch.bfloat16)
+        expert_output = torch.randn(
+            batch_size * seq_len,
+            moe_config.moe_latent_size,
+            dtype=torch.float32,
+            requires_grad=True,
+        )
+
+        with (
+            patch.object(moe.gate, "forward") as mock_gate,
+            patch.object(moe.experts, "forward") as mock_experts,
+        ):
+            mock_gate.return_value = (
+                torch.rand(batch_size * seq_len, moe_config.n_activated_experts, dtype=torch.bfloat16),
+                torch.randint(
+                    0,
+                    moe_config.n_routed_experts,
+                    (batch_size * seq_len, moe_config.n_activated_experts),
+                ),
+                None,
+            )
+            mock_experts.return_value = expert_output
+
+            output = moe(x)
+
+        assert output.dtype == torch.bfloat16
+        output.float().sum().backward()
+        assert expert_output.grad is not None
+        assert expert_output.grad.dtype == torch.float32
+        assert torch.isfinite(expert_output.grad).all()
+
     def test_forward_gate_receives_original_input(self, moe_config, backend_config, device):
         """Test that the gate receives the original (non-projected) input."""
         moe_config.moe_latent_size = 64

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -435,6 +435,25 @@ def _import_parallelizer_with_stubs(monkeypatch):
     parallelizer_utils_stub.fully_shard_by_dtype = fully_shard_by_dtype
     parallelizer_utils_stub.get_internal_fsdp_mp_policy = lambda mp_policy: ("INTERNAL_MP_POLICY", mp_policy)
     parallelizer_utils_stub.configure_fsdp_unused_param_reduction = lambda module: 0
+
+    def reject_unsupported_mtp_cp(model):
+        if model.supports.mtp_enabled and not model.supports.supports_mtp_cp:
+            raise RuntimeError("Model does not support MTP with context parallelism")
+
+    parallelizer_utils_stub.reject_unsupported_mtp_cp = reject_unsupported_mtp_cp
+
+    def reject_unsupported_mtp_cp_pp(model):
+        is_pp_stage_fn = getattr(model, "_is_pipeline_parallel_stage", None)
+        if (
+            model.supports.mtp_enabled
+            and not model.supports.supports_mtp_cp_pp
+            and callable(is_pp_stage_fn)
+            and is_pp_stage_fn()
+        ):
+            raise NotImplementedError("MTP with context and pipeline parallelism is not supported")
+
+    parallelizer_utils_stub.reject_unsupported_mtp_cp_pp = reject_unsupported_mtp_cp_pp
+
     monkeypatch.setitem(
         sys.modules,
         "nemo_automodel.components.distributed.parallelizer_utils",
@@ -1595,7 +1614,14 @@ def test_parallelize_model_applies_tp_before_cp_ep_ac_and_fsdp(monkeypatch):
     model = type(
         "Outer",
         (),
-        {"moe_config": type("MC", (), {"n_routed_experts": 4})()},
+        {
+            "moe_config": type("MC", (), {"n_routed_experts": 4})(),
+            "supports": types.SimpleNamespace(
+                mtp_enabled=False,
+                supports_mtp_cp=False,
+                supports_mtp_cp_pp=False,
+            ),
+        },
     )()
 
     P.parallelize_model(
@@ -1618,6 +1644,82 @@ def test_parallelize_model_applies_tp_before_cp_ep_ac_and_fsdp(monkeypatch):
         tp_shard_plan=None,
         tp_size=2,
     )
+
+
+def test_parallelize_model_rejects_cp_mtp_pipeline_stage_before_ep_or_cp(monkeypatch):
+    """The MoE/EP path must reject the same unsupported topology on every PP stage."""
+    P = _import_parallelizer_with_stubs(monkeypatch)
+    apply_cp_mock = MagicMock()
+    apply_ep_mock = MagicMock()
+    monkeypatch.setattr(P, "apply_cp", apply_cp_mock)
+    monkeypatch.setattr(P, "apply_ep", apply_ep_mock)
+
+    world_mesh = FakeWorldMesh(
+        {"cp": 2, ("dp",): 2},
+        mesh_dim_names=["dp", "cp"],
+    )
+    moe_mesh = FakeMoeMesh({"ep": 2})
+    model = type(
+        "PipelineStage",
+        (),
+        {
+            "supports": types.SimpleNamespace(mtp_enabled=True, supports_mtp_cp_pp=False),
+            "mtp_config": type("MTP", (), {"enabled": True})(),
+            "moe_config": type("MC", (), {"n_routed_experts": 4})(),
+            "_is_pipeline_parallel_stage": lambda self: True,
+        },
+    )()
+
+    with pytest.raises(NotImplementedError, match="MTP with context and pipeline parallelism"):
+        P.parallelize_model(
+            model=model,
+            world_mesh=world_mesh,
+            moe_mesh=moe_mesh,
+            dp_axis_names=("dp",),
+            cp_axis_name="cp",
+            ep_axis_name="ep",
+        )
+
+    apply_cp_mock.assert_not_called()
+    apply_ep_mock.assert_not_called()
+
+
+def test_parallelize_model_rejects_cp_mtp_without_capability_before_ep_or_cp(monkeypatch):
+    """The MoE/EP path must enforce the same MTP+CP capability as the dense path."""
+    P = _import_parallelizer_with_stubs(monkeypatch)
+    apply_cp_mock = MagicMock()
+    apply_ep_mock = MagicMock()
+    monkeypatch.setattr(P, "apply_cp", apply_cp_mock)
+    monkeypatch.setattr(P, "apply_ep", apply_ep_mock)
+
+    world_mesh = FakeWorldMesh({"cp": 2, ("dp",): 2}, mesh_dim_names=["dp", "cp"])
+    moe_mesh = FakeMoeMesh({"ep": 2})
+    model = type(
+        "UnsupportedMTPModel",
+        (),
+        {
+            "supports": types.SimpleNamespace(
+                mtp_enabled=True,
+                supports_mtp_cp=False,
+                supports_mtp_cp_pp=False,
+            ),
+            "mtp_config": type("MTP", (), {"enabled": True})(),
+            "moe_config": type("MC", (), {"n_routed_experts": 4})(),
+        },
+    )()
+
+    with pytest.raises(RuntimeError, match="does not support MTP with context parallelism"):
+        P.parallelize_model(
+            model=model,
+            world_mesh=world_mesh,
+            moe_mesh=moe_mesh,
+            dp_axis_names=("dp",),
+            cp_axis_name="cp",
+            ep_axis_name="ep",
+        )
+
+    apply_cp_mock.assert_not_called()
+    apply_ep_mock.assert_not_called()
 
 
 def test_parallelize_model_forwards_offload_policy_to_fsdp(monkeypatch):

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -2301,6 +2301,7 @@ class _CPPreEmbedModel(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.scale = torch.nn.Parameter(torch.tensor(1.0))
+        self.supports = SimpleNamespace(mtp_enabled=False, supports_mtp_cp=False)
         self.hook_calls = []
 
     def prepare_model_inputs_for_cp(self, batch, *, num_chunks=1):

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -2500,6 +2500,7 @@ def test_forward_backward_step_model_cp_hook(monkeypatch, cp_size, uses_thd, sup
             super().__init__()
             self.lin = nn.Linear(4, 8)
             self.prepared = False
+            self.supports = SimpleNamespace(mtp_enabled=False)
 
         def prepare_model_inputs_for_cp(self, batch, **kwargs):
             self.prepared = True
@@ -2583,3 +2584,145 @@ def test_forward_backward_step_model_cp_hook(monkeypatch, cp_size, uses_thd, sup
     # backward through the local loss populated grads
     assert model.lin.weight.grad is not None
     assert torch.isfinite(model.lin.weight.grad).all()
+
+
+def test_forward_backward_step_shards_global_mtp_inputs_and_targets(monkeypatch):
+    """The recipe consumes raw packed lengths, shifts globally, then reuses the CP layout."""
+    from nemo_automodel.components.models.common.mtp import (
+        MTPConfig,
+        prepare_mtp_context_parallel_inputs,
+    )
+
+    captured = {}
+    local_indices = torch.tensor([0, 1, 4, 5])
+
+    class _MTPModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.scale = nn.Parameter(torch.tensor(1.0))
+            self.mtp_config = MTPConfig(num_layers=1, layer_pattern="*")
+            self.prepared_before_shard = False
+            self.supports = SimpleNamespace(mtp_enabled=True, supports_mtp_cp=True)
+
+        def prepare_mtp_inputs_for_cp(self, batch, *, ignore_index=-100):
+            self.prepared_before_shard = True
+            return prepare_mtp_context_parallel_inputs(
+                batch,
+                num_depths=self.mtp_config.num_layers,
+                ignore_index=ignore_index,
+            )
+
+        def forward(
+            self,
+            input_ids,
+            *,
+            mtp_per_depth_input_ids,
+            mtp_per_depth_position_ids,
+            **kwargs,
+        ):
+            captured["model_input_ids"] = input_ids.detach().clone()
+            captured["mtp_input_ids"] = tuple(t.detach().clone() for t in mtp_per_depth_input_ids)
+            captured["mtp_position_ids"] = tuple(t.detach().clone() for t in mtp_per_depth_position_ids)
+            hidden = self.scale * input_ids.float().unsqueeze(-1)
+            return SimpleNamespace(
+                logits=hidden,
+                mtp_per_depth_h=[hidden],
+                mtp_per_depth_logits=None,
+                mtp_loss_scaling_factor=1.0,
+            )
+
+    model = _MTPModel()
+
+    class _FakeContextParallelSharder:
+        def __init__(self, resolved_model, device_mesh, batch, **kwargs):
+            del device_mesh, kwargs
+            assert resolved_model is model
+            assert model.prepared_before_shard
+            assert batch["input_ids"].shape == (1, 6)
+            assert batch["seq_lens_padded"].tolist() == [[3, 3, -1000]]
+
+        def shard(self, batch):
+            assert model.prepared_before_shard
+            local_batch = dict(batch)
+            for key in ("input_ids", "labels", "position_ids"):
+                local_batch[key] = local_batch[key].index_select(1, local_indices)
+            local_batch.pop("seq_lens")
+            local_batch.pop("seq_lens_padded")
+            return nullcontext, local_batch
+
+        def shard_token_tensor(self, tensor, seq_dim=1, fill=None):
+            del fill
+            return tensor.index_select(seq_dim, local_indices)
+
+    recipe = TrainFinetuneRecipeForNextTokenPrediction.__new__(TrainFinetuneRecipeForNextTokenPrediction)
+    object.__setattr__(
+        recipe,
+        "cfg",
+        SimpleNamespace(mtp=SimpleNamespace(ignore_index=-100, scaling_factor=1.0)),
+    )
+    object.__setattr__(recipe, "dist_env", SimpleNamespace(device=torch.device("cpu")))
+    object.__setattr__(recipe, "device_mesh", object())
+    object.__setattr__(recipe, "pp_enabled", False)
+    object.__setattr__(recipe, "tokenizer", SimpleNamespace(pad_token_id=0))
+    object.__setattr__(recipe, "te_fp8", None)
+    object.__setattr__(recipe, "model_parts", [model])
+    object.__setattr__(recipe, "distributed_config", SimpleNamespace(defer_fsdp_grad_sync=True))
+    object.__setattr__(recipe, "loss_fn", object())
+    object.__setattr__(recipe, "_get_cp_group_size", lambda: 2)
+    object.__setattr__(recipe, "_get_dp_group_size", lambda include_cp=False: 1)
+
+    def _fake_calculate_loss(loss_fn, *, logits, **kwargs):
+        del loss_fn, kwargs
+        return logits.sum() * 0.0
+
+    def _fake_calculate_mtp_loss(loss_fn, *, mtp_per_depth_h, mtp_per_depth_targets, cu_seqlens, **kwargs):
+        del loss_fn, kwargs
+        captured["mtp_targets"] = tuple(t.detach().clone() for t in mtp_per_depth_targets)
+        captured["cu_seqlens"] = cu_seqlens
+        return sum(hidden.sum() for hidden in mtp_per_depth_h) * 0.01
+
+    monkeypatch.setattr("nemo_automodel.recipes.llm.train_ft.ContextParallelSharder", _FakeContextParallelSharder)
+    monkeypatch.setattr("nemo_automodel.recipes.llm.train_ft.calculate_loss", _fake_calculate_loss)
+    monkeypatch.setattr("nemo_automodel.recipes.llm.train_ft.calculate_mtp_loss", _fake_calculate_mtp_loss)
+    monkeypatch.setattr("nemo_automodel.recipes.llm.train_ft.get_final_hidden_states", lambda out: None)
+    monkeypatch.setattr("nemo_automodel.recipes.llm.train_ft.get_sync_ctx", lambda *args, **kwargs: nullcontext())
+
+    batch = {
+        "input_ids": torch.tensor([[10, 11, 12, 20, 21, 22]]),
+        "labels": torch.tensor([[11, 12, -100, 21, 22, -100]]),
+        "position_ids": torch.tensor([[0, 1, 2, 0, 1, 2]]),
+        "seq_lens": torch.tensor([[3, 3, -1000]]),
+        "seq_lens_padded": torch.tensor([[3, 3, -1000]]),
+    }
+    loss_buffer = []
+
+    model.supports.supports_mtp_cp = False
+    with pytest.raises(NotImplementedError, match="supports_mtp_cp=False"):
+        recipe._forward_backward_step(
+            idx=0,
+            batch=batch,
+            loss_buffer=loss_buffer,
+            num_label_tokens=4,
+            num_batches=1,
+            is_train=True,
+        )
+    assert not model.prepared_before_shard
+    assert loss_buffer == []
+    model.supports.supports_mtp_cp = True
+
+    recipe._forward_backward_step(
+        idx=0,
+        batch=batch,
+        loss_buffer=loss_buffer,
+        num_label_tokens=4,
+        num_batches=1,
+        is_train=True,
+    )
+
+    assert captured["model_input_ids"].tolist() == [[10, 11, 21, 22]]
+    assert captured["mtp_input_ids"][0].tolist() == [[11, 12, 22, 0]]
+    assert captured["mtp_position_ids"][0].tolist() == [[1, 2, 2, 0]]
+    assert captured["mtp_targets"][0].tolist() == [[12, -100, -100, -100]]
+    assert captured["cu_seqlens"] is None
+    assert model.scale.grad is not None
+    assert len(loss_buffer) == 1

--- a/tests/unit_tests/test_validation.py
+++ b/tests/unit_tests/test_validation.py
@@ -389,6 +389,19 @@ class TestModelSupportsEP:
         assert model.supports.supports_ep is False
 
 
+class TestModelSupportsMTP:
+    def test_mtp_enabled_reflects_live_config(self):
+        model = _Bare()
+        model.mtp_config = SimpleNamespace(enabled=False)
+        _attach(model)
+
+        assert model.supports.mtp_enabled is False
+        model.mtp_config.enabled = True
+        assert model.supports.mtp_enabled is True
+        assert model.supports.supports_mtp_cp is False
+        assert model.supports.supports_mtp_cp_pp is False
+
+
 class TestModelSupportsSequencePacking:
     def test_true_with_seq_lens(self):
         model = _WithSeqLens()


### PR DESCRIPTION
Cherry-pick of #3801 into `r0.6.0`.

# What does this PR do?

Adds Nemotron 3.5 Super VL support to the release branch, including RADIO checkpoint conversion, packed THD context parallelism, MTP plumbing, and the Tulu-3 full-SFT and CORD-v2 LoRA recipes.

The release branch lacks prerequisites used by #3801, so this backport also includes:
- #3543 (`cb03cf61ae2da0a591516fac4f21cfc6eecf48c1`): MTP context-parallel caller inputs and capability checks.
- #3544 (`8e6f8547160f22afce62e63441d844e4cc4cf43e`): global MTP input/target preparation and recipe integration.
- #3559 (`8b4db0075182b2f9d82e9c8f9342d911aea9ed6c`): mixed-resolution image batches in the NemotronOmni tile path.

Implementation source: `6ae5ca23895d1e06c81cc6103732a20510833fda` (#3801). All four source commits are recorded in the commit message.

# Changelog

- Register `NemotronH_Omni_Reasoning_V3` and retain the implementation's RADIO loading, fused-QKV conversion, router-bias precision, and MoE latent-output dtype fixes.
- Preserve deterministic replacement sampling, variable-resolution image packing, packed-THD media selection, and MTP/CP integration.
- Resolve release conflicts while retaining the scalar MTP loss API and training-only MTP lifecycle. Treat the legacy language adapter's absent direct-load capability as unsupported.
- Connect mixed-resolution merging to the release VLM collaters and add regression coverage from packing through actual neat/THD collation.
- Include the three recipes and model-coverage page shipped by #3801.

# Validation

- Focused CPU suite with the release's Transformers 5.12.1: **1,147 passed, 42 skipped**. Covers NemotronOmni/NemotronV3, MTP loss/input preparation, VLM datasets and collaters, registry/capabilities, distributed strategies, MoE, Qwen3.5-MoE MTP, and LLM/VLM recipe helpers.
- `ruff format .` and `ruff check --fix .` passed using the repository's Ruff 0.12 series.
- Example YAML linter passed for all three new recipes.
- `make -C docs/fern docs-check` passed: 456 MDX files validated; Fern reported 0 errors and 1 warning.
- `git diff --check` passed.
- GPU parity and full 121B training were not rerun locally for this release backport. The original PR documents its H100 parity, full-SFT, CP8/MTP, and CORD-v2 LoRA validation; release CI will validate this branch.
