### PR TITLE
chore: CI proxy for #3870

### DIFF
--- a/nemo_automodel/components/loss/infonce.py
+++ b/nemo_automodel/components/loss/infonce.py
@@ -22,7 +22,34 @@ def infonce_loss(
     use_in_batch_negatives: bool = True,
     normalize: bool = True,
 ) -> torch.Tensor:
-    """InfoNCE contrastive loss with optional hard negatives."""
+    """InfoNCE contrastive loss with optional hard negatives.
+
+    Args:
+        queries: Tensor of shape [batch, hidden] -- pooled query embeddings.
+        documents: Tensor of shape [batch, hidden] -- pooled embeddings of the
+            positive document for each query, row-aligned with ``queries``.
+        hard_negatives: Optional Tensor of shape [batch, negatives, hidden] --
+            mined negative *documents* for each query. Rows are per-query, so
+            these are candidates for the ``"q2d"`` direction only.
+        hard_negatives_mask: Optional Tensor of shape [batch, negatives] --
+            1 for a real negative, 0 for padding in a ragged batch. Padded
+            columns are scored as ``-inf`` and contribute nothing.
+        temperature: Logit scale divisor; a 0-dim Tensor when it is learned.
+        direction: ``"q2d"``, ``"d2q"``, or ``"symmetric"``.
+        use_in_batch_negatives: Score every query against every document in the
+            batch instead of only its own positive.
+        normalize: L2-normalize the embeddings before scoring.
+
+    Returns:
+        Scalar Tensor: the mean cross-entropy over the batch.
+
+    Raises:
+        ValueError: If the embedding shapes disagree with the layouts above, if
+            ``direction`` is unknown, or if the requested directions have no
+            candidates to score against -- ``use_in_batch_negatives=False``
+            needs ``hard_negatives`` *and* ``direction="q2d"``, because the
+            document-to-query direction can only draw candidates from the batch.
+    """
     if queries.dim() != 2 or documents.dim() != 2:
         raise ValueError(
             f"infonce_loss: queries and documents must be 2-D [B, D]; got queries={tuple(queries.shape)}, "
@@ -51,8 +78,17 @@ def infonce_loss(
                 f"infonce_loss: hard_negatives_mask must be [B, K]; got {tuple(hard_negatives_mask.shape)}"
             )
 
-    if not use_in_batch_negatives and not has_hard_negs:
-        raise ValueError("infonce_loss: no negatives provided")
+    if not use_in_batch_negatives:
+        if not has_hard_negs:
+            raise ValueError("infonce_loss: no negatives provided")
+        if direction != "q2d":
+            raise ValueError(
+                f"infonce_loss: direction={direction!r} scores each document against the other "
+                "queries in the batch, and hard negatives are document-side candidates that "
+                "cannot stand in for them. With use_in_batch_negatives=False that direction has "
+                "no candidates at all and its cross-entropy is identically zero. Set "
+                "use_in_batch_negatives=True or direction='q2d'."
+            )
 
     if normalize:
         q = F.normalize(queries, dim=-1)
@@ -101,7 +137,46 @@ def infonce_distill_loss(
     normalize: bool = True,
     divergence: str = "kl",
 ) -> torch.Tensor:
-    """Soft listwise distillation on InfoNCE candidate sets."""
+    """Soft listwise distillation on InfoNCE candidate sets.
+
+    Builds the same candidate sets as :func:`infonce_loss` for the student and
+    the (detached) teacher, then matches the student's distribution over those
+    candidates to the teacher's.
+
+    Args:
+        student_queries: Tensor of shape [batch, student_hidden].
+        student_documents: Tensor of shape [batch, student_hidden], row-aligned
+            with ``student_queries``.
+        teacher_queries: Tensor of shape [batch, teacher_hidden]. Detached.
+        teacher_documents: Tensor of shape [batch, teacher_hidden], row-aligned
+            with ``teacher_queries``. Detached.
+        student_hard_negatives: Optional Tensor of shape
+            [batch, negatives, student_hidden] -- mined negative *documents*,
+            per query, so they are candidates for ``"q2d"`` only.
+        teacher_hard_negatives: Optional Tensor of shape
+            [batch, negatives, teacher_hidden], aligned with
+            ``student_hard_negatives``. Required when it is given. Detached.
+        hard_negatives_mask: Optional Tensor of shape [batch, negatives] -- 1
+            for a real negative, 0 for padding. Padded columns are scored as
+            ``-inf`` and masked out of the divergence.
+        temperature: Logit scale divisor.
+        direction: ``"q2d"``, ``"d2q"``, or ``"symmetric"``.
+        use_in_batch_negatives: Score every query against every document in the
+            batch instead of only its own positive.
+        normalize: L2-normalize the embeddings before scoring.
+        divergence: ``"kl"``, ``"ce"``, or ``"mse"``.
+
+    Returns:
+        Scalar Tensor: the mean divergence over the batch.
+
+    Raises:
+        ValueError: If the embedding shapes disagree with the layouts above, if
+            ``direction`` or ``divergence`` is unknown, or if the requested
+            directions have no candidates to score against --
+            ``use_in_batch_negatives=False`` needs hard negatives *and*
+            ``direction="q2d"``, because the document-to-query direction can
+            only draw candidates from the batch.
+    """
     if student_queries.dim() != 2 or student_documents.dim() != 2:
         raise ValueError(
             f"infonce_distill_loss: student embeddings must be 2-D [B, D_s]; got queries={tuple(student_queries.shape)}, "
@@ -141,8 +216,18 @@ def infonce_distill_loss(
         if hard_negatives_mask is not None and hard_negatives_mask.shape != (batch, student_hard_negatives.shape[1]):
             raise ValueError("infonce_distill_loss: hard_negatives_mask must be [B, K]")
 
-    if not use_in_batch_negatives and not has_hard_negs:
-        raise ValueError("infonce_distill_loss: no negatives available")
+    if not use_in_batch_negatives:
+        if not has_hard_negs:
+            raise ValueError("infonce_distill_loss: no negatives available")
+        if direction != "q2d":
+            raise ValueError(
+                f"infonce_distill_loss: direction={direction!r} scores each document against the "
+                "other queries in the batch, and hard negatives are document-side candidates that "
+                "cannot stand in for them. With use_in_batch_negatives=False that direction leaves "
+                "a single candidate, so student and teacher distributions are both degenerate and "
+                "the divergence is identically zero. Set use_in_batch_negatives=True or "
+                "direction='q2d'."
+            )
 
     s_q = student_queries.float()
     s_d = student_documents.float()

--- a/tests/unit_tests/loss/test_infonce.py
+++ b/tests/unit_tests/loss/test_infonce.py
@@ -91,6 +91,43 @@ def test_infonce_loss_no_in_batch_with_hard_negatives():
     assert torch.isfinite(loss)
 
 
+@pytest.mark.parametrize("direction", ["d2q", "symmetric"])
+def test_infonce_loss_no_in_batch_rejects_document_side_direction(direction):
+    """``d2q`` can only draw candidates from the batch, so dropping them is not a valid config."""
+    torch.manual_seed(0)
+    q = torch.randn(4, 8)
+    d = torch.randn(4, 8)
+    n = torch.randn(4, 3, 8)
+
+    with pytest.raises(ValueError, match="no candidates at all"):
+        infonce_loss(q, d, hard_negatives=n, direction=direction, use_in_batch_negatives=False)
+
+
+@pytest.mark.parametrize(
+    "direction, use_in_batch_negatives",
+    [("q2d", True), ("q2d", False), ("d2q", True), ("symmetric", True)],
+)
+def test_infonce_loss_accepted_configs_score_real_candidates(direction, use_in_batch_negatives):
+    """Every accepted config must score >1 candidate: a 1-class CE is 0 with no gradient."""
+    torch.manual_seed(0)
+    q = torch.randn(4, 8, requires_grad=True)
+    d = torch.randn(4, 8, requires_grad=True)
+    n = torch.randn(4, 3, 8, requires_grad=True)
+
+    loss = infonce_loss(
+        q,
+        d,
+        hard_negatives=n,
+        direction=direction,
+        use_in_batch_negatives=use_in_batch_negatives,
+    )
+    loss.backward()
+
+    assert loss.item() > 0.0
+    assert q.grad.abs().sum().item() > 0.0
+    assert d.grad.abs().sum().item() > 0.0
+
+
 def test_infonce_loss_without_normalize():
     torch.manual_seed(0)
     q = torch.randn(4, 8)
@@ -398,6 +435,49 @@ def test_distill_loss_no_negatives_error():
         infonce_distill_loss(s_q, s_d, t_q, t_d, use_in_batch_negatives=False)
 
 
+@pytest.mark.parametrize("direction", ["d2q", "symmetric"])
+def test_distill_loss_no_in_batch_rejects_document_side_direction(direction):
+    """The document-to-query candidate set is the batch; without it the divergence is 0."""
+    s_q, s_d, t_q, t_d, s_n, t_n = _distill_inputs()
+
+    with pytest.raises(ValueError, match="a single candidate"):
+        infonce_distill_loss(
+            s_q,
+            s_d,
+            t_q,
+            t_d,
+            student_hard_negatives=s_n,
+            teacher_hard_negatives=t_n,
+            direction=direction,
+            use_in_batch_negatives=False,
+        )
+
+
+@pytest.mark.parametrize(
+    "direction, use_in_batch_negatives",
+    [("q2d", True), ("q2d", False), ("d2q", True), ("symmetric", True)],
+)
+def test_distill_loss_accepted_configs_score_real_candidates(direction, use_in_batch_negatives):
+    """A degenerate 1-candidate set makes both distributions one-hot and the divergence 0."""
+    s_q, s_d, t_q, t_d, s_n, t_n = _distill_inputs(requires_grad=True)
+
+    loss = infonce_distill_loss(
+        s_q,
+        s_d,
+        t_q,
+        t_d,
+        student_hard_negatives=s_n,
+        teacher_hard_negatives=t_n,
+        direction=direction,
+        use_in_batch_negatives=use_in_batch_negatives,
+    )
+    loss.backward()
+
+    assert loss.item() > 0.0
+    assert s_q.grad.abs().sum().item() > 0.0
+    assert s_d.grad.abs().sum().item() > 0.0
+
+
 # ---------------------------------------------------------------------------
 # InfoNCELoss module
 # ---------------------------------------------------------------------------
@@ -410,6 +490,18 @@ def test_infonce_module_forward():
     loss = loss_fn(q, d)
 
     assert torch.isfinite(loss)
+
+
+def test_infonce_module_surfaces_document_side_direction_conflict():
+    """The recipe builds this module straight from YAML, so the config path must fail loudly."""
+    torch.manual_seed(0)
+    loss_fn = InfoNCELoss(direction="symmetric", use_in_batch_negatives=False)
+    q = torch.randn(4, 8)
+    d = torch.randn(4, 8)
+    n = torch.randn(4, 3, 8)
+
+    with pytest.raises(ValueError, match="no candidates at all"):
+        loss_fn(q, d, hard_negatives=n)
 
 
 def test_infonce_module_rejects_nonpositive_temperature():


### PR DESCRIPTION
## What does this PR do?

CI-only proxy for #3870. **Do not merge / do not review.** #3870 remains the source of truth.

Latest upstream `main` was merged into the source PR branch and pushed before creating this proxy. Both PRs point to the same updated commit, preserving the contributor's commits and associating CI checks with the same revision. This proxy runs through the internal contributor queue and maintainer runners.

The previous source CI build never received an external runner and timed out after 24 hours; downstream tests were skipped. See [the cancelled build](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/34877186076/job/104398335173).

## Changelog

- Mirrors #3870: reject InfoNCE configurations whose document-to-query direction has no negative candidates, with regression coverage.
- Includes the latest `main` through a merge commit on the original PR branch.
- Adds no proxy-specific source changes.

## Pre-checks

- Merge completed without conflicts; the approved loss code and tests are unchanged.
- Focused CPU validation after merging: `tests/unit_tests/loss/test_infonce.py` — **62 passed**.
- Repository formatting and lint checks passed without changing files; Git whitespace checks passed.
- The merge commit includes a DCO signoff, and the original contributor commits are preserved.

## Additional information

Keep fixes on the original PR branch and synchronize this proxy if its head changes. Close this proxy once CI completes; merge only #3870.

Source and proxy head: `81ae22c7b143f72431d64dc8011417c26006e380`. Merged upstream main: `7fe64e71fadd60096b6fb393d0158e3f6926759a`.
